### PR TITLE
fix(schema): merge partial locale raw maps

### DIFF
--- a/.beans/archive/csl26-l59t--partial-locale-messagesdate-formatslegacy-term-ali.md
+++ b/.beans/archive/csl26-l59t--partial-locale-messagesdate-formatslegacy-term-ali.md
@@ -1,0 +1,20 @@
+---
+# csl26-l59t
+title: Partial-locale messages/date_formats/legacy_term_aliases replace instead of merge
+status: completed
+type: bug
+priority: normal
+created_at: 2026-07-03T16:36:01Z
+updated_at: 2026-07-03T17:18:39Z
+parent: csl26-h7oc
+---
+
+Locale::from_raw_with_base (crates/citum-schema-style/src/locale/raw_conversion.rs) wholesale-replaces messages, date_formats, and legacy_term_aliases from the raw locale rather than merging them key-by-key into the base, unlike roles/locators/terms/vocab which do merge. Since these fields default to empty HashMaps when absent from a locale's YAML (serde default), a partial locale file that defines no messages: section (e.g. ar-AR.yaml, eu-ES.yaml) silently loses every en-US fallback MF2 message -- including patterns like pattern.originally-published-as, the exact class of bug csl26-6n17 was filed to fix.
+
+Flagged by Copilot review on PR #998 (csl26-6n17). Confirmed pre-existing on main (unchanged by that PR's refactor) -- the PR's from_raw docstring was corrected to accurately describe this replace-vs-merge split rather than silently fixing the behavior, since a real fix requires deciding merge semantics for three different maps across every non-en-US locale and re-running a full fidelity sweep -- out of scope for that PR.
+
+## Todo
+- [x] Decide merge semantics for messages/date_formats/legacy_term_aliases (merge into base, raw entries override on key collision, matching roles/locators/terms behavior)
+- [x] Implement in from_raw_with_base
+- [x] Full report-core.js fidelity sweep across all locales (not just en-US), since this changes every partial locale's effective fallback
+- [x] Update raw_conversion.rs docstring once behavior is fixed

--- a/crates/citum-schema-style/src/locale/mod.rs
+++ b/crates/citum-schema-style/src/locale/mod.rs
@@ -329,6 +329,62 @@ locale: en-US
         assert!(locale.grammar_options.punctuation_in_quote);
     }
 
+    /// Partial locales inherit base messages, date formats, and aliases.
+    #[test]
+    fn test_partial_locale_merges_raw_maps_with_base() {
+        let yaml = r#"
+locale-schema-version: "2"
+locale: zz-ZZ
+messages:
+  pattern.in-container: "inside {$container}"
+date-formats:
+  numeric-short: "dd/MM/y"
+locators:
+  page:
+    long:
+      singular: page-localized
+      plural: pages-localized
+legacy-term-aliases:
+  page: term.page-label-long
+"#;
+        let locale = Locale::from_yaml_str(yaml).unwrap();
+
+        assert_eq!(
+            locale
+                .messages
+                .get("pattern.originally-published-as")
+                .map(String::as_str),
+            Some("originally published as {$title}")
+        );
+        assert_eq!(
+            locale
+                .messages
+                .get("pattern.in-container")
+                .map(String::as_str),
+            Some("inside {$container}")
+        );
+        assert_eq!(
+            locale.date_formats.get("textual-full").map(String::as_str),
+            Some("MMMM d, yyyy")
+        );
+        assert_eq!(
+            locale.date_formats.get("numeric-short").map(String::as_str),
+            Some("dd/MM/y")
+        );
+        assert_eq!(
+            locale.legacy_term_aliases.get("and").map(String::as_str),
+            Some("term.and")
+        );
+        assert_eq!(
+            locale.legacy_term_aliases.get("page").map(String::as_str),
+            Some("term.page-label-long")
+        );
+        assert_eq!(
+            locale.resolved_locator_term(&LocatorType::Page, false, &TermForm::Long, None),
+            Some("page-localized".to_string())
+        );
+    }
+
     /// apply_override merges messages key-by-key into the base locale.
     #[test]
     fn test_apply_override_merges_messages() {

--- a/crates/citum-schema-style/src/locale/raw_conversion.rs
+++ b/crates/citum-schema-style/src/locale/raw_conversion.rs
@@ -15,7 +15,7 @@ use super::message::{MessageEvaluator, Mf2MessageEvaluator, NoOpEvaluator};
 use super::raw;
 use super::types::{
     ContributorTerm, DateTerms, LocaleOverride, LocatorTerm, MaybeGendered, MessageSyntax,
-    MonthNames, SimpleTerm, SingularPlural,
+    MonthNames, SimpleTerm, SingularPlural, TermForm,
 };
 use crate::citation::LocatorType;
 use crate::template::ContributorRole;
@@ -107,14 +107,11 @@ impl Locale {
     /// locale file (e.g. `ar-AR`, `eu-ES`) only overrides the fields it
     /// specifies, and everything else falls back to the English baseline —
     /// but the inheritance is field-granular, not uniform. `roles`,
-    /// `locators`, `terms`, and `vocab` are merged key-by-key into the base,
-    /// so an omitted key keeps the base's value. `messages`, `date_formats`,
-    /// and `legacy_term_aliases` are replaced wholesale from the raw locale
-    /// (defaulting to empty when the section is absent from the YAML), so a
-    /// partial locale that omits `messages:` entirely loses the base's MF2
-    /// messages rather than falling back to them. This whole-map replacement
-    /// is pre-existing behavior, not introduced by the `en_us()` YAML
-    /// single-sourcing above — see follow-up bean for reconciling it.
+    /// `locators`, `terms`, `vocab`, `messages`, `date_formats`, and
+    /// `legacy_term_aliases` are merged key-by-key into the base, so an
+    /// omitted key keeps the base's value while an explicit raw entry
+    /// overrides it. Inherited message fallbacks do not shadow structured
+    /// terms supplied by the raw locale.
     fn from_raw(raw: raw::RawLocale) -> Self {
         Self::from_raw_with_base(raw, Locale::en_us())
     }
@@ -127,8 +124,7 @@ impl Locale {
     /// [`Locale::default()`] (a non-circular, fully-formed empty locale)
     /// rather than from `en_us()`. Non-en-US locale loading is unaffected —
     /// [`Locale::from_raw`] still calls this with `Locale::en_us()` as the
-    /// base, preserving today's partial-locale inheritance behavior (see
-    /// that function's doc comment for which fields merge vs. replace).
+    /// base, preserving partial-locale inheritance behavior.
     #[allow(
         clippy::too_many_lines,
         reason = "Complex parsing of raw locale data with multiple term types"
@@ -139,6 +135,7 @@ impl Locale {
 
         let mut locale = base;
         locale.locale = raw.locale.clone();
+        Self::remove_base_messages_shadowed_by_raw_terms(&raw, &mut locale.messages);
         locale.dates = DateTerms {
             months: MonthNames {
                 long: raw.dates.months.long,
@@ -161,9 +158,9 @@ impl Locale {
 
         locale.locale_schema_version = raw.locale_schema_version;
         locale.evaluation = raw.evaluation.unwrap_or_default();
-        locale.messages = raw.messages;
-        locale.date_formats = raw.date_formats;
-        locale.legacy_term_aliases = raw.legacy_term_aliases;
+        locale.messages.extend(raw.messages);
+        locale.date_formats.extend(raw.date_formats);
+        locale.legacy_term_aliases.extend(raw.legacy_term_aliases);
 
         if let Some(raw_vocab) = raw.vocab {
             locale.vocab.genre.extend(raw_vocab.genre);
@@ -388,6 +385,46 @@ impl Locale {
             "reviewed-author" => Some(ContributorRole::ReviewedAuthor),
             "composer" => Some(ContributorRole::Composer),
             _ => None,
+        }
+    }
+
+    fn remove_base_messages_shadowed_by_raw_terms(
+        raw: &raw::RawLocale,
+        messages: &mut HashMap<String, String>,
+    ) {
+        for key in raw.locators.keys() {
+            if let Some(locator) = Self::parse_builtin_locator_type(key) {
+                for form in [TermForm::Long, TermForm::Short] {
+                    if let Some(message_id) = Self::locator_message_id(&locator, &form) {
+                        messages.remove(message_id);
+                    }
+                }
+            }
+        }
+
+        for key in raw.roles.keys() {
+            if let Some(role) = Self::parse_role_name(key) {
+                for form in [
+                    TermForm::Long,
+                    TermForm::Short,
+                    TermForm::Verb,
+                    TermForm::VerbShort,
+                ] {
+                    if let Some(message_id) = Self::role_message_id(&role, &form) {
+                        messages.remove(message_id);
+                    }
+                }
+            }
+        }
+
+        for key in raw.terms.keys() {
+            if let Some(term) = Self::parse_general_term(key) {
+                for form in [TermForm::Long, TermForm::Short] {
+                    if let Some(message_id) = Self::general_message_id(&term, &form) {
+                        messages.remove(message_id);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Merge partial locale `messages`, `date_formats`, and
`legacy_term_aliases` key-by-key into the base locale instead of replacing
those maps wholesale.

This keeps en-US fallback messages/date formats/aliases available for
partial locales while still allowing explicit raw locale entries to override
inherited keys. The conversion also removes inherited term-backed message
fallbacks when the raw locale supplies structured terms, so localized
locators/roles/terms such as Arabic page labels are not shadowed by
inherited English MF2 messages.

Archives bean `csl26-l59t`.

## Validation

- `cargo test -p citum-schema-style test_partial_locale_merges_raw_maps_with_base`
- `cargo test -p citum-engine --test gendered_locale arabic_gendered_page_locator_and_role`
- `just pre-commit`
- `node scripts/report-core.js > /tmp/csl26-l59t-report-core.json`

Fidelity sweep summary: total impact 74.32, 154 styles, citations
3552/3680, bibliography 7818/8571, quality score 0.955.
