### PR TITLE
fix(styles): chicago author-date bibliography cluster lift

### DIFF
--- a/.beans/csl26-2uq2--sqi-sprawl-penalty-double-counts-merged-type-selec.md
+++ b/.beans/csl26-2uq2--sqi-sprawl-penalty-double-counts-merged-type-selec.md
@@ -1,0 +1,18 @@
+---
+# csl26-2uq2
+title: SQI sprawl penalty double-counts merged type selectors
+status: todo
+type: bug
+priority: low
+created_at: 2026-07-02T23:42:57Z
+updated_at: 2026-07-02T23:42:57Z
+---
+
+report-core.js's concision metric counts every type in a combined type-variant selector key individually: collectTemplateScopes does variantSelectorCount += typeSelectors.length || 1 (scripts/report-core.js:1681), and sprawlPenalty charges 0.8 per selector past 18 (scripts/report-core.js:2150). A merged 'manuscript, collection' key therefore scores as 2 selectors even though merging is the DRY move — the metric penalizes exactly the consolidation it should reward. Observed on PR #996: chicago-author-date-18th SQI dipped 0.926 -> 0.925 (~0.001) from a functionally-correct 2-type merge that lifted 6 bibliography refs.
+
+Likely fix: count merged selector keys once for sprawl purposes (or discount additional types in one key), keeping the targetBonus math consistent so existing SQI baselines do not jump. Audit other consumers of variantSelectorCount (targetBonus at scripts/report-core.js:2145) before changing semantics.
+
+## Todo
+- [ ] Decide counting semantics (1 per key vs discounted) and check baseline impact across embedded styles
+- [ ] Implement + update scripts tests
+- [ ] Confirm chicago-author-date-18th SQI no longer penalized for the manuscript, collection merge

--- a/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
+++ b/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
@@ -5,7 +5,7 @@ status: in-progress
 type: task
 priority: high
 created_at: 2026-06-30T18:46:08Z
-updated_at: 2026-06-30T19:59:04Z
+updated_at: 2026-07-02T23:19:17Z
 parent: csl26-h7oc
 ---
 
@@ -41,3 +41,95 @@ are layered on.
 
 - 2026-06-30 tune attempt: `webpage` citation variant added to render publisher/year for publisher-owned web pages. `node scripts/report-core.js --style chicago-author-date-18th` now reports headline fidelity 0.808, SQI 0.975, and `chicago-shared-corpus` 12/15 citations + 298/402 bibliography. Residual citation failures: `chi-article-magazine` (`Gourmet 2000b` vs `(2000)`), `chi-multi-source` classic book (`Augustine, De civitate Dei` vs `Augustine 1931`), and `chi-personal-communication` (`Johnson to O’Laughlin 1916` vs `Hiram Johnson`). Invalid/failed probes reverted: citation substitute keys `publisher`/`parent-serial` are schema-invalid; article-magazine `title: parent-serial` duplicates `Gourmet`; raw `container-title` is invalid in citation type-variants; personal_communication sender-recipient-year variant regresses `secondary-roles` recipient citation. Fidelity not green; SQI/QA/PR intentionally not run.
 - 2026-06-30 recovery attempt on `codex/chicago-author-date-full-fidelity`: citation fidelity is now green for `chicago-shared-corpus` (`15/15`). Implemented bounded support for `parent-serial` substitutes, field-presence/absence `render-when` groups, classic conversion from CSL/Zotero `type: classic`, collection-editor substitution, custom contributor-role rendering, and audio-visual event/dimensions preservation. Bibliography improved from `298/402` to `331/400` in the shared oracle run; `node scripts/report-core.js --style chicago-author-date-18th` reports headline fidelity `0.868` and SQI `0.927`. Remaining bibliography failures are broad rich-reference clusters (book original/reprint/rich contributors, interviews, manuscripts, web pages, recordings/media, broadcasts, and manuscript/archive edge cases), so the original 100% + clean SQI + QA completion gate is not met. This draft PR is a substrate/progress PR, not a completed full-fidelity tune.
+
+- 2026-07-02 bounded cluster-lift PR (`fix/chicago-author-date-bib-clusters`):
+  shared-corpus bibliography 331/400 -> 344/400 (citations stayed 15/15).
+  Root-caused and fixed four clusters:
+  - **Title casing**: the engine's legacy type->title-category fallback only
+    recognized a small hardcoded set (component: article/chapter/entry;
+    monograph: book/thesis/report); `broadcast`, `manuscript`, `motion-picture`,
+    `song`, `webpage`, and the note-field-routed `collection` type fell through
+    with no case transform. Fixed via a style-local `titles.type-mapping`
+    (YAML) rather than widening the shared engine default (would affect every
+    embedded style). Also found and fixed three Rust engine bugs surfaced by
+    this cluster: (1) the CSL `substitute` chain (title standing in for a
+    missing author) bypassed all text-case resolution entirely — added
+    `resolve_substitute_text_case` (`citum-engine/src/values/title.rs`) and
+    wired it into `resolve_title_substitute`
+    (`citum-engine/src/values/contributor/substitute.rs`); (2) `to_title_case`
+    hunted past leading digits to capitalize the next letter ("35 mm film" ->
+    "35 Mm film") — `capitalize_first_word` now stops at a leading digit
+    (`citum-engine/src/values/text_case.rs`); (3) title-case hyphenated-compound
+    handling didn't recognize en dash as a hyphen substitute ("Aging-Disability"
+    stayed uncapitalized on the second half) — added en-dash awareness to
+    `capitalize_hyphenated`; (4) the bibliography sentence-initial
+    auto-capitalization pass wrongly capitalized a contributor's literal name
+    ("the author" -> "The author") when the component had a static YAML
+    `prefix:` instead of a dynamic role-label prefix
+    (`citum-engine/src/processor/rendering/grouped/sentence_initial.rs`).
+  - **Original/reprint dates**: fixed the missing period before the
+    parenthesized original year (`Fitzgerald, F. Scott (1925) 1992` ->
+    `Fitzgerald, F. Scott. (1925) 1992.`) and the missing "Translated by"
+    verb-label — `role.omit` was suppressing the verb-form label entirely
+    instead of only the decorative default/preset label
+    (`citum-engine/src/values/contributor/labels.rs`), plus wiring
+    `text-case: capitalize-first` into `format_role_term`
+    (`citum-engine/src/values/contributor/mod.rs`) since verb-form output is
+    pre-formatted and skips the generic case pass. **Deferred**: the
+    "Reprint"/"Originally published as X (publisher)" trailer text and
+    `original-publisher`/`original-publisher-place` wiring — blocked on
+    `TemplateConditionField` (a closed enum) not exposing those fields for
+    `render-when`, plus each fixture item's free-text `edition` field has
+    bespoke, non-systematic oracle capitalization that doesn't reduce to a
+    simple rule. Deeper than "mostly YAML wiring"; needs its own pass.
+  - **Manuscript/archive block**: the 7 manuscript-type refs in this corpus
+    are tagged via a note-field `type: collection` override (routes to
+    `ref_type() == "collection"` per the CSL type conversion contract), but
+    the style had no `collection` type-variant at all, so they fell to the
+    generic article-shaped default template. Merged `manuscript, collection`
+    into one type-variant key (both need the same archival rendering:
+    author/title substitute + archive-location/archive-collection/archive-name
+    fields). **Deferred**: the CSL-`document`-routed archival refs (Purcell
+    map, Agassiz, Henshaw, Johnson, Concerning-a-court-of-arbitration — 5
+    refs) needed the same treatment, but `document` is also used by ~30
+    unrelated annotation/placeholder items in this corpus; adding `document`
+    to the merged type-variant dropped the oracle's total entry count from
+    400 to 397 (some of those placeholder items stopped rendering
+    distinguishably), so it was reverted as a real regression rather than a
+    net win. Date ranges (`issued: 1790/1803` rendering as bare `1790`) and
+    uncertain dates (`[1772?]` rendering as `n.d.`) are unresolved — likely
+    engine-side date-form gaps, not investigated further in this PR.
+  - **Contributor label punctuation**: `contributor-role-form: short` mapped
+    to `RoleLabelPreset::ShortSuffix` (parenthetical: `Lattimore (eds.)`);
+    CMOS wants the comma form. Switched to `short-comma` ->
+    `RoleLabelPreset::ShortSuffixComma` (`Lattimore, eds.`).
+  Verification: `just pre-commit` (fmt/clippy/nextest, 1707 tests) green;
+  `node scripts/report-core.js` full run (154 embedded styles) against
+  `core-quality-baseline.json` green (fidelity=1.0 for all, 0 warnings) —
+  no regressions from the shared-engine changes. chicago-author-date-18th
+  fidelity 0.875 -> 0.898, SQI 0.926 -> 0.925 (marginal miss of the stated
+  0.926 floor: the `manuscript, collection` merge is scored as 2
+  "variant selectors" by `report-core.js`'s sprawl-penalty concision metric,
+  a ~0.001 mechanical cost for a functionally-correct DRY fix, not a
+  maintainability regression — flagged for the reviewer rather than reverted
+  the fix that lifted 6 bibliography refs). taylor-and-francis-chicago-author-date
+  inherits identically (fidelity 0.875 -> 0.898, quality unaffected at 1.0).
+  chicago-notes-18th and chicago-shortened-notes-bibliography unchanged (no
+  regression). Ratcheted `chicago-shared-corpus.min_pass_rate` for both
+  chicago-author-date-18th and taylor-and-francis-chicago-author-date from
+  0.73 to 0.86 (combined rate 359/415 = 0.865, floor set just below) in
+  `scripts/report-data/verification-policy.yaml`.
+  **Target not fully met**: bibliography landed at 344/400, short of the
+  ≥360/400 target — the two deferred pieces above (original/reprint trailer
+  text, `document`-type archival refs) account for most of the gap and were
+  each classified as genuinely deeper than "mostly YAML wiring" per the
+  bounded-PR scope rule, rather than absorbed here.
+  **Explicitly out of scope** (deferred structural clusters, unchanged from
+  the prior note): broadcast/episode grammar (`Episode 6, "…," written
+  by…`), hearings/legal, multi-volume chains (`Bk. 3 of…, vol. 2 of…`),
+  review-of framing, patents (missing "filed" date / country prefix),
+  dataset versioning (`Version 1.2. With … et al`), personal_communication
+  edge cases (text/Facebook/email message genres), and the ~8-entry
+  index-misaligned tail (classic/legal-citation placeholder items the
+  oracle doesn't render at all). Bean stays in-progress; 100% + clean-SQI
+  gate not met.

--- a/.beans/csl26-q05f--expose-original-publication-fields-to-render-when.md
+++ b/.beans/csl26-q05f--expose-original-publication-fields-to-render-when.md
@@ -1,0 +1,22 @@
+---
+# csl26-q05f
+title: Expose original-publication fields to render-when
+status: todo
+type: feature
+priority: normal
+created_at: 2026-07-02T23:42:51Z
+updated_at: 2026-07-02T23:42:51Z
+parent: csl26-h7oc
+blocking:
+    - csl26-giun
+---
+
+TemplateConditionField (crates/citum-schema-style/src/template.rs:1335) is a closed enum and does not expose original-date / original-publisher / original-publisher-place, so type-variants cannot gate on them with render-when. This blocks the CMOS 18 Reprint / 'Originally published as X (publisher)' trailer cluster deferred from the chicago-author-date bibliography cluster-lift PR (#996, bean csl26-giun) — one of the two deferred pieces accounting for most of the gap between 344/400 and the >=360/400 target.
+
+Scope: add the original-publication fields to TemplateConditionField (plus schema regen via just schema-gen), wire engine condition evaluation, then use them in chicago-author-date-18th.yaml to render the reprint/original-publication trailers. Accessors already exist (original_date, original_publisher_str, original_publisher_place — see csl26-ifhx scrap notes). Note from #996: fixture edition free-text has bespoke oracle capitalization that does not reduce to a simple rule; expect per-item judgment when tuning the trailer text.
+
+## Todo
+- [ ] Add original-publication variants to TemplateConditionField + schema regen
+- [ ] Engine: evaluate the new condition fields
+- [ ] Rust tests per CODING_STANDARDS conventions
+- [ ] Wire chicago-author-date-18th reprint/originally-published trailers; measure shared-corpus delta

--- a/crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs
@@ -111,12 +111,17 @@ impl Renderer<'_> {
 
         let locale = Some(self.locale.locale.as_str());
         match &component.template_component {
-            TemplateComponent::Contributor(_) => {
+            TemplateComponent::Contributor(contributor) => {
                 let case =
                     crate::values::text_case::resolve_text_case(TextCase::CapitalizeFirst, locale);
                 if let Some(prefix) = component.prefix.as_mut() {
                     // Explicit template prefix (e.g. ". Translated by ") — capitalize it.
                     *prefix = crate::values::text_case::apply_text_case(prefix, case);
+                } else if contributor.rendering.prefix.is_some() {
+                    // A static YAML `prefix:` (e.g. "Narrated by ") already supplies
+                    // the sentence-initial capital as authored. The contributor's own
+                    // value is a name (or literal descriptive text like "the author")
+                    // and must not also be capitalized on top of it.
                 } else {
                     // No explicit prefix: the role label (e.g. "edited by ") is baked
                     // into the rendered value.  Capitalize the first word so that

--- a/crates/citum-engine/src/values/contributor/labels.rs
+++ b/crates/citum-engine/src/values/contributor/labels.rs
@@ -262,7 +262,18 @@ pub(super) fn resolve_role_labels<F: OutputFormat<Output = String>>(
         );
     }
 
-    if role_omitted {
+    // `role.omit` suppresses the *decorative* default/preset label (e.g. a
+    // trailing "(Trans.)"), not a `form: verb`/`form: verb-short` label: the
+    // verb phrase ("Translated by X") is structural to that form, not an
+    // optional suffix, so a style that both requests verb form and omits the
+    // role's default label (to avoid double-labeling under a different form)
+    // must still get its verb label.
+    if role_omitted
+        && !matches!(
+            component.form,
+            ContributorForm::Verb | ContributorForm::VerbShort
+        )
+    {
         return (None, None);
     }
 

--- a/crates/citum-engine/src/values/contributor/mod.rs
+++ b/crates/citum-engine/src/values/contributor/mod.rs
@@ -127,6 +127,17 @@ pub(super) fn format_role_term<F: crate::render::format::OutputFormat<Output = S
     } else {
         term.to_string()
     };
+    // Locale role terms are stored lowercase (e.g. "translated by") since
+    // they usually sit mid-sentence. A `form: verb` component is marked
+    // `pre_formatted`, which skips the generic title/value text-case pass,
+    // so a style that positions the verb label as its own clause (e.g.
+    // after a `". "` prefix) must opt in here explicitly.
+    let term_str = match effective_rendering.text_case {
+        Some(citum_schema::options::titles::TextCase::CapitalizeFirst) => {
+            crate::values::text_case::capitalize_first_word(&term_str)
+        }
+        _ => term_str,
+    };
     fmt.text(&format!("{prefix}{term_str}{suffix}"))
 }
 

--- a/crates/citum-engine/src/values/contributor/substitute.rs
+++ b/crates/citum-engine/src/values/contributor/substitute.rs
@@ -11,11 +11,15 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use crate::processor::rendering::get_variable_key;
 use crate::reference::Reference;
 use crate::render::format::OutputFormat;
+use crate::values::text_case::apply_text_case;
+use crate::values::title::resolve_substitute_text_case;
 use crate::values::{ProcHints, ProcValues, RenderContext, RenderOptions};
 use citum_schema::options::{RoleLabelPreset, SubstituteKey};
 use citum_schema::reference::Title;
 use citum_schema::reference::{ClassExtension, ContributorRole as DataRole};
-use citum_schema::template::{ContributorRole, Rendering, TemplateComponent, TemplateContributor};
+use citum_schema::template::{
+    ContributorRole, Rendering, TemplateComponent, TemplateContributor, TitleType,
+};
 
 enum ResolvedRole {
     BuiltIn(ContributorRole),
@@ -450,16 +454,34 @@ pub(super) fn resolve_role_substitute<F: OutputFormat<Output = String>>(
     None
 }
 
+/// The `substituted_key` recorded on `ProcValues` for a title substitution,
+/// keyed by which title slot filled the missing-author position.
+fn substituted_key_for_title_type(title_type: &TitleType) -> &'static str {
+    match title_type {
+        TitleType::ParentSerial => "title:ParentSerial",
+        _ => "title:Primary",
+    }
+}
+
 fn resolve_title_substitute<F: OutputFormat<Output = String>>(
     title: Title,
+    title_type: &TitleType,
     component: &TemplateContributor,
     options: &RenderOptions<'_>,
     reference: &Reference,
     fmt: &F,
-    substituted_key: &'static str,
     quote_in_citation: bool,
 ) -> ProcValues<F::Output> {
+    let substituted_key = substituted_key_for_title_type(title_type);
     let title_str = title_substitute_text(title, options.context);
+    // The substitute chain has no `TemplateTitle` to carry a per-component
+    // `text-case:` override, so only the style's category-level `titles:`
+    // config (keyed by reference type) applies here — see
+    // `resolve_substitute_text_case`.
+    let title_str = match resolve_substitute_text_case(title_type, reference, options) {
+        Some(case) => apply_text_case(&title_str, case),
+        None => title_str,
+    };
     let value = if options.context == RenderContext::Citation && quote_in_citation {
         fmt.quote(fmt.text(&title_str))
     } else {
@@ -556,11 +578,11 @@ pub(super) fn resolve_author_substitute<F: OutputFormat<Output = String>>(
                 if let Some(title) = resolve_parent_serial_title(reference) {
                     return Some(resolve_title_substitute(
                         title,
+                        &TitleType::ParentSerial,
                         component,
                         options,
                         reference,
                         fmt,
-                        "title:ParentSerial",
                         false,
                     ));
                 }
@@ -569,11 +591,11 @@ pub(super) fn resolve_author_substitute<F: OutputFormat<Output = String>>(
                 if let Some(title) = reference.title() {
                     return Some(resolve_title_substitute(
                         title,
+                        &TitleType::Primary,
                         component,
                         options,
                         reference,
                         fmt,
-                        "title:Primary",
                         true,
                     ));
                 }

--- a/crates/citum-engine/src/values/text_case.rs
+++ b/crates/citum-engine/src/values/text_case.rs
@@ -121,16 +121,26 @@ fn to_sentence_case(text: &str) -> String {
 
 /// Capitalize the first alphabetic character of the string,
 /// preserving leading whitespace and punctuation.
+///
+/// A leading digit blocks capitalization entirely rather than being skipped
+/// over: a string like `"35 mm film"` has no leading word to capitalize (the
+/// first token is a numeral, not a word), so it is left as-is instead of
+/// capitalizing the first letter found later in the string (which would
+/// wrongly produce `"35 Mm film"`).
 pub(crate) fn capitalize_first_word(text: &str) -> String {
     let mut result = String::with_capacity(text.len());
     let mut found_first = false;
+    let mut blocked_by_digit = false;
     for ch in text.chars() {
-        if !found_first && ch.is_alphabetic() {
+        if !found_first && !blocked_by_digit && ch.is_alphabetic() {
             for upper in ch.to_uppercase() {
                 result.push(upper);
             }
             found_first = true;
         } else {
+            if !found_first && ch.is_ascii_digit() {
+                blocked_by_digit = true;
+            }
             result.push(ch);
         }
     }
@@ -243,26 +253,49 @@ const TITLE_CASE_STOP_WORDS: &[&str] = &[
     "the", "to", "up", "yet", "v", "vs",
 ];
 
-/// Capitalize each component of a hyphenated compound word for title case.
+/// Hyphen-like characters that join compound words for title-case purposes.
+///
+/// Includes the ASCII hyphen-minus and the en dash: bibliographic titles
+/// commonly use an en dash as a hyphen substitute in compounds like
+/// "Aging–Disability Nexus" (as-typed source data), and CMOS title-cases
+/// each component the same way it would for an ASCII-hyphenated compound.
+const HYPHEN_LIKE_CHARS: [char; 2] = ['-', '\u{2013}'];
+
+fn contains_hyphen_like(text: &str) -> bool {
+    text.contains(HYPHEN_LIKE_CHARS)
+}
+
+/// Capitalize each component of a hyphen-joined compound word for title case.
 ///
 /// When `force_all` is true (first/last word, post-punctuation), every component
 /// is capitalized. Otherwise interior stop-word components stay lowercase.
+/// Splits on both the ASCII hyphen and the en dash (see [`HYPHEN_LIKE_CHARS`]),
+/// preserving whichever separator character was actually used.
 fn capitalize_hyphenated(word: &str, force_all: bool) -> String {
-    word.split('-')
-        .map(|part| {
-            if force_all {
-                capitalize_first_word(part)
-            } else {
-                let alpha_core = part.trim_matches(|c: char| !c.is_alphanumeric());
-                if TITLE_CASE_STOP_WORDS.contains(&alpha_core) {
-                    part.to_string()
-                } else {
-                    capitalize_first_word(part)
-                }
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("-")
+    let mut result = String::with_capacity(word.len());
+    let mut last_end = 0;
+    for (idx, sep) in word.match_indices(HYPHEN_LIKE_CHARS) {
+        let part = word.get(last_end..idx).unwrap_or_default();
+        result.push_str(&capitalize_hyphen_part(part, force_all));
+        result.push_str(sep);
+        last_end = idx + sep.len();
+    }
+    let tail = word.get(last_end..).unwrap_or_default();
+    result.push_str(&capitalize_hyphen_part(tail, force_all));
+    result
+}
+
+fn capitalize_hyphen_part(part: &str, force_all: bool) -> String {
+    if force_all {
+        capitalize_first_word(part)
+    } else {
+        let alpha_core = part.trim_matches(|c: char| !c.is_alphanumeric());
+        if TITLE_CASE_STOP_WORDS.contains(&alpha_core) {
+            part.to_string()
+        } else {
+            capitalize_first_word(part)
+        }
+    }
 }
 
 fn trim_trailing_closing_punctuation(word: &str) -> &str {
@@ -292,7 +325,7 @@ fn to_title_case(text: &str) -> String {
     for (i, word) in words.iter().enumerate() {
         let lower = word.to_lowercase();
         if i == 0 || i == last_idx || capitalize_next {
-            if lower.contains('-') {
+            if contains_hyphen_like(&lower) {
                 parts.push(capitalize_hyphenated(&lower, true));
             } else {
                 parts.push(capitalize_first_word(&lower));
@@ -303,7 +336,7 @@ fn to_title_case(text: &str) -> String {
             let alpha_core = lower.trim_matches(|c: char| !c.is_alphanumeric());
             if TITLE_CASE_STOP_WORDS.contains(&alpha_core) {
                 parts.push(lower);
-            } else if lower.contains('-') {
+            } else if contains_hyphen_like(&lower) {
                 parts.push(capitalize_hyphenated(&lower, false));
             } else {
                 parts.push(capitalize_first_word(&lower));
@@ -374,6 +407,18 @@ mod tests {
     #[test]
     fn test_capitalize_first_word_already_upper() {
         assert_eq!(capitalize_first_word("Hello"), "Hello");
+    }
+
+    #[test]
+    fn given_leading_numeral_when_capitalize_first_word_then_left_as_is() {
+        // "35 mm film" has no leading word to capitalize; the first letter
+        // ("m" in "mm") must not be hunted down and capitalized instead.
+        assert_eq!(capitalize_first_word("35 mm film"), "35 mm film");
+    }
+
+    #[test]
+    fn given_leading_letter_when_capitalize_first_word_then_capitalized() {
+        assert_eq!(capitalize_first_word("in Korean"), "In Korean");
     }
 
     // --- capitalize_first_word_markup_aware ---
@@ -542,6 +587,17 @@ mod tests {
     fn test_title_case_hyphenated_stop_word_part() {
         // "well-to-do": "to" is a stop word → stays lowercase in interior position
         assert_eq!(to_title_case("a well-to-do family"), "A Well-to-Do Family");
+    }
+
+    #[test]
+    fn given_en_dash_compound_when_title_case_then_both_sides_capitalized() {
+        // Source data sometimes uses an en dash ("–") as a hyphen substitute
+        // in a compound like "Aging–Disability"; CMOS title-cases each side
+        // the same way it would for an ASCII-hyphenated compound.
+        assert_eq!(
+            to_title_case("the aging\u{2013}disability nexus"),
+            "The Aging\u{2013}Disability Nexus"
+        );
     }
 
     // --- apply_to_structured_parts ---

--- a/crates/citum-engine/src/values/title.rs
+++ b/crates/citum-engine/src/values/title.rs
@@ -276,6 +276,30 @@ fn resolve_effective_text_case(
     None
 }
 
+/// Resolve the effective text-case for a title rendered outside its normal
+/// `title:` template component, e.g. when the CSL `substitute` chain falls
+/// through to `title` because the reference has no author/editor/translator.
+///
+/// There is no `TemplateTitle` to consult for a per-component override in
+/// that path, so this only resolves the style's category-level `titles:`
+/// configuration (mirroring the second half of [`resolve_effective_text_case`]).
+pub(crate) fn resolve_substitute_text_case(
+    title_type: &TitleType,
+    reference: &Reference,
+    options: &RenderOptions<'_>,
+) -> Option<TextCase> {
+    let ref_type = reference.ref_type();
+    let lang = reference.language();
+    let rendering = crate::render::component::get_title_category_rendering(
+        title_type,
+        Some(&ref_type),
+        lang.as_deref(),
+        options.config,
+    )?;
+    let tc = rendering.text_case?;
+    Some(apply_language_fallback(tc, reference))
+}
+
 fn effective_title_quote_depth(
     template: &TemplateTitle,
     reference: &Reference,

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -56,6 +56,19 @@ options:
       - translator
   dates: long
   titles:
+    # CMOS 18 title-cases nearly every reference-type title (article, book,
+    # broadcast, manuscript, motion picture, song, webpage); the engine's
+    # legacy type->category fallback only recognizes a small hardcoded set
+    # (component: articles/chapters/entries; monograph: book/thesis/report).
+    # Map the remaining CMOS title-case types explicitly rather than widen
+    # the shared engine default, which would affect every embedded style.
+    type-mapping:
+      broadcast: component
+      collection: component
+      manuscript: component
+      motion-picture: component
+      song: component
+      webpage: component
     component:
       text-case: title
     monograph:
@@ -152,7 +165,10 @@ citation:
 bibliography:
   options:
     substitute:
-      contributor-role-form: short
+      # CMOS 18: when editor substitutes for a missing author, the short
+      # role label follows a comma ("Lattimore, eds.") rather than sitting
+      # in parentheses ("Lattimore (eds.)").
+      contributor-role-form: short-comma
       template:
       - editor
       - translator
@@ -305,6 +321,7 @@ bibliography:
         form: year
         wrap:
           punctuation: parentheses
+        prefix: ". "
       - date: issued
         form: year
         prefix: " "
@@ -321,6 +338,7 @@ bibliography:
       form: verb
       name-order: given-first
       prefix: ". "
+      text-case: capitalize-first
     - contributor: illustrator
       form: long
       name-order: given-first
@@ -387,7 +405,12 @@ bibliography:
     - variable: dimensions
       prefix: ". "
     - variable: url
-    manuscript:
+    # `collection` is included here because a note-field `type: collection`
+    # override is how this corpus tags archival manuscripts cataloged as
+    # collections (e.g. "Revere family papers") — see
+    # docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md. Both route to the same
+    # archival rendering shape (author/title substitute, archive fields).
+    manuscript, collection:
     - contributor: author
       form: long
       name-order: family-first
@@ -400,7 +423,6 @@ bibliography:
       render-when:
         field-present: issued
     - title: primary
-      text-case: as-is
     - date: issued
       form: month-day
     - variable: raw-genre
@@ -491,6 +513,7 @@ bibliography:
         delimiter: none
       - group:
         - variable: raw-medium
+          text-case: capitalize-first
         - variable: dimensions
           prefix: ", "
         delimiter: none
@@ -533,6 +556,7 @@ bibliography:
         delimiter: none
       - group:
         - variable: raw-medium
+          text-case: capitalize-first
         - variable: dimensions
           prefix: ", "
         delimiter: none
@@ -669,6 +693,7 @@ bibliography:
     - variable: publisher
     - group:
       - variable: raw-medium
+        text-case: capitalize-first
       - variable: dimensions
         prefix: ", "
     - variable: url
@@ -688,7 +713,6 @@ bibliography:
     - date: issued
       form: year
     - title: primary
-      text-case: as-is
     - contributor: narrator
       form: long
       name-order: given-first
@@ -725,6 +749,7 @@ bibliography:
       delimiter: " "
     - group:
       - variable: raw-medium
+        text-case: capitalize-first
       - variable: dimensions
         prefix: ", "
       delimiter: none

--- a/scripts/report-data/verification-policy.yaml
+++ b/scripts/report-data/verification-policy.yaml
@@ -176,7 +176,9 @@ styles:
       # interim floor set just below the 2026-06-30 baseline (combined
       # citation+bibliography match rate 309/417 = 0.741) to lock against
       # regression during per-variant tuning; ratchet upward as each variant
-      # is tuned toward 100%.
+      # is tuned toward 100%. Ratcheted again after the csl26-giun bibliography
+      # cluster lift (2026-07-02): combined rate 359/415 = 0.865, floor set
+      # just below at 0.86.
       - id: chicago-shared-corpus
         label: Chicago shared corpus (citation + bibliography)
         runner: citeproc-oracle
@@ -184,7 +186,7 @@ styles:
         citations_fixture: tests/fixtures/test-items-library/chicago-18th-citations.json
         scope: both
         count_toward_fidelity: true
-        min_pass_rate: 0.73
+        min_pass_rate: 0.86
       - id: relational-comprehensive-smoke
         label: Relational comprehensive native smoke
         runner: native-smoke
@@ -242,6 +244,8 @@ styles:
     # lands (csl26-gzwj). Promoted to gating (csl26-h7oc): same interim floor
     # as chicago-author-date-18th since the two are currently numerically
     # identical (309/417 = 0.741); will diverge once T&F-specific tuning starts.
+    # Ratcheted again after the csl26-giun bibliography cluster lift
+    # (2026-07-02): combined rate 359/415 = 0.865, floor set just below at 0.86.
     benchmark_runs:
       - id: chicago-shared-corpus
         label: Chicago shared corpus (citation + bibliography)
@@ -250,7 +254,7 @@ styles:
         citations_fixture: tests/fixtures/test-items-library/chicago-18th-citations.json
         scope: both
         count_toward_fidelity: true
-        min_pass_rate: 0.73
+        min_pass_rate: 0.86
   american-physics-society:
     secondary:
       - biblatex


### PR DESCRIPTION
## Summary

Bounded bibliography cluster lift for `chicago-author-date-18th` (bean `csl26-giun`, epic `csl26-40n4` / `csl26-h7oc`). This is a progress PR, not a terminal 100% tune.

**Shared Chicago corpus (`chicago-18th.json`, 400 refs / `chicago-18th-citations.json`, 15 citations):**

| | before | after |
|---|---|---|
| citations | 15/15 | 15/15 |
| bibliography | 331/400 (0.828) | **344/400 (0.860)** |

Target was ≥360/400; landed at 344/400. Two sub-pieces of the four named clusters turned out deeper than "mostly YAML wiring" and were deferred with reasoning in the bean rather than absorbed into this PR (see below and the bean's dated note).

## Per-cluster summary

1. **Title casing** — root cause: the engine's legacy type→title-category fallback only recognizes a small hardcoded set (`component`: article/chapter/entry; `monograph`: book/thesis/report). `broadcast`, `manuscript`, `motion-picture`, `song`, `webpage`, and the note-field-routed `collection` type fell through with no case transform.
   - **Style (YAML)**: added `titles.type-mapping` in `chicago-author-date-18th.yaml` rather than widening the shared engine default (would affect every embedded style). Also added `text-case: capitalize-first` to `raw-medium` fields missing it.
   - **Engine (Rust)**, four bugs surfaced while root-causing this cluster:
     - CSL `substitute` (title standing in for a missing author) bypassed all text-case resolution — added `resolve_substitute_text_case` (`values/title.rs`), wired into `resolve_title_substitute` (`values/contributor/substitute.rs`).
     - `to_title_case` hunted past a leading digit to capitalize the next letter (`"35 mm film"` → `"35 Mm film"`) — `capitalize_first_word` now stops at a leading digit (`values/text_case.rs`).
     - Title-case hyphenated-compound handling didn't recognize en dash as a hyphen substitute (`"Aging-Disability"` stayed uncapitalized past the dash) — added en-dash awareness to `capitalize_hyphenated`.
     - The bibliography sentence-initial auto-capitalization pass wrongly capitalized a contributor's literal name (`"the author"` → `"The author"`) when the component used a static YAML `prefix:` instead of a dynamic role-label prefix (`processor/rendering/grouped/sentence_initial.rs`).
2. **Original/reprint dates** — fixed the missing period before the parenthesized original year (`Fitzgerald, F. Scott (1925) 1992` → `Fitzgerald, F. Scott. (1925) 1992.`) and the missing "Translated by" verb label: `role.omit` was suppressing the verb-form label entirely instead of only the decorative default/preset label (`values/contributor/labels.rs`), plus wiring `text-case: capitalize-first` into `format_role_term` since verb-form output is pre-formatted and skips the generic case pass (`values/contributor/mod.rs`).
   - **Deferred**: the "Reprint"/"Originally published as X (publisher)" trailer text and `original-publisher`/`original-publisher-place` wiring. Blocked on `TemplateConditionField` (a closed enum) not exposing those fields for `render-when`, and each fixture item's free-text `edition` field has bespoke, non-systematic oracle capitalization.
3. **Manuscript/archive block** — the 7 manuscript-type refs in this corpus are tagged via a note-field `type: collection` override (routes to `ref_type() == "collection"` per the CSL type conversion contract), but the style had no `collection` type-variant, so they fell to the generic article-shaped default template. Merged `manuscript, collection` into one type-variant key.
   - **Deferred**: the CSL-`document`-routed archival refs (Purcell map, Agassiz, Henshaw, Johnson, Concerning-a-court-of-arbitration — 5 refs). `document` is also used by ~30 unrelated annotation/placeholder items in this corpus; adding `document` to the merged type-variant dropped the oracle's total entry count from 400 to 397 (a real regression, not a net win), so it was reverted. Date ranges and uncertain dates are unresolved (likely engine-side, not investigated further).
4. **Contributor label punctuation** — `contributor-role-form: short` mapped to a parenthetical role label (`Lattimore (eds.)`); CMOS wants the comma form. Switched to `short-comma` → `Lattimore, eds.`.

## Verification

- `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings && cargo nextest run` — green, 1707/1707 tests.
- `node scripts/report-core.js` (all 154 embedded styles) vs `scripts/report-data/core-quality-baseline.json` — **green, fidelity=1.0 for all styles, 0 warnings**. Confirms the shared-engine changes (text-case, contributor labels, substitute path, sentence-initial capitalization) don't regress any other embedded style.
- Four Chicago variants (`node scripts/report-core.js --style <name>`, fresh cache to avoid stale oracle results):

| style | fidelity before → after | SQI before → after | shared-corpus bib |
|---|---|---|---|
| chicago-author-date-18th | 0.875 → **0.898** | 0.926 → 0.925 | 331/400 → 344/400 |
| taylor-and-francis-chicago-author-date | 0.875 → **0.898** | 1.0 (unchanged) | 331/400 → 344/400 (inherits) |
| chicago-notes-18th | 0.838 (unchanged) | 0.855 (unchanged) | 7/15 citations (unaffected — citation-only style) |
| chicago-shortened-notes-bibliography | 0.704 (unchanged) | 1.0 (unchanged) | 6/15 + 264/402 (unaffected) |

**SQI note**: chicago-author-date-18th's SQI is 0.925, a ~0.001 miss of the stated 0.926 floor. This traces entirely to `report-core.js`'s concision sub-score: merging `manuscript, collection` into one type-variant key is scored as 2 "variant selectors" by its sprawl-penalty formula, even though it's one coherent, DRY block (the alternative — a separate duplicated `collection:` key — costs the same). This is a mechanical cost of a functionally-correct fix that lifted 6 bibliography refs, not a maintainability regression; flagging for review rather than reverting.

- Gate ratchet: `scripts/report-data/verification-policy.yaml` — raised `chicago-shared-corpus.min_pass_rate` for `chicago-author-date-18th` and `taylor-and-francis-chicago-author-date` from 0.73 to 0.86 (combined citation+bibliography rate 359/415 = 0.865, floor set just below, rounded down to 2 decimals).
- Bean `csl26-giun`: dated progress note appended (full per-cluster breakdown, deferred items enumerated), stays `in-progress` (100% + clean-SQI gate not met).

## Deferred / out of scope (unchanged from the epic's prior scoping + this PR's findings)

Broadcast/episode grammar, hearings/legal, multi-volume chains, review-of framing, patents (missing filed-date/country prefix), dataset versioning, personal_communication edge cases (text/Facebook/email genres), the `document`-type archival refs (see cluster 3 above), the original/reprint trailer text (see cluster 2 above), and an ~8-entry index-misaligned tail (classic/legal-citation placeholder items the oracle doesn't render at all).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run` (1707/1707 passing)
- [x] `node scripts/report-core.js` full run vs core-quality-baseline (154 styles, fidelity=1.0, 0 warnings)
- [x] `node scripts/report-core.js --style` for all four Chicago variants (no regressions)
- [x] Bean `csl26-giun` updated with dated progress note

🤖 Generated with [Claude Code](https://claude.com/claude-code)
