### PR TITLE
docs: add conversion pre-flight to style workflow

### DIFF
--- a/.beans/archive/csl26-cdjx--wire-conversion-contract-into-style-workflow-docs.md
+++ b/.beans/archive/csl26-cdjx--wire-conversion-contract-into-style-workflow-docs.md
@@ -1,0 +1,30 @@
+---
+# csl26-cdjx
+title: Wire conversion contract into style workflow docs and skills
+status: completed
+type: task
+priority: normal
+created_at: 2026-07-02T18:52:44Z
+updated_at: 2026-07-02T18:56:28Z
+parent: csl26-cvfy
+---
+
+Follow-on to the conversion-layer contract (docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md, merged in PR #993). The style-workflow classification vocabulary (style-defect / migration-artifact / processor-defect / intentional divergence) in docs/policies/STYLE_WORKFLOW_DECISION_RULES.md has no operational test for attributing a mismatch to the conversion layer. Add a conversion-layer pre-flight rule to the policy (citum convert refs + canonicalization-table check), thin pointers from the style-tune and style-qa skills, and a note in style-migrate-enhance and migrate-research that the newly-routed CSL types (collection, review, review-book, performance, figure, graphic, musical_score, pamphlet, periodical, entry, post-weblog) now reach styles as real ref_types, so migration recommendations should cover their type-variants. Interim manual procedure until csl26-3r34 mechanizes tagging in oracle.js.
+
+## Summary of Changes
+
+- `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md` (v1.4): new
+  "Conversion-layer pre-flight" section — verify the reference converts
+  truthfully against the CSL_TYPE_CONVERSION_CONTRACT canonicalization
+  table before classifying; processor-defect (conversion) claims need
+  pre-flight evidence and a contract-test reproduction. Reading guidance
+  for newly-routed types and validated note-field overrides.
+- `docs/guides/STYLE_WORKFLOW_EXECUTION.md`: fidelity-loop classification
+  step references the pre-flight.
+- Skills (host-neutral pointers, logic stays in the policy):
+  `style-tune`, `style-qa` (reject unevidenced conversion claims),
+  `style-migrate-enhance` (missing type-variants for newly-routed types
+  are reportable migration gaps), `.skills/migrate-research`.
+- `.codex/agents/migration-researcher.md`: same pointer for the Codex
+  host.
+- Interim manual procedure until csl26-3r34 mechanizes tagging.

--- a/.claude/skills/style-migrate-enhance/SKILL.md
+++ b/.claude/skills/style-migrate-enhance/SKILL.md
@@ -38,6 +38,11 @@ authoring path for high-impact styles.
 - Updated style YAML file(s).
 - Shared metrics and rerun evidence in the format described by the shared execution guide.
 - Migration-pattern gaps and recommended converter/preset follow-up when observed.
+  Every CSL 1.0.2 type reaches styles as its real `ref_type` under the
+  conversion contract (`docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md`), so when
+  the source CSL style handles a type like `collection`, `review`,
+  `performance`, or `figure`, a missing `type-variants` entry in the migrated
+  YAML is a reportable migration gap, not converter noise.
 
 ## Autonomous Operation
 

--- a/.claude/skills/style-qa/SKILL.md
+++ b/.claude/skills/style-qa/SKILL.md
@@ -32,6 +32,9 @@ Authoritative shared process docs:
   gate alongside fidelity for the embedded portfolio.
 - For `dependent` styles, SQI drift is advisory only; do not reject on SQI alone.
 - Reject when a registered divergence is reported as an unexplained defect.
+- Reject when a residual is classified `processor-defect` (conversion)
+  without the conversion-layer pre-flight evidence required by the
+  Decision Rules.
 - Reject when formatting defects are introduced.
 - Approve when fidelity is preserved or improved, formatting is clean, and (for
   `embedded-core`) SQI is clean.

--- a/.claude/skills/style-tune/SKILL.md
+++ b/.claude/skills/style-tune/SKILL.md
@@ -49,7 +49,10 @@ Follow the full `tune` loop from `docs/guides/STYLE_WORKFLOW_EXECUTION.md`:
 4. **QA gate** — hand off to `../style-qa/SKILL.md` with `tier: embedded-core`.
 
 ## Failure Classification
-Use the shared decision rules for all mismatches:
+Use the shared decision rules for all mismatches. For type- or
+field-population-shaped mismatches, run the conversion-layer pre-flight
+(Decision Rules → "Conversion-layer pre-flight") before classifying —
+never iterate YAML against a reference that converted wrongly.
 - `style-defect` → fix in YAML.
 - `migration-artifact` → note gap, do not cycle YAML to compensate; fix the seed
   if a converter improvement is available, otherwise hand-author around it.

--- a/.codex/agents/migration-researcher.md
+++ b/.codex/agents/migration-researcher.md
@@ -24,7 +24,7 @@ output_contract:
   - State the chosen cluster.
   - State the target semantic class and implementation form.
   - State the selected parent style when one exists.
-  - Classify it as `migration-artifact`, `style-defect`, `processor-defect`, or `intentional divergence`.
+  - Classify it as `migration-artifact`, `style-defect`, `processor-defect`, or `intentional divergence`, running the conversion-layer pre-flight from `docs/policies/STYLE_WORKFLOW_DECISION_RULES.md` first for type- or field-population-shaped clusters.
   - Preserve the config-wrapper contract for `profile + config-wrapper` targets.
   - Accept `journal + structural-wrapper` as a valid stopping point.
   - If classified as `migration-artifact`, make at most one tightly scoped code change for that pass.

--- a/.skills/migrate-research/SKILL.md
+++ b/.skills/migrate-research/SKILL.md
@@ -28,7 +28,9 @@ Read first:
 - Start with the smallest trustworthy evidence surface.
 - State the target semantic class and implementation form before proposing a fix.
 - Classify each cluster as `migration-artifact`, `style-defect`, `processor-defect`,
-  or `intentional divergence`.
+  or `intentional divergence`. For type- or field-population-shaped clusters,
+  run the conversion-layer pre-flight from the shared decision rules
+  (`docs/policies/STYLE_WORKFLOW_DECISION_RULES.md`) before classifying.
 - Record the selected parent style when the target is a known wrapper.
 - Preserve the config-wrapper contract for `profile + config-wrapper` targets.
 - Treat `journal + structural-wrapper` as a valid endpoint; do not force thin-wrapper reduction.

--- a/docs/guides/STYLE_WORKFLOW_EXECUTION.md
+++ b/docs/guides/STYLE_WORKFLOW_EXECUTION.md
@@ -97,7 +97,9 @@ first iteration.
    a concrete candidate. Record oracle fidelity baseline and SQI baseline.
 2. **Fidelity loop:**
    a. Run the oracle (`node scripts/oracle.js <legacy-style> --json`).
-   b. Classify each failure per the shared decision rules.
+   b. Classify each failure per the shared decision rules; for type- or
+      field-population-shaped failures, run the conversion-layer pre-flight
+      (Decision Rules → "Conversion-layer pre-flight") first.
    c. Apply the smallest correct YAML change toward the target reference output.
    d. Re-run oracle. Repeat until fidelity is 100%.
    e. If a residual is clearly a `processor-defect` or `intentional divergence`,

--- a/docs/policies/STYLE_WORKFLOW_DECISION_RULES.md
+++ b/docs/policies/STYLE_WORKFLOW_DECISION_RULES.md
@@ -1,11 +1,12 @@
 # Style Workflow Decision Rules
 
 **Status:** Active
-**Version:** 1.3
-**Date:** 2026-04-04
+**Version:** 1.4
+**Date:** 2026-07-02
 **Related:** [STYLE_WORKFLOW_EXECUTION.md](../guides/STYLE_WORKFLOW_EXECUTION.md),
 [SKILL_AGENT_REFACTOR.md](../architecture/SKILL_AGENT_REFACTOR.md),
-[MIGRATION_STRATEGY_ANALYSIS.md](../architecture/MIGRATION_STRATEGY_ANALYSIS.md)
+[MIGRATION_STRATEGY_ANALYSIS.md](../architecture/MIGRATION_STRATEGY_ANALYSIS.md),
+[CSL_TYPE_CONVERSION_CONTRACT.md](../specs/CSL_TYPE_CONVERSION_CONTRACT.md)
 
 ## Rule
 Shared style-workflow agents must classify each mismatch as `style-defect`, `migration-artifact`, `processor-defect`, or `intentional divergence`, and must stop iterating once a cluster is clearly outside the active workflow's scope.
@@ -23,6 +24,45 @@ Before editing YAML, shared style workflows must classify the target on **three*
 3. portfolio tier: `embedded-core` or `dependent`
 
 All three classifications are operational, not cosmetic.
+
+### Conversion-layer pre-flight
+
+Before classifying any mismatch whose reference type or field population
+looks suspicious (wrong type-variant selected, fields missing that the
+fixture clearly carries, output that reads like a generic default), verify
+the reference converts truthfully **before** touching YAML:
+
+```bash
+cargo run --bin citum -- convert refs <item>.json --from csl-json -o /tmp/converted.yaml
+```
+
+Compare the converted class/type/fields against the canonicalization table
+in [CSL_TYPE_CONVERSION_CONTRACT.md](../specs/CSL_TYPE_CONVERSION_CONTRACT.md)
+(the authoritative statement of which `ref_type()` output each CSL 1.0.2
+input type must produce, including the intentional divergences).
+
+- Conversion wrong (type collapsed, fields dropped, note-field `type:`
+  override misapplied) → classify `processor-defect` (conversion). It must
+  reproduce in the conversion contract-test module
+  (`citum_schema_data::reference::conversion::contract_tests`) before any
+  Rust fix, and no YAML iteration happens on that cluster.
+- Conversion correct → the defect is style- or migration-side; classify
+  against the remaining categories as usual.
+
+Two facts of the conversion contract matter when reading oracle output:
+every CSL 1.0.2 type now reaches styles as its real `ref_type` (including
+`collection`, `entry`, `figure`, `graphic`, `musical_score`, `pamphlet`,
+`performance`, `periodical`, `review`, `review-book`, `post-weblog`), and
+note-field `type:` overrides apply only for recognized types — a
+misspelled override keeps the top-level type and stays visible in the
+note. A style that predates the contract may simply lack a `type-variants`
+entry for a newly-routed type; that is a `style-defect` (or a
+migration-gap when the source CSL style handled the type), not a
+processor problem.
+
+This pre-flight is the interim manual procedure; bean `csl26-3r34`
+(attributed fidelity reporting) will mechanize the tagging in
+`oracle.js`/`report-core.js`.
 
 ### Portfolio tier
 
@@ -53,6 +93,9 @@ with the binary and defines the maintainability standard for the whole portfolio
 Style work in Citum repeatedly follows the same decision logic: determine whether the defect belongs in YAML, migration, engine behavior, or adjudication, then route the work accordingly. Putting that logic in one policy keeps the Claude and Codex wrappers thin and reduces drift between hosts.
 
 ## Application
+- Run the conversion-layer pre-flight before classifying a type- or
+  field-population-shaped mismatch; a `processor-defect` (conversion)
+  claim needs the pre-flight evidence attached.
 - `style-defect` routes to style-local YAML repair.
 - `migration-artifact` stays in migration-focused work.
 - `processor-defect` routes to engine or processor follow-up.
@@ -81,6 +124,11 @@ Style work in Citum repeatedly follows the same decision logic: determine whethe
 - Rich-input evidence ordering and per-skill output phrasing live in the execution guide.
 
 ## Changelog
+- v1.4 (2026-07-02): Added the conversion-layer pre-flight (verify the
+  reference converts truthfully against `CSL_TYPE_CONVERSION_CONTRACT.md`
+  before classifying) and the newly-routed-types reading guidance,
+  following the conversion contract landing in PR #993. Interim manual
+  procedure until `csl26-3r34` mechanizes the tagging.
 - v1.3 (2026-06-24): Added the third classification axis (portfolio tier:
   `embedded-core` vs `dependent`), tier-dependent quality bar (SQI is a hard
   gate for embedded-core), and the embedded-tier authoring rule (migrate as


### PR DESCRIPTION
## Summary

Follow-on to #993 (bean `csl26-cdjx`, child of epic `csl26-cvfy`): wires the
CSL type conversion contract into the shared style workflow so mismatch
classification has an operational test instead of manual multi-file tracing.

- **`docs/policies/STYLE_WORKFLOW_DECISION_RULES.md` (v1.4)** — new
  "Conversion-layer pre-flight" section: convert the suspicious reference
  (`citum convert refs`), compare against the canonicalization table in
  `CSL_TYPE_CONVERSION_CONTRACT.md`, and require a contract-test reproduction
  plus attached evidence for any `processor-defect` (conversion) claim.
  Includes reading guidance for the newly-routed CSL types and validated
  note-field overrides.
- **`docs/guides/STYLE_WORKFLOW_EXECUTION.md`** — fidelity-loop
  classification step references the pre-flight.
- **Skills** (thin host-neutral pointers; logic stays in the policy per its
  own rationale): `style-tune` and `.skills/migrate-research` run the
  pre-flight before classifying; `style-qa` rejects unevidenced conversion
  claims; `style-migrate-enhance` reports missing type-variants for
  newly-routed types as migration gaps.
- **`.codex/agents/migration-researcher.md`** — same pointer for the Codex
  host.

Interim manual procedure until `csl26-3r34` (Phase 5, attributed fidelity
reporting) mechanizes the tagging in `oracle.js`/`report-core.js`.

## Test plan

- [x] `alint check` clean in both plain and `--base` modes
- [x] `./scripts/validate-frontmatter.sh --copilot-strict` — 19 files pass
- [x] Markdown/docs-only change — no build impact; bean archived per
  lifecycle policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
