### PR TITLE
fix(styles): tune chicago author-date fidelity

### DIFF
--- a/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
+++ b/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
@@ -1,11 +1,11 @@
 ---
 # csl26-giun
 title: Tune chicago-author-date-18th to full fidelity
-status: todo
+status: in-progress
 type: task
 priority: high
 created_at: 2026-06-30T18:46:08Z
-updated_at: 2026-06-30T18:55:07Z
+updated_at: 2026-06-30T19:59:04Z
 parent: csl26-h7oc
 ---
 
@@ -38,3 +38,6 @@ are layered on.
 - [ ] SQI loop: `report-core` → hoist/preset/prune → re-check, until clean
 - [ ] style-qa-reviewer handoff (tier: embedded-core)
 - [ ] Confirm no regression on `references-expanded.json` / `core` fixture sets
+
+- 2026-06-30 tune attempt: `webpage` citation variant added to render publisher/year for publisher-owned web pages. `node scripts/report-core.js --style chicago-author-date-18th` now reports headline fidelity 0.808, SQI 0.975, and `chicago-shared-corpus` 12/15 citations + 298/402 bibliography. Residual citation failures: `chi-article-magazine` (`Gourmet 2000b` vs `(2000)`), `chi-multi-source` classic book (`Augustine, De civitate Dei` vs `Augustine 1931`), and `chi-personal-communication` (`Johnson to O’Laughlin 1916` vs `Hiram Johnson`). Invalid/failed probes reverted: citation substitute keys `publisher`/`parent-serial` are schema-invalid; article-magazine `title: parent-serial` duplicates `Gourmet`; raw `container-title` is invalid in citation type-variants; personal_communication sender-recipient-year variant regresses `secondary-roles` recipient citation. Fidelity not green; SQI/QA/PR intentionally not run.
+- 2026-06-30 recovery attempt on `codex/chicago-author-date-full-fidelity`: citation fidelity is now green for `chicago-shared-corpus` (`15/15`). Implemented bounded support for `parent-serial` substitutes, field-presence/absence `render-when` groups, classic conversion from CSL/Zotero `type: classic`, collection-editor substitution, custom contributor-role rendering, and audio-visual event/dimensions preservation. Bibliography improved from `298/402` to `331/400` in the shared oracle run; `node scripts/report-core.js --style chicago-author-date-18th` reports headline fidelity `0.868` and SQI `0.927`. Remaining bibliography failures are broad rich-reference clusters (book original/reprint/rich contributors, interviews, manuscripts, web pages, recordings/media, broadcasts, and manuscript/archive edge cases), so the original 100% + clean SQI + QA completion gate is not met. This draft PR is a substrate/progress PR, not a completed full-fidelity tune.

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -12,6 +12,8 @@ use std::fmt::Write as _;
 use crate::grouping::GroupSorter;
 use citum_schema::grouping::GroupSort;
 use citum_schema::locale::Locale;
+use citum_schema::options::{Substitute, SubstituteKey};
+use citum_schema::reference::{ClassExtension, Title};
 
 /// Handles disambiguation logic for author-date citations.
 ///
@@ -235,7 +237,7 @@ impl<'a> Disambiguator<'a> {
             let names = reference.author().map_or_else(Vec::new, |authors| {
                 self.render_name_for_disambiguation(&authors)
             });
-            let author_key = self.build_author_key(&names);
+            let author_key = self.build_author_slot_key(reference, &names);
             let group_key = self.build_group_key(reference, &author_key);
             // Year-suffix letters (a, b, c…) must follow the effective bibliography
             // sort order. Reuse the bibliography title sort key (leading-article
@@ -257,6 +259,61 @@ impl<'a> Disambiguator<'a> {
         }
 
         cache
+    }
+
+    fn build_author_slot_key(
+        &self,
+        reference: &Reference,
+        author_names: &[crate::reference::FlatName],
+    ) -> String {
+        let author_key = self.build_author_key(author_names);
+        if !author_key.is_empty() {
+            return author_key;
+        }
+
+        let substitute = self
+            .config
+            .substitute
+            .as_ref()
+            .map(citum_schema::options::SubstituteConfig::resolve)
+            .unwrap_or_default();
+
+        self.build_substitute_author_key(reference, &substitute)
+            .unwrap_or_default()
+    }
+
+    fn build_substitute_author_key(
+        &self,
+        reference: &Reference,
+        substitute: &Substitute,
+    ) -> Option<String> {
+        for key in &substitute.template {
+            let resolved = match key {
+                SubstituteKey::CollectionEditor => reference
+                    .contributor(citum_schema::reference::ContributorRole::Unknown(
+                        "collection-editor".to_string(),
+                    ))
+                    .map(|names| {
+                        self.build_author_key(&self.render_name_for_disambiguation(&names))
+                    }),
+                SubstituteKey::Editor => reference.editor().map(|names| {
+                    self.build_author_key(&self.render_name_for_disambiguation(&names))
+                }),
+                SubstituteKey::Translator => reference.translator().map(|names| {
+                    self.build_author_key(&self.render_name_for_disambiguation(&names))
+                }),
+                SubstituteKey::ParentSerial => {
+                    resolve_parent_serial_title(reference).map(Self::title_substitute_key)
+                }
+                SubstituteKey::Title => reference.title().map(Self::title_substitute_key),
+            };
+
+            if let Some(key) = resolved.filter(|key| !key.is_empty()) {
+                return Some(key);
+            }
+        }
+
+        None
     }
 
     /// Calculates how many references in `refs` share the same `author_key`.
@@ -696,7 +753,9 @@ impl<'a> Disambiguator<'a> {
                     .title_key
                     .as_deref()
                     .unwrap_or_default();
-                a_title.cmp(b_title)
+                a_title
+                    .cmp(b_title)
+                    .then_with(|| year_suffix_date_key(a).cmp(&year_suffix_date_key(b)))
             });
             sorter.sort_references(pre_sorted, sort_spec)
         } else {
@@ -712,7 +771,9 @@ impl<'a> Disambiguator<'a> {
                     .title_key
                     .as_deref()
                     .unwrap_or_default();
-                a_title.cmp(b_title)
+                a_title
+                    .cmp(b_title)
+                    .then_with(|| year_suffix_date_key(a).cmp(&year_suffix_date_key(b)))
             });
             sorted
         }
@@ -840,6 +901,12 @@ impl<'a> Disambiguator<'a> {
         }
 
         self.append_lowercased_families(&mut key, names, names.len(), ',');
+        key
+    }
+
+    fn title_substitute_key(title: Title) -> String {
+        let mut key = String::new();
+        Self::push_lowercased(&mut key, title.to_string().trim());
         key
     }
 
@@ -986,6 +1053,22 @@ impl<'a> Disambiguator<'a> {
             .get(&Self::reference_cache_key(reference))
             .expect("disambiguation cache missing reference")
     }
+}
+
+fn resolve_parent_serial_title(reference: &Reference) -> Option<Title> {
+    match reference.extension() {
+        ClassExtension::SerialComponent(_)
+        | ClassExtension::LegalCase(_)
+        | ClassExtension::Treaty(_) => reference.container_title(),
+        _ => None,
+    }
+}
+
+fn year_suffix_date_key(reference: &Reference) -> String {
+    reference
+        .effective_issued_date()
+        .map(|date| date.to_string())
+        .unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -523,6 +523,7 @@ fn test_repro_djot_rendering() {
                             ..Default::default()
                         },
                         delimiter: None,
+                        render_when: None,
                         custom: None,
                     }),
                 ]),

--- a/crates/citum-engine/src/processor/matching.rs
+++ b/crates/citum-engine/src/processor/matching.rs
@@ -82,8 +82,14 @@ impl<'a> Matcher<'a> {
         // Fall back through the substitute template order
         for key in &substitute.template {
             let contributor = match key {
+                SubstituteKey::CollectionEditor => {
+                    reference.contributor(citum_schema::reference::ContributorRole::Unknown(
+                        "collection-editor".to_string(),
+                    ))
+                }
                 SubstituteKey::Editor => reference.editor(),
                 SubstituteKey::Translator => reference.translator(),
+                SubstituteKey::ParentSerial => None,
                 SubstituteKey::Title => None, // Title is not a contributor
             };
             if contributor.is_some() {

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -14,7 +14,9 @@ use crate::error::ProcessorError;
 use crate::reference::Reference;
 use crate::render::{ProcTemplate, ProcTemplateComponent};
 use crate::values::{ComponentValues, ProcHints, RenderContext, RenderOptions};
-use citum_schema::template::{TemplateComponent, WrapConfig, WrapPunctuation};
+use citum_schema::template::{
+    TemplateComponent, TemplateConditionField, TemplateGroupCondition, WrapConfig, WrapPunctuation,
+};
 use std::borrow::Cow;
 
 struct GroupRenderState<'a> {
@@ -63,6 +65,36 @@ struct HintInputs<'a> {
     integral_name_state: Option<citum_schema::citation::IntegralNameState>,
     org_abbreviation_state: Option<citum_schema::citation::IntegralNameState>,
     first_reference_note_number: Option<u32>,
+}
+
+fn group_condition_matches(reference: &Reference, condition: &TemplateGroupCondition) -> bool {
+    condition
+        .field_present
+        .as_ref()
+        .is_none_or(|field| condition_field_present(reference, field))
+        && condition
+            .field_absent
+            .as_ref()
+            .is_none_or(|field| !condition_field_present(reference, field))
+}
+
+fn condition_field_present(reference: &Reference, field: &TemplateConditionField) -> bool {
+    match field {
+        TemplateConditionField::Author => reference.author().is_some(),
+        TemplateConditionField::Editor => reference.editor().is_some(),
+        TemplateConditionField::Recipient => reference
+            .contributor(citum_schema::reference::ContributorRole::Recipient)
+            .is_some(),
+        TemplateConditionField::Translator => reference.translator().is_some(),
+        TemplateConditionField::Title => reference.title().is_some(),
+        TemplateConditionField::Issued => reference.effective_issued_date().is_some(),
+        TemplateConditionField::OriginalPublished => reference.original_date().is_some(),
+        TemplateConditionField::Publisher => reference.publisher_str().is_some(),
+        TemplateConditionField::Doi => reference.doi().is_some(),
+        TemplateConditionField::Genre => reference.genre().is_some(),
+        TemplateConditionField::Archive => reference.archive().is_some(),
+        TemplateConditionField::ArchiveLocation => reference.archive_location().is_some(),
+    }
 }
 
 impl Renderer<'_> {
@@ -1069,6 +1101,13 @@ impl Renderer<'_> {
         F: crate::render::format::OutputFormat<Output = String>,
     {
         if group.rendering.suppress == Some(true) {
+            return None;
+        }
+        if group
+            .render_when
+            .as_ref()
+            .is_some_and(|condition| !group_condition_matches(ctx.reference, condition))
+        {
             return None;
         }
 

--- a/crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs
@@ -131,15 +131,25 @@ impl Renderer<'_> {
                     };
                 }
             }
-            // Pre-formatted group components — capitalize the first word of the
-            // rendered group value (e.g. "edited by Smith" as first child).
-            TemplateComponent::Group(_) => {
+            // Pre-formatted groups keep child identity only in the template
+            // structure. Auto-case title groups and contributor-role prose,
+            // but keep date/term/data groups' rendered casing intact.
+            TemplateComponent::Group(group) if group_supports_sentence_initial_casing(group) => {
                 let case =
                     crate::values::text_case::resolve_text_case(TextCase::CapitalizeFirst, locale);
                 // Groups are always pre-formatted (rendered markup); use the markup-aware
                 // variant so HTML tags and LaTeX/Typst command prefixes are not corrupted.
                 component.value =
                     crate::values::text_case::apply_text_case_markup_aware(&component.value, case);
+            }
+            TemplateComponent::Message(message) if !message.message.starts_with("term.") => {
+                let case =
+                    crate::values::text_case::resolve_text_case(TextCase::CapitalizeFirst, locale);
+                component.value = if component.pre_formatted {
+                    crate::values::text_case::apply_text_case_markup_aware(&component.value, case)
+                } else {
+                    crate::values::text_case::apply_text_case(&component.value, case)
+                };
             }
             TemplateComponent::Term(_) | TemplateComponent::Message(_)
                 if self.is_note_start_term_component(component) =>
@@ -164,5 +174,28 @@ impl Renderer<'_> {
             &component.template_component,
             TemplateComponent::Message(message) if message.message == "term.ibid"
         )
+    }
+}
+
+fn group_supports_sentence_initial_casing(group: &citum_schema::template::TemplateGroup) -> bool {
+    group.group.iter().find_map(first_sentence_casing_candidate) == Some(true)
+}
+
+fn first_sentence_casing_candidate(component: &TemplateComponent) -> Option<bool> {
+    if component.rendering().suppress == Some(true) {
+        return None;
+    }
+
+    match component {
+        TemplateComponent::Contributor(contributor) => Some(matches!(
+            contributor.form,
+            citum_schema::template::ContributorForm::Verb
+                | citum_schema::template::ContributorForm::VerbShort
+        )),
+        TemplateComponent::Title(_) => Some(true),
+        TemplateComponent::Group(group) => {
+            group.group.iter().find_map(first_sentence_casing_candidate)
+        }
+        _ => Some(false),
     }
 }

--- a/crates/citum-engine/src/processor/rendering/tests.rs
+++ b/crates/citum-engine/src/processor/rendering/tests.rs
@@ -101,6 +101,7 @@ fn explicit_author_year_group_style() -> Style {
                     ],
                     delimiter: Some(DelimiterPunctuation::Space),
                     rendering: Rendering::default(),
+                    render_when: None,
                     custom: None,
                 }),
                 TemplateComponent::Variable(TemplateVariable {
@@ -150,6 +151,7 @@ fn explicit_author_year_group_with_locator_delimiter_style() -> Style {
                     ],
                     delimiter: Some(DelimiterPunctuation::Space),
                     rendering: Rendering::default(),
+                    render_when: None,
                     custom: None,
                 }),
                 TemplateComponent::Variable(TemplateVariable {
@@ -382,6 +384,7 @@ fn test_strip_author_component_nested_list() {
         ],
         delimiter: Some(DelimiterPunctuation::Space),
         rendering: Rendering::default(),
+        render_when: None,
         custom: None,
     });
 
@@ -1077,4 +1080,137 @@ fn test_bibliography_type_specific_rendering() {
         result,
         "Arendt, Hannah (1975) _Thinking in Public_ (Young-Bruehl, Elisabeth). Schocken Books."
     );
+}
+
+fn render_single_bibliography_entry(style: Style, reference: Reference) -> String {
+    let id = reference
+        .id()
+        .map(|id| id.to_string())
+        .unwrap_or_else(|| "ref1".to_string());
+    let mut bibliography = Bibliography::new();
+    bibliography.insert(id, reference);
+
+    Processor::new(style, bibliography)
+        .render_bibliography_with_format::<crate::render::plain::PlainText>()
+}
+
+fn bibliography_style_with_template(template: Vec<TemplateComponent>) -> Style {
+    Style {
+        info: StyleInfo {
+            title: Some("Sentence Initial Bibliography".to_string()),
+            ..Default::default()
+        },
+        bibliography: Some(citum_schema::BibliographySpec {
+            template: Some(template),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn sentence_initial_date_group_preserves_no_date_term_case() {
+    let reference = Reference::from(LegacyReference {
+        id: "no-date".to_string(),
+        ref_type: "book".to_string(),
+        author: Some(vec![Name::new("Forthcoming", "A.")]),
+        title: Some("Foundations of Declarative Bibliography".to_string()),
+        publisher: Some("University Press".to_string()),
+        ..Default::default()
+    });
+    let style = bibliography_style_with_template(vec![
+        TemplateComponent::Contributor(TemplateContributor {
+            contributor: ContributorRole::Author,
+            form: ContributorForm::Long,
+            name_order: Some(NameOrder::FamilyFirst),
+            ..Default::default()
+        }),
+        TemplateComponent::Group(TemplateGroup {
+            group: vec![TemplateComponent::Date(TemplateDate {
+                date: citum_schema::template::DateVariable::Issued,
+                form: DateForm::Year,
+                ..Default::default()
+            })],
+            ..Default::default()
+        }),
+        TemplateComponent::Title(TemplateTitle {
+            title: TitleType::Primary,
+            ..Default::default()
+        }),
+        TemplateComponent::Variable(TemplateVariable {
+            variable: SimpleVariable::Publisher,
+            ..Default::default()
+        }),
+    ]);
+
+    let result = render_single_bibliography_entry(style, reference);
+
+    assert_eq!(
+        result,
+        "Forthcoming, A. n.d. Foundations of Declarative Bibliography. University Press"
+    );
+}
+
+#[test]
+fn sentence_initial_term_group_preserves_locale_term_case() {
+    let reference = Reference::from(LegacyReference {
+        id: "term-group".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("Untitled".to_string()),
+        ..Default::default()
+    });
+    let no_date_term = TemplateComponent::Term(TemplateTerm {
+        term: citum_schema::locale::GeneralTerm::NoDate,
+        form: Some(citum_schema::locale::TermForm::Short),
+        ..Default::default()
+    });
+
+    for component in [
+        no_date_term,
+        TemplateComponent::Message(TemplateMessage {
+            message: "term.no-date".to_string(),
+            form: Some(citum_schema::locale::TermForm::Short),
+            ..Default::default()
+        }),
+    ] {
+        let style =
+            bibliography_style_with_template(vec![TemplateComponent::Group(TemplateGroup {
+                group: vec![
+                    component,
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        ..Default::default()
+                    }),
+                ],
+                delimiter: Some(DelimiterPunctuation::Space),
+                ..Default::default()
+            })]);
+
+        let result = render_single_bibliography_entry(style, reference.clone());
+        assert_eq!(result, "n.d. Untitled");
+    }
+}
+
+#[test]
+fn sentence_initial_group_still_capitalizes_leading_contributor_role_prose() {
+    let reference = Reference::from(LegacyReference {
+        id: "edited".to_string(),
+        ref_type: "book".to_string(),
+        editor: Some(vec![Name::new("Smith", "Ada")]),
+        title: Some("Collected Sources".to_string()),
+        ..Default::default()
+    });
+    let style = bibliography_style_with_template(vec![TemplateComponent::Group(TemplateGroup {
+        group: vec![TemplateComponent::Contributor(TemplateContributor {
+            contributor: ContributorRole::Editor,
+            form: ContributorForm::Verb,
+            name_order: Some(NameOrder::GivenFirst),
+            ..Default::default()
+        })],
+        ..Default::default()
+    })]);
+
+    let result = render_single_bibliography_entry(style, reference);
+
+    assert_eq!(result, "Edited by Ada Smith");
 }

--- a/crates/citum-engine/src/values/contributor/mod.rs
+++ b/crates/citum-engine/src/values/contributor/mod.rs
@@ -79,6 +79,15 @@ pub(super) fn contributor_role_to_reference_role(
         ContributorRole::ReviewedAuthor => Some(citum_schema::reference::ContributorRole::Unknown(
             "reviewed-author".to_string(),
         )),
+        ContributorRole::Unknown(role) => Some(match role.as_str() {
+            "compiler" => citum_schema::reference::ContributorRole::Compiler,
+            "performer" => citum_schema::reference::ContributorRole::Performer,
+            "narrator" => citum_schema::reference::ContributorRole::Narrator,
+            "host" => citum_schema::reference::ContributorRole::Host,
+            "producer" | "executive-producer" => citum_schema::reference::ContributorRole::Producer,
+            "writer" => citum_schema::reference::ContributorRole::Writer,
+            _ => citum_schema::reference::ContributorRole::Unknown(role.clone()),
+        }),
         ContributorRole::Interviewee | ContributorRole::Publisher => None,
         _ => None,
     }

--- a/crates/citum-engine/src/values/contributor/substitute.rs
+++ b/crates/citum-engine/src/values/contributor/substitute.rs
@@ -13,8 +13,8 @@ use crate::reference::Reference;
 use crate::render::format::OutputFormat;
 use crate::values::{ProcHints, ProcValues, RenderContext, RenderOptions};
 use citum_schema::options::{RoleLabelPreset, SubstituteKey};
-use citum_schema::reference::ContributorRole as DataRole;
 use citum_schema::reference::Title;
+use citum_schema::reference::{ClassExtension, ContributorRole as DataRole};
 use citum_schema::template::{ContributorRole, Rendering, TemplateComponent, TemplateContributor};
 
 enum ResolvedRole {
@@ -456,9 +456,11 @@ fn resolve_title_substitute<F: OutputFormat<Output = String>>(
     options: &RenderOptions<'_>,
     reference: &Reference,
     fmt: &F,
+    substituted_key: &'static str,
+    quote_in_citation: bool,
 ) -> ProcValues<F::Output> {
     let title_str = title_substitute_text(title, options.context);
-    let value = if options.context == RenderContext::Citation {
+    let value = if options.context == RenderContext::Citation && quote_in_citation {
         fmt.quote(fmt.text(&title_str))
     } else {
         fmt.text(&title_str)
@@ -476,7 +478,7 @@ fn resolve_title_substitute<F: OutputFormat<Output = String>>(
         prefix: None,
         suffix: None,
         url,
-        substituted_key: Some("title:Primary".to_string()),
+        substituted_key: Some(substituted_key.to_string()),
         pre_formatted: true,
     }
 }
@@ -498,6 +500,15 @@ fn title_substitute_text(title: Title, context: RenderContext) -> String {
     }
 }
 
+fn resolve_parent_serial_title(reference: &Reference) -> Option<Title> {
+    match reference.extension() {
+        ClassExtension::SerialComponent(_)
+        | ClassExtension::LegalCase(_)
+        | ClassExtension::Treaty(_) => reference.container_title(),
+        _ => None,
+    }
+}
+
 /// Attempt to substitute an empty author field with editor, title, or translator.
 ///
 /// Returns `Some(ProcValues)` if a substitute was found, `None` if the chain
@@ -513,6 +524,20 @@ pub(super) fn resolve_author_substitute<F: OutputFormat<Output = String>>(
 ) -> Option<ProcValues<F::Output>> {
     for key in &substitute.template {
         match key {
+            SubstituteKey::CollectionEditor => {
+                if let Some(result) = resolve_contributor_substitute_for_role(
+                    &ResolvedRole::BuiltIn(ContributorRole::CollectionEditor),
+                    component,
+                    hints,
+                    options,
+                    reference,
+                    effective_rendering,
+                    fmt,
+                    substitute,
+                ) {
+                    return Some(result);
+                }
+            }
             SubstituteKey::Editor => {
                 if let Some(result) = resolve_contributor_substitute_for_role(
                     &ResolvedRole::BuiltIn(ContributorRole::Editor),
@@ -527,10 +552,29 @@ pub(super) fn resolve_author_substitute<F: OutputFormat<Output = String>>(
                     return Some(result);
                 }
             }
+            SubstituteKey::ParentSerial => {
+                if let Some(title) = resolve_parent_serial_title(reference) {
+                    return Some(resolve_title_substitute(
+                        title,
+                        component,
+                        options,
+                        reference,
+                        fmt,
+                        "title:ParentSerial",
+                        false,
+                    ));
+                }
+            }
             SubstituteKey::Title => {
                 if let Some(title) = reference.title() {
                     return Some(resolve_title_substitute(
-                        title, component, options, reference, fmt,
+                        title,
+                        component,
+                        options,
+                        reference,
+                        fmt,
+                        "title:Primary",
+                        true,
                     ));
                 }
             }

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -14,6 +14,7 @@ use citum_edtf::{Day, Edtf, MonthOrSeason, Timezone, UnspecifiedYear, Year};
 use citum_schema::locale::{GeneralTerm, TermForm};
 use citum_schema::options::dates::TimeFormat;
 use citum_schema::reference::types::RefDate;
+use citum_schema::reference::{ClassExtension, WorkRelation};
 use citum_schema::template::{DateForm, DateVariable as TemplateDateVar, TemplateDate};
 
 fn month_to_string(month: u32, months: &[String]) -> String {
@@ -39,6 +40,27 @@ fn extract_month(date: &EdtfString, months: &[String]) -> String {
         Some(month) => month_to_string(month, months),
         None => String::new(),
     }
+}
+
+fn event_date(reference: &Reference) -> Option<EdtfString> {
+    match reference.extension() {
+        ClassExtension::Event(event) => event.date.clone(),
+        ClassExtension::Monograph(monograph) => embedded_event_date(monograph.event.as_ref()?),
+        ClassExtension::AudioVisual(audio_visual) => {
+            embedded_event_date(audio_visual.event.as_ref()?)
+        }
+        _ => None,
+    }
+}
+
+fn embedded_event_date(relation: &WorkRelation) -> Option<EdtfString> {
+    let WorkRelation::Embedded(reference) = relation else {
+        return None;
+    };
+    let ClassExtension::Event(event) = reference.extension() else {
+        return None;
+    };
+    event.date.clone()
 }
 
 /// Compute the delta for unspecified year ranges.
@@ -742,6 +764,7 @@ impl ComponentValues for TemplateDate {
             TemplateDateVar::Issued => reference.effective_issued_date(),
             TemplateDateVar::Accessed => reference.accessed(),
             TemplateDateVar::OriginalPublished => reference.original_date(),
+            TemplateDateVar::EventDate => event_date(reference),
             _ => None,
         };
 

--- a/crates/citum-engine/src/values/variable.rs
+++ b/crates/citum-engine/src/values/variable.rs
@@ -12,7 +12,7 @@ use crate::reference::Reference;
 use crate::values::{ComponentValues, ProcHints, ProcValues, RenderOptions};
 use citum_schema::locale::ArchiveHierarchyField;
 use citum_schema::options::titles::TextCase;
-use citum_schema::reference::{ClassExtension, RichText};
+use citum_schema::reference::{ClassExtension, RichText, WorkRelation};
 use citum_schema::template::{SimpleVariable, TemplateVariable};
 
 /// Extracts the short title from a parent reference if available.
@@ -26,6 +26,87 @@ fn container_title_short(reference: &Reference) -> Option<String> {
         citum_schema::reference::types::Title::Single(s) => Some(s),
         _ => None,
     })
+}
+
+fn event_place(reference: &Reference) -> Option<String> {
+    match reference.extension() {
+        ClassExtension::Event(event) => event.location.clone(),
+        ClassExtension::Monograph(monograph) => embedded_event_place(monograph.event.as_ref()?),
+        ClassExtension::AudioVisual(audio_visual) => {
+            embedded_event_place(audio_visual.event.as_ref()?)
+        }
+        _ => None,
+    }
+}
+
+fn event_title(reference: &Reference) -> Option<String> {
+    match reference.extension() {
+        ClassExtension::Event(event) => event.title.as_ref().map(ToString::to_string),
+        ClassExtension::Monograph(monograph) => embedded_event_title(monograph.event.as_ref()?),
+        ClassExtension::AudioVisual(audio_visual) => {
+            embedded_event_title(audio_visual.event.as_ref()?)
+        }
+        _ => None,
+    }
+}
+
+fn embedded_event_title(relation: &WorkRelation) -> Option<String> {
+    let WorkRelation::Embedded(reference) = relation else {
+        return None;
+    };
+    let ClassExtension::Event(event) = reference.extension() else {
+        return None;
+    };
+    event.title.as_ref().map(ToString::to_string)
+}
+
+fn embedded_event_place(relation: &WorkRelation) -> Option<String> {
+    let WorkRelation::Embedded(reference) = relation else {
+        return None;
+    };
+    let ClassExtension::Event(event) = reference.extension() else {
+        return None;
+    };
+    event.location.clone()
+}
+
+fn dimensions(reference: &Reference) -> Option<String> {
+    match reference.extension() {
+        ClassExtension::Monograph(monograph) => {
+            monograph.duration.clone().or(monograph.size.clone())
+        }
+        ClassExtension::AudioVisual(audio_visual) => audio_visual.dimensions.clone(),
+        _ => None,
+    }
+}
+
+fn raw_medium(reference: &Reference) -> Option<String> {
+    match reference.extension() {
+        ClassExtension::Monograph(monograph) => monograph.medium.clone(),
+        ClassExtension::CollectionComponent(component) => component.medium.clone(),
+        ClassExtension::SerialComponent(component) => component.medium.clone(),
+        ClassExtension::AudioVisual(audio_visual) => audio_visual.medium.clone(),
+        ClassExtension::Software(software) => software.platform.clone(),
+        _ => None,
+    }
+}
+
+fn raw_genre(reference: &Reference) -> Option<String> {
+    match reference.extension() {
+        ClassExtension::Monograph(monograph) => monograph.genre.clone(),
+        ClassExtension::CollectionComponent(component) => component.genre.clone(),
+        ClassExtension::SerialComponent(component) => component.genre.clone(),
+        ClassExtension::Event(event) => event.genre.clone(),
+        ClassExtension::AudioVisual(audio_visual) => audio_visual.core.genre.clone(),
+        _ => None,
+    }
+}
+
+fn references(reference: &Reference) -> Option<String> {
+    match reference.extension() {
+        ClassExtension::Monograph(monograph) => monograph.references.clone(),
+        _ => None,
+    }
 }
 
 fn resolve_archive_name(reference: &Reference, options: &RenderOptions<'_>) -> Option<String> {
@@ -142,6 +223,10 @@ fn resolve_variable_value(
         SimpleVariable::PublisherPlace => reference.publisher_place(),
         SimpleVariable::OriginalPublisher => reference.original_publisher_str(),
         SimpleVariable::OriginalPublisherPlace => reference.original_publisher_place(),
+        SimpleVariable::EventTitle => event_title(reference),
+        SimpleVariable::EventPlace => event_place(reference),
+        SimpleVariable::Dimensions => dimensions(reference),
+        SimpleVariable::References => references(reference),
         // A genre that merely restates the reference's own type (e.g. an
         // entry-encyclopedia carrying genre "entry-encyclopedia") is the data
         // model's internal type-carrier, round-tripped through `ref_type()` for
@@ -151,7 +236,9 @@ fn resolve_variable_value(
             .genre()
             .filter(|genre| *genre != reference.ref_type())
             .map(|k| options.locale.lookup_genre(&k)),
+        SimpleVariable::RawGenre => raw_genre(reference),
         SimpleVariable::Medium => reference.medium().map(|k| options.locale.lookup_medium(&k)),
+        SimpleVariable::RawMedium => raw_medium(reference),
         SimpleVariable::Status => reference.status(),
         SimpleVariable::Abstract | SimpleVariable::Note => None,
         SimpleVariable::Archive => reference.archive(),

--- a/crates/citum-schema-data/src/reference/conversion/media.rs
+++ b/crates/citum-schema-data/src/reference/conversion/media.rs
@@ -16,6 +16,8 @@ pub(super) fn from_software_ref(
     ctx: RefContext,
 ) -> InputReference {
     let original = legacy_original_relation(&legacy);
+    let version = legacy_extra_str(&legacy, "version");
+    let platform = legacy.medium.clone();
     InputReference::Software(Box::new(Software {
         id: ctx.id,
         title: build_title(ctx.title, ctx.short_title),
@@ -27,10 +29,10 @@ pub(super) fn from_software_ref(
             name: n.into(),
             place: legacy.publisher_place.map(Into::into),
         }),
-        version: None,
+        version,
         repository: None,
         license: None,
-        platform: None,
+        platform,
         doi: ctx.doi,
         url: ctx.url,
         accessed: ctx.accessed,
@@ -47,68 +49,15 @@ pub(super) fn from_audio_visual_ref(
     ctx: RefContext,
 ) -> InputReference {
     let original = legacy_original_relation(&legacy);
-    let r#type = match legacy.ref_type.as_str() {
-        "motion_picture" => AudioVisualType::Film,
-        "song" => AudioVisualType::Recording,
-        "broadcast" => AudioVisualType::Broadcast,
-        _ => AudioVisualType::Broadcast,
-    };
-    let mut contributors = Vec::new();
-    push_legacy_contributor(
-        &mut contributors,
-        ContributorRole::Director,
-        legacy.director.clone(),
+    let r#type = audio_visual_type(&legacy.ref_type);
+    let contributors = audio_visual_contributors(&legacy);
+    let event = relation_event(
+        legacy_extra_str(&legacy, "event-title"),
+        legacy_extra_str(&legacy, "event-place"),
+        legacy_extra_date(&legacy, "event-date"),
     );
-    push_legacy_contributor(
-        &mut contributors,
-        ContributorRole::Composer,
-        legacy_extra_names(&legacy, "composer"),
-    );
-    // For recordings (song type), `author` is the performer; store it as Performer
-    // so that Composer takes precedence as the primary author in APA style.
-    let author_role = if legacy.ref_type == "song" {
-        ContributorRole::Performer
-    } else {
-        ContributorRole::Author
-    };
-    push_legacy_contributor(
-        &mut contributors,
-        ContributorRole::Performer,
-        legacy_extra_names(&legacy, "performer"),
-    );
-    push_legacy_contributor(
-        &mut contributors,
-        ContributorRole::Producer,
-        legacy_extra_names(&legacy, "producer")
-            .or_else(|| legacy_extra_names(&legacy, "executive-producer")),
-    );
-    push_legacy_contributor(&mut contributors, author_role, legacy.author.clone());
-    push_legacy_contributor(
-        &mut contributors,
-        ContributorRole::Translator,
-        legacy.translator.clone(),
-    );
-
-    let mut numbering: Vec<Numbering> = legacy
-        .number
-        .into_iter()
-        .map(|number| Numbering {
-            r#type: NumberingType::Number,
-            value: number,
-        })
-        .collect();
-    if let Some(vol) = legacy.volume.map(|v| v.to_string()) {
-        numbering.push(Numbering {
-            r#type: NumberingType::Volume,
-            value: vol,
-        });
-    }
-    if let Some(chapter) = legacy.chapter_number.clone() {
-        numbering.push(Numbering {
-            r#type: NumberingType::Chapter,
-            value: chapter,
-        });
-    }
+    let dimensions = legacy_extra_str(&legacy, "dimensions");
+    let numbering = audio_visual_numbering(&legacy);
 
     InputReference::AudioVisual(Box::new(AudioVisualWork {
         id: ctx.id,
@@ -129,12 +78,14 @@ pub(super) fn from_audio_visual_ref(
                 ..Default::default()
             }))))
         }),
+        event,
         numbering,
         publisher: legacy.publisher.map(|name| Publisher {
             name: name.into(),
             place: legacy.publisher_place.map(Into::into),
         }),
         medium: legacy.medium,
+        dimensions,
         platform: None,
         url: ctx.url,
         accessed: ctx.accessed,
@@ -142,4 +93,102 @@ pub(super) fn from_audio_visual_ref(
         note: ctx.note.map(RichText::Plain),
         unknown_fields: Default::default(),
     }))
+}
+
+fn audio_visual_type(ref_type: &str) -> AudioVisualType {
+    match ref_type {
+        "motion_picture" => AudioVisualType::Film,
+        "song" => AudioVisualType::Recording,
+        "broadcast" => AudioVisualType::Broadcast,
+        _ => AudioVisualType::Broadcast,
+    }
+}
+
+fn audio_visual_contributors(legacy: &csl_legacy::csl_json::Reference) -> Vec<ContributorEntry> {
+    let mut contributors = Vec::new();
+    push_legacy_contributor(
+        &mut contributors,
+        ContributorRole::Director,
+        legacy
+            .director
+            .clone()
+            .or_else(|| legacy_extra_names(legacy, "director")),
+    );
+    push_legacy_contributor(
+        &mut contributors,
+        ContributorRole::Composer,
+        legacy_extra_names(legacy, "composer"),
+    );
+    push_legacy_contributor(
+        &mut contributors,
+        ContributorRole::Performer,
+        legacy_extra_names(legacy, "performer"),
+    );
+    push_legacy_contributor(
+        &mut contributors,
+        ContributorRole::Narrator,
+        legacy_extra_names(legacy, "narrator"),
+    );
+    push_legacy_contributor(
+        &mut contributors,
+        ContributorRole::Unknown("contributor".to_string()),
+        legacy_extra_names(legacy, "contributor"),
+    );
+    push_legacy_contributor(
+        &mut contributors,
+        ContributorRole::Producer,
+        legacy_extra_names(legacy, "producer")
+            .or_else(|| legacy_extra_names(legacy, "executive-producer")),
+    );
+    push_legacy_contributor(
+        &mut contributors,
+        ContributorRole::Writer,
+        legacy_extra_names(legacy, "script-writer"),
+    );
+    push_legacy_contributor(
+        &mut contributors,
+        audio_visual_author_role(legacy),
+        legacy.author.clone(),
+    );
+    push_legacy_contributor(
+        &mut contributors,
+        ContributorRole::Translator,
+        legacy.translator.clone(),
+    );
+    contributors
+}
+
+fn audio_visual_author_role(legacy: &csl_legacy::csl_json::Reference) -> ContributorRole {
+    // For recordings, CSL/Zotero `author` is the performer; store it that way
+    // so that composer can remain the primary rendered author where applicable.
+    if legacy.ref_type == "song" {
+        ContributorRole::Performer
+    } else {
+        ContributorRole::Author
+    }
+}
+
+fn audio_visual_numbering(legacy: &csl_legacy::csl_json::Reference) -> Vec<Numbering> {
+    let mut numbering: Vec<Numbering> = legacy
+        .number
+        .iter()
+        .cloned()
+        .map(|number| Numbering {
+            r#type: NumberingType::Number,
+            value: number,
+        })
+        .collect();
+    if let Some(vol) = legacy.volume.as_ref().map(ToString::to_string) {
+        numbering.push(Numbering {
+            r#type: NumberingType::Volume,
+            value: vol,
+        });
+    }
+    if let Some(chapter) = legacy.chapter_number.clone() {
+        numbering.push(Numbering {
+            r#type: NumberingType::Chapter,
+            value: chapter,
+        });
+    }
+    numbering
 }

--- a/crates/citum-schema-data/src/reference/conversion/mod.rs
+++ b/crates/citum-schema-data/src/reference/conversion/mod.rs
@@ -349,6 +349,7 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
             | "thesis"
             | "manual"
             | "manuscript"
+            | "classic"
             | "webpage"
             | "post"
             | "post-weblog"
@@ -518,6 +519,23 @@ mod tests {
 
         assert_eq!(converted.number(), Some("2".to_string()));
         assert_eq!(converted.report_number(), None);
+    }
+
+    #[test]
+    fn legacy_note_type_classic_maps_to_classic_reference() {
+        let legacy = csl_legacy::csl_json::Reference {
+            id: "classic-1".to_string(),
+            ref_type: "book".to_string(),
+            title: Some("De civitate Dei".to_string()),
+            issued: Some(legacy_year(1931)),
+            note: Some("type: classic".to_string()),
+            ..Default::default()
+        };
+
+        let converted = InputReference::from(legacy);
+
+        assert_eq!(converted.ref_type(), "classic");
+        assert!(matches!(converted.extension(), ClassExtension::Classic(_)));
     }
 
     #[test]

--- a/crates/citum-schema-data/src/reference/conversion/scholarly.rs
+++ b/crates/citum-schema-data/src/reference/conversion/scholarly.rs
@@ -12,6 +12,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
     reason = "submodule shares the parent's helper + type pool by design"
 )]
 use super::*;
+use crate::reference::Classic;
 
 #[allow(
     clippy::too_many_lines,
@@ -86,6 +87,11 @@ pub(super) fn from_monograph_ref(
     let references = legacy_extra_str(&legacy, "references");
     let scale = legacy_extra_str(&legacy, "scale");
     let dimensions = legacy_extra_str(&legacy, "dimensions");
+    let event = relation_event(
+        legacy_extra_str(&legacy, "event-title"),
+        legacy_extra_str(&legacy, "event-place"),
+        legacy_extra_date(&legacy, "event-date"),
+    );
     let collection_title = legacy.collection_title.clone();
     let mut contributors = legacy_named_contributors(&legacy);
     push_legacy_contributor(
@@ -115,8 +121,23 @@ pub(super) fn from_monograph_ref(
     );
     push_legacy_contributor(
         &mut contributors,
+        ContributorRole::Illustrator,
+        legacy_extra_names(&legacy, "illustrator"),
+    );
+    push_legacy_contributor(
+        &mut contributors,
+        ContributorRole::Unknown("contributor".to_string()),
+        legacy_extra_names(&legacy, "contributor"),
+    );
+    push_legacy_contributor(
+        &mut contributors,
         ContributorRole::Compiler,
         legacy_extra_names(&legacy, "compiler"),
+    );
+    push_legacy_contributor(
+        &mut contributors,
+        ContributorRole::Unknown("collection-editor".to_string()),
+        legacy_extra_names(&legacy, "collection-editor"),
     );
     push_legacy_contributor(
         &mut contributors,
@@ -231,6 +252,39 @@ pub(super) fn from_monograph_ref(
         None => (None, None),
     };
 
+    if legacy.ref_type == "classic" {
+        return InputReference::Classic(Box::new(Classic {
+            id: ctx.id,
+            title: build_title(title, ctx.short_title.clone()),
+            container,
+            original,
+            author,
+            editor,
+            translator,
+            volume,
+            issue: None,
+            edition,
+            number,
+            part_number: None,
+            supplement_number: None,
+            printing_number: legacy.printing_number,
+            numbering,
+            created: ctx.created,
+            issued: ctx.issued,
+            publisher: legacy.publisher.map(|n| Publisher {
+                name: n.into(),
+                place: legacy.publisher_place.map(Into::into),
+            }),
+            url: ctx.url,
+            accessed: ctx.accessed,
+            language: ctx.language,
+            field_languages: HashMap::new(),
+            note: ctx.note.map(RichText::Plain),
+            keywords: None,
+            unknown_fields: Default::default(),
+        }));
+    }
+
     InputReference::Monograph(Box::new(Monograph {
         id: ctx.id,
         r#type,
@@ -272,6 +326,7 @@ pub(super) fn from_monograph_ref(
         eprint: None,
         keywords: None,
         original,
+        event,
         status,
         available_date,
         size,

--- a/crates/citum-schema-data/src/reference/tests.rs
+++ b/crates/citum-schema-data/src/reference/tests.rs
@@ -672,6 +672,23 @@ fn conversion_applies_note_type_override() {
 }
 
 #[test]
+fn conversion_applies_note_type_classic_override() {
+    let json = r#"{
+        "id": "classic-override",
+        "type": "book",
+        "title": "De civitate Dei",
+        "note": "type: classic",
+        "issued": {"date-parts": [[1931]]}
+    }"#;
+
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
+    let reference: InputReference = legacy.into();
+
+    assert_eq!(reference.ref_type(), "classic");
+    assert!(matches!(reference.extension(), ClassExtension::Classic(_)));
+}
+
+#[test]
 fn conversion_promotes_genre_and_preserves_free_text() {
     let json = r#"{
         "id": "note-genre",

--- a/crates/citum-schema-data/src/reference/types/specialized.rs
+++ b/crates/citum-schema-data/src/reference/types/specialized.rs
@@ -676,6 +676,9 @@ pub struct AudioVisualWork {
     /// Container series or program (work-to-work relation).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container: Option<WorkRelation>,
+    /// Event or performance associated with the recording.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event: Option<WorkRelation>,
     /// Season and episode numbering.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub numbering: Vec<Numbering>,
@@ -685,6 +688,9 @@ pub struct AudioVisualWork {
     /// Physical delivery format or presentation descriptor.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub medium: Option<String>,
+    /// Physical extent or running time.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dimensions: Option<String>,
     /// Digital distribution host or streaming service.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub platform: Option<String>,
@@ -740,6 +746,7 @@ struct AudioVisualDeser {
     genre: Option<String>,
     // AudioVisualWork-specific fields
     container: Option<WorkRelation>,
+    event: Option<WorkRelation>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     numbering: Vec<Numbering>,
     /// Catalog or episode number shorthand (normalized into `numbering`).
@@ -747,6 +754,7 @@ struct AudioVisualDeser {
     number: Option<String>,
     publisher: Option<Publisher>,
     medium: Option<String>,
+    dimensions: Option<String>,
     platform: Option<String>,
     #[serde(alias = "URL")]
     url: Option<Url>,
@@ -790,9 +798,11 @@ impl From<AudioVisualDeser> for AudioVisualWork {
                 genre: raw.genre,
             },
             container: raw.container,
+            event: raw.event,
             numbering,
             publisher: raw.publisher,
             medium: raw.medium,
+            dimensions: raw.dimensions,
             platform: raw.platform,
             url: raw.url,
             accessed: raw.accessed,

--- a/crates/citum-schema-data/src/reference/types/structural.rs
+++ b/crates/citum-schema-data/src/reference/types/structural.rs
@@ -224,6 +224,9 @@ pub struct Monograph {
     /// Original publication relation (for reprints or translations).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub original: Option<WorkRelation>,
+    /// Event or performance associated with the work.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event: Option<WorkRelation>,
     /// Publication status (e.g., `"forthcoming"`, `"in press"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
@@ -316,6 +319,7 @@ struct MonographDeser {
     eprint: Option<EprintInfo>,
     keywords: Option<Vec<String>>,
     original: Option<WorkRelation>,
+    event: Option<WorkRelation>,
     status: Option<String>,
     #[cfg_attr(feature = "bindings", specta(type = Option<String>))]
     available_date: Option<EdtfString>,
@@ -369,6 +373,7 @@ impl From<MonographDeser> for Monograph {
             eprint: raw.eprint,
             keywords: raw.keywords,
             original: raw.original,
+            event: raw.event,
             status: raw.status,
             available_date: raw.available_date,
             size: raw.size,

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -74,6 +74,7 @@ citation:
       template:
       - editor
       - translator
+      - parent-serial
       - title
     contributors:
       shorten:
@@ -82,20 +83,55 @@ citation:
         and-others: et-al
         delimiter-precedes-last: contextual
   type-variants:
-    personal_communication:
+    classic:
     - contributor: author
-      form: long
-      name-order: given-first
+      form: short
       shorten:
         min: 3
         use-first: 1
         and-others: et-al
     - title: primary
-      wrap:
-        punctuation: quotes
       prefix: ", "
-    - variable: locator
-      prefix: ", "
+    personal_communication:
+    - group:
+      - contributor: author
+        form: short
+        shorten:
+          min: 3
+          use-first: 1
+          and-others: et-al
+      - contributor: recipient
+        form: short
+        prefix: " to "
+      - date: issued
+        form: year
+        prefix: " "
+      render-when:
+        field-present: recipient
+        field-absent: title
+      delimiter: none
+    - group:
+      - contributor: author
+        form: long
+        name-order: given-first
+        shorten:
+          min: 3
+          use-first: 1
+          and-others: et-al
+      - title: primary
+        wrap:
+          punctuation: quotes
+        prefix: ", "
+      - variable: locator
+        prefix: ", "
+      render-when:
+        field-present: title
+      delimiter: none
+    webpage:
+    - variable: publisher
+    - date: issued
+      form: year
+      prefix: " "
   template:
   - group:
     - contributor: author
@@ -120,6 +156,7 @@ bibliography:
       template:
       - editor
       - translator
+      - collection-editor
       - title
     contributors:
       display-as-sort: first
@@ -167,10 +204,36 @@ bibliography:
           - archival
   type-variants:
     article-journal:
-      modify:
-        - match:
-            variable: doi
-          prefix: https://doi.org/
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 7
+        use-first: 3
+        and-others: et-al
+    - date: issued
+      form: year
+    - title: primary
+      wrap:
+        punctuation: quotes
+    - title: parent-serial
+      emph: true
+    - group:
+      - number: volume
+      - number: issue
+        prefix: " ("
+        suffix: ")"
+      delimiter: none
+    - number: pages
+      prefix: ": "
+    - variable: number
+      prefix: ": "
+    - variable: doi
+      prefix: https://doi.org/
+    - group:
+      - variable: url
+      render-when:
+        field-absent: doi
     article-magazine:
     - contributor: author
       form: long
@@ -237,13 +300,39 @@ bibliography:
       shorten:
         min: 8
         use-first: 3
-    - date: issued
-      form: year
+    - group:
+      - date: original-published
+        form: year
+        wrap:
+          punctuation: parentheses
+      - date: issued
+        form: year
+        prefix: " "
+      render-when:
+        field-present: original-published
+      delimiter: none
+    - group:
+      - date: issued
+        form: year
+      render-when:
+        field-absent: original-published
     - title: primary
     - contributor: translator
       form: verb
       name-order: given-first
       prefix: ". "
+    - contributor: illustrator
+      form: long
+      name-order: given-first
+      prefix: "Illustrated by "
+    - contributor: narrator
+      form: long
+      name-order: given-first
+      prefix: "Narrated by "
+    - contributor: contributor
+      form: long
+      name-order: given-first
+      prefix: "With "
     - group:
       - contributor: editor
         form: verb
@@ -278,6 +367,18 @@ bibliography:
       wrap:
         punctuation: quotes
       prefix: ", "
+    - contributor: writer
+      form: long
+      name-order: given-first
+      prefix: ", written by "
+    - contributor: performer
+      form: long
+      name-order: given-first
+      prefix: ", performed by "
+    - contributor: contributor
+      form: long
+      name-order: given-first
+      prefix: ", with "
     - date: issued
       form: month-day
       prefix: ". Aired "
@@ -293,30 +394,159 @@ bibliography:
       shorten:
         min: 8
         use-first: 3
-    - date: issued
-      form: year
+    - group:
+      - date: issued
+        form: year
+      render-when:
+        field-present: issued
     - title: primary
-    - variable: genre
+      text-case: as-is
+    - date: issued
+      form: month-day
+    - variable: raw-genre
     - variable: archive-location
+    - variable: archive-collection
     - group:
       - variable: archive-name
       - variable: archive-place
         prefix: ", "
     - variable: url
     webpage:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
-    - variable: publisher
-    - date: issued
-      form: year
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - variable: url
+    - group:
+      - title: parent-monograph
+      - date: issued
+        form: year
+      - variable: raw-genre
+        text-case: capitalize-first
+      - message: pattern.accessed-date
+        args:
+          date:
+            group:
+              - date: accessed
+                form: month-day
+              - date: accessed
+                form: year
+                prefix: ", "
+            delimiter: " "
+        text-case: capitalize-first
+      - variable: url
+      render-when:
+        field-absent: title
+      delimiter: ". "
+    - group:
+      - contributor: author
+        form: long
+        name-order: family-first
+        shorten:
+          min: 8
+          use-first: 3
+      - variable: publisher
+      - date: issued
+        form: year
+      - title: primary
+        wrap:
+          punctuation: quotes
+      - variable: raw-genre
+        text-case: capitalize-first
+      - title: parent-monograph
+      - date: issued
+        form: month-day
+      - message: pattern.accessed-date
+        args:
+          date:
+            group:
+              - date: accessed
+                form: month-day
+              - date: accessed
+                form: year
+                prefix: ", "
+            delimiter: " "
+        text-case: capitalize-first
+      - variable: references
+      - variable: url
+      render-when:
+        field-present: title
+      delimiter: ". "
+    interview:
+    - group:
+      - title: primary
+        text-case: as-is
+        wrap:
+          punctuation: quotes
+      - date: issued
+        form: year
+      - contributor: interviewer
+        form: long
+        name-order: given-first
+        prefix: "Interview by "
+      - variable: event-title
+      - date: event-date
+        form: full
+      - group:
+        - variable: status
+          text-case: capitalize-first
+        - date: issued
+          form: month-day
+          prefix: " "
+        delimiter: none
+      - group:
+        - variable: raw-medium
+        - variable: dimensions
+          prefix: ", "
+        delimiter: none
+      - variable: url
+      render-when:
+        field-present: title
+      delimiter: ". "
+    - group:
+      - contributor: author
+        form: long
+        name-order: family-first
+        shorten:
+          min: 8
+          use-first: 3
+      - date: issued
+        form: year
+      - contributor: interviewer
+        form: long
+        name-order: given-first
+        prefix: "Interview by "
+      - variable: raw-genre
+        text-case: capitalize-first
+      - group:
+        - variable: event-title
+        - variable: event-place
+        delimiter: ", "
+      - title: parent-monograph
+        text-case: as-is
+      - variable: publisher
+      - date: event-date
+        form: full
+      - date: issued
+        form: month-day
+      - group:
+        - variable: status
+          text-case: capitalize-first
+        - date: issued
+          form: month-day
+          prefix: " "
+        delimiter: none
+      - group:
+        - variable: raw-medium
+        - variable: dimensions
+          prefix: ", "
+        delimiter: none
+      - variable: archive-location
+      - variable: archive-collection
+      - group:
+        - variable: archive-name
+        - variable: archive-place
+          prefix: ", "
+      - variable: references
+      - variable: url
+      render-when:
+        field-absent: title
+      delimiter: ". "
     chapter:
     - contributor: author
       form: long
@@ -386,6 +616,27 @@ bibliography:
       prefix: ", "
     - variable: doi
       prefix: ". https://doi.org/"
+    software:
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
+    - variable: publisher
+    - date: issued
+      form: year
+    - title: primary
+      text-case: title
+    - variable: raw-genre
+    - variable: version
+      prefix: "V. "
+    - date: issued
+      form: month-day
+      prefix: "Released "
+    - variable: raw-medium
+      prefix: "Released. "
+    - variable: url
     legal-case:
       extends: book
       modify:
@@ -411,11 +662,73 @@ bibliography:
     - date: issued
       form: year
     - title: primary
+    - contributor: contributor
+      form: long
+      name-order: given-first
+      prefix: "With "
     - variable: publisher
     - group:
-      - variable: medium
+      - variable: raw-medium
       - variable: dimensions
         prefix: ", "
+    - variable: url
+    song:
+    - group:
+      - contributor: author
+        form: long
+        name-order: family-first
+        shorten:
+          min: 8
+          use-first: 3
+      - contributor: director
+        form: long
+        name-order: family-first
+        suffix: ", dir."
+      delimiter: none
+    - date: issued
+      form: year
+    - title: primary
+      text-case: as-is
+    - contributor: narrator
+      form: long
+      name-order: given-first
+      prefix: "Narrated by "
+    - contributor: performer
+      form: long
+      name-order: given-first
+      prefix: "Performed by "
+      shorten:
+        min: 4
+        use-first: 3
+        and-others: et-al
+    - contributor: contributor
+      form: long
+      name-order: given-first
+      prefix: "With "
+      shorten:
+        min: 4
+        use-first: 3
+        and-others: et-al
+    - group:
+      - number: chapter-number
+        prefix: "Track "
+      - title: parent-monograph
+        emph: true
+        prefix: " on "
+      delimiter: none
+    - date: event-date
+      form: full
+      prefix: "Recorded "
+    - group:
+      - variable: publisher
+      - variable: number
+      delimiter: " "
+    - group:
+      - variable: raw-medium
+      - variable: dimensions
+        prefix: ", "
+      delimiter: none
+    - variable: note
     - variable: url
     patent:
     - contributor: author
@@ -448,6 +761,86 @@ bibliography:
       remove:
         - match:
             contributor: translator
+    personal_communication:
+    - group:
+      - contributor: author
+        form: long
+        name-order: family-first
+        shorten:
+          min: 8
+          use-first: 3
+      - date: issued
+        form: year
+      - group:
+        - variable: genre
+          text-case: capitalize-first
+        - contributor: recipient
+          form: long
+          name-order: given-first
+          prefix: " to "
+        render-when:
+          field-present: genre
+        delimiter: none
+      - group:
+        - contributor: recipient
+          form: long
+          name-order: given-first
+          prefix: "To "
+        render-when:
+          field-present: recipient
+          field-absent: genre
+        delimiter: none
+      - date: issued
+        form: month-day
+      - variable: archive-location
+      - variable: archive-collection
+      - variable: archive-name
+      render-when:
+        field-present: archive-location
+      delimiter: ". "
+    - group:
+      - contributor: author
+        form: long
+        name-order: family-first
+        shorten:
+          min: 8
+          use-first: 3
+      - date: issued
+        form: year
+      - group:
+        - variable: genre
+          text-case: capitalize-first
+        - contributor: recipient
+          form: long
+          name-order: given-first
+          prefix: " to "
+        render-when:
+          field-present: genre
+        delimiter: none
+      - group:
+        - contributor: recipient
+          form: long
+          name-order: given-first
+          prefix: "To "
+        render-when:
+          field-present: recipient
+          field-absent: genre
+        delimiter: none
+      - message: pattern.in-container
+        args:
+          container:
+            group:
+            - title: parent-monograph
+              emph: true
+        text-case: capitalize-first
+      - contributor: editor
+        form: verb
+        name-order: given-first
+      - variable: publisher
+      render-when:
+        field-present: publisher
+        field-absent: archive-location
+      delimiter: ". "
     personal-communication: []
   template:
   - contributor: author

--- a/crates/citum-schema-style/embedded/styles/springer-basic-author-date-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/springer-basic-author-date-core.yaml
@@ -82,6 +82,7 @@ bibliography:
     - title: primary
       prefix: " "
     - message: pattern.in-container
+      text-case: capitalize-first
       args:
         container:
           group:
@@ -296,6 +297,7 @@ bibliography:
   - delimiter: " "
     group:
     - message: pattern.in-container-colon
+      text-case: capitalize-first
       args:
         container:
           group:

--- a/crates/citum-schema-style/src/options/substitute.rs
+++ b/crates/citum-schema-style/src/options/substitute.rs
@@ -131,7 +131,11 @@ impl Substitute {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "lowercase")]
 pub enum SubstituteKey {
+    #[serde(rename = "collection-editor")]
+    CollectionEditor,
     Editor,
+    #[serde(rename = "parent-serial")]
+    ParentSerial,
     Title,
     Translator,
 }

--- a/crates/citum-schema-style/src/style/diagnostics.rs
+++ b/crates/citum-schema-style/src/style/diagnostics.rs
@@ -367,7 +367,7 @@ fn component_allowed_fields(kind: &str) -> &'static [&'static str] {
         "variable" => &["variable", "links", "custom"],
         "message" => &["message", "form", "gender", "args", "custom"],
         "term" => &["term", "form", "gender", "custom"],
-        "group" => &["group", "delimiter", "custom"],
+        "group" => &["group", "render-when", "delimiter", "custom"],
         _ => &[],
     }
 }

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -1229,7 +1229,9 @@ pub enum SimpleVariable {
     Annote,
     Keyword,
     Genre,
+    RawGenre,
     Medium,
+    RawMedium,
     Source,
     Status,
     Archive,
@@ -1250,8 +1252,10 @@ pub enum SimpleVariable {
     PublisherPlace,
     OriginalPublisher,
     OriginalPublisherPlace,
+    EventTitle,
     EventPlace,
     Dimensions,
+    References,
     Scale,
     Version,
     Locator,
@@ -1298,6 +1302,9 @@ pub struct TemplateTerm {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct TemplateGroup {
     pub group: Vec<TemplateComponent>,
+    /// Optional field-presence condition that controls whether the group renders.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub render_when: Option<TemplateGroupCondition>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delimiter: Option<DelimiterPunctuation>,
     #[serde(flatten, default)]
@@ -1306,6 +1313,50 @@ pub struct TemplateGroup {
     /// Custom user-defined fields for extensions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// Field-presence condition for rendering a template group.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct TemplateGroupCondition {
+    /// Required field that must be present for the group to render.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field_present: Option<TemplateConditionField>,
+    /// Required field that must be absent for the group to render.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field_absent: Option<TemplateConditionField>,
+}
+
+/// Reference fields that can be tested by a template group condition.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum TemplateConditionField {
+    /// The primary author contributor.
+    Author,
+    /// The editor contributor.
+    Editor,
+    /// The recipient contributor.
+    Recipient,
+    /// The translator contributor.
+    Translator,
+    /// The primary title.
+    Title,
+    /// The issued date.
+    Issued,
+    /// The original publication date.
+    OriginalPublished,
+    /// The publisher name.
+    Publisher,
+    /// The DOI identifier.
+    Doi,
+    /// The reference genre or item type label.
+    Genre,
+    /// The archive or repository name.
+    Archive,
+    /// The archive shelfmark or repository location.
+    ArchiveLocation,
 }
 
 /// Delimiter punctuation options.

--- a/crates/citum-schema-style/src/tests.rs
+++ b/crates/citum-schema-style/src/tests.rs
@@ -216,6 +216,61 @@ bibliography:
 }
 
 #[test]
+fn substitute_parent_serial_and_group_conditions_parse() {
+    let yaml = r#"
+info:
+  title: Conditional style
+citation:
+  options:
+    substitute:
+      template:
+      - editor
+      - parent-serial
+      - title
+  template:
+  - group:
+    - contributor: author
+      form: short
+    render-when:
+      field-present: recipient
+      field-absent: title
+"#;
+    let style: Style = serde_yaml::from_str(yaml).unwrap();
+    let citation = style.citation.unwrap();
+    let substitute = citation
+        .options
+        .as_ref()
+        .unwrap()
+        .substitute
+        .as_ref()
+        .unwrap()
+        .resolve();
+
+    assert_eq!(
+        substitute.template,
+        vec![
+            options::SubstituteKey::Editor,
+            options::SubstituteKey::ParentSerial,
+            options::SubstituteKey::Title,
+        ]
+    );
+
+    let template = citation.resolve_template().unwrap();
+    let template::TemplateComponent::Group(group) = &template[0] else {
+        panic!("expected group component");
+    };
+    let condition = group.render_when.as_ref().expect("condition should parse");
+    assert_eq!(
+        condition.field_present,
+        Some(template::TemplateConditionField::Recipient)
+    );
+    assert_eq!(
+        condition.field_absent,
+        Some(template::TemplateConditionField::Title)
+    );
+}
+
+#[test]
 fn test_style_custom_fields() {
     let yaml = r#"
 version: "1.1"

--- a/docs/schemas/bib.json
+++ b/docs/schemas/bib.json
@@ -349,6 +349,16 @@
                 }
               ]
             },
+            "event": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "status": {
               "type": [
                 "string",
@@ -3259,6 +3269,16 @@
                 }
               ]
             },
+            "event": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/WorkRelation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "numbering": {
               "type": "array",
               "items": {
@@ -3283,6 +3303,12 @@
               ]
             },
             "medium": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "dimensions": {
               "type": [
                 "string",
                 "null"

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -2113,7 +2113,9 @@
         "annote",
         "keyword",
         "genre",
+        "raw-genre",
         "medium",
+        "raw-medium",
         "source",
         "status",
         "archive",
@@ -2134,8 +2136,10 @@
         "publisher-place",
         "original-publisher",
         "original-publisher-place",
+        "event-title",
         "event-place",
         "dimensions",
+        "references",
         "scale",
         "version",
         "locator",
@@ -2367,6 +2371,17 @@
             "$ref": "#/$defs/TemplateComponent"
           }
         },
+        "render-when": {
+          "description": "Optional field-presence condition that controls whether the group renders.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemplateGroupCondition"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "delimiter": {
           "anyOf": [
             {
@@ -2496,6 +2511,100 @@
       "additionalProperties": false,
       "required": [
         "group"
+      ]
+    },
+    "TemplateGroupCondition": {
+      "description": "Field-presence condition for rendering a template group.",
+      "type": "object",
+      "properties": {
+        "field-present": {
+          "description": "Required field that must be present for the group to render.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemplateConditionField"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "field-absent": {
+          "description": "Required field that must be absent for the group to render.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemplateConditionField"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TemplateConditionField": {
+      "description": "Reference fields that can be tested by a template group condition.",
+      "oneOf": [
+        {
+          "description": "The primary author contributor.",
+          "type": "string",
+          "const": "author"
+        },
+        {
+          "description": "The editor contributor.",
+          "type": "string",
+          "const": "editor"
+        },
+        {
+          "description": "The recipient contributor.",
+          "type": "string",
+          "const": "recipient"
+        },
+        {
+          "description": "The translator contributor.",
+          "type": "string",
+          "const": "translator"
+        },
+        {
+          "description": "The primary title.",
+          "type": "string",
+          "const": "title"
+        },
+        {
+          "description": "The issued date.",
+          "type": "string",
+          "const": "issued"
+        },
+        {
+          "description": "The original publication date.",
+          "type": "string",
+          "const": "original-published"
+        },
+        {
+          "description": "The publisher name.",
+          "type": "string",
+          "const": "publisher"
+        },
+        {
+          "description": "The DOI identifier.",
+          "type": "string",
+          "const": "doi"
+        },
+        {
+          "description": "The reference genre or item type label.",
+          "type": "string",
+          "const": "genre"
+        },
+        {
+          "description": "The archive or repository name.",
+          "type": "string",
+          "const": "archive"
+        },
+        {
+          "description": "The archive shelfmark or repository location.",
+          "type": "string",
+          "const": "archive-location"
+        }
       ]
     },
     "DelimiterPunctuation": {

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -1800,7 +1800,9 @@
         "annote",
         "keyword",
         "genre",
+        "raw-genre",
         "medium",
+        "raw-medium",
         "source",
         "status",
         "archive",
@@ -1821,8 +1823,10 @@
         "publisher-place",
         "original-publisher",
         "original-publisher-place",
+        "event-title",
         "event-place",
         "dimensions",
+        "references",
         "scale",
         "version",
         "locator",
@@ -2084,6 +2088,17 @@
             "$ref": "#/$defs/TemplateComponent"
           }
         },
+        "render-when": {
+          "description": "Optional field-presence condition that controls whether the group renders.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemplateGroupCondition"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "delimiter": {
           "anyOf": [
             {
@@ -2213,6 +2228,100 @@
       "additionalProperties": false,
       "required": [
         "group"
+      ]
+    },
+    "TemplateGroupCondition": {
+      "description": "Field-presence condition for rendering a template group.",
+      "type": "object",
+      "properties": {
+        "field-present": {
+          "description": "Required field that must be present for the group to render.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemplateConditionField"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "field-absent": {
+          "description": "Required field that must be absent for the group to render.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemplateConditionField"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TemplateConditionField": {
+      "description": "Reference fields that can be tested by a template group condition.",
+      "oneOf": [
+        {
+          "description": "The primary author contributor.",
+          "type": "string",
+          "const": "author"
+        },
+        {
+          "description": "The editor contributor.",
+          "type": "string",
+          "const": "editor"
+        },
+        {
+          "description": "The recipient contributor.",
+          "type": "string",
+          "const": "recipient"
+        },
+        {
+          "description": "The translator contributor.",
+          "type": "string",
+          "const": "translator"
+        },
+        {
+          "description": "The primary title.",
+          "type": "string",
+          "const": "title"
+        },
+        {
+          "description": "The issued date.",
+          "type": "string",
+          "const": "issued"
+        },
+        {
+          "description": "The original publication date.",
+          "type": "string",
+          "const": "original-published"
+        },
+        {
+          "description": "The publisher name.",
+          "type": "string",
+          "const": "publisher"
+        },
+        {
+          "description": "The DOI identifier.",
+          "type": "string",
+          "const": "doi"
+        },
+        {
+          "description": "The reference genre or item type label.",
+          "type": "string",
+          "const": "genre"
+        },
+        {
+          "description": "The archive or repository name.",
+          "type": "string",
+          "const": "archive"
+        },
+        {
+          "description": "The archive shelfmark or repository location.",
+          "type": "string",
+          "const": "archive-location"
+        }
       ]
     },
     "DelimiterPunctuation": {
@@ -2859,7 +2968,9 @@
       "description": "Fields that can be used as author substitutes.",
       "type": "string",
       "enum": [
+        "collection-editor",
         "editor",
+        "parent-serial",
         "title",
         "translator"
       ]

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -81,7 +81,13 @@ const KNOWN_DEPENDENTS = {
 
 // chicago-notes-18th-script has no CSL/citeproc counterpart (it is a derivative
 // embedded style; its behavior is covered by engine multilingual tests).
-const SKIPPED_STYLES = ['alpha', 'chicago-notes-18th-script', 'iso690-author-date', 'iso690-numeric'];
+const SKIPPED_STYLES = [
+  'alpha',
+  'chicago-18-base',
+  'chicago-notes-18th-script',
+  'iso690-author-date',
+  'iso690-numeric',
+];
 const PROJECT_ROOT = path.dirname(__dirname);
 const DEFAULT_REPORT_CACHE_DIR = path.join(PROJECT_ROOT, '.oracle-cache', 'report-core');
 const DEFAULT_PARALLELISM = 4;

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -88,6 +88,7 @@ test('discoverCoreStyles skips hidden embedded core wrappers', () => {
   const styles = discoverCoreStyles();
 
   assert.equal(styles.some((style) => style.name.endsWith('-core')), false);
+  assert.equal(styles.some((style) => style.name === 'chicago-18-base'), false);
 });
 
 test('resolveSelectedStyles filters to requested style names and rejects unknown styles', () => {


### PR DESCRIPTION
## Summary

This is a draft progress PR for `csl26-giun`, continuing the Chicago author-date full-fidelity tune. It does not claim the original 100% fidelity completion gate is met.

Implemented substrate and style work that gets `chicago-shared-corpus` citations green and lifts bibliography coverage materially:

- add `parent-serial` and `collection-editor` substitute support
- add narrow `render-when` support on template groups for field presence/absence
- convert CSL/Zotero `book` records with `type: classic` into Citum classic references
- preserve richer media/event/dimension/contributor data during legacy conversion
- tune Chicago author-date citation and bibliography templates across webpage, interview, article-journal, software, book, manuscript, motion-picture, song, and personal-communication clusters
- regenerate checked-in schemas

## Current Fidelity State

Final local report:

- `node scripts/report-core.js --style chicago-author-date-18th`
- headline fidelity: `0.868`
- SQI: `0.927`
- citations overall: `63/63`
- bibliography overall: `424/498`

Shared-corpus recovery state recorded in the bean:

- citations: `15/15`
- bibliography: `331/400`

Remaining work is still broad bibliography fidelity, especially rich book/reprint/contributor cases, interviews, manuscripts/archive cases, broadcasts/media, and related SQI cleanup.

## Validation

- `just schema-gen`
- `cargo test -p citum-schema-style substitute_parent_serial_and_group_conditions_parse`
- `cargo test -p citum-schema-style style_base_chicago_author_date_base_is_valid`
- `cargo test -p citum-schema-data --features legacy-convert classic`
- `cargo check -p citum-engine`
- `cargo test -p citum-engine --test citations disambiguation::suffixes_continue_past_z`
- `just pre-commit`
- pre-push hook: bean hygiene, `cargo fmt --check`, `cargo clippy --all-targets --all-features`, `cargo nextest run`
