### PR TITLE
chore(beans): link csl26-shco to chicago-family epic

### DIFF
--- a/.beans/csl26-lxy3--tune-chicago-notes-18th-to-full-fidelity.md
+++ b/.beans/csl26-lxy3--tune-chicago-notes-18th-to-full-fidelity.md
@@ -9,6 +9,7 @@ updated_at: 2026-06-30T18:55:24Z
 parent: csl26-h7oc
 blocked_by:
     - csl26-ucg3
+    - csl26-shco
 ---
 
 Tune `chicago-notes-18th` to 100% fidelity + clean SQI via the `style-tune`

--- a/.beans/csl26-shco--chicago-shared-corpus-converter-defects.md
+++ b/.beans/csl26-shco--chicago-shared-corpus-converter-defects.md
@@ -6,6 +6,7 @@ type: bug
 priority: medium
 created_at: 2026-07-01T00:00:00Z
 updated_at: 2026-07-01T00:00:00Z
+parent: csl26-h7oc
 ---
 
 `chicago-notes-18th`'s `chicago-shared-corpus` benchmark (registered in


### PR DESCRIPTION
## Summary
- `csl26-shco` (filed in #991, scoping the chicago-shared-corpus converter/engine defects) was left disconnected from the existing Chicago-family bean hierarchy.
- Set `parent: csl26-h7oc` on `csl26-shco`, making it a proper descendant of `csl26-40n4` (the Chicago family substrate epic).
- Added `csl26-shco` to `csl26-lxy3`'s `blocked_by` list alongside `csl26-ucg3`, since the chicago-notes-18th fidelity loop can't reach 100% via YAML alone until the converter-layer defects `csl26-shco` scopes are fixed.

## Test plan
- [x] Both files' YAML frontmatter validated with `yaml.safe_load`
- [x] Pre-commit/pre-push bean hygiene hooks passed
- Metadata-only change, no code/schema impact
