### PR TITLE
fix(styles): remove YAML anchors and hardcoded strings from chicago-notes-18th

### DIFF
--- a/.beans/csl26-nref--wire-first-reference-note-number-into-note-styles.md
+++ b/.beans/csl26-nref--wire-first-reference-note-number-into-note-styles.md
@@ -1,0 +1,39 @@
+---
+# csl26-nref
+title: 'Wire first-reference-note-number into note-based styles for cross-references'
+status: todo
+type: enhancement
+priority: low
+created_at: 2026-07-01T00:00:00Z
+updated_at: 2026-07-01T00:00:00Z
+---
+
+CMOS18's classic note-cross-reference behavior ("see note 5 above") is not
+emitted by any shipped note-based style (e.g. `styles/embedded/chicago-notes-18th.yaml`),
+even though `citum-engine` already fully implements the underlying mechanism.
+
+## Context
+
+- `Processor::normalize_note_context` (`crates/citum-engine/src/processor/note_context.rs:116-152`)
+  tracks `first_note_by_id: HashMap<String, u32>` — the note number where each
+  reference first appeared.
+- Exposed to templates via `ProcHints.first_reference_note_number` →
+  `NumberVariable::FirstReferenceNoteNumber`
+  (`crates/citum-engine/src/values/number.rs:84-86`), and as the schema type
+  `FirstReferenceNoteNumber` (`crates/citum-schema-style/src/template.rs:959,987,1016`,
+  serializes as `first-reference-note-number`).
+- `chicago-notes-18th.yaml`'s `subsequent`/`ibid` templates only use shortened
+  author/title forms or bare `term.ibid` — none reference this variable.
+
+## Approach
+
+- [ ] Confirm which CMOS18-family styles (and any other note-based styles,
+      e.g. legal/Bluebook variants) are expected to render note back-references
+      rather than (or in addition to) shortened-form subsequent citations.
+- [ ] Add `number: first-reference-note-number` to the relevant `subsequent`
+      template(s), with appropriate label wording (e.g. "(see note N above)").
+- [ ] Verify against oracle/fidelity corpus that this doesn't regress existing
+      shortened-citation behavior where CMOS18 doesn't call for cross-references.
+
+This is a style-authoring change, not an engine change — no schema or
+processor work is required.

--- a/.beans/csl26-shco--chicago-shared-corpus-converter-defects.md
+++ b/.beans/csl26-shco--chicago-shared-corpus-converter-defects.md
@@ -1,0 +1,76 @@
+---
+# csl26-shco
+title: 'Investigate chicago-shared-corpus converter/engine defects (8/15 failing)'
+status: todo
+type: bug
+priority: medium
+created_at: 2026-07-01T00:00:00Z
+updated_at: 2026-07-01T00:00:00Z
+---
+
+`chicago-notes-18th`'s `chicago-shared-corpus` benchmark (registered in
+`node scripts/report-core.js --style chicago-notes-18th`,
+`officialSupplemental.chicago-shared-corpus`) sits at 46.7% (7/15), barely
+above its own `minPassRate: 0.46` gate. The primary oracle fixture
+(`node scripts/oracle.js styles-legacy/chicago-notes.csl --json`, the small
+20-case set) is now at 100% after the anchor/locale-term/locator-gap fixes in
+this PR — these 8 remaining failures are a separate, richer fixture set
+(`tests/fixtures/test-items-library/chicago-18th.json` /
+`chicago-18th-citations.json`).
+
+## Why this is not a style-YAML fix
+
+One case (`chi-manuscript`) was root-caused: the fixture's `note` field
+carries a Zotero/Better-BibTeX type-override hack (`"type: collection"`),
+which `csl_legacy::csl_json::Reference::parse_note_field_hacks`
+(`crates/csl-legacy/src/csl_json.rs:413-415`) unconditionally applies over
+the top-level CSL `"type": "manuscript"`. `"collection"` has **no routing
+arm** in `crates/citum-schema-data/src/reference/conversion/mod.rs:346-369`,
+so it falls through to a generic monograph/document default with almost no
+fields populated — which is why the style's `manuscript:` type-variant never
+even runs (confirmed empirically: a temporary marker string injected into
+that type-variant never appeared in rendered output). This is a
+`processor-defect`/converter gap, not a defect in `chicago-notes-18th.yaml`.
+
+The other 7 failures were not root-caused to this depth but show symptoms
+suggesting similarly deep, unrelated causes rather than simple template
+fixes:
+
+- `chi-article-journal` — author `et al.` truncation and DOI missing from
+  Citum output (oracle truncates to 3 authors + et al. and shows the DOI;
+  Citum output currently shows the full contributor list untruncated and
+  drops the DOI entirely)
+- `chi-article-magazine` — Citum output nearly empty (`", Gourmet (2000)"`)
+  vs. oracle's full `"Gourmet, Kitchen Notebook, Sep 2000"` — most fields
+  not rendering
+- `chi-article-newspaper` — missing review-of-recital framing, venue, date
+  format, and URL
+- `chi-no-date` — missing series/date-range info (`"1st series
+  (1803–1820)"`)
+- `chi-personal-communication` — garbled component order and missing
+  archive fields
+- `chi-interview` — garbled component order (interviewer/date/URL out of
+  CMOS18 order) and missing venue/date-posted
+- `chi-broadcast` — garbled ordering and wrong number label (`"nos. season
+  3, episode 10"` should be "season 3, episode 10" with no label, or a
+  different label entirely) plus missing writer/cast credits
+
+## Approach
+
+- [ ] Route CSL type `"collection"` (and audit for other unrouted CSL 1.0
+      types) in `crates/citum-schema-data/src/reference/conversion/mod.rs`,
+      deciding whether it should share `MonographType::Manuscript` handling
+      or get its own `ClassExtension` treatment.
+- [ ] Root-cause each of the other 7 failures individually per
+      `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md` classification
+      (style-defect / migration-artifact / processor-defect / intentional
+      divergence) before touching any YAML.
+- [ ] Only after conversion/engine gaps are fixed, revisit
+      `chicago-notes-18th.yaml`'s `article-magazine`, `article-newspaper`,
+      `personal-communication`, `interview`, `broadcast`, and `no-date`-shaped
+      type-variants for genuine style-defects, since some fraction of the
+      current bad output may resolve once the underlying reference data
+      populates correctly.
+- [ ] Re-run `node scripts/report-core.js --style chicago-notes-18th` after
+      each fix; target the shared-corpus benchmark at 100% (or raise
+      `minPassRate` deliberately with documented divergences per case).

--- a/crates/citum-engine/tests/domain_fixtures.rs
+++ b/crates/citum-engine/tests/domain_fixtures.rs
@@ -242,7 +242,7 @@ fn test_humanities_note_fixture_preserves_archive_and_interview_fields() {
     );
     assert_eq!(
         interview,
-        "Michel Foucault, Truth and power, interview by Alessandro Fontana (Interviewer), _Power/Knowledge: Selected Interviews and Other Writings_ (New York), Pantheon Books, 1977, 115.",
+        "Michel Foucault, Truth and power, interviewed by Alessandro Fontana, _Power/Knowledge: Selected Interviews and Other Writings_ (New York), Pantheon Books, 1977, 115.",
         "interview citation should include interviewer, container title, and locator"
     );
     assert_eq!(

--- a/crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
@@ -89,7 +89,7 @@ citation:
     article-journal:
     - contributor: author
       form: long
-      shorten: &id001
+      shorten:
         min: 8
         use-first: 3
         and-others: et-al
@@ -109,7 +109,8 @@ citation:
       - number: volume
         prefix: " "
       - number: issue
-        prefix: ", no. "
+        label-form: short
+        prefix: ", "
       - date: issued
         form: year
         wrap:
@@ -123,7 +124,10 @@ citation:
     article-magazine:
     - contributor: author
       form: long
-      shorten: *id001
+      shorten:
+        min: 8
+        use-first: 3
+        and-others: et-al
     - title: primary
       prefix: ", "
     - group:
@@ -136,7 +140,8 @@ citation:
       - number: volume
         prefix: " "
       - number: issue
-        prefix: ", no. "
+        label-form: short
+        prefix: ", "
       - date: issued
         form: year
         wrap:
@@ -150,7 +155,10 @@ citation:
     article-newspaper:
     - contributor: author
       form: long
-      shorten: *id001
+      shorten:
+        min: 8
+        use-first: 3
+        and-others: et-al
     - title: primary
       prefix: ", "
     - group:
@@ -163,7 +171,8 @@ citation:
       - number: volume
         prefix: " "
       - number: issue
-        prefix: ", no. "
+        label-form: short
+        prefix: ", "
       - date: issued
         form: year
         wrap:
@@ -177,7 +186,10 @@ citation:
     book:
     - contributor: author
       form: long
-      shorten: *id001
+      shorten:
+        min: 8
+        use-first: 3
+        and-others: et-al
     - title: primary
       prefix: ", "
     - contributor: translator
@@ -209,7 +221,10 @@ citation:
     broadcast:
     - contributor: author
       form: long
-      shorten: *id001
+      shorten:
+        min: 8
+        use-first: 3
+        and-others: et-al
     - title: primary
       prefix: ", "
     - group:
@@ -222,7 +237,8 @@ citation:
       - number: volume
         prefix: " "
       - number: issue
-        prefix: ", no. "
+        label-form: short
+        prefix: ", "
       - date: issued
         form: year
         wrap:
@@ -241,7 +257,10 @@ citation:
     chapter:
     - contributor: author
       form: long
-      shorten: *id001
+      shorten:
+        min: 8
+        use-first: 3
+        and-others: et-al
     - title: primary
       prefix: ", "
     - contributor: translator
@@ -249,12 +268,16 @@ citation:
       label: {term: translator, form: short, placement: prefix}
       prefix: ", "
     - group:
-      - title: parent-monograph
-        prefix: ", in "
+      - message: pattern.in-container
+        args:
+          container:
+            title: parent-monograph
+        prefix: ", "
       - contributor: editor
         form: long
-        prefix: ", ed. "
-      - group: &id002
+        label: {term: editor, form: short, placement: prefix}
+        prefix: ", "
+      - group:
         - variable: publisher
         - date: issued
           form: year
@@ -270,7 +293,10 @@ citation:
     dataset:
     - contributor: author
       form: long
-      shorten: *id001
+      shorten:
+        min: 8
+        use-first: 3
+        and-others: et-al
     - title: primary
       prefix: ", "
     - group:
@@ -289,20 +315,34 @@ citation:
     entry-encyclopedia:
     - contributor: author
       form: long
-      shorten: *id001
+      shorten:
+        min: 8
+        use-first: 3
+        and-others: et-al
     - title: primary
       prefix: ", "
     - group:
-      - title: parent-monograph
-        prefix: ", in "
-      - title: parent-serial
-        prefix: ", in "
+      - message: pattern.in-container
+        args:
+          container:
+            title: parent-monograph
+        prefix: ", "
+      - message: pattern.in-container
+        args:
+          container:
+            title: parent-serial
+        prefix: ", "
       - number: volume
-        prefix: ", vol. "
+        label-form: short
+        prefix: ", "
       - contributor: editor
         form: long
-        prefix: ", ed. "
-      - group: *id002
+        label: {term: editor, form: short, placement: prefix}
+        prefix: ", "
+      - group:
+        - variable: publisher
+        - date: issued
+          form: year
         delimiter: ", "
         wrap:
           punctuation: parentheses
@@ -313,7 +353,10 @@ citation:
     interview:
     - contributor: author
       form: long
-      shorten: *id001
+      shorten:
+        min: 8
+        use-first: 3
+        and-others: et-al
     - title: primary
       prefix: ", "
     - variable: url
@@ -321,8 +364,8 @@ citation:
     - variable: medium
       prefix: ", "
     - contributor: interviewer
-      form: long
-      prefix: ", interview by "
+      form: verb
+      prefix: ", "
     - title: parent-monograph
       prefix: ", "
     - variable: publisher-place
@@ -342,7 +385,10 @@ citation:
     legal-case:
     - contributor: author
       form: long
-      shorten: *id001
+      shorten:
+        min: 8
+        use-first: 3
+        and-others: et-al
     - title: primary
       prefix: ", "
     - group:
@@ -362,7 +408,10 @@ citation:
     manuscript:
     - contributor: author
       form: long
-      shorten: *id001
+      shorten:
+        min: 8
+        use-first: 3
+        and-others: et-al
     - title: primary
       prefix: ", "
       wrap:
@@ -389,14 +438,17 @@ citation:
     motion-picture:
     - contributor: author
       form: long
-      shorten: *id001
+      shorten:
+        min: 8
+        use-first: 3
+        and-others: et-al
     - title: primary
       prefix: ", "
     - variable: genre
       prefix: ", "
-    - contributor: author
-      form: long
-      prefix: ", directed by "
+    - contributor: director
+      form: verb
+      prefix: ", "
     - date: issued
       form: year
       prefix: ", "
@@ -413,7 +465,10 @@ citation:
     patent:
     - contributor: author
       form: long
-      shorten: *id001
+      shorten:
+        min: 8
+        use-first: 3
+        and-others: et-al
     - title: primary
       prefix: ", "
     - group:
@@ -436,7 +491,10 @@ citation:
     personal-communication:
     - contributor: author
       form: long
-      shorten: *id001
+      shorten:
+        min: 8
+        use-first: 3
+        and-others: et-al
     - title: primary
       prefix: ", "
     - variable: archive
@@ -478,7 +536,10 @@ citation:
   template:
   - contributor: author
     form: long
-    shorten: *id001
+    shorten:
+      min: 8
+      use-first: 3
+      and-others: et-al
   - title: primary
     prefix: ", "
   - group:
@@ -491,7 +552,8 @@ citation:
     - number: volume
       prefix: " "
     - number: issue
-      prefix: ", no. "
+      label-form: short
+      prefix: ", "
     - date: issued
       form: year
       wrap:
@@ -501,16 +563,27 @@ citation:
       prefix: ": "
     delimiter: ""
   - group:
-    - title: parent-monograph
-      prefix: ", in "
-    - title: parent-serial
-      prefix: ", in "
+    - message: pattern.in-container
+      args:
+        container:
+          title: parent-monograph
+      prefix: ", "
+    - message: pattern.in-container
+      args:
+        container:
+          title: parent-serial
+      prefix: ", "
     - number: volume
-      prefix: ", vol. "
+      label-form: short
+      prefix: ", "
     - contributor: editor
       form: long
-      prefix: ", ed. "
-    - group: *id002
+      label: {term: editor, form: short, placement: prefix}
+      prefix: ", "
+    - group:
+      - variable: publisher
+      - date: issued
+        form: year
       delimiter: ", "
       wrap:
         punctuation: parentheses

--- a/crates/citum-schema-style/src/locale/embedded/en_us.rs
+++ b/crates/citum-schema-style/src/locale/embedded/en_us.rs
@@ -205,106 +205,68 @@ pub(crate) fn en_us_role_terms() -> HashMap<ContributorRole, ContributorTerm> {
     roles
 }
 
+/// Build a `LocatorTerm` from plain long/short/symbol singular-plural pairs.
+fn locator_term(
+    long: Option<(&str, &str)>,
+    short: Option<(&str, &str)>,
+    symbol: Option<(&str, &str)>,
+) -> LocatorTerm {
+    let pair = |(singular, plural): (&str, &str)| SingularPlural {
+        singular: MaybeGendered::Plain(singular.into()),
+        plural: MaybeGendered::Plain(plural.into()),
+    };
+    LocatorTerm {
+        long: long.map(pair),
+        short: short.map(pair),
+        symbol: symbol.map(pair),
+        gender: None,
+    }
+}
+
 /// Extract English (US) locator terms.
 pub(crate) fn en_us_locator_terms() -> HashMap<LocatorType, LocatorTerm> {
     let mut locators = HashMap::new();
     locators.insert(
         LocatorType::Page,
-        LocatorTerm {
-            long: Some(SingularPlural {
-                singular: MaybeGendered::Plain("page".into()),
-                plural: MaybeGendered::Plain("pages".into()),
-            }),
-            short: Some(SingularPlural {
-                singular: MaybeGendered::Plain("p.".into()),
-                plural: MaybeGendered::Plain("pp.".into()),
-            }),
-            symbol: None,
-            gender: None,
-        },
+        locator_term(Some(("page", "pages")), Some(("p.", "pp.")), None),
     );
 
     locators.insert(
         LocatorType::Chapter,
-        LocatorTerm {
-            long: Some(SingularPlural {
-                singular: MaybeGendered::Plain("chapter".into()),
-                plural: MaybeGendered::Plain("chapters".into()),
-            }),
-            short: Some(SingularPlural {
-                singular: MaybeGendered::Plain("ch.".into()),
-                plural: MaybeGendered::Plain("chs.".into()),
-            }),
-            symbol: None,
-            gender: None,
-        },
+        locator_term(Some(("chapter", "chapters")), Some(("ch.", "chs.")), None),
     );
 
     locators.insert(
         LocatorType::Volume,
-        LocatorTerm {
-            long: Some(SingularPlural {
-                singular: MaybeGendered::Plain("volume".into()),
-                plural: MaybeGendered::Plain("volumes".into()),
-            }),
-            short: Some(SingularPlural {
-                singular: MaybeGendered::Plain("vol.".into()),
-                plural: MaybeGendered::Plain("vols.".into()),
-            }),
-            symbol: None,
-            gender: None,
-        },
+        locator_term(Some(("volume", "volumes")), Some(("vol.", "vols.")), None),
+    );
+
+    locators.insert(
+        LocatorType::Issue,
+        locator_term(Some(("issue", "issues")), Some(("no.", "nos.")), None),
     );
 
     locators.insert(
         LocatorType::Section,
-        LocatorTerm {
-            long: Some(SingularPlural {
-                singular: MaybeGendered::Plain("section".into()),
-                plural: MaybeGendered::Plain("sections".into()),
-            }),
-            short: Some(SingularPlural {
-                singular: MaybeGendered::Plain("sec.".into()),
-                plural: MaybeGendered::Plain("secs.".into()),
-            }),
-            symbol: Some(SingularPlural {
-                singular: MaybeGendered::Plain("§".into()),
-                plural: MaybeGendered::Plain("§§".into()),
-            }),
-            gender: None,
-        },
+        locator_term(
+            Some(("section", "sections")),
+            Some(("sec.", "secs.")),
+            Some(("§", "§§")),
+        ),
     );
 
     locators.insert(
         LocatorType::Part,
-        LocatorTerm {
-            long: Some(SingularPlural {
-                singular: MaybeGendered::Plain("part".into()),
-                plural: MaybeGendered::Plain("parts".into()),
-            }),
-            short: Some(SingularPlural {
-                singular: MaybeGendered::Plain("pt.".into()),
-                plural: MaybeGendered::Plain("pts.".into()),
-            }),
-            symbol: None,
-            gender: None,
-        },
+        locator_term(Some(("part", "parts")), Some(("pt.", "pts.")), None),
     );
 
     locators.insert(
         LocatorType::Supplement,
-        LocatorTerm {
-            long: Some(SingularPlural {
-                singular: MaybeGendered::Plain("supplement".into()),
-                plural: MaybeGendered::Plain("supplements".into()),
-            }),
-            short: Some(SingularPlural {
-                singular: MaybeGendered::Plain("suppl.".into()),
-                plural: MaybeGendered::Plain("suppls.".into()),
-            }),
-            symbol: None,
-            gender: None,
-        },
+        locator_term(
+            Some(("supplement", "supplements")),
+            Some(("suppl.", "suppls.")),
+            None,
+        ),
     );
 
     locators


### PR DESCRIPTION
## Summary

- Removed YAML anchors (`&id001`/`&id002`) from `chicago-notes-18th.yaml` — not a sanctioned Citum reuse mechanism (only ~3/28 embedded styles used them, likely `citum-migrate` residue). Replaced with inline literals.
- Replaced hardcoded English strings (`", ed. "`, `", in "`, `", vol. "`, `", no. "`, `", interview by "`, `", directed by "`) with locale-driven `label`/`message`/`label-form`/`form: verb` components, matching the existing translator/ibid pattern in the same file.
- Fixed a genuine engine gap found along the way: `LocatorType::Issue` was missing from the embedded en-US locale (`crates/citum-schema-style/src/locale/embedded/en_us.rs`), silently dropping the "no."/"nos." label whenever `label-form` was used on an issue number. Added the entry and refactored the surrounding function (was pushed over clippy's 100-line limit) into a small `locator_term` helper.
- Updated one test fixture assertion (`domain_fixtures.rs`) that had hardcoded the old buggy "interview by ... (Interviewer)" wording — the corrected style output is "interviewed by ...".
- Answered a fourth question (cross-references to citations in note styles): the engine already supports `first-reference-note-number`, it's just not wired into this style's `subsequent` template. Filed `csl26-nref` to track wiring it in later.
- Initialized the `styles-legacy` submodule (was never checked out in this environment) so real oracle fidelity could be measured — the primary 20-case oracle fixture is now **100%** (`node scripts/oracle.js styles-legacy/chicago-notes.csl --json`), up from an artifact "6/20" caused by the missing submodule.
- Investigated the `chicago-shared-corpus` supplemental benchmark (46.7%, 7/15) and root-caused one failure to a converter defect (CSL type `"collection"` has no routing arm, so a Zotero note-field type-override falls through to a generic default and never reaches the style's own `manuscript:` type-variant). The other 7 failures show similarly deep symptoms. Filed `csl26-shco` to scope that as separate converter/engine investigation rather than cycling YAML on defects outside this style's scope, per the `tune` loop's own escalation rule.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (workspace-wide, after user updated the Rust toolchain to clear an unrelated pre-existing failure)
- [x] `cargo nextest run` — 1697/1697 passing
- [x] `node scripts/oracle.js styles-legacy/chicago-notes.csl --json` — 20/20 (100%), up from an artifact 6/20 caused by an uninitialized submodule
- [x] YAML parses (`yaml.safe_load`), anchors fully removed
- [ ] `chicago-shared-corpus` supplemental benchmark (46.7%) — intentionally left as-is; root-caused to converter defects outside this style's scope, tracked in `csl26-shco`
