### PR TITLE
feat(schema): original-publication render-when fields

### DIFF
--- a/.beans/archive/csl26-q05f--expose-original-publication-fields-to-render-when.md
+++ b/.beans/archive/csl26-q05f--expose-original-publication-fields-to-render-when.md
@@ -1,11 +1,11 @@
 ---
 # csl26-q05f
 title: Expose original-publication fields to render-when
-status: in-progress
+status: completed
 type: feature
 priority: normal
 created_at: 2026-07-02T23:42:51Z
-updated_at: 2026-07-03T00:30:38Z
+updated_at: 2026-07-03T00:41:13Z
 parent: csl26-h7oc
 blocking:
     - csl26-giun
@@ -116,3 +116,5 @@ unchanged — correctly inherits the parent's (unchanged) pass count.
 
 Bean left in-progress per instructions: final report-core sweep and PR
 are the supervisor's after #996 merges.
+
+2026-07-02 supervisor close-out: rebased onto main post-#996 (commits 85cb069f, d6688270), independently re-verified (oracle 15/15 + 344/400; report-core author-date 0.898/0.921, T&F 0.898/1.0; nextest 1713/1713). PR #997 opened with both commits per user decision. Literal-Reprint trailer word deferred (needs TemplateConditionField::Edition; zero corpus cost).

--- a/.beans/csl26-6n17--single-source-en-us-fallback-messages-from-embedde.md
+++ b/.beans/csl26-6n17--single-source-en-us-fallback-messages-from-embedde.md
@@ -1,0 +1,38 @@
+---
+# csl26-6n17
+title: Single-source en-US fallback messages from embedded YAML
+status: todo
+type: bug
+priority: normal
+created_at: 2026-07-03T12:17:42Z
+updated_at: 2026-07-03T12:17:42Z
+parent: csl26-h7oc
+---
+
+crates/citum-schema-style/src/locale/embedded/en_us.rs::en_us_archive_messages() hardcodes ~20 MF2 message literals in Rust that Locale::en_us() uses as the fallback for the ~26/28 embedded styles with no info.default-locale. The canonical source, crates/citum-schema-style/embedded/locales/en-US.yaml's messages: section, has 70 entries and drifted out of sync — a real bug (surfaced by PR #997/csl26-q05f: pattern.originally-published-as existed in YAML but silently did nothing for no-default-locale styles until added to the Rust literal directly as a workaround).
+
+## Why this is not a simple single-sourcing patch
+
+An attempt to fix it by extracting the full YAML messages: section at runtime (mirroring embedded_en_us_vocab()'s existing extract_top_level_yaml_section pattern) was tried and reverted after discovering the two sources have PRE-EXISTING VALUE DRIFT, not just coverage gaps:
+
+- role.translator.label: YAML says trans. (lowercase); the legacy hardcoded ContributorTerm says Trans. -- multiple APA bibliography test fixtures pin the old (arguably inconsistent -- role.editor.label is lowercase ed.) capitalized form.
+- Chapter locator abbreviation: YAML's term.chapter-label says chap.; the legacy hardcoded en_us_locator_terms() says ch. -- MLA-style locator tests pin ch..
+- test_no_date_term_resolves_long_and_short_forms broke outright: expected n.d., got no date -- a real regression, not just a stylistic difference.
+
+MF2 messages are resolved before the legacy structured Terms/LocatorTerm fields (see Locale::resolved_role_term / resolved_general_term), so fully activating the YAML messages: section doesn't just add missing keys -- it flips precedence on every key where the two sources disagree, for every style relying on the Locale::en_us() fallback (26/28 embedded styles have no default-locale).
+
+## Scope for this bean
+
+- Audit every key present in both the Rust hardcoded literal's implied vocabulary (roles, locators, terms) AND the YAML messages: section for value drift, not just coverage gaps.
+- Decide per-conflict which source is correct (YAML is presumably intended as canonical, but chap. vs ch. and n.d. vs no date need a real CMOS/style-guide check, not an assumption).
+- Fix the outright regression (no-date term) as a prerequisite.
+- Only then single-source via the extract_top_level_yaml_section pattern already used for vocab.
+- Verify with a full node scripts/report-core.js sweep across all 154 embedded styles (not just Chicago) before merging, since this touches the fallback locale for the large majority of them.
+
+## Todo
+- [ ] Enumerate every legacy-hardcoded term/message key with a YAML messages: counterpart; diff values
+- [ ] Classify each conflict: YAML-is-correct-fix-legacy vs legacy-is-correct-fix-YAML vs genuinely ambiguous (needs style-guide research)
+- [ ] Root-cause and fix the no-date term regression specifically
+- [ ] Implement single-sourcing (extract_top_level_yaml_section pattern) once conflicts are resolved
+- [ ] Full report-core.js sweep (154 styles) confirming no unintended fidelity regressions
+- [ ] Update/remove now-stale pinned test expectations (Trans./ch. etc.) with justification per change, not a blanket accept

--- a/.beans/csl26-q05f--expose-original-publication-fields-to-render-when.md
+++ b/.beans/csl26-q05f--expose-original-publication-fields-to-render-when.md
@@ -5,7 +5,7 @@ status: in-progress
 type: feature
 priority: normal
 created_at: 2026-07-02T23:42:51Z
-updated_at: 2026-07-03T00:29:04Z
+updated_at: 2026-07-03T00:30:38Z
 parent: csl26-h7oc
 blocking:
     - csl26-giun
@@ -19,6 +19,100 @@ Scope: add the original-publication fields to TemplateConditionField (plus schem
 - [x] Add original-publication variants to TemplateConditionField + schema regen
 - [x] Engine: evaluate the new condition fields
 - [x] Rust tests per CODING_STANDARDS conventions
-- [ ] Wire chicago-author-date-18th reprint/originally-published trailers; measure shared-corpus delta
+- [x] Wire chicago-author-date-18th reprint/originally-published trailers; measure shared-corpus delta
 
 2026-07-02 scoping correction (pre-implementation): TemplateConditionField already has OriginalPublished -> reference.original_date() (crates/citum-engine/src/processor/rendering/grouped/core.rs:91). The actual enum gap is original-publisher / original-publisher-place (and possibly original-title). Verify the render-side component support for those fields before assuming the condition enum is the only blocker.
+
+## Summary of Changes (2026-07-03)
+
+Implemented on branch feat/original-publication-render-when, stacked on
+fix/chicago-author-date-bib-clusters (#996).
+
+**Layer 1 — condition enum** (crates/citum-schema-style/src/template.rs):
+added `TemplateConditionField::{OriginalPublisher, OriginalPublisherPlace,
+OriginalTitle}`. `OriginalPublished` (date) already existed per the
+pre-implementation scoping correction.
+
+**Layer 2 — engine evaluation** (crates/citum-engine/src/processor/rendering/
+grouped/core.rs `condition_field_present`): wired the three new fields to
+the existing `original_publisher_str` / `original_publisher_place` /
+`original_title` accessors.
+
+**Layer 3 — render side (the real gap)**: original-publisher and
+original-publisher-place were already renderable via
+`SimpleVariable::{OriginalPublisher, OriginalPublisherPlace}` (pre-existing,
+unused). original-title had no render path: added
+`TitleType::Original` + `resolve_primary_title` support
+(crates/citum-engine/src/values/title.rs). Also found and fixed a real
+adjacent gap while wiring the reprint trailer: `number:` components
+(e.g. `edition`) silently ignored `text-case` overrides, unlike
+variable/title/term components — fixed in
+crates/citum-engine/src/values/number.rs (mirrors the existing
+variable.rs pattern). Both are exercised by new integration tests in
+crates/citum-engine/tests/bibliography.rs (rstest given/when/then for
+the condition fields and the text-case fix, plus a single-scenario test
+for TitleType::Original).
+
+**Layer 4 — YAML** (chicago-author-date-18th.yaml `book` type-variant):
+added an original-publisher/-place mid-clause (suppressed when
+original-title is present), an unconditional `number: edition` render,
+and a trailing "Originally published as {original-title} ({original-
+publisher-or-place})" group gated on original-title presence.
+
+Schema regenerated (`docs/schemas/style.json`, `server.json`).
+`just pre-commit` equivalent (fmt/clippy/nextest, no `just` binary
+available in this environment) green: 1713/1713.
+
+**Oracle** (`chicago-18th.json`, --case-sensitive): citations stayed
+15/15. Bibliography stayed 344/400 — no regressions, but no net
+pass-count gain either. Ogawa (original-title case) is now a byte-exact
+match (previously passed only via fuzzy similarity, missing the whole
+trailer sentence). Ellison/Roy/Schweitzer (original-publisher, no
+edition) now render the correct original-publisher clause too (still
+pass, higher-fidelity text, missing only the literal "Reprint" word,
+deliberately not implemented — see below).
+
+**Why bibliography didn't net-improve**: the only 7 refs in the fixture
+carrying original-publisher/-place/-title are Ogawa, Ellison, Roy,
+Schweitzer (already covered, described above), plus three that remain
+failing for reasons outside this bean's scope:
+- fitzgeraldGreatGatsby1992 / emersonNature1985 (book, `edition` set):
+  content is now 100% correct except that citeproc-js capitalizes one
+  word mid-clause ("and Notes...", "with An...") in a way that does not
+  reduce to any CSL-declared rule (traced into citeproc-js's
+  `capitalizeFirst` — confirmed against the vendored citeproc.js: it
+  should only capitalize the first word of the whole string, so this is
+  a citeproc-js-internal quirk, not a style or citum defect). Matches
+  the #996-inherited caveat exactly; not chased further.
+- dindorfScholiaGraecaHomeri1962 (`classic`, no author, editor only):
+  citeproc-js leads with title (not the substituted editor) for
+  editor-only classic works — an unrelated author-substitute/ordering
+  gap in the (currently variant-less, default-template) `classic` type,
+  not an original-publication field gap. Out of scope; would need its
+  own type-variant work.
+- langeBlackMariaOakland1965 (`graphic`, no book variant at all): needs
+  medium/dimensions/archive/status/url support, unrelated to this bean.
+
+Deliberately not implemented: the literal "Reprint, {publisher}" word
+(CSL's `source-publication-description-bib` "reprint" text) — doing so
+correctly requires distinguishing "edition present" from "edition
+absent" cases (CSL renders edition text OR the literal word, never
+both), which would need a `TemplateConditionField::Edition` addition
+beyond this bean's stated scope. Since every refs in this fixture with
+original-publisher-or-place already has a working, correct output
+(either edition text or a plain publisher join), skipping the literal
+word costs nothing in this corpus and was left out to keep the change
+minimal.
+
+**report-core.js**: `chicago-author-date-18th` fidelity 0.898 (baseline
+0.898, unchanged), quality/SQI 0.921 (baseline 0.925, -0.004) — the dip
+is entirely the `concision` subscore (structurally-necessary
+single-item `group: [...]` wrappers needed to attach `render-when`,
+since conditions can only be set on TemplateGroup, not bare
+components); `withinScopeDuplicates` rose 39->45. No other subscore
+moved. `taylor-and-francis-chicago-author-date`: fidelity 0.898,
+quality 1.0 intact (hard requirement met), bibliography 441/498
+unchanged — correctly inherits the parent's (unchanged) pass count.
+
+Bean left in-progress per instructions: final report-core sweep and PR
+are the supervisor's after #996 merges.

--- a/.beans/csl26-q05f--expose-original-publication-fields-to-render-when.md
+++ b/.beans/csl26-q05f--expose-original-publication-fields-to-render-when.md
@@ -1,11 +1,11 @@
 ---
 # csl26-q05f
 title: Expose original-publication fields to render-when
-status: todo
+status: in-progress
 type: feature
 priority: normal
 created_at: 2026-07-02T23:42:51Z
-updated_at: 2026-07-02T23:42:51Z
+updated_at: 2026-07-03T00:29:04Z
 parent: csl26-h7oc
 blocking:
     - csl26-giun
@@ -16,7 +16,9 @@ TemplateConditionField (crates/citum-schema-style/src/template.rs:1335) is a clo
 Scope: add the original-publication fields to TemplateConditionField (plus schema regen via just schema-gen), wire engine condition evaluation, then use them in chicago-author-date-18th.yaml to render the reprint/original-publication trailers. Accessors already exist (original_date, original_publisher_str, original_publisher_place — see csl26-ifhx scrap notes). Note from #996: fixture edition free-text has bespoke oracle capitalization that does not reduce to a simple rule; expect per-item judgment when tuning the trailer text.
 
 ## Todo
-- [ ] Add original-publication variants to TemplateConditionField + schema regen
-- [ ] Engine: evaluate the new condition fields
-- [ ] Rust tests per CODING_STANDARDS conventions
+- [x] Add original-publication variants to TemplateConditionField + schema regen
+- [x] Engine: evaluate the new condition fields
+- [x] Rust tests per CODING_STANDARDS conventions
 - [ ] Wire chicago-author-date-18th reprint/originally-published trailers; measure shared-corpus delta
+
+2026-07-02 scoping correction (pre-implementation): TemplateConditionField already has OriginalPublished -> reference.original_date() (crates/citum-engine/src/processor/rendering/grouped/core.rs:91). The actual enum gap is original-publisher / original-publisher-place (and possibly original-title). Verify the render-side component support for those fields before assuming the condition enum is the only blocker.

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -90,6 +90,11 @@ fn condition_field_present(reference: &Reference, field: &TemplateConditionField
         TemplateConditionField::Issued => reference.effective_issued_date().is_some(),
         TemplateConditionField::OriginalPublished => reference.original_date().is_some(),
         TemplateConditionField::Publisher => reference.publisher_str().is_some(),
+        TemplateConditionField::OriginalPublisher => reference.original_publisher_str().is_some(),
+        TemplateConditionField::OriginalPublisherPlace => {
+            reference.original_publisher_place().is_some()
+        }
+        TemplateConditionField::OriginalTitle => reference.original_title().is_some(),
         TemplateConditionField::Doi => reference.doi().is_some(),
         TemplateConditionField::Genre => reference.genre().is_some(),
         TemplateConditionField::Archive => reference.archive().is_some(),

--- a/crates/citum-engine/src/values/number.rs
+++ b/crates/citum-engine/src/values/number.rs
@@ -172,6 +172,14 @@ impl ComponentValues for TemplateNumber {
             // Resolve effective rendering options
             let effective_rendering = &self.rendering;
 
+            // Free-text number values (e.g. `edition`) honor an explicit
+            // text-case override the same way string variables do.
+            let value = if let Some(tc) = effective_rendering.text_case {
+                crate::values::text_case::apply_text_case(&value, tc)
+            } else {
+                value
+            };
+
             // Handle label if label_form is specified
             let prefix = if let Some(label_form) = &self.label_form {
                 resolve_number_label(

--- a/crates/citum-engine/src/values/title.rs
+++ b/crates/citum-engine/src/values/title.rs
@@ -420,6 +420,7 @@ fn resolve_primary_title(reference: &Reference, title_type: &TitleType) -> Optio
             _ => None,
         },
         TitleType::CollectionTitle => reference.collection_title(),
+        TitleType::Original => reference.original_title(),
         _ => None,
     }
 }

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -42,8 +42,9 @@ use citum_schema::{
     },
     template::{
         DateForm, DateVariable, DelimiterPunctuation, NumberVariable, Rendering, SimpleVariable,
-        TemplateComponent, TemplateDate, TemplateGroup, TemplateNumber, TemplateTitle,
-        TemplateVariable, TitleForm, TitleType,
+        TemplateComponent, TemplateConditionField, TemplateDate, TemplateGroup,
+        TemplateGroupCondition, TemplateNumber, TemplateTitle, TemplateVariable, TitleForm,
+        TitleType,
     },
 };
 use indexmap::IndexMap;
@@ -3720,6 +3721,213 @@ fn original_published_date_variable_renders_for_patent_references() {
         .to_string();
 
     assert_eq!(rendered, "(1901) 1992. Improved Widget");
+}
+
+/// Builds an `original` sub-reference JSON fragment with an optional publisher
+/// name and/or publisher place, matching the shape produced by the CMOS 18
+/// reprint fixtures (e.g. a reprint with only an original publisher, or only
+/// an original publisher place).
+fn original_publisher_fragment(
+    original_publisher: Option<&str>,
+    original_publisher_place: Option<&str>,
+) -> serde_json::Value {
+    let mut original = serde_json::json!({
+        "class": "monograph",
+        "type": "book",
+        "id": "orig",
+        "issued": "1900",
+    });
+    let publisher = match (original_publisher, original_publisher_place) {
+        (Some(name), Some(place)) => Some(serde_json::json!({ "name": name, "place": place })),
+        (Some(name), None) => Some(serde_json::json!({ "name": name })),
+        (None, Some(place)) => Some(serde_json::json!({ "name": "", "place": place })),
+        (None, None) => None,
+    };
+    if let Some(publisher) = publisher {
+        original
+            .as_object_mut()
+            .expect("original fragment is an object")
+            .insert("publisher".to_string(), publisher);
+    }
+    original
+}
+
+#[rstest]
+#[case::original_publisher_present(Some("Kodansha"), None, "10.1000/marker-doi")]
+#[case::original_publisher_place_present_alone(
+    None,
+    Some("Oxford"),
+    "https://example.test/marker-url"
+)]
+#[case::neither_present(None, None, "")]
+fn given_original_publication_fields_when_a_bibliography_group_checks_field_presence_then_it_renders_conditionally(
+    #[case] original_publisher: Option<&str>,
+    #[case] original_publisher_place: Option<&str>,
+    #[case] expected: &str,
+) {
+    let style = Style {
+        info: StyleInfo {
+            title: Some("Original-publication condition test".to_string()),
+            ..Default::default()
+        },
+        bibliography: Some(BibliographySpec {
+            template: Some(vec![
+                TemplateComponent::Group(TemplateGroup {
+                    group: vec![TemplateComponent::Variable(TemplateVariable {
+                        variable: SimpleVariable::Doi,
+                        ..Default::default()
+                    })],
+                    render_when: Some(TemplateGroupCondition {
+                        field_present: Some(TemplateConditionField::OriginalPublisher),
+                        field_absent: None,
+                    }),
+                    ..Default::default()
+                }),
+                TemplateComponent::Group(TemplateGroup {
+                    group: vec![TemplateComponent::Variable(TemplateVariable {
+                        variable: SimpleVariable::Url,
+                        ..Default::default()
+                    })],
+                    render_when: Some(TemplateGroupCondition {
+                        field_present: Some(TemplateConditionField::OriginalPublisherPlace),
+                        field_absent: Some(TemplateConditionField::OriginalPublisher),
+                    }),
+                    ..Default::default()
+                }),
+            ]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let reference: InputReference = serde_json::from_value(serde_json::json!({
+        "class": "monograph",
+        "type": "book",
+        "id": "primary",
+        "title": "Primary Work",
+        "issued": "1995",
+        "doi": "10.1000/marker-doi",
+        "url": "https://example.test/marker-url",
+        "original": original_publisher_fragment(original_publisher, original_publisher_place),
+    }))
+    .unwrap();
+
+    let bibliography = IndexMap::from([("primary".to_string(), reference)]);
+    let processor = Processor::new(style, bibliography);
+    let rendered = processor
+        .render_selected_bibliography_with_format::<PlainText, _>(["primary".to_string()])
+        .trim()
+        .to_string();
+
+    assert_eq!(rendered, expected);
+}
+
+#[test]
+fn original_title_variable_renders_the_original_language_title() {
+    let style = Style {
+        info: StyleInfo {
+            title: Some("Original-title test".to_string()),
+            ..Default::default()
+        },
+        bibliography: Some(BibliographySpec {
+            template: Some(vec![
+                TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    form: Some(TitleForm::Long),
+                    ..Default::default()
+                }),
+                TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Original,
+                    form: Some(TitleForm::Long),
+                    rendering: Rendering {
+                        prefix: Some(" / ".to_string()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+            ]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let reference: InputReference = serde_json::from_str(
+        r#"{
+            "class": "monograph",
+            "type": "book",
+            "id": "memory-police",
+            "title": "The Memory Police",
+            "issued": "2020",
+            "original": {
+                "class": "monograph",
+                "type": "book",
+                "id": "memory-police-orig",
+                "title": "Hisoyaka na kesshō",
+                "issued": "1994"
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let bibliography = IndexMap::from([("memory-police".to_string(), reference)]);
+    let processor = Processor::new(style, bibliography);
+    let rendered = processor
+        .render_selected_bibliography_with_format::<PlainText, _>(["memory-police".to_string()])
+        .trim()
+        .to_string();
+
+    assert_eq!(rendered, "The Memory Police / Hisoyaka na kesshō");
+}
+
+#[rstest]
+#[case::with_capitalize_first_case(
+    Some(citum_schema::options::titles::TextCase::CapitalizeFirst),
+    "Reprinted with a new preface"
+)]
+#[case::without_a_case_override(None, "reprinted with a new preface")]
+fn given_a_number_component_with_free_text_when_a_text_case_override_is_set_then_it_is_applied(
+    #[case] text_case: Option<citum_schema::options::titles::TextCase>,
+    #[case] expected: &str,
+) {
+    let style = Style {
+        info: StyleInfo {
+            title: Some("Number text-case test".to_string()),
+            ..Default::default()
+        },
+        bibliography: Some(BibliographySpec {
+            template: Some(vec![TemplateComponent::Number(TemplateNumber {
+                number: NumberVariable::Edition,
+                rendering: Rendering {
+                    text_case,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let reference: InputReference = serde_json::from_str(
+        r#"{
+            "class": "monograph",
+            "type": "book",
+            "id": "reprint",
+            "title": "A Reprinted Work",
+            "issued": "2000",
+            "edition": "reprinted with a new preface"
+        }"#,
+    )
+    .unwrap();
+
+    let bibliography = IndexMap::from([("reprint".to_string(), reference)]);
+    let processor = Processor::new(style, bibliography);
+    let rendered = processor
+        .render_selected_bibliography_with_format::<PlainText, _>(["reprint".to_string()])
+        .trim()
+        .to_string();
+
+    assert_eq!(rendered, expected);
 }
 
 mod annotated_html_preview {

--- a/crates/citum-schema-style/embedded/locales/ar-AR.yaml
+++ b/crates/citum-schema-style/embedded/locales/ar-AR.yaml
@@ -92,6 +92,7 @@ messages:
   pattern.accessed-date-colon: "تاريخ الوصول: {$date}"
   pattern.in-container: "في {$container}"
   pattern.in-container-colon: "في: {$container}"
+  pattern.originally-published-as: "نُشر في الأصل بعنوان {$title}"
   pattern.cited-date: "تاريخ الاستشهاد {$date}"
   pattern.issued-date: "تاريخ الإصدار {$date}"
   pattern.retrieved-date: "تاريخ الاسترجاع {$date}"

--- a/crates/citum-schema-style/embedded/locales/de-DE.yaml
+++ b/crates/citum-schema-style/embedded/locales/de-DE.yaml
@@ -777,6 +777,7 @@ messages:
   pattern.accessed-date-colon: "Zugriff: {$date}"
   pattern.in-container: "in {$container}"
   pattern.in-container-colon: "in: {$container}"
+  pattern.originally-published-as: "ursprünglich erschienen als {$title}"
   pattern.cited-date: "zitiert {$date}"
   pattern.issued-date: "erteilt {$date}"
   pattern.retrieved-date: "abgerufen {$date}"

--- a/crates/citum-schema-style/embedded/locales/en-US.yaml
+++ b/crates/citum-schema-style/embedded/locales/en-US.yaml
@@ -909,6 +909,7 @@ messages:
   pattern.accessed-date-colon: "accessed: {$date}"
   pattern.in-container: "in {$container}"
   pattern.in-container-colon: "in: {$container}"
+  pattern.originally-published-as: "originally published as {$title}"
   pattern.cited-date: "cited {$date}"
   pattern.issued-date: "issued {$date}"
   pattern.retrieved-date: "retrieved {$date}"

--- a/crates/citum-schema-style/embedded/locales/es-ES.yaml
+++ b/crates/citum-schema-style/embedded/locales/es-ES.yaml
@@ -299,6 +299,7 @@ messages:
   pattern.accessed-date-colon: "consultado: {$date}"
   pattern.in-container: "en {$container}"
   pattern.in-container-colon: "en: {$container}"
+  pattern.originally-published-as: "publicado originalmente como {$title}"
   pattern.cited-date: "citado el {$date}"
   pattern.issued-date: "emitido el {$date}"
   pattern.retrieved-date: "recuperado el {$date}"

--- a/crates/citum-schema-style/embedded/locales/eu-ES.yaml
+++ b/crates/citum-schema-style/embedded/locales/eu-ES.yaml
@@ -101,6 +101,7 @@ messages:
   pattern.accessed-date-colon: "kontsulta-data: {$date}"
   pattern.in-container: "{$container}(e)n"
   pattern.in-container-colon: "{$container}(e)n:"
+  pattern.originally-published-as: "jatorriz {$title} izenburuarekin argitaratua"
   pattern.cited-date: "aipatua: {$date}"
   pattern.issued-date: "emana: {$date}"
   pattern.retrieved-date: "berreskuratua: {$date}"

--- a/crates/citum-schema-style/embedded/locales/fr-FR.yaml
+++ b/crates/citum-schema-style/embedded/locales/fr-FR.yaml
@@ -887,6 +887,7 @@ messages:
   pattern.accessed-date-colon: "consulté le : {$date}"
   pattern.in-container: "dans {$container}"
   pattern.in-container-colon: "dans : {$container}"
+  pattern.originally-published-as: "publié à l'origine sous le titre {$title}"
   pattern.cited-date: "cité le {$date}"
   pattern.issued-date: "délivré le {$date}"
   pattern.retrieved-date: "consulté le {$date}"

--- a/crates/citum-schema-style/embedded/locales/tr-TR.yaml
+++ b/crates/citum-schema-style/embedded/locales/tr-TR.yaml
@@ -774,6 +774,7 @@ messages:
   pattern.accessed-date-colon: "erişim tarihi: {$date}"
   pattern.in-container: "{$container} içinde"
   pattern.in-container-colon: "{$container} içinde:"
+  pattern.originally-published-as: "özgün olarak {$title} adıyla yayımlandı"
   pattern.cited-date: "alıntılama tarihi: {$date}"
   pattern.issued-date: "veriliş tarihi: {$date}"
   pattern.retrieved-date: "erişim tarihi: {$date}"

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -364,9 +364,45 @@ bibliography:
       - number: issue
         prefix: " ("
         suffix: ")"
+    - group:
+      - variable: original-publisher
+      render-when:
+        field-absent: original-title
+    - group:
+      - variable: original-publisher-place
+      render-when:
+        field-absent: original-publisher
+    - number: edition
+      text-case: capitalize-first
     - variable: publisher
     - variable: doi
     - variable: url
+    - group:
+      # CMOS 18 13.101: a translation or reprint under a different title notes
+      # the original title (and, where known, its publisher or place).
+      - message: pattern.originally-published-as
+        args:
+          title:
+            group:
+            - title: original
+              emph: true
+              text-case: title
+        text-case: capitalize-first
+      - group:
+        - variable: original-publisher
+        wrap:
+          punctuation: parentheses
+        prefix: " "
+      - group:
+        - variable: original-publisher-place
+        wrap:
+          punctuation: parentheses
+        prefix: " "
+        render-when:
+          field-absent: original-publisher
+      delimiter: none
+      render-when:
+        field-present: original-title
     broadcast:
     - contributor: author
       form: long

--- a/crates/citum-schema-style/src/locale/embedded/en_us.rs
+++ b/crates/citum-schema-style/src/locale/embedded/en_us.rs
@@ -75,6 +75,10 @@ pub(crate) fn en_us_archive_messages() -> HashMap<String, String> {
             "pattern.in-container-colon".into(),
             "in: {$container}".into(),
         ),
+        (
+            "pattern.originally-published-as".into(),
+            "originally published as {$title}".into(),
+        ),
         ("pattern.cited-date".into(), "cited {$date}".into()),
         ("pattern.issued-date".into(), "issued {$date}".into()),
         ("pattern.retrieved-date".into(), "retrieved {$date}".into()),

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -894,6 +894,8 @@ pub enum TitleType {
     ParentSerial,
     /// Title of a series or collection containing the cited work.
     CollectionTitle,
+    /// Title of the work's original publication (e.g. a translation's source-language title).
+    Original,
 }
 
 /// Title rendering forms.
@@ -1349,6 +1351,12 @@ pub enum TemplateConditionField {
     OriginalPublished,
     /// The publisher name.
     Publisher,
+    /// The original publisher name (e.g. a reprint's first publisher).
+    OriginalPublisher,
+    /// The original publisher place (e.g. a reprint's first place of publication).
+    OriginalPublisherPlace,
+    /// The original title (e.g. a translation's title in its source language).
+    OriginalTitle,
     /// The DOI identifier.
     Doi,
     /// The reference genre or item type label.

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -1749,6 +1749,11 @@
           "description": "Title of a series or collection containing the cited work.",
           "type": "string",
           "const": "collection-title"
+        },
+        {
+          "description": "Title of the work's original publication (e.g. a translation's source-language title).",
+          "type": "string",
+          "const": "original"
         }
       ]
     },
@@ -2584,6 +2589,21 @@
           "description": "The publisher name.",
           "type": "string",
           "const": "publisher"
+        },
+        {
+          "description": "The original publisher name (e.g. a reprint's first publisher).",
+          "type": "string",
+          "const": "original-publisher"
+        },
+        {
+          "description": "The original publisher place (e.g. a reprint's first place of publication).",
+          "type": "string",
+          "const": "original-publisher-place"
+        },
+        {
+          "description": "The original title (e.g. a translation's title in its source language).",
+          "type": "string",
+          "const": "original-title"
         },
         {
           "description": "The DOI identifier.",

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -1436,6 +1436,11 @@
           "description": "Title of a series or collection containing the cited work.",
           "type": "string",
           "const": "collection-title"
+        },
+        {
+          "description": "Title of the work's original publication (e.g. a translation's source-language title).",
+          "type": "string",
+          "const": "original"
         }
       ]
     },
@@ -2301,6 +2306,21 @@
           "description": "The publisher name.",
           "type": "string",
           "const": "publisher"
+        },
+        {
+          "description": "The original publisher name (e.g. a reprint's first publisher).",
+          "type": "string",
+          "const": "original-publisher"
+        },
+        {
+          "description": "The original publisher place (e.g. a reprint's first place of publication).",
+          "type": "string",
+          "const": "original-publisher-place"
+        },
+        {
+          "description": "The original title (e.g. a translation's title in its source language).",
+          "type": "string",
+          "const": "original-title"
         },
         {
           "description": "The DOI identifier.",


### PR DESCRIPTION
Implements bean csl26-q05f (follow-up from #996): expose original-publication
fields to `render-when` conditions and wire the CMOS 18 reprint /
"Originally published as" trailers in chicago-author-date-18th.

## Evidence

Shared Chicago corpus (`chicago-18th.json`, 400 refs / 15 citations, case-sensitive):

| surface | before | after |
|---|---|---|
| citations | 15/15 | 15/15 |
| bibliography | 344/400 | 344/400 |

**No net pass-count movement, by design honesty:** the trailer output is now
content-complete and CMOS-correct — Ogawa (*The Memory Police*) is byte-exact
against the oracle (previously passing only via fuzzy similarity); Ellison,
Roy, and Schweitzer render materially more correct text. The remaining
original-publication failures (Fitzgerald, Emerson) differ from the oracle by
exactly one mid-clause word's capitalization, traced to a citeproc-js-internal
`capitalizeFirst` quirk in the vendored source rather than a derivable rule.
Dindorf and Lange fail for unrelated, separately-tracked reasons
(author-substitute ordering for `classic` works; `graphic`-type gaps).

report-core: chicago-author-date-18th fidelity 0.898 (unchanged), SQI
0.925 → 0.921 — the dip is entirely the concision subscore, from
structurally-necessary single-item `group:` wrappers required to attach
`render-when` (adjacent to the metric concern tracked in csl26-2uq2).
taylor-and-francis-chicago-author-date inherits identically: fidelity 0.898,
quality 1.0 intact. Full 1713-test suite green; schemas regenerated in the
same commit as the schema change.

## Changes

**feat(schema): add original-publication conditions**
- `TemplateConditionField` gains `OriginalPublisher`, `OriginalPublisherPlace`,
  `OriginalTitle` (`crates/citum-schema-style/src/template.rs`);
  `OriginalPublished` (date) already existed.
- Engine evaluation wired in `condition_field_present`
  (`crates/citum-engine/src/processor/rendering/grouped/core.rs`), reusing
  existing accessors.
- Missing render path added for `original-title`: `TitleType::Original` in
  `crates/citum-engine/src/values/title.rs`
  (`original-publisher`/`-place` were already renderable but unused).
- Adjacent engine bug fixed: `number:` components silently ignored
  `text-case` overrides (`crates/citum-engine/src/values/number.rs`).
- 6 new integration tests (`crates/citum-engine/tests/bibliography.rs`).

**fix(styles): wire chicago 18th reprint trailers**
- `book` type-variant: original-publisher/-place mid-clause (suppressed when
  original-title is present), unconditional edition render, trailing
  "Originally published as … (…)" group.

## Deferred

- Literal "Reprint" trailer word: needs a `TemplateConditionField::Edition`
  addition beyond this bean's scope; costs nothing in this corpus.
- The citeproc-js capitalization quirk cases: candidates for documented
  known-divergences rather than chasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
