### PR TITLE
feat(schema): csl type conversion contract tests

### DIFF
--- a/.beans/csl26-3r34--attributed-fidelity-reporting-tag-conversion-layer.md
+++ b/.beans/csl26-3r34--attributed-fidelity-reporting-tag-conversion-layer.md
@@ -1,0 +1,27 @@
+---
+# csl26-3r34
+title: 'Attributed fidelity reporting: tag conversion-layer suspects in oracle.js'
+status: todo
+type: task
+created_at: 2026-07-02T13:19:55Z
+updated_at: 2026-07-02T13:19:55Z
+parent: csl26-cvfy
+---
+
+Phase 5 follow-on of the conversion-layer contract-test epic (see
+docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md, Non-goals). Now that the
+conversion layer has an explicit CSL 1.0.2 routing contract
+(CSL_TYPES in crates/csl-legacy/src/csl_json.rs, contract tests in
+crates/citum-schema-data/src/reference/conversion/contract_tests.rs),
+expose per-reference conversion diagnostics from `citum render refs`
+(e.g. a --json field noting 'rendered via fallback/default type') so
+scripts/oracle.js and scripts/report-core.js can tag a failing fixture
+case as 'conversion-layer suspect' before it is counted as a
+style-fidelity failure. This mechanizes the classification rule in
+docs/policies/STYLE_WORKFLOW_DECISION_RULES.md (style-defect /
+migration-artifact / processor-defect / intentional divergence)
+instead of leaving it to manual tracing.
+
+Separate PR from the routing-closure work; see the parent epic
+csl26-cvfy for the problem statement and the manual-attribution cost
+this eliminates.

--- a/.beans/csl26-blyb--drop-quick-xml-rustsec-2026-01940195-suppressions.md
+++ b/.beans/csl26-blyb--drop-quick-xml-rustsec-2026-01940195-suppressions.md
@@ -1,0 +1,10 @@
+---
+# csl26-blyb
+title: Drop quick-xml RUSTSEC-2026-0194/0195 suppressions when Typst stack updates
+status: todo
+type: task
+created_at: 2026-07-02T18:01:16Z
+updated_at: 2026-07-02T18:01:16Z
+---
+
+RUSTSEC-2026-0194 (quadratic attribute check) and RUSTSEC-2026-0195 (NsReader memory-exhaustion DoS) are suppressed in .cargo/audit.toml and deny.toml because both quick-xml instances are transitive: citationberg/hayagriva pin 0.38.4 and syntect/plist pin 0.39.4, all reached only through the Typst stack used by citum-pdf. The fix requires quick-xml >=0.41, a breaking bump those upstreams have not shipped. When typst (or citationberg/hayagriva/plist directly) release versions on quick-xml >=0.41, bump the deps and remove both suppressions from BOTH files (they must stay in sync). Renovate vulnerabilityAlerts will not auto-resolve suppressed advisories, so this needs a manual periodic check.

--- a/.beans/csl26-cvfy--conversion-layer-contract-tests-and-loud-fail.md
+++ b/.beans/csl26-cvfy--conversion-layer-contract-tests-and-loud-fail.md
@@ -1,11 +1,11 @@
 ---
 # csl26-cvfy
-title: 'CSL-JSON conversion-layer contract tests + loud-fail on unmapped types'
-status: todo
+title: CSL-JSON conversion-layer contract tests + loud-fail on unmapped types
+status: in-progress
 type: epic
 priority: medium
 created_at: 2026-07-02T00:00:00Z
-updated_at: 2026-07-02T00:00:00Z
+updated_at: 2026-07-02T17:22:41Z
 ---
 
 ## Problem
@@ -179,21 +179,59 @@ sufficient input for that spec's first draft, but the spec itself is not
 written yet.
 
 ## Todo
-- [ ] Author `docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md` (or similarly
+- [x] Author `docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md` (or similarly
       named) — Draft status, scoping Phases 1-4 as the MVP and Phase 5 as
       a stretch/follow-on
-- [ ] Phase 1: source-of-truth CSL 1.0 type vocabulary + gap audit against
+- [x] Phase 1: source-of-truth CSL 1.0 type vocabulary + gap audit against
       current `conversion/mod.rs` routing arms
-- [ ] Phase 2: red test reproducing the `chi-manuscript`/`collection`
+- [x] Phase 2: red test reproducing the `chi-manuscript`/`collection`
       regression at the conversion layer, independent of any style
-- [ ] Phase 3: validate note-field type-override against the vocabulary
+- [x] Phase 3: validate note-field type-override against the vocabulary
       (sequence after Phase 4's routing fix per the dependency noted above)
-- [ ] Phase 4: close routing gaps; design + implement loud-fail for
+- [x] Phase 4: close routing gaps; design + implement loud-fail for
       unmapped types, coordinated with `csl26-1bdr`'s prior art
 - [ ] Phase 5 (stretch, separate PR): attributed fidelity reporting in
       `oracle.js`/`report-core.js`
-- [ ] Re-run `node scripts/report-core.js --style chicago-notes-18th`
+- [x] Re-run `node scripts/report-core.js --style chicago-notes-18th`
       after Phase 4 lands to confirm `chi-manuscript` (and any other
       newly-routed types in the shared corpus) improve without YAML
       changes, validating the "conversion bugs, not style bugs" diagnosis
-      in `csl26-shco`
+      in `csl26-shco`. **Outcome:** the conversion layer is fixed and
+      verified (`chi-manuscript` converts to `ref_type() == "collection"`
+      with `archive-info` intact; contract test + CLI trace both green),
+      the full corpus shows zero style regressions and a small
+      bibliography improvement (7790→7792 passed), but the shared-corpus
+      citation itself still fails (7/15 unchanged) because the *migrated
+      style* has no `collection` type-variant — the failure is now
+      cleanly attributable to the style/migration layer, which is
+      exactly `csl26-shco` scope. Diagnosis mechanism validated; the
+      "without YAML changes" improvement expectation was optimistic.
+
+## Summary of Changes
+
+Implemented in PR #993 (branch `epic/csl-json-conversion-contract-tests`):
+
+- `docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md` (Active): vocabulary
+  source of truth, canonicalization table, routing closure design,
+  loud-fail pattern, note-override policy.
+- `crates/csl-legacy/src/csl_json.rs`: `CSL_TYPES` (45 CSL 1.0.2 types)
+  + `CSL_TYPE_EXTENSIONS`; `parse_note_field_hacks` now applies a
+  `type: X` override only for recognized types — unrecognized values
+  keep the top-level type and stay in the note.
+- `crates/citum-schema-data/src/reference/conversion/`: 12 routing gaps
+  closed (11 anticipated + test-discovered `post-weblog`→`post`
+  collapse; `speech`→`event` collapse also fixed). CSL `collection`
+  routes as an *archival* document shape (genre-discriminated) because
+  Citum's editorial `Collection` class has no author/archive fields —
+  recorded in the spec. Wildcard fallback now `debug_assert!`s on known
+  CSL types (mirrors `accessors.rs` `TODO(csl26-1bdr)` prior art).
+- `conversion/contract_tests.rs`: expectation-table round-trip test over
+  all 45 types (zero exceptions), chi-manuscript regression test with
+  archive-preservation assertion, capitalized-genre (`Map`) regression
+  test.
+- Fidelity: zero regressions across the core corpus; bibliography
+  passed 7790→7792; chicago-author-date-18th and
+  taylor-and-francis-chicago-author-date +0.002 each.
+
+Phase 5 filed as `csl26-3r34`. Remaining `chi-manuscript` citation
+mismatch reclassified as a style/migration-layer defect (`csl26-shco`).

--- a/.beans/csl26-cvfy--conversion-layer-contract-tests-and-loud-fail.md
+++ b/.beans/csl26-cvfy--conversion-layer-contract-tests-and-loud-fail.md
@@ -1,0 +1,199 @@
+---
+# csl26-cvfy
+title: 'CSL-JSON conversion-layer contract tests + loud-fail on unmapped types'
+status: todo
+type: epic
+priority: medium
+created_at: 2026-07-02T00:00:00Z
+updated_at: 2026-07-02T00:00:00Z
+---
+
+## Problem
+
+Style fidelity is measured by running raw CSL-JSON fixtures through the
+*entire* pipeline — CSL-JSON parsing → note-field-hack extraction →
+CSL-type routing → `InputReference` → style template rendering — and
+diffing the final citation text against citeproc-js
+(`node scripts/oracle.js`, `node scripts/report-core.js`). A single
+pass/fail number comes out. When it fails, nothing tells you *which layer*
+broke: style-authoring bug, CSL-type-routing bug, or CSL-JSON parsing
+quirk. Today's session spent real wall-clock time doing this attribution
+by hand for one failure (root-causing `chi-manuscript` in the
+`chicago-shared-corpus` fixture, see `csl26-shco`):
+
+1. Ran `node scripts/oracle.js styles-legacy/chicago-notes.csl
+   --refs-fixture tests/fixtures/test-items-library/chicago-18th.json
+   --citations-fixture .../chicago-18th-citations.json --json` and got a
+   garbled citation with no clue why.
+2. Isolated the single reference into its own fixture file and rendered it
+   directly via `cargo run --bin citum -- render refs -b <item> -s
+   <style> -m cite --json` to reproduce in isolation.
+3. Injected a temporary marker string into the style YAML's
+   `manuscript:` type-variant to *empirically* prove the type-variant was
+   never being selected at all (it wasn't — the marker never appeared).
+4. Ran `cargo convert refs <item> --from csl-json -o <out>.yaml` to inspect
+   the intermediate `InputReference` and found `type: document` instead of
+   the expected `type: manuscript`.
+5. Traced through `crates/csl-legacy/src/csl_json.rs` (note-field hack
+   parser) → `crates/citum-schema-data/src/reference/conversion/mod.rs`
+   (CSL-type routing switch) → `conversion/scholarly.rs` to find the root
+   cause: the fixture's `note` field carries a Zotero/Better-BibTeX
+   type-override (`"type: collection"`), which
+   `Reference::parse_note_field_hacks` (`csl_json.rs:413-415`)
+   unconditionally applies over the top-level `"type": "manuscript"`, and
+   `"collection"` has **no arm at all** in the routing `match` in
+   `conversion/mod.rs:346-369` — so it silently falls through to a
+   generic default.
+
+That is five tool invocations and four source files to attribute *one* of
+eight known-failing fixture cases in `chicago-shared-corpus` alone. This
+does not scale, and it will recur every time a `tune` pass touches a style
+whose fixture references exercise an edge case in the conversion layer.
+
+## Root causes (concrete, file:line)
+
+1. **The CSL-type routing table is hand-maintained and silently
+   incomplete.** `crates/citum-schema-data/src/reference/conversion/mod.rs`,
+   the `match legacy.ref_type.as_str()` block starting at line 346, has no
+   exhaustiveness check against CSL 1.0's actual type vocabulary. An
+   unmapped `ref_type` string (e.g. `"collection"`) falls through to
+   whatever the final wildcard arm does (verify current behavior — as of
+   this writing it lands on a generic monograph/document shape with most
+   fields unset).
+2. **The note-field type-override is unvalidated.**
+   `crates/csl-legacy/src/csl_json.rs:413-415`
+   (`Reference::parse_note_field_hacks`) does
+   `self.ref_type = value.to_string();` for any `note:` line matching
+   `type: X`, with no check that `X` is a recognized CSL type. A typo or
+   copy-pasted artifact in a Zotero export silently reclassifies the
+   reference.
+3. **Prior art exists for the "loud fail" pattern, but at the wrong
+   layer.** `crates/citum-schema-data/src/reference/accessors.rs:1462-1478`
+   (the `ClassExtension::Unknown` arm of `ref_type()`) already has a
+   `debug_assert!` plus a `TODO(csl26-1bdr)` gesturing at
+   `CompatibilityWarning` plumbing for *unknown top-level classes*
+   (`class:` field, e.g. `monograph`/`serial`/`legal-case`) — see the
+   archived bean `csl26-1bdr` and
+   `docs/specs/INPUT_REFERENCE_CLASS_DISCRIMINATOR.md`. That mechanism is
+   one level too coarse: it only fires for a completely unrecognized
+   `class`, not for a recognized class (`monograph`) whose legacy CSL
+   `type` string (`collection`) doesn't map to any of that class's known
+   type variants. This bean is the analogous fix one level down — do not
+   conflate the two; check whether the existing
+   `ReferenceClass::KNOWN` const (`crates/citum-schema-data/src/reference/classes.rs:76`)
+   and its `discriminator_tests.rs` fuzz coverage suggest a pattern worth
+   mirroring for per-class type vocabularies.
+4. **Failure attribution is entirely manual.** `scripts/oracle.js`'s
+   `renderWithCitumProcessor` (line 476) shells out to
+   `cargo run --bin citum -- render refs` — the *exact same* CLI path used
+   for the manual investigation above. This means any fix to the
+   conversion layer is immediately visible to oracle.js with no separate
+   JS-side change required, and it also means oracle.js is well
+   positioned to get per-reference conversion diagnostics for free if the
+   CLI exposes them (see Phase 4 below).
+
+## Proposed pivot
+
+Decouple "does this CSL-JSON reference convert to a sane `InputReference`"
+from "does this style render the correct text" — make the former a fast,
+targeted, independently-owned test surface that fails at the point of the
+actual defect, not three layers downstream in a citation-text diff.
+
+### Phase 1 — Establish the CSL 1.0 type vocabulary as a source of truth
+Determine whether `csl-legacy` (or anywhere else in the workspace) already
+has a canonical list of CSL 1.0 `type` strings. If not, author one (likely
+as a Rust `const` slice in `crates/csl-legacy/src` alongside — or feeding
+— the routing table), sourced from the CSL 1.0 spec's `csl-types.rnc` /
+official type list, not reverse-engineered from what happens to appear in
+fixtures today. This must include less-common types the current routing
+table has no arm for (audit needed — `collection` was found by accident,
+there are likely others: e.g. `figure`, `graphic`, `map`, `musical_score`,
+`performance`, `review`, `review-book`, `song`, `standard`, `treaty`, verify
+each against the current `match` arms in `conversion/mod.rs`).
+
+### Phase 2 — Exhaustiveness test at the conversion layer
+Add a test (likely in
+`crates/citum-schema-data/src/reference/conversion/tests.rs` or a new
+sibling module) that iterates the Phase 1 vocabulary and asserts each
+value produces a `ref_type()` round-trip that is *not* a generic/default
+fallback — i.e., converting `"type": "collection"` through
+`InputReference::from` and back through `.ref_type()` must not silently
+collapse into `"document"` or another type the fixture didn't ask for.
+This is the test that should have caught the `chi-manuscript` case; write
+it first as a red test reproducing that exact regression before touching
+`conversion/mod.rs`.
+
+### Phase 3 — Validate the note-field type-override
+In `Reference::parse_note_field_hacks`
+(`crates/csl-legacy/src/csl_json.rs:413-415`), check the override value
+against the Phase 1 vocabulary before assigning `self.ref_type`. Decide
+(and document, this needs a product decision, not just an engineering
+one) what happens on an unrecognized override: ignore it and keep the
+top-level type, or apply it anyway but flag a compatibility warning. Given
+the `chi-manuscript` fixture item apparently *wants* `"collection"` as its
+true type (not just a bad override), this phase depends on Phase 4's
+routing fix landing first, or the "ignore unrecognized override" policy
+would incorrectly suppress a legitimate CSL type this fixture is
+exercising.
+
+### Phase 4 — Close routing gaps + make fallthrough loud
+For every Phase 1 vocabulary entry with no arm in `conversion/mod.rs`,
+either add a real routing arm (preferred, if a sensible `ClassExtension`
+mapping exists — `collection` likely wants its own arm rather than
+defaulting into `Monograph`/`Document`) or make the fallback path loud:
+a `debug_assert!` plus `CompatibilityWarning` plumbing analogous to the
+existing unknown-*class* mechanism at `accessors.rs:1462-1478`, but scoped
+to unknown-*type-within-known-class*. Coordinate with whatever comes out
+of the still-pending `csl26-1bdr` follow-on work so the two loud-fail
+mechanisms share a design rather than diverging.
+
+### Phase 5 — Attributed fidelity reporting (stretch goal, separate PR)
+Once Phase 2-4 land, consider exposing per-reference conversion
+diagnostics from `citum render refs` (e.g. a `--json` field noting
+"rendered via fallback/default type") so `scripts/oracle.js` and
+`scripts/report-core.js` can tag a failing fixture case as
+"conversion-layer suspect" *before* it's counted as a style-fidelity
+failure, instead of requiring the manual trace this bean's problem
+statement describes. This directly mechanizes the classification rule
+already written in `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md`
+(style-defect / migration-artifact / processor-defect / intentional
+divergence) instead of leaving it as pure human/LLM judgment every time.
+
+## Non-goals
+- Do not fix `chicago-shared-corpus`'s remaining 8 fixture failures as
+  part of this epic — that's `csl26-shco`'s scope, and several of those
+  failures may turn out to be genuine style-defects once conversion-layer
+  noise is removed. This epic is about the *testing architecture*, not
+  about driving any one style to 100%.
+- Do not expand this into a general InputReference schema redesign — the
+  archived `csl26-1bdr` already covers the top-level `class:` discriminator
+  question and is a settled, separate concern (pre-1.0 major-bump
+  opt-out). Stay scoped to the CSL-legacy-`type`-string → Citum-type
+  mapping completeness problem.
+
+## Spec requirement
+Per `CLAUDE.md`'s Documentation Rule, author a spec in `docs/specs/`
+(status `Draft` → `Active` in the implementation commit) before
+implementing Phase 2 onward — this bean and its problem statement are
+sufficient input for that spec's first draft, but the spec itself is not
+written yet.
+
+## Todo
+- [ ] Author `docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md` (or similarly
+      named) — Draft status, scoping Phases 1-4 as the MVP and Phase 5 as
+      a stretch/follow-on
+- [ ] Phase 1: source-of-truth CSL 1.0 type vocabulary + gap audit against
+      current `conversion/mod.rs` routing arms
+- [ ] Phase 2: red test reproducing the `chi-manuscript`/`collection`
+      regression at the conversion layer, independent of any style
+- [ ] Phase 3: validate note-field type-override against the vocabulary
+      (sequence after Phase 4's routing fix per the dependency noted above)
+- [ ] Phase 4: close routing gaps; design + implement loud-fail for
+      unmapped types, coordinated with `csl26-1bdr`'s prior art
+- [ ] Phase 5 (stretch, separate PR): attributed fidelity reporting in
+      `oracle.js`/`report-core.js`
+- [ ] Re-run `node scripts/report-core.js --style chicago-notes-18th`
+      after Phase 4 lands to confirm `chi-manuscript` (and any other
+      newly-routed types in the shared corpus) improve without YAML
+      changes, validating the "conversion bugs, not style bugs" diagnosis
+      in `csl26-shco`

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -15,4 +15,6 @@ ignore = [
     "RUSTSEC-2025-0141",  # bincode unmaintained (transitive via deno_core/syntect)
     "RUSTSEC-2026-0186",  # memmap2 unsound (transitive via gix stack)
     "RUSTSEC-2026-0192",  # ttf-parser unmaintained (transitive via Typst stack)
+    "RUSTSEC-2026-0194",  # quick-xml quadratic attr check (transitive via Typst stack; fix needs quick-xml >=0.41 upstream — removal tracked in bean csl26-blyb)
+    "RUSTSEC-2026-0195",  # quick-xml NsReader memory-exhaustion DoS (same transitive paths and fix version as 0194 — bean csl26-blyb)
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
 
       - name: Run repository hygiene (alint)
-        uses: asamarts/alint@3c15d45a21884dc39f1f351a85e03297da237b87  # v0.9.22
+        uses: asamarts/alint@9a341559646a0a128957a0f70671e0835fb38dcb  # v0.13.0
 
   hygiene-beans:
     name: Hygiene Checks — Beans

--- a/crates/citum-schema-data/src/reference/accessors.rs
+++ b/crates/citum-schema-data/src/reference/accessors.rs
@@ -1481,31 +1481,53 @@ impl InputReference {
 
     fn monograph_ref_type(&self, r: &Monograph) -> String {
         match r.r#type {
-            MonographType::Book => if r
-                .medium
-                .as_deref()
-                .is_some_and(|m| m.to_ascii_lowercase().contains("interview"))
-            {
-                "interview"
-            } else {
-                "book"
+            MonographType::Book => {
+                if r.genre
+                    .as_deref()
+                    .is_some_and(|genre| genre.eq_ignore_ascii_case("musical_score"))
+                {
+                    return "musical-score".to_string();
+                }
+                if r.genre.as_deref().is_some_and(|genre| genre == "pamphlet") {
+                    return "pamphlet".to_string();
+                }
+                if r.medium
+                    .as_deref()
+                    .is_some_and(|m| m.to_ascii_lowercase().contains("interview"))
+                {
+                    "interview"
+                } else {
+                    "book"
+                }
+                .to_string()
             }
-            .to_string(),
             MonographType::Manual => "manual".to_string(),
             MonographType::Report => "report".to_string(),
             MonographType::Thesis => "thesis".to_string(),
             MonographType::Webpage => "webpage".to_string(),
-            MonographType::Post => "post".to_string(),
+            MonographType::Post => if r.genre.as_deref() == Some("post-weblog") {
+                "post-weblog"
+            } else {
+                "post"
+            }
+            .to_string(),
             MonographType::Interview => "interview".to_string(),
             MonographType::Manuscript => "manuscript".to_string(),
             MonographType::Preprint => "preprint".to_string(),
             MonographType::PersonalCommunication => "personal-communication".to_string(),
             MonographType::Document => {
-                if r.genre
-                    .as_deref()
-                    .is_some_and(|genre| genre.eq_ignore_ascii_case("map"))
-                {
-                    return "map".to_string();
+                // Case-insensitive: real-world exports carry capitalized
+                // genre labels (e.g. Zotero's `Map`), and the pre-existing
+                // map back-map matched them ignoring case; the canonical
+                // lowercase CSL type string is returned either way.
+                if let Some(genre) = r.genre.as_deref() {
+                    let lowered = genre.to_ascii_lowercase();
+                    if matches!(
+                        lowered.as_str(),
+                        "map" | "figure" | "graphic" | "periodical" | "collection"
+                    ) {
+                        return lowered;
+                    }
                 }
                 if let Some(genre) = r.genre.as_deref()
                     && matches!(genre, "bill-proceeding" | "bill-record")
@@ -1535,6 +1557,7 @@ fn collection_component_ref_type(r: &CollectionComponent) -> String {
         MonographComponentType::Chapter => match r.genre.as_deref() {
             Some("entry-dictionary") => "entry-dictionary",
             Some("entry-encyclopedia") => "entry-encyclopedia",
+            Some("entry") => "entry",
             _ => "chapter",
         }
         .to_string(),
@@ -1546,6 +1569,11 @@ fn collection_component_ref_type(r: &CollectionComponent) -> String {
 fn serial_component_ref_type(r: &SerialComponent) -> String {
     if r.genre.as_deref() == Some("entry-encyclopedia") {
         return "entry-encyclopedia".to_string();
+    }
+    if let Some(genre) = r.genre.as_deref()
+        && matches!(genre, "review" | "review-book")
+    {
+        return genre.to_string();
     }
     let container_type = r.container.as_ref().and_then(|c| match c {
         WorkRelation::Embedded(p) => Some(p.ref_type()),
@@ -1573,6 +1601,7 @@ fn event_ref_type(r: &Event) -> &'static str {
     match lowered.as_deref() {
         Some(g) if g.contains("conference") || g.contains("paper") => "paper-conference",
         Some(g) if g.contains("broadcast") => "broadcast",
+        Some(g) if g.contains("performance") => "performance",
         Some(g) if g.contains("talk") || g.contains("speech") => "speech",
         _ => "event",
     }

--- a/crates/citum-schema-data/src/reference/conversion/contract_tests.rs
+++ b/crates/citum-schema-data/src/reference/conversion/contract_tests.rs
@@ -1,0 +1,208 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Contract test: every CSL 1.0.2 item type in
+//! [`csl_legacy::csl_json::CSL_TYPES`] converts to an `InputReference`
+//! whose `ref_type()` is a faithful round trip, not a silent collapse into
+//! the generic document/monograph fallback. See
+//! `docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md` for the canonicalization
+//! rules and the rationale behind each intentional divergence documented
+//! inline in [`EXPECTATIONS`] below.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    reason = "Panicking is acceptable and often desired in tests."
+)]
+
+use super::*;
+use csl_legacy::csl_json::CSL_TYPES;
+
+/// Build the minimal legacy reference the contract test converts for a
+/// given CSL type: an id, the type under test, a title, and an issued
+/// year. This is deliberately the *smallest* shape a real CSL-JSON export
+/// would carry. A type that needs more than this to avoid the generic
+/// document/monograph fallback is either a genuine routing gap (fix the
+/// converter, not this helper) or a documented, shape-dependent
+/// divergence (see the comments on [`EXPECTATIONS`] and the spec).
+fn minimal_reference(ref_type: &str) -> csl_legacy::csl_json::Reference {
+    csl_legacy::csl_json::Reference {
+        id: format!("contract-{ref_type}"),
+        ref_type: ref_type.to_string(),
+        title: Some("Contract Test Title".to_string()),
+        issued: Some(csl_legacy::csl_json::DateVariable {
+            date_parts: Some(vec![vec![2024]]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// Expected `ref_type()` output for every CSL 1.0.2 type, given the
+/// minimal shape [`minimal_reference`] builds. Most entries are the
+/// identity mapping; the ones that are not are intentional and documented
+/// inline (also recorded in
+/// `docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md`'s canonicalization table).
+const EXPECTATIONS: &[(&str, &str)] = &[
+    // Bare `article` carries no container-title, so the converter treats
+    // it as a standalone preprint rather than a truncated journal article
+    // — this mirrors real-world CSL-JSON exports where a container-less
+    // `article` is an arXiv/SSRN-style preprint. See `from_preprint_ref`.
+    ("article", "preprint"),
+    ("article-journal", "article-journal"),
+    ("article-magazine", "article-magazine"),
+    ("article-newspaper", "article-newspaper"),
+    // A minimal `bill` (no `authority`, `chapter-number`, or
+    // `container-title`/`volume`/`page` combination) carries none of the
+    // shape signals `from_bill_ref` uses to distinguish a hearing,
+    // bill-proceeding, or bill-record from a generic government
+    // document. See `reference/tests.rs` for the shapes that *do*
+    // round-trip distinctly (`test_parse_csl_bill_*`).
+    ("bill", "document"),
+    ("book", "book"),
+    ("broadcast", "broadcast"),
+    ("chapter", "chapter"),
+    ("classic", "classic"),
+    ("collection", "collection"),
+    ("dataset", "dataset"),
+    ("document", "document"),
+    ("entry", "entry"),
+    ("entry-dictionary", "entry-dictionary"),
+    ("entry-encyclopedia", "entry-encyclopedia"),
+    ("event", "event"),
+    ("figure", "figure"),
+    ("graphic", "graphic"),
+    ("hearing", "hearing"),
+    ("interview", "interview"),
+    // `legal_case` (the CSL 1.0.2 spelling) canonicalizes to the
+    // hyphenated `legal-case` on output, matching this codebase's
+    // convention of canonicalizing underscore CSL spellings to hyphens
+    // (see also `motion_picture`, `musical_score`,
+    // `personal_communication`).
+    ("legal_case", "legal-case"),
+    // `legislation` is the CSL 1.0.2 closed-vocabulary type; it routes to
+    // the same converter as the `statute` extension spelling and shares
+    // its canonical output.
+    ("legislation", "statute"),
+    ("manuscript", "manuscript"),
+    ("map", "map"),
+    ("motion_picture", "motion-picture"),
+    ("musical_score", "musical-score"),
+    ("pamphlet", "pamphlet"),
+    ("paper-conference", "paper-conference"),
+    ("patent", "patent"),
+    ("performance", "performance"),
+    ("periodical", "periodical"),
+    ("personal_communication", "personal-communication"),
+    ("post", "post"),
+    ("post-weblog", "post-weblog"),
+    ("regulation", "regulation"),
+    ("report", "report"),
+    ("review", "review"),
+    ("review-book", "review-book"),
+    ("software", "software"),
+    ("song", "song"),
+    ("speech", "speech"),
+    ("standard", "standard"),
+    ("thesis", "thesis"),
+    ("treaty", "treaty"),
+    ("webpage", "webpage"),
+];
+
+#[test]
+fn every_csl_1_0_2_type_has_an_expectation_table_entry() {
+    for csl_type in CSL_TYPES {
+        assert!(
+            EXPECTATIONS.iter().any(|(input, _)| input == csl_type),
+            "CSL_TYPES entry `{csl_type}` has no entry in the contract test's \
+             EXPECTATIONS table; every CSL 1.0.2 type must be covered"
+        );
+    }
+    assert_eq!(
+        EXPECTATIONS.len(),
+        CSL_TYPES.len(),
+        "EXPECTATIONS table size has drifted from CSL_TYPES; add or remove \
+         an entry so the two stay in lockstep"
+    );
+}
+
+#[test]
+fn every_csl_1_0_2_type_round_trips_through_ref_type() {
+    // Collect every mismatch instead of stopping at the first one: a
+    // routing regression usually breaks more than one type at a time, and
+    // seeing the whole set in one run is what turns this into a fast
+    // diagnostic instead of a bisection exercise (see the epic's problem
+    // statement in bean csl26-cvfy).
+    let failures: Vec<String> = EXPECTATIONS
+        .iter()
+        .filter_map(|(csl_type, expected)| {
+            let legacy = minimal_reference(csl_type);
+            let actual = InputReference::from(legacy).ref_type();
+            (&actual != expected)
+                .then(|| format!("{csl_type}: expected `{expected}`, got `{actual}`"))
+        })
+        .collect();
+
+    assert!(
+        failures.is_empty(),
+        "CSL type round-trip mismatches (see docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md):\n{}",
+        failures.join("\n")
+    );
+}
+
+/// Regression test for the `TLIB-SEL-MAP-1` fixture case
+/// (`tests/fixtures/references-expanded.json`): a `map` reference whose
+/// user-supplied genre uses a capitalized export label (`"Map"`, as
+/// Zotero emits) must still round-trip to the canonical lowercase `map`,
+/// not fall through the genre back-map into `document`. The back-map has
+/// matched genre case-insensitively since before the routing closure;
+/// this pins that behavior for all genre-discriminated document types.
+#[test]
+fn map_with_capitalized_export_genre_still_round_trips_as_map() {
+    let mut legacy = minimal_reference("map");
+    legacy.genre = Some("Map".to_string());
+
+    let converted = InputReference::from(legacy);
+
+    assert_eq!(converted.ref_type(), "map");
+}
+
+/// Regression test for the `chi-manuscript` fixture case (bean
+/// `csl26-shco`): a reference with top-level `"type": "manuscript"` and a
+/// note-field override `"type: collection"` must round-trip as
+/// `collection`, not silently collapse into the generic `document`
+/// fallback. CSL 1.0.2's `collection` is an *archival* collection
+/// (author, archive, archive-place), so it converts to the archival
+/// monograph/document shape — which carries those fields — with a
+/// genre-discriminated round trip, not to the editorial
+/// `ClassExtension::Collection` (anthology/proceedings), which has no
+/// author or archive fields and would drop them. See
+/// `docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md`.
+#[test]
+fn manuscript_with_recognized_collection_note_override_converts_to_collection() {
+    let mut legacy = minimal_reference("manuscript");
+    legacy.note = Some("type: collection".to_string());
+    legacy.archive = Some("University of Georgia Library".to_string());
+    legacy.parse_note_field_hacks();
+
+    assert_eq!(legacy.ref_type, "collection");
+
+    let converted = InputReference::from(legacy);
+
+    assert_eq!(converted.ref_type(), "collection");
+    let crate::reference::ClassExtension::Monograph(monograph) = converted.extension() else {
+        panic!(
+            "expected the archival Monograph shape for a `collection` conversion, got `{}`",
+            converted.ref_type()
+        );
+    };
+    assert_eq!(
+        monograph.archive.as_deref(),
+        Some("University of Georgia Library"),
+        "archival fields must survive the collection conversion"
+    );
+}

--- a/crates/citum-schema-data/src/reference/conversion/mod.rs
+++ b/crates/citum-schema-data/src/reference/conversion/mod.rs
@@ -20,6 +20,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! `RefContext` struct that bundles the fields every converter pre-extracts
 //! live here in `mod.rs` so submodules can pull them in with `use super::*;`.
 
+#[cfg(test)]
+mod contract_tests;
 mod legal;
 mod media;
 mod scholarly;
@@ -355,7 +357,9 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
             | "post-weblog"
             | "interview"
             | "personal_communication"
-            | "personal-communication" => scholarly::from_monograph_ref(legacy, ctx),
+            | "personal-communication"
+            | "musical_score"
+            | "pamphlet" => scholarly::from_monograph_ref(legacy, ctx),
             "report"
                 if legacy.page.is_some()
                     && (legacy.editor.is_some() || legacy.container_title.is_some()) =>
@@ -363,12 +367,10 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
                 scholarly::from_collection_component_ref(legacy, ctx)
             }
             "report" => scholarly::from_monograph_ref(legacy, ctx),
-            "chapter" | "paper-conference" | "entry-dictionary" | "entry-encyclopedia" => {
-                scholarly::from_collection_component_ref(legacy, ctx)
-            }
-            "article-journal" | "article-magazine" | "article-newspaper" => {
-                scholarly::from_serial_component_ref(legacy, ctx)
-            }
+            "chapter" | "paper-conference" | "entry" | "entry-dictionary"
+            | "entry-encyclopedia" => scholarly::from_collection_component_ref(legacy, ctx),
+            "article-journal" | "article-magazine" | "article-newspaper" | "review"
+            | "review-book" => scholarly::from_serial_component_ref(legacy, ctx),
             "article" => {
                 if legacy.container_title.is_none() {
                     scholarly::from_preprint_ref(legacy, ctx)
@@ -378,7 +380,9 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
             }
             "motion_picture" | "song" => media::from_audio_visual_ref(legacy, ctx),
             "broadcast" => scholarly::from_serial_component_ref(legacy, ctx),
-            "speech" | "presentation" | "event" => scholarly::from_event_ref(legacy, ctx),
+            "speech" | "presentation" | "performance" | "event" => {
+                scholarly::from_event_ref(legacy, ctx)
+            }
             "bill" => legal::from_bill_ref(legacy, ctx),
             "hearing" => legal::from_hearing_ref(legacy, ctx),
             "legal-case" | "legal_case" => legal::from_legal_case_ref(legacy, ctx),
@@ -388,7 +392,34 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
             "standard" => legal::from_standard_ref(legacy, ctx),
             "patent" => legal::from_patent_ref(legacy, ctx),
             "dataset" => scholarly::from_dataset_ref(legacy, ctx),
-            _ => scholarly::from_document_ref(legacy, ctx),
+            // `collection` is CSL 1.0.2's *archival* collection (a body of
+            // manuscripts/papers held by an archive: author, archive,
+            // archive-place). It routes with the other archival/document
+            // shapes so those fields survive; Citum's editorial
+            // `ClassExtension::Collection` (anthology/proceedings) has no
+            // author or archive fields and would silently drop them. See
+            // docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md.
+            "document" | "map" | "figure" | "graphic" | "periodical" | "collection" => {
+                scholarly::from_document_ref(legacy, ctx)
+            }
+            _ => {
+                // Every CSL 1.0.2 type string has an explicit arm above; a
+                // known type reaching this fallback means a routing arm was
+                // dropped, not that the type is genuinely unmapped.
+                //
+                // TODO(csl26-1bdr): Layer 5 `CompatibilityWarning` plumbing
+                // will surface unrecognized types as a soft-degrade warning
+                // rather than silent fall-through. Until then this
+                // fallback mirrors the ClassExtension::Unknown loud-fail
+                // pattern in accessors.rs.
+                debug_assert!(
+                    !csl_legacy::csl_json::CSL_TYPES.contains(&legacy.ref_type.as_str()),
+                    "unmapped CSL 1.0.2 type `{}` fell through to the document fallback; \
+                     add a routing arm in conversion/mod.rs",
+                    legacy.ref_type
+                );
+                scholarly::from_document_ref(legacy, ctx)
+            }
         }
     }
 }

--- a/crates/citum-schema-data/src/reference/conversion/scholarly.rs
+++ b/crates/citum-schema-data/src/reference/conversion/scholarly.rs
@@ -285,6 +285,20 @@ pub(super) fn from_monograph_ref(
         }));
     }
 
+    // Seed genre from ref_type for CSL types whose round trip through
+    // `ref_type()` depends on genre (see `monograph_ref_type`'s Book and
+    // Post arms in accessors.rs); never overwrites a user-supplied genre.
+    // `post-weblog` needs this too: it shares `MonographType::Post` with
+    // plain `post` (both match `ref_type.contains("post")` above), so
+    // genre is the only signal that distinguishes them on the way back out.
+    let genre = legacy.genre.clone().or_else(|| {
+        matches!(
+            legacy.ref_type.as_str(),
+            "musical_score" | "pamphlet" | "post-weblog"
+        )
+        .then(|| legacy.ref_type.clone())
+    });
+
     InputReference::Monograph(Box::new(Monograph {
         id: ctx.id,
         r#type,
@@ -318,7 +332,7 @@ pub(super) fn from_monograph_ref(
         supplement_number: None,
         printing_number: legacy.printing_number,
         numbering,
-        genre: legacy.genre,
+        genre,
         medium: legacy.medium,
         archive,
         archive_location: legacy.archive_location,
@@ -543,6 +557,7 @@ fn collection_component_metadata(
         genre = match legacy.ref_type.as_str() {
             "entry-dictionary" => Some("entry-dictionary".to_string()),
             "entry-encyclopedia" => Some("entry-encyclopedia".to_string()),
+            "entry" => Some("entry".to_string()),
             _ => None,
         };
     }
@@ -638,6 +653,9 @@ pub(super) fn from_serial_component_ref(
     let mut genre = legacy.genre.clone();
     if legacy.ref_type == "entry-encyclopedia" && genre.is_none() {
         genre = Some("entry-encyclopedia".to_string());
+    }
+    if matches!(legacy.ref_type.as_str(), "review" | "review-book") && genre.is_none() {
+        genre = Some(legacy.ref_type.clone());
     }
     let host_names = legacy_extra_names(&legacy, "host");
     let narrator_names = legacy_extra_names(&legacy, "narrator");
@@ -852,12 +870,15 @@ pub(super) fn from_document_ref(
 
     let volume = legacy.volume.map(|v| v.to_string());
     let number = legacy.number.clone();
-    let genre = legacy.genre.or_else(|| {
-        if legacy.ref_type == "map" {
-            Some("map".to_string())
-        } else {
-            None
-        }
+    // Seed genre from ref_type for CSL types whose round trip through
+    // `ref_type()` depends on genre (see `monograph_ref_type`'s Document
+    // arm in accessors.rs); never overwrites a user-supplied genre.
+    let genre = legacy.genre.clone().or_else(|| {
+        matches!(
+            legacy.ref_type.as_str(),
+            "map" | "figure" | "graphic" | "periodical" | "collection"
+        )
+        .then(|| legacy.ref_type.clone())
     });
     let author = legacy.author.clone().map(Contributor::from);
     let editor = legacy.editor.clone().map(Contributor::from);
@@ -1062,7 +1083,13 @@ pub(super) fn from_event_ref(
         location: event_place.or(legacy.publisher_place.clone()),
         date: event_date.or_else(|| (!ctx.issued.is_empty()).then_some(ctx.issued)),
         available_date,
-        genre: legacy.genre,
+        // Seed genre from ref_type for CSL types whose round trip through
+        // `ref_type()` depends on genre (see `event_ref_type` in
+        // accessors.rs); never overwrites a user-supplied genre.
+        genre: legacy.genre.clone().or_else(|| {
+            matches!(legacy.ref_type.as_str(), "speech" | "performance")
+                .then(|| legacy.ref_type.clone())
+        }),
         network: None,
         contributors,
         url: ctx.url,

--- a/crates/citum-schema-data/src/reference/tests.rs
+++ b/crates/citum-schema-data/src/reference/tests.rs
@@ -726,6 +726,24 @@ fn conversion_preserves_pre_existing_fields() {
 }
 
 #[test]
+fn conversion_ignores_unrecognized_note_type_override_and_keeps_the_line() {
+    let json = r#"{
+        "id": "note-type-typo",
+        "type": "book",
+        "note": "type: colection"
+    }"#;
+
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(json).unwrap();
+    let reference: InputReference = legacy.into();
+
+    assert_eq!(reference.ref_type(), "book");
+    assert_eq!(
+        reference.note(),
+        Some(super::RichText::Plain("type: colection".to_string()))
+    );
+}
+
+#[test]
 fn test_audio_visual_film_round_trip() {
     let yaml = r#"
 class: audio-visual

--- a/crates/csl-legacy/src/csl_json.rs
+++ b/crates/csl-legacy/src/csl_json.rs
@@ -502,8 +502,16 @@ impl Reference {
 
             // Process the key-value pair; only mark as parsed when the key is recognized
             if key.eq_ignore_ascii_case("type") {
-                self.ref_type = value.to_string();
-                parsed_indices.insert(idx);
+                // Only apply the override when `value` is a recognized CSL
+                // type (1.0.2 or a known extension). An unrecognized value
+                // (typo, or a vocabulary the current release doesn't know)
+                // is left alone: the top-level `type` wins, and the line
+                // stays in the rebuilt `note` rather than being silently
+                // consumed. See docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md.
+                if CSL_TYPES.contains(&value) || CSL_TYPE_EXTENSIONS.contains(&value) {
+                    self.ref_type = value.to_string();
+                    parsed_indices.insert(idx);
+                }
             } else if is_date_variable(key) {
                 handle_date_variable(self, key, value);
                 parsed_indices.insert(idx);
@@ -992,6 +1000,42 @@ mod tests {
         ref_obj.parse_note_field_hacks();
         assert_eq!(ref_obj.ref_type, "article-journal");
         assert_eq!(ref_obj.note, None);
+    }
+
+    #[test]
+    fn test_parse_note_field_type_override_recognizes_extension_spelling() {
+        // "legal-case" is not itself in CSL_TYPES (the CSL 1.0.2 spelling
+        // is "legal_case"), but it is a known CSL_TYPE_EXTENSIONS entry,
+        // so the override must still apply.
+        let mut ref_obj = Reference {
+            id: "test".to_string(),
+            ref_type: "document".to_string(),
+            note: Some("type: legal-case".to_string()),
+            ..Default::default()
+        };
+
+        ref_obj.parse_note_field_hacks();
+        assert_eq!(ref_obj.ref_type, "legal-case");
+        assert_eq!(ref_obj.note, None);
+    }
+
+    #[test]
+    fn test_parse_note_field_unrecognized_type_override_is_ignored() {
+        // "colection" is a typo (missing an "l") and matches neither
+        // CSL_TYPES nor CSL_TYPE_EXTENSIONS. The top-level type must win,
+        // and the unrecognized line stays in the rebuilt note instead of
+        // being silently consumed. See
+        // docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md.
+        let mut ref_obj = Reference {
+            id: "test".to_string(),
+            ref_type: "book".to_string(),
+            note: Some("type: colection".to_string()),
+            ..Default::default()
+        };
+
+        ref_obj.parse_note_field_hacks();
+        assert_eq!(ref_obj.ref_type, "book");
+        assert_eq!(ref_obj.note, Some("type: colection".to_string()));
     }
 
     #[test]

--- a/crates/csl-legacy/src/csl_json.rs
+++ b/crates/csl-legacy/src/csl_json.rs
@@ -14,6 +14,97 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::{HashMap, HashSet};
 
+/// Canonical CSL 1.0.2 item-type vocabulary.
+///
+/// Source: `schemas/styles/csl-types.rnc` at the tagged `v1.0.2` release of
+/// the CSL schema repository
+/// (<https://github.com/citation-style-language/schema/blob/v1.0.2/schemas/styles/csl-types.rnc>,
+/// verified identical against `master` at time of writing). This is the
+/// complete, closed set of `"type"` strings a conformant CSL 1.0.2 producer
+/// may emit. It is the source of truth consumed by:
+///
+/// - the CSL-type routing table in
+///   `citum_schema_data::reference::conversion` (every entry here must
+///   have an explicit routing arm — see
+///   `docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md`);
+/// - [`Reference::parse_note_field_hacks`], which validates `note:`-field
+///   `type: X` overrides against this list (plus [`CSL_TYPE_EXTENSIONS`])
+///   before applying them.
+pub const CSL_TYPES: &[&str] = &[
+    "article",
+    "article-journal",
+    "article-magazine",
+    "article-newspaper",
+    "bill",
+    "book",
+    "broadcast",
+    "chapter",
+    "classic",
+    "collection",
+    "dataset",
+    "document",
+    "entry",
+    "entry-dictionary",
+    "entry-encyclopedia",
+    "event",
+    "figure",
+    "graphic",
+    "hearing",
+    "interview",
+    "legal_case",
+    "legislation",
+    "manuscript",
+    "map",
+    "motion_picture",
+    "musical_score",
+    "pamphlet",
+    "paper-conference",
+    "patent",
+    "performance",
+    "periodical",
+    "personal_communication",
+    "post",
+    "post-weblog",
+    "regulation",
+    "report",
+    "review",
+    "review-book",
+    "software",
+    "song",
+    "speech",
+    "standard",
+    "thesis",
+    "treaty",
+    "webpage",
+];
+
+/// Non-CSL-1.0.2 `"type"` strings the legacy conversion layer also treats
+/// as first-class inputs.
+///
+/// These spellings show up in real-world CSL-JSON exports (Zotero,
+/// BibTeX/BibLaTeX round-trips, etc.) but are not part of the official CSL
+/// 1.0.2 vocabulary in [`CSL_TYPES`]. They are accepted because
+/// `citum_schema_data::reference::conversion`'s routing table has
+/// historically routed them like a known type, not because a producer
+/// following the CSL 1.0.2 spec would ever emit them. Listed here so
+/// [`Reference::parse_note_field_hacks`] recognizes them too, and so the
+/// conversion-layer contract test can distinguish "known extension" from
+/// "unrecognized/typo".
+pub const CSL_TYPE_EXTENSIONS: &[&str] = &[
+    // Zotero/BibLaTeX "manual" export; routed like a technical manual.
+    "manual",
+    // Historical alias accepted alongside `speech`/`event`; routed to the
+    // event converter.
+    "presentation",
+    // Hyphenated respelling of the CSL 1.0.2 `personal_communication` type.
+    "personal-communication",
+    // Hyphenated respelling of the CSL 1.0.2 `legal_case` type.
+    "legal-case",
+    // Not part of CSL 1.0.2 (`legislation` is the closed-vocabulary
+    // equivalent); routed to the same statute converter as `legislation`.
+    "statute",
+];
+
 /// A bibliographic reference item.
 /// This is compatible with CSL-JSON format.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,8 @@ ignore = [
     { id = "RUSTSEC-2025-0141", reason = "Transitive through deno_core and syntect; no direct dependency or safe local replacement in this PR." },
     { id = "RUSTSEC-2026-0186", reason = "memmap2 unsound: transitive through gix-ref/gix-protocol/gix; no upstream memmap2 fix available in the gix ecosystem yet." },
     { id = "RUSTSEC-2026-0192", reason = "ttf-parser unmaintained: transitive through the current Typst stack; no direct dependency or actionable local patch path in this PR." },
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml quadratic attribute check: transitive through the Typst stack (citationberg/hayagriva at 0.38.4, syntect/plist at 0.39.4); the fix requires quick-xml >=0.41, a breaking bump those upstreams have not shipped yet." },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml NsReader memory-exhaustion DoS: same transitive paths and fix version as RUSTSEC-2026-0194." },
 ]
 
 [licenses]

--- a/docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md
+++ b/docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md
@@ -1,0 +1,321 @@
+# CSL 1.0.2 Type Conversion Contract
+
+**Status:** Draft
+**Version:** 1.0
+**Date:** 2026-07-02
+**Supersedes:** None
+**Related:** bean `csl26-cvfy`, bean `csl26-shco`, bean `csl26-1bdr`, [`INPUT_REFERENCE_CLASS_DISCRIMINATOR.md`](./INPUT_REFERENCE_CLASS_DISCRIMINATOR.md)
+
+## Purpose
+
+Legacy CSL-JSON references convert to `InputReference` through two
+unvalidated hops: a `note:`-field `type: X` override
+(`csl_legacy::csl_json::Reference::parse_note_field_hacks`) that
+unconditionally rewrites the top-level `type`, and a hand-maintained
+routing `match` (`citum_schema_data::reference::conversion`) that silently
+falls through to a generic document/monograph shape for any CSL type
+string it doesn't recognize. Neither hop is checked against the actual
+CSL 1.0.2 type vocabulary, so a real CSL type with no routing arm — or a
+typo in a `note:` override — reclassifies a reference with no error, no
+warning, and no test failure. The only way the defect surfaces is a wrong
+citation downstream, several pipeline layers away from the actual cause
+(see the root-cause investigation logged in bean `csl26-cvfy`, root-caused
+to a `chi-manuscript` fixture case in the `chicago-shared-corpus` suite,
+tracked separately as bean `csl26-shco`).
+
+This spec establishes the CSL 1.0.2 vocabulary as a source of truth, adds
+a contract test that asserts every type in that vocabulary produces a
+faithful (non-fallback) `ref_type()` round trip, closes every routing gap
+the contract test found, and validates the `note:`-field override against
+the same vocabulary.
+
+## Scope
+
+In scope:
+- The canonical CSL 1.0.2 item-type vocabulary (`CSL_TYPES`) and the
+  non-CSL-1.0.2 spellings the conversion layer already accepts
+  (`CSL_TYPE_EXTENSIONS`), both in `crates/csl-legacy/src/csl_json.rs`.
+- Closing every CSL 1.0.2 routing gap in
+  `citum_schema_data::reference::conversion` so each type produces a
+  `ref_type()` round trip that is not a silent collapse into the generic
+  document/monograph fallback.
+- Making the routing fallback loud in debug builds when it receives a
+  known CSL 1.0.2 type (mirrors the existing `ClassExtension::Unknown`
+  pattern in `accessors.rs`).
+- Validating the `note:`-field `type: X` override against the vocabulary
+  before applying it.
+- The canonicalization/equivalence table: which `ref_type()` output counts
+  as a faithful round trip for each CSL 1.0.2 input type, including the
+  intentional divergences.
+
+Out of scope (see [Non-goals](#non-goals)):
+- `CompatibilityWarning` plumbing for the loud-fail path (owned by bean
+  `csl26-1bdr` / `FORWARD_COMPATIBILITY.md`).
+- Attributed fidelity reporting in `oracle.js`/`report-core.js` (Phase 5,
+  tracked as a follow-on bean).
+- Driving `chicago-shared-corpus` or any other style to 100% fidelity
+  (bean `csl26-shco`'s scope, not this one).
+- Any change to `InputReference`'s wire shape or the class discriminator
+  design (`csl26-1bdr`'s settled scope).
+
+## Design
+
+### CSL 1.0.2 vocabulary as source of truth
+
+`crates/csl-legacy/src/csl_json.rs` defines two public constants:
+
+```rust
+pub const CSL_TYPES: &[&str] = &[ /* 45 entries */ ];
+pub const CSL_TYPE_EXTENSIONS: &[&str] = &[ /* 5 entries */ ];
+```
+
+`CSL_TYPES` is sourced from `schemas/styles/csl-types.rnc` at the tagged
+`v1.0.2` release of the [CSL schema
+repository](https://github.com/citation-style-language/schema/blob/v1.0.2/schemas/styles/csl-types.rnc)
+(verified identical against `master` at the time of writing), and contains
+exactly these 45 strings:
+
+```text
+article, article-journal, article-magazine, article-newspaper, bill,
+book, broadcast, chapter, classic, collection, dataset, document, entry,
+entry-dictionary, entry-encyclopedia, event, figure, graphic, hearing,
+interview, legal_case, legislation, manuscript, map, motion_picture,
+musical_score, pamphlet, paper-conference, patent, performance,
+periodical, personal_communication, post, post-weblog, regulation,
+report, review, review-book, software, song, speech, standard, thesis,
+treaty, webpage
+```
+
+**`regulation` is confirmed CSL 1.0.2, not CSL-M.** The `v1.0.2`-tagged
+schema file was fetched and diffed against `master`; both contain
+`regulation` in the type list. It stays in `CSL_TYPES`, not a CSL-M
+extensions list.
+
+`CSL_TYPE_EXTENSIONS` audits the routing table for strings the conversion
+layer has historically accepted that are **not** part of CSL 1.0.2:
+
+| Extension string | Why it's accepted |
+|---|---|
+| `manual` | Zotero/BibLaTeX "manual" export; routed like a technical manual (`MonographType::Manual`). |
+| `presentation` | Historical alias accepted alongside `speech`/`event`; routed to the event converter. |
+| `personal-communication` | Hyphenated respelling of the CSL 1.0.2 `personal_communication` type. |
+| `legal-case` | Hyphenated respelling of the CSL 1.0.2 `legal_case` type. |
+| `statute` | Not part of CSL 1.0.2 (`legislation` is the closed-vocabulary equivalent); routed to the same converter and shares its canonical output. |
+
+Both constants are consumed by:
+1. The conversion-layer contract test
+   (`citum_schema_data::reference::conversion::contract_tests`), which
+   iterates `CSL_TYPES` and asserts a faithful round trip.
+2. The routing fallback's `debug_assert!` (see [Loud-fail
+   design](#loud-fail-design-for-the-routing-fallback)).
+3. `Reference::parse_note_field_hacks`, which validates `note:`-field type
+   overrides against `CSL_TYPES ∪ CSL_TYPE_EXTENSIONS` (see [Note-field
+   override policy](#note-field-override-policy)).
+
+### Canonicalization / equivalence table
+
+`ref_type()` is not required to echo the input string verbatim — several
+CSL 1.0.2 types have a **documented, intentional** canonical output that
+differs from the input spelling. The contract test's `EXPECTATIONS` table
+in `conversion/contract_tests.rs` encodes exactly these mappings; this
+table is the authoritative list.
+
+| CSL 1.0.2 input | Canonical `ref_type()` output | Rationale |
+|---|---|---|
+| `legal_case` | `legal-case` | Codebase-wide convention: underscore CSL spellings canonicalize to hyphens on output (pre-existing, not introduced by this spec). |
+| `motion_picture` | `motion-picture` | Same convention. |
+| `musical_score` | `musical-score` | Same convention (new arm added by this spec). |
+| `personal_communication` | `personal-communication` | Same convention (pre-existing). |
+| `legislation` | `statute` | `legislation` is the CSL 1.0.2 closed-vocabulary type; it routes to the same converter as the `statute` extension spelling and shares its canonical output — there is no separate `Legislation` class. |
+| `article` (no `container-title`) | `preprint` | A container-less `article` has no journal context; the converter treats it as a standalone preprint (arXiv/SSRN-style), which matches how such exports actually occur in the wild. See `from_preprint_ref`. |
+| `bill` (minimal shape: no `authority`, `chapter-number`, or `container-title`+`volume`+`page`) | `document` | `from_bill_ref` is deliberately polymorphic: `title`+`authority` → hearing; titleless+`authority`/`chapter-number` → `bill-proceeding` genre; titleless+`container-title`+`volume`+`page` → `bill-record` genre. A minimal bill with none of those signals is indistinguishable from a generic government document, and real CSL-JSON `bill` exports always carry one of the distinguishing shapes (see `reference/tests.rs`'s `test_parse_csl_bill_*` tests for the shapes that *do* round-trip distinctly). |
+
+All other CSL 1.0.2 types round-trip to the identical string.
+
+### Routing closure
+
+Before this spec, `citum_schema_data::reference::conversion::mod`'s
+top-level `match legacy.ref_type.as_str()` had no arm — direct or via
+genre-seeding — for: `collection`, `entry`, `figure`, `graphic`,
+`musical_score`, `pamphlet`, `performance`, `periodical`, `review`,
+`review-book`. Three further types had an arm but did not round-trip
+correctly under the contract test's minimal-fixture shape: `map` and
+`document` reached the correct constructor only via the (soon-to-be-loud)
+wildcard arm, and `speech` reached `from_event_ref` but `event_ref_type`
+had no way to recover `"speech"` from an empty `genre` field (a real gap
+found while writing the contract test, not anticipated at bean-filing
+time). A twelfth gap, `post-weblog` silently collapsing to `"post"`, was
+also found this way — `post-weblog` had a working routing arm but shared
+`MonographType::Post` with plain `post` and nothing distinguished them on
+the way back out.
+
+Each gap closes with the same shape: route to an existing (or, for
+`collection`, one new) constructor, and seed `genre` from `ref_type` only
+when the legacy reference didn't already supply one — this is the
+established pattern (`from_document_ref`'s pre-existing `"map"` handling)
+generalized to the other genre-discriminated types:
+
+| CSL type | Route | Round-trip mechanism |
+|---|---|---|
+| `collection` | New `scholarly::from_collection_ref` → `ClassExtension::Collection` | `ref_type()` already maps every non-`EditedBook` `CollectionType` back to `"collection"`. |
+| `document` | Explicit arm → `from_document_ref` (previously only reachable via the wildcard) | Already `"document"`. |
+| `entry` | `from_collection_component_ref` | Genre seeded `"entry"`; `collection_component_ref_type` gains an `entry` arm. |
+| `figure`, `graphic` | `from_document_ref` | Genre seeded from `ref_type`; `monograph_ref_type`'s `Document` arm gains `figure`/`graphic`. |
+| `map` | Explicit arm → `from_document_ref` (genre logic pre-existing) | Unchanged behavior, now reachable without falling through the loud wildcard. |
+| `musical_score`, `pamphlet` | `from_monograph_ref` (stays `MonographType::Book`) | Genre seeded from `ref_type`; `monograph_ref_type`'s `Book` arm checks genre first (`musical_score` → `"musical-score"`, `pamphlet` → `"pamphlet"`). |
+| `performance` | `from_event_ref` | Genre seeded from `ref_type`; `event_ref_type` gains a `contains("performance")` arm. |
+| `periodical` | `from_document_ref` (judgment call, see below) | Genre seeded from `ref_type`; `monograph_ref_type`'s `Document` arm gains `periodical`. |
+| `review`, `review-book` | `from_serial_component_ref` | Genre seeded from `ref_type`; `serial_component_ref_type` checks genre before falling back to container-type inference. |
+| `speech` | Unchanged route (`from_event_ref`) | Genre seeded from `ref_type` when absent — this is the fix; the routing arm already existed. |
+| `post-weblog` | Unchanged route (`from_monograph_ref`) | Genre seeded `"post-weblog"`; `monograph_ref_type`'s `Post` arm checks genre before defaulting to `"post"`. |
+
+**Genre-seeding never overwrites a user-supplied genre.** Every seeding
+site uses `legacy.genre.clone().or_else(|| matches!(...).then(|| ...))` —
+if the legacy reference already carries an explicit `genre`, that value
+wins and the CSL-type-derived seed is not applied. This means a
+`musical_score` (or any seeded type) with an explicit, unrelated `genre`
+value degrades gracefully: it round-trips through whatever `ref_type()`
+its actual genre implies, not through the seeded value. This is an
+accepted, pre-existing trade-off (the same trade-off `from_document_ref`'s
+original `"map"` handling already made) — the contract test only exercises
+the minimal shape, so this edge case is not separately asserted, but it is
+the same shape of divergence already accepted for `map`, `bill-proceeding`,
+and `bill-record`.
+
+**`periodical` routing decision.** `periodical` describes a standalone
+reference to a serial publication itself (the publication, not an
+article within it) — semantically closer to a generic bibliographic
+document than to a `Serial` container, which in this codebase exists only
+as an embedded parent for `SerialComponent`/`Collection`-style relations,
+never as a freestanding top-level reference type. Building a dedicated
+standalone-`Serial` constructor for a rarely-used CSL type would add a new
+shape with no other caller, for a case the genre-tagged `Document`
+pathway already serves adequately. `from_document_ref` + genre was
+chosen for the same reason `figure`/`graphic`/`map` were: minimal new
+surface area, consistent with the established genre-discrimination
+pattern.
+
+**Underscore/hyphen spellings.** New arms accept the CSL 1.0.2 spelling
+only (`musical_score`, not `musical-score`) — this mirrors the
+instruction to "accept the CSL spelling" rather than proactively
+inventing new hyphen aliases; `legal_case`/`legal-case` and
+`personal_communication`/`personal-communication` accepting both
+spellings is pre-existing behavior this spec did not extend to the new
+types.
+
+### Loud-fail design for the routing fallback
+
+The routing `match`'s final wildcard arm still falls through to
+`from_document_ref` (unconditional fallback is required — an
+unrecognized `type:` string, e.g. a producer-specific extension this
+codebase has never seen, must still parse into *something* usable), but
+it is now preceded by a `debug_assert!` that fires if the fallen-through
+type is a **known** CSL 1.0.2 type:
+
+```rust
+debug_assert!(
+    !csl_legacy::csl_json::CSL_TYPES.contains(&legacy.ref_type.as_str()),
+    "unmapped CSL 1.0.2 type `{}` fell through to the document fallback; \
+     add a routing arm in conversion/mod.rs",
+    legacy.ref_type
+);
+```
+
+This mirrors the `ClassExtension::Unknown` arm of `InputReference::ref_type()`
+(`accessors.rs`, `TODO(csl26-1bdr)`) exactly in spirit: a `debug_assert!`
+plus a `TODO(csl26-1bdr)` comment gesturing at the same future
+`CompatibilityWarning` plumbing that bean owns. No new warning
+infrastructure is built here — this spec deliberately reuses the existing
+pattern rather than diverging into a second ad hoc mechanism.
+`debug_assert!` was chosen over a hard `panic!`/`Result` because
+`InputReference::from` is an infallible `From` impl consumed throughout
+the codebase (CLI, migrate, engine); changing its signature to fallible is
+out of scope, and a silent-in-release/loud-in-debug assertion is the
+same trade-off the existing `Unknown`-class pattern already made.
+
+### Note-field override policy
+
+`Reference::parse_note_field_hacks` applies a `note:`-field `type: X`
+line only when `X` is in `CSL_TYPES ∪ CSL_TYPE_EXTENSIONS`:
+
+```rust
+if key.eq_ignore_ascii_case("type") {
+    if CSL_TYPES.contains(&value) || CSL_TYPE_EXTENSIONS.contains(&value) {
+        self.ref_type = value.to_string();
+        parsed_indices.insert(idx);
+    }
+    // else: leave ref_type and the note line untouched.
+}
+```
+
+**Policy: ignore and keep, not apply-and-warn.** An unrecognized override
+(a typo, e.g. `type: colection`, or a future vocabulary term this release
+doesn't know) does **not** change `ref_type`, and the `note:` line is
+**not** consumed — it stays in the rebuilt `note` field rather than being
+silently swallowed. This was an explicit product decision (locked before
+implementation): the alternative — apply the override anyway and flag a
+`CompatibilityWarning` — was rejected because it still risks routing a
+reference through a class-specific converter that has never seen that
+`ref_type` string, hitting the *same* generic-fallback problem this spec
+exists to close, just one layer earlier. Ignoring preserves the top-level
+`type`, which is guaranteed to be routable (or itself loudly asserted, see
+above), and leaves a human-readable trace (the unconsumed note line) for
+whoever investigates the data quality issue.
+
+This is also what makes the `chi-manuscript` regression fixable: the
+reference's note carries `type: collection`, and `collection` is a real
+CSL 1.0.2 type (already in `CSL_TYPES`), so the override is recognized
+and applied — the reference correctly becomes a `collection`, not a
+`manuscript` with a discarded override. The bug was never in the
+override-validation policy; it was the missing `collection` routing arm
+(see [Routing closure](#routing-closure)).
+
+## Non-goals
+
+- **`CompatibilityWarning` plumbing.** The loud-fail `debug_assert!` in
+  the routing fallback is deliberately the same stopgap the
+  `ClassExtension::Unknown` arm already uses. Wiring both into a real
+  warning channel is bean `csl26-1bdr`'s Layer 5 scope, tracked by the
+  `TODO(csl26-1bdr)` comments this spec adds.
+- **Attributed fidelity reporting (Phase 5).** Exposing per-reference
+  conversion diagnostics from `citum render refs --json` (e.g., "rendered
+  via fallback/default type") so `scripts/oracle.js` and
+  `scripts/report-core.js` can tag a failing fixture case as
+  "conversion-layer suspect" before it's counted as a style-fidelity
+  failure is out of scope for this spec. Tracked as a follow-on task
+  under bean `csl26-cvfy` (see the epic's todo list) for a separate PR.
+- **Driving any specific style to 100% fidelity.** `chicago-shared-corpus`
+  and any other style's remaining fixture failures are bean `csl26-shco`'s
+  scope. This spec closes the conversion-layer defect the `chi-manuscript`
+  case exposed; it does not audit or fix other failures in that corpus.
+- **`InputReference` wire-shape changes.** No change to the class
+  discriminator design settled in
+  [`INPUT_REFERENCE_CLASS_DISCRIMINATOR.md`](./INPUT_REFERENCE_CLASS_DISCRIMINATOR.md).
+
+## Acceptance Criteria
+
+- [ ] `CSL_TYPES` and `CSL_TYPE_EXTENSIONS` defined in
+      `crates/csl-legacy/src/csl_json.rs` with provenance documented in
+      `///` comments.
+- [ ] `conversion::contract_tests::every_csl_1_0_2_type_round_trips_through_ref_type`
+      asserts every `CSL_TYPES` entry against the canonicalization table
+      above, with zero allowlisted exceptions.
+- [ ] `conversion::contract_tests::manuscript_with_recognized_collection_note_override_converts_to_collection`
+      reproduces and fixes the `chi-manuscript` regression.
+- [ ] Every routing gap in the table above has an explicit arm; the
+      wildcard fallback carries the `debug_assert!` loud-fail.
+- [ ] `Reference::parse_note_field_hacks` validates `type:` overrides
+      against `CSL_TYPES ∪ CSL_TYPE_EXTENSIONS`; unrecognized overrides
+      are ignored and the note line is preserved (tests in
+      `crates/csl-legacy/src/csl_json.rs` and
+      `crates/citum-schema-data/src/reference/tests.rs`).
+- [ ] Phase 5 (attributed fidelity reporting) — tracked as a follow-on
+      bean, not required for this spec's Active status.
+- [ ] `node scripts/report-core.js --style chicago-notes-18th` re-run to
+      confirm `chi-manuscript` improves — tracked in bean `csl26-cvfy`'s
+      todo list, not part of this implementation PR.
+
+## Changelog
+
+- v1.0 (2026-07-02): Initial version; spec flips to Active in the same
+  commit that lands the routing closure.

--- a/docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md
+++ b/docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md
@@ -1,6 +1,6 @@
 # CSL 1.0.2 Type Conversion Contract
 
-**Status:** Draft
+**Status:** Active
 **Version:** 1.0
 **Date:** 2026-07-02
 **Supersedes:** None
@@ -149,15 +149,15 @@ also found this way — `post-weblog` had a working routing arm but shared
 `MonographType::Post` with plain `post` and nothing distinguished them on
 the way back out.
 
-Each gap closes with the same shape: route to an existing (or, for
-`collection`, one new) constructor, and seed `genre` from `ref_type` only
-when the legacy reference didn't already supply one — this is the
-established pattern (`from_document_ref`'s pre-existing `"map"` handling)
-generalized to the other genre-discriminated types:
+Each gap closes with the same shape: route to an existing constructor,
+and seed `genre` from `ref_type` only when the legacy reference didn't
+already supply one — this is the established pattern
+(`from_document_ref`'s pre-existing `"map"` handling) generalized to the
+other genre-discriminated types:
 
 | CSL type | Route | Round-trip mechanism |
 |---|---|---|
-| `collection` | New `scholarly::from_collection_ref` → `ClassExtension::Collection` | `ref_type()` already maps every non-`EditedBook` `CollectionType` back to `"collection"`. |
+| `collection` | `from_document_ref` (see the archival-semantics note below) | Genre seeded from `ref_type`; `monograph_ref_type`'s `Document` arm gains `collection`. |
 | `document` | Explicit arm → `from_document_ref` (previously only reachable via the wildcard) | Already `"document"`. |
 | `entry` | `from_collection_component_ref` | Genre seeded `"entry"`; `collection_component_ref_type` gains an `entry` arm. |
 | `figure`, `graphic` | `from_document_ref` | Genre seeded from `ref_type`; `monograph_ref_type`'s `Document` arm gains `figure`/`graphic`. |
@@ -181,6 +181,26 @@ original `"map"` handling already made) — the contract test only exercises
 the minimal shape, so this edge case is not separately asserted, but it is
 the same shape of divergence already accepted for `map`, `bill-proceeding`,
 and `bill-record`.
+
+**`collection` routing decision (archival, not editorial).** CSL 1.0.2's
+`collection` denotes an **archival collection** — a body of manuscripts or
+papers held by an archive, carrying an author/creator, an `archive`, an
+`archive-place`, and often an `archive_collection` note override (this is
+exactly the shape of the Chicago 18th fixtures that motivated this spec:
+"Egmont Manuscripts, Phillipps Collection, University of Georgia
+Library"). Citum's `ClassExtension::Collection` models the *editorial*
+collection (anthology, proceedings, edited volume): it has `editor` but
+**no `author` field and no archive fields**, so routing CSL `collection`
+into it silently drops the author and the entire archival location — the
+very data these references exist to cite. (`ref_type()` mapping
+`ClassExtension::Collection` → `"collection"` predates this spec and is a
+lossy legacy-output concession, not evidence the two concepts coincide.)
+`collection` therefore routes through `from_document_ref` with a
+genre-discriminated round trip, the same as the other archival/document
+shapes, preserving `author`, `archive`, `archive_location`, and
+`archive_info`. If archival collections ever warrant first-class
+modeling, that is a schema addition (author + archive fields on a
+dedicated class), which this spec's non-goals exclude.
 
 **`periodical` routing decision.** `periodical` describes a standalone
 reference to a serial publication itself (the publication, not an
@@ -294,15 +314,15 @@ override-validation policy; it was the missing `collection` routing arm
 
 ## Acceptance Criteria
 
-- [ ] `CSL_TYPES` and `CSL_TYPE_EXTENSIONS` defined in
+- [x] `CSL_TYPES` and `CSL_TYPE_EXTENSIONS` defined in
       `crates/csl-legacy/src/csl_json.rs` with provenance documented in
       `///` comments.
-- [ ] `conversion::contract_tests::every_csl_1_0_2_type_round_trips_through_ref_type`
+- [x] `conversion::contract_tests::every_csl_1_0_2_type_round_trips_through_ref_type`
       asserts every `CSL_TYPES` entry against the canonicalization table
       above, with zero allowlisted exceptions.
-- [ ] `conversion::contract_tests::manuscript_with_recognized_collection_note_override_converts_to_collection`
+- [x] `conversion::contract_tests::manuscript_with_recognized_collection_note_override_converts_to_collection`
       reproduces and fixes the `chi-manuscript` regression.
-- [ ] Every routing gap in the table above has an explicit arm; the
+- [x] Every routing gap in the table above has an explicit arm; the
       wildcard fallback carries the `debug_assert!` loud-fail.
 - [ ] `Reference::parse_note_field_hacks` validates `type:` overrides
       against `CSL_TYPES ∪ CSL_TYPE_EXTENSIONS`; unrecognized overrides

--- a/docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md
+++ b/docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md
@@ -324,7 +324,7 @@ override-validation policy; it was the missing `collection` routing arm
       reproduces and fixes the `chi-manuscript` regression.
 - [x] Every routing gap in the table above has an explicit arm; the
       wildcard fallback carries the `debug_assert!` loud-fail.
-- [ ] `Reference::parse_note_field_hacks` validates `type:` overrides
+- [x] `Reference::parse_note_field_hacks` validates `type:` overrides
       against `CSL_TYPES ∪ CSL_TYPE_EXTENSIONS`; unrecognized overrides
       are ignored and the note line is preserved (tests in
       `crates/csl-legacy/src/csl_json.rs` and

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -127,6 +127,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | [`TYPE_REFACTOR_v3.md`](./TYPE_REFACTOR_v3.md) — unified type system refactor for high-fidelity work modeling | Active | `metadata.rs`, `domain_fixtures.rs` |
 | [`TYPE_SYSTEM_ARCHITECTURE.md`](./TYPE_SYSTEM_ARCHITECTURE.md) — overall type system architecture and classification hierarchy | Draft | `crates/citum-schema/tests/` |
 | [`INPUT_REFERENCE_CLASS_DISCRIMINATOR.md`](./INPUT_REFERENCE_CLASS_DISCRIMINATOR.md) — discriminated union for reference-class dispatch | Active | `crates/citum-schema/tests/` |
+| [`CSL_TYPE_CONVERSION_CONTRACT.md`](./CSL_TYPE_CONVERSION_CONTRACT.md) — CSL 1.0.2 type vocabulary, routing closure, and note-override validation | Active | `crates/citum-schema-data/src/reference/conversion/contract_tests.rs` |
 | [`GENERALIZED_RELATIONAL_CONTAINER_MODEL.md`](./GENERALIZED_RELATIONAL_CONTAINER_MODEL.md) — recursive relational container model replacing flat variables | Active | `metadata.rs` |
 | [`DATE_MODEL.md`](./DATE_MODEL.md) — refined date model for created vs. issued distinction | Active | `metadata.rs` |
 | [`NUMBERING_SEMANTICS.md`](./NUMBERING_SEMANTICS.md) — canonical semantics for numbering, report, and part fields | Active | `metadata.rs` |


### PR DESCRIPTION
## Summary

Implements epic `csl26-cvfy`: the CSL-JSON conversion layer is now an
independently tested contract instead of an opaque middle of the fidelity
pipeline.

- **Spec**: `docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md` (Active) — CSL 1.0.2
  vocabulary source of truth, canonicalization table, routing-closure design,
  loud-fail pattern, note-override policy.
- **Vocabulary**: `CSL_TYPES` (45 CSL 1.0.2 types, from the `v1.0.2`-tagged
  `csl-types.rnc`) + `CSL_TYPE_EXTENSIONS` in `csl-legacy`.
- **Contract test**: every CSL 1.0.2 type round-trips through
  `InputReference::from(...).ref_type()` against an explicit expectation table
  with zero allowlisted exceptions; failures list all mismatches per run.
- **Routing closure**: 12 silent-collapse gaps fixed — the 11 anticipated
  (`collection`, `entry`, `figure`, `graphic`, `map`, `musical_score`,
  `pamphlet`, `performance`, `periodical`, `review`, `review-book`) plus
  test-discovered `post-weblog`→`post` and `speech`→`event` collapses.
  The wildcard fallback now `debug_assert!`s when a known CSL type reaches it
  (mirrors the `ClassExtension::Unknown` prior art; `csl26-1bdr` owns future
  `CompatibilityWarning` plumbing).
- **Note-override validation**: `parse_note_field_hacks` applies `type: X`
  only for recognized types; a typo keeps the top-level type and the line
  stays in the note.

### Design call worth reviewer attention

CSL 1.0.2 `collection` is an **archival** collection (author, archive,
archive-place — the Chicago 18th fixture shape). Citum's editorial
`ClassExtension::Collection` (anthology/proceedings) has no author or archive
fields and silently drops them, so `collection` routes through the archival
document shape with a genre-discriminated round trip instead. Rationale
recorded in the spec.

## Test plan

- [x] Red-first: contract test captured all 12 collapses against pre-fix
  routing before any converter change
- [x] `cargo fmt --check` && `cargo clippy --all-targets --all-features -- -D warnings` && `cargo nextest run` — 1704/1704
- [x] Schema regen no-op (`citum schema --out-dir docs/schemas`)
- [x] `chi-manuscript` end-to-end: converts to `ref_type() == "collection"`
  with `archive-info` (Phillipps Collection) intact
- [x] Full `report-core.js` vs pre-change baseline: **zero style
  regressions**; bibliography passed 7790→7792;
  `chicago-author-date-18th` and `taylor-and-francis-chicago-author-date`
  +0.002 each
- [x] `chicago-shared-corpus` unchanged (7/15): the remaining
  `chi-manuscript` mismatch is now attributable to the style/migration layer
  (migrated style lacks a `collection` type-variant) — `csl26-shco` scope,
  recorded in the epic bean

Phase 5 (attributed fidelity reporting in `oracle.js`/`report-core.js`) is
filed as follow-up bean `csl26-3r34`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
