### PR TITLE
Engine review: audit + high/medium finding fixes

### DIFF
--- a/.beans/archive/csl26-nj72--comprehensive-review-of-citum-engine-crate.md
+++ b/.beans/archive/csl26-nj72--comprehensive-review-of-citum-engine-crate.md
@@ -1,0 +1,24 @@
+---
+# csl26-nj72
+title: Comprehensive review of citum-engine crate
+status: completed
+type: task
+priority: normal
+created_at: 2026-07-04T01:32:12Z
+updated_at: 2026-07-04T01:40:43Z
+---
+
+Careful, comprehensive code review of crates/citum_engine. Findings recorded in a date-stamped audit document in docs/architecture/audits/ on a new branch.
+
+## Summary of Changes
+
+Reviewed citum-engine (~45k lines): full read of the API layer, processor
+spine, FFI, and grouping/sorting; mechanical panic/unsafe/TODO scans crate-
+wide. Baseline verified: clippy -D warnings clean, 846/846 nextest pass.
+
+Findings recorded in docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md
+on branch audit/citum-engine-review-2026-07: 2 high (process::exit(1) in
+Processor::process_document; hardcoded harvard-cite-them-right style id in
+the engine), 10 medium (heading type-name hack, session/tier-1 duplication,
+uncached Sorter, per-component Config clones, pointer-keyed disambiguation
+cache, etc.), 7 low. Follow-up beans suggested in the audit doc.

--- a/.beans/archive/csl26-vq1g--fix-engine-review-high-selected-medium-findings.md
+++ b/.beans/archive/csl26-vq1g--fix-engine-review-high-selected-medium-findings.md
@@ -1,11 +1,11 @@
 ---
 # csl26-vq1g
 title: Fix engine review high + selected medium findings
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-07-04T02:02:06Z
-updated_at: 2026-07-04T02:42:45Z
+updated_at: 2026-07-04T10:38:01Z
 ---
 
 Implement approved plan from audit csl26-nj72 on branch audit/citum-engine-review-2026-07. Commits: (1) process_document returns Result, (2) no-date-form style option replaces harvard hardcode, (3) headings via OutputFormat, (4) id stubs in custom-group path, (5) warning scanner sub-spec recursion, (6) non-UTF-8 refs input error, (7) crate CLAUDE.md refresh, (8) follow-up beans. Then open PR.
@@ -18,4 +18,15 @@ Implement approved plan from audit csl26-nj72 on branch audit/citum-engine-revie
 - [x] Commit 6: refs input UTF-8 (b7662f8c)
 - [x] Commit 7: CLAUDE.md refresh (06f548a0)
 - [x] Commit 8: follow-up beans (csl26-aawl, csl26-54bk, csl26-dog9, csl26-wj7z, csl26-b801, csl26-qi7l, csl26-wfua, csl26-dr0r)
-- [ ] Push branch + open PR + CI green
+- [x] Push branch + open PR + CI green (PR #1001, all checks pass)
+
+## Summary of Changes
+
+All planned commits landed on audit/citum-engine-review-2026-07 and PR #1001
+opened with all CI checks green (semver, fidelity, hygiene, release dry runs,
+rust lint+test, security audit, WASM smoke). Both high findings fixed
+(process_document returns Result; no-date-form style option replaces the
+harvard hardcode), four medium findings fixed (OutputFormat headings, id
+stubs, sub-spec warning scan, non-UTF-8 refs error), crate CLAUDE.md
+refreshed, and eight follow-up beans filed for deferred findings. Merge is
+the user's action.

--- a/.beans/csl26-54bk--cache-resolved-refs-and-style-in-documentsession.md
+++ b/.beans/csl26-54bk--cache-resolved-refs-and-style-in-documentsession.md
@@ -1,0 +1,10 @@
+---
+# csl26-54bk
+title: Cache resolved refs and style in DocumentSession
+status: todo
+type: task
+created_at: 2026-07-04T02:42:25Z
+updated_at: 2026-07-04T02:42:25Z
+---
+
+Every session mutation re-parses RefsInput (full YAML/JSON parse), re-runs warning scans, rebuilds the Processor (disambiguation hints), and re-renders the whole document. Cache the resolved Bibliography (invalidate on put_references) and consider caching the resolved style. docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md finding 5.

--- a/.beans/csl26-aawl--extract-shared-tier-1session-document-pipeline.md
+++ b/.beans/csl26-aawl--extract-shared-tier-1session-document-pipeline.md
@@ -1,0 +1,10 @@
+---
+# csl26-aawl
+title: Extract shared tier-1/session document pipeline
+status: todo
+type: task
+created_at: 2026-07-04T02:42:25Z
+updated_at: 2026-07-04T02:42:25Z
+---
+
+DocumentSession::render_citations duplicates ~130 lines of format_document_with_style (locale warning, warning scans, missing-ref filtering, nocite, 6-way OutputFormatKind dispatch repeated 5x). Extract a shared prepare_processor helper and a single format-dispatch helper. Fold in session loose ends: unused _style_input param in DocumentSession::new; diff_formatted_citations omits deletions; process_document_with_caller_blocks silently ignores frontmatter errors. docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md findings 4, 17.

--- a/.beans/csl26-b801--unify-sorter-into-groupsorter-with-cached-keys.md
+++ b/.beans/csl26-b801--unify-sorter-into-groupsorter-with-cached-keys.md
@@ -1,0 +1,10 @@
+---
+# csl26-b801
+title: Unify Sorter into GroupSorter with cached keys
+status: todo
+type: task
+created_at: 2026-07-04T02:42:26Z
+updated_at: 2026-07-04T02:42:26Z
+---
+
+processor/sorting.rs Sorter recomputes author/title sort keys (collation, article stripping) on every comparison; grouping/sorting.rs GroupSorter already has the cached Schwartzian pattern. Unify the two stacks, dedupe compare_optional_years, and implement or explicitly reject the silent no-op SortKey::CitationNumber. docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md finding 8.

--- a/.beans/csl26-dog9--design-explicit-render-run-state-for-processor.md
+++ b/.beans/csl26-dog9--design-explicit-render-run-state-for-processor.md
@@ -1,0 +1,10 @@
+---
+# csl26-dog9
+title: 'Design: explicit render-run state for Processor'
+status: todo
+type: task
+created_at: 2026-07-04T02:42:26Z
+updated_at: 2026-07-04T02:42:26Z
+---
+
+Processor uses RefCell interior mutability (citation_numbers, cited_ids, first_note_by_id, dynamic compound maps), making &self render methods order-dependent and non-idempotent, with invariants recorded only in comments. Design an explicit per-run state object so ordering contracts are typed and Processor becomes reusable/shareable. docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md finding 6.

--- a/.beans/csl26-dr0r--engine-review-low-severity-cleanups.md
+++ b/.beans/csl26-dr0r--engine-review-low-severity-cleanups.md
@@ -1,0 +1,10 @@
+---
+# csl26-dr0r
+title: Engine review low-severity cleanups
+status: todo
+type: task
+created_at: 2026-07-04T02:42:26Z
+updated_at: 2026-07-04T02:42:26Z
+---
+
+Batch of low findings from the engine review: collection-editor lookups via ContributorRole::Unknown (add first-class role); get_variable_key builds variable-once keys from Debug formatting (use explicit names); with_compound_sets silently discards invalid sets without a warning; Renderer is pub with all-pub fields incl. RefCell scratch state (tighten to pub(crate)). docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md findings 14, 15, 16, 18.

--- a/.beans/csl26-qi7l--reduce-per-component-config-clones-in-render-path.md
+++ b/.beans/csl26-qi7l--reduce-per-component-config-clones-in-render-path.md
@@ -1,0 +1,10 @@
+---
+# csl26-qi7l
+title: Reduce per-component config clones in render path
+status: todo
+type: task
+created_at: 2026-07-04T02:42:26Z
+updated_at: 2026-07-04T02:42:26Z
+---
+
+Each ProcTemplateComponent carries an owned Config clone plus BibliographyConfig clone; RenderOptions/Renderer construction clones BibliographyConfig too. O(entries x components) deep clones per render pass. Borrow or Rc/Arc the configs. Watch cargo bench --bench rendering. docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md finding 9.

--- a/.beans/csl26-vq1g--fix-engine-review-high-selected-medium-findings.md
+++ b/.beans/csl26-vq1g--fix-engine-review-high-selected-medium-findings.md
@@ -1,0 +1,21 @@
+---
+# csl26-vq1g
+title: Fix engine review high + selected medium findings
+status: in-progress
+type: task
+priority: normal
+created_at: 2026-07-04T02:02:06Z
+updated_at: 2026-07-04T02:42:45Z
+---
+
+Implement approved plan from audit csl26-nj72 on branch audit/citum-engine-review-2026-07. Commits: (1) process_document returns Result, (2) no-date-form style option replaces harvard hardcode, (3) headings via OutputFormat, (4) id stubs in custom-group path, (5) warning scanner sub-spec recursion, (6) non-UTF-8 refs input error, (7) crate CLAUDE.md refresh, (8) follow-up beans. Then open PR.
+
+- [x] Commit 1: process_document Result (6f10c907)
+- [x] Commit 2: no-date-form option + schema-gen (02197175)
+- [x] Commit 3: OutputFormat headings (e0609b1f)
+- [x] Commit 4: sorted_id_stubs (69f5a397)
+- [x] Commit 5: warnings sub-spec scan (635101c8)
+- [x] Commit 6: refs input UTF-8 (b7662f8c)
+- [x] Commit 7: CLAUDE.md refresh (06f548a0)
+- [x] Commit 8: follow-up beans (csl26-aawl, csl26-54bk, csl26-dog9, csl26-wj7z, csl26-b801, csl26-qi7l, csl26-wfua, csl26-dr0r)
+- [ ] Push branch + open PR + CI green

--- a/.beans/csl26-wfua--consolidate-engine-error-types-on-thiserror.md
+++ b/.beans/csl26-wfua--consolidate-engine-error-types-on-thiserror.md
@@ -1,0 +1,10 @@
+---
+# csl26-wfua
+title: Consolidate engine error types on thiserror
+status: todo
+type: task
+created_at: 2026-07-04T02:42:26Z
+updated_at: 2026-07-04T02:42:26Z
+---
+
+FormatDocumentError and DocumentSessionError hand-roll Display/Error despite thiserror being a dependency; ProcessorError variants are stringly (ParseError("BIBLIOGRAPHY"/"FRONTMATTER", ...) used for validation and frontmatter). Add typed variants and derive consistently. docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md finding 13.

--- a/.beans/csl26-wj7z--key-disambiguation-cache-by-reference-id.md
+++ b/.beans/csl26-wj7z--key-disambiguation-cache-by-reference-id.md
@@ -1,0 +1,10 @@
+---
+# csl26-wj7z
+title: Key disambiguation cache by reference id
+status: todo
+type: task
+created_at: 2026-07-04T02:42:26Z
+updated_at: 2026-07-04T02:42:26Z
+---
+
+Disambiguator::reference_cache_key uses the pointer address of &Reference and reference_data expects a hit. Correct only because cache build and lookups happen within one calculate_hints call over an unmoved IndexMap. Key by reference id (index fallback for id-less refs) and drop the expect_used exception. docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md finding 7.

--- a/crates/citum-cli/src/commands/render/mod.rs
+++ b/crates/citum-cli/src/commands/render/mod.rs
@@ -233,22 +233,22 @@ fn render_doc_with_output_format(
             let parser = DjotParser;
             match output_format {
                 OutputFormat::Plain => {
-                    Ok(processor.process_document::<_, PlainText>(content, &parser, doc_format))
+                    Ok(processor.process_document::<_, PlainText>(content, &parser, doc_format)?)
                 }
                 OutputFormat::Html => {
-                    Ok(processor.process_document::<_, Html>(content, &parser, doc_format))
+                    Ok(processor.process_document::<_, Html>(content, &parser, doc_format)?)
                 }
                 OutputFormat::Djot => {
-                    Ok(processor.process_document::<_, Djot>(content, &parser, doc_format))
+                    Ok(processor.process_document::<_, Djot>(content, &parser, doc_format)?)
                 }
                 OutputFormat::Markdown => {
-                    Ok(processor.process_document::<_, Markdown>(content, &parser, doc_format))
+                    Ok(processor.process_document::<_, Markdown>(content, &parser, doc_format)?)
                 }
                 OutputFormat::Latex => {
-                    Ok(processor.process_document::<_, Latex>(content, &parser, doc_format))
+                    Ok(processor.process_document::<_, Latex>(content, &parser, doc_format)?)
                 }
                 OutputFormat::Typst => {
-                    Ok(processor.process_document::<_, Typst>(content, &parser, doc_format))
+                    Ok(processor.process_document::<_, Typst>(content, &parser, doc_format)?)
                 }
             }
         }
@@ -256,22 +256,22 @@ fn render_doc_with_output_format(
             let parser = MarkdownParser;
             match output_format {
                 OutputFormat::Plain => {
-                    Ok(processor.process_document::<_, PlainText>(content, &parser, doc_format))
+                    Ok(processor.process_document::<_, PlainText>(content, &parser, doc_format)?)
                 }
                 OutputFormat::Html => {
-                    Ok(processor.process_document::<_, Html>(content, &parser, doc_format))
+                    Ok(processor.process_document::<_, Html>(content, &parser, doc_format)?)
                 }
                 OutputFormat::Djot => {
-                    Ok(processor.process_document::<_, Djot>(content, &parser, doc_format))
+                    Ok(processor.process_document::<_, Djot>(content, &parser, doc_format)?)
                 }
                 OutputFormat::Markdown => {
-                    Ok(processor.process_document::<_, Markdown>(content, &parser, doc_format))
+                    Ok(processor.process_document::<_, Markdown>(content, &parser, doc_format)?)
                 }
                 OutputFormat::Latex => {
-                    Ok(processor.process_document::<_, Latex>(content, &parser, doc_format))
+                    Ok(processor.process_document::<_, Latex>(content, &parser, doc_format)?)
                 }
                 OutputFormat::Typst => {
-                    Ok(processor.process_document::<_, Typst>(content, &parser, doc_format))
+                    Ok(processor.process_document::<_, Typst>(content, &parser, doc_format)?)
                 }
             }
         }

--- a/crates/citum-engine/CLAUDE.md
+++ b/crates/citum-engine/CLAUDE.md
@@ -9,15 +9,15 @@ The citation/bibliography rendering engine. Consumes Citum-schema styles + Input
 | `src/lib.rs` | Crate roots and public API |
 | `src/api/` | Public engine entry points (call from CLI, FFI, WASM) |
 | `src/processor/` | Style-driven processing core |
-| `src/render/` | Render passes — `citations.rs`, bibliography, sort, layout |
+| `src/render/` | Render passes — `citation.rs`, bibliography, sort, layout |
 | `src/grouping/` | Cite-group resolution (integral multi-cite, et al.) |
 | `src/values/` | Resolved value types (`MaybeGendered`, dates, names) |
-| `src/ffi/` | C ABI surface: `mod.rs` (~570 lines) + `biblatex.rs` (uses `BibRefContext<'a>` to avoid `too_many_arguments`) |
+| `src/ffi/` | C ABI surface: `mod.rs` (processor lifecycle + render entry points) |
 | `src/sort_partitioning.rs` | Bibliography sort & partition logic |
 
 ## Gotchas
 
-- **Integral multi-cites** join via locale-aware prose ("Smith (2020) and Jones (2021)"). Grouped integral locator punctuation must not duplicate delimiters — see commit `88a6f62`. File: `src/render/citations.rs`.
+- **Integral multi-cites** join via locale-aware prose ("Smith (2020) and Jones (2021)"). Grouped integral locator punctuation must not duplicate delimiters — see commit `88a6f62`. File: `src/render/citation.rs`.
 - **Oracle routing:** check the style's `originKey` before picking an oracle. CSL-derived → CSL oracle (`node scripts/oracle.js`); biblatex-derived → biblatex oracle. Never run a CSL-shape oracle against a biblatex-derived style — the diff is meaningless.
 - **Locale MF2 is live** for locator/role term resolution — `messages:` consulted first, falls back to legacy `terms:` / `roles:` / `locators:`. Gendered role labels still flow through `roles:` (multi-selector MF2 follow-up pending).
 - **No `unwrap()` / `unsafe`.** Result/Option must surface as engine errors via `src/error.rs`.

--- a/crates/citum-engine/src/api/refs_input.rs
+++ b/crates/citum-engine/src/api/refs_input.rs
@@ -28,8 +28,8 @@ use serde::{Deserialize, Serialize};
 pub enum RefsInput {
     /// Local filesystem path to a refs file.
     ///
-    /// YAML/JSON/CBOR extensions are loaded as native Citum refs; `.bib`
-    /// extensions are parsed as BibLaTeX.
+    /// `.bib` extensions are parsed as BibLaTeX; all other extensions are
+    /// parsed as native Citum YAML (JSON parses as a YAML subset).
     Path(String),
     /// Inline YAML refs string.
     Yaml(String),
@@ -190,7 +190,8 @@ impl RefsInput {
     /// Resolve refs input locally from Path, Yaml, Json, or Biblatex variants.
     ///
     /// For `Path` inputs, `.bib` files are parsed as BibLaTeX; all other
-    /// extensions are parsed as native Citum YAML/JSON/CBOR.
+    /// extensions are parsed as native Citum YAML (JSON parses as a YAML
+    /// subset).
     ///
     /// # Errors
     ///
@@ -216,7 +217,12 @@ impl RefsInput {
                         path, e
                     ))
                 })?;
-                let yaml_str = String::from_utf8_lossy(&bytes);
+                let yaml_str = String::from_utf8(bytes).map_err(|_| {
+                    crate::api::FormatDocumentError::RefsInputParse(format!(
+                        "Refs input file '{}' is not valid UTF-8",
+                        path
+                    ))
+                })?;
                 parse_yaml_bibliography(&yaml_str).map_err(|e| {
                     crate::api::FormatDocumentError::RefsInputParse(format!(
                         "Failed to parse refs input from '{}': {}",
@@ -366,6 +372,26 @@ mod tests {
                 assert!(msg.contains("Failed to read"));
             }
             _ => panic!("Expected RefsInputPath error"),
+        }
+    }
+
+    #[test]
+    fn refs_input_path_invalid_utf8_returns_parse_error() {
+        let mut tmp = tempfile::Builder::new()
+            .suffix(".yaml")
+            .tempfile()
+            .expect("Failed to create temp .yaml file");
+        tmp.write_all(&[0xff, 0xfe, 0x00, 0x01])
+            .expect("Failed to write temp file");
+        tmp.flush().expect("Failed to flush temp file");
+
+        let input = RefsInput::Path(tmp.path().to_string_lossy().to_string());
+        let result = input.resolve_local();
+        match result {
+            Err(crate::api::FormatDocumentError::RefsInputParse(msg)) => {
+                assert!(msg.contains("not valid UTF-8"));
+            }
+            _ => panic!("Expected RefsInputParse error"),
         }
     }
 

--- a/crates/citum-engine/src/api/warnings.rs
+++ b/crates/citum-engine/src/api/warnings.rs
@@ -148,18 +148,74 @@ pub fn unknown_enum_warnings(processor: &Processor) -> Vec<Warning> {
             scan_template_for_unknowns(template, &format!("template '{name}'"), &mut warnings);
         }
     }
-    if let Some(citation) = &processor.style.citation
-        && let Some(template) = &citation.template
-    {
-        scan_template_for_unknowns(template, "citation layout", &mut warnings);
+    if let Some(citation) = &processor.style.citation {
+        scan_citation_spec_for_unknowns(citation, "citation layout", &mut warnings);
     }
-    if let Some(bib) = &processor.style.bibliography
-        && let Some(template) = &bib.template
-    {
-        scan_template_for_unknowns(template, "bibliography layout", &mut warnings);
+    if let Some(bib) = &processor.style.bibliography {
+        if let Some(template) = &bib.template {
+            scan_template_for_unknowns(template, "bibliography layout", &mut warnings);
+        }
+        if let Some(type_variants) = &bib.type_variants {
+            for variant in type_variants.values() {
+                if let Some(template) = variant.as_template() {
+                    scan_template_for_unknowns(template, "bibliography layout", &mut warnings);
+                }
+            }
+        }
+        if let Some(locales) = &bib.locales {
+            for locale_spec in locales {
+                scan_template_for_unknowns(
+                    &locale_spec.template,
+                    "bibliography layout",
+                    &mut warnings,
+                );
+            }
+        }
     }
 
     warnings
+}
+
+/// Recursively scan a [`citum_schema::CitationSpec`] and its mode/position
+/// sub-specs (`integral`, `non-integral`, `subsequent`, `ibid`), plus its
+/// `type-variants` and per-locale templates, for unknown enum variants.
+///
+/// The top-level `unknown_enum_warnings` scan previously inspected only the
+/// main citation template, missing unknown terms/roles/date-forms nested in
+/// sub-specs, type-variants, and localized templates.
+fn scan_citation_spec_for_unknowns(
+    spec: &citum_schema::CitationSpec,
+    location: &str,
+    warnings: &mut Vec<Warning>,
+) {
+    if let Some(template) = &spec.template {
+        scan_template_for_unknowns(template, location, warnings);
+    }
+    if let Some(type_variants) = &spec.type_variants {
+        for variant in type_variants.values() {
+            if let Some(template) = variant.as_template() {
+                scan_template_for_unknowns(template, location, warnings);
+            }
+        }
+    }
+    if let Some(locales) = &spec.locales {
+        for locale_spec in locales {
+            scan_template_for_unknowns(&locale_spec.template, location, warnings);
+        }
+    }
+
+    if let Some(child) = &spec.integral {
+        scan_citation_spec_for_unknowns(child, &format!("{location} (integral)"), warnings);
+    }
+    if let Some(child) = &spec.non_integral {
+        scan_citation_spec_for_unknowns(child, &format!("{location} (non-integral)"), warnings);
+    }
+    if let Some(child) = &spec.subsequent {
+        scan_citation_spec_for_unknowns(child, &format!("{location} (subsequent)"), warnings);
+    }
+    if let Some(child) = &spec.ibid {
+        scan_citation_spec_for_unknowns(child, &format!("{location} (ibid)"), warnings);
+    }
 }
 
 fn scan_template_for_unknowns(
@@ -217,5 +273,41 @@ fn scan_template_for_unknowns(
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_enum_warnings_reports_unknown_term_in_integral_sub_spec() {
+        let yaml = "info:\n  title: Test\ncitation:\n  integral:\n    template:\n      - term: not-a-real-term\n";
+        let style = citum_schema::Style::from_yaml_str(yaml).unwrap();
+        let processor = Processor::new(style, Bibliography::new());
+
+        let warnings = unknown_enum_warnings(&processor);
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.message.contains("not-a-real-term") && w.message.contains("(integral)")),
+            "expected a warning for the unknown term in citation.integral.template, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_enum_warnings_reports_unknown_term_in_type_variants() {
+        let yaml = "info:\n  title: Test\ncitation:\n  type-variants:\n    book:\n      - term: not-a-real-term-2\n";
+        let style = citum_schema::Style::from_yaml_str(yaml).unwrap();
+        let processor = Processor::new(style, Bibliography::new());
+
+        let warnings = unknown_enum_warnings(&processor);
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.message.contains("not-a-real-term-2")),
+            "expected a warning for the unknown term in citation.type-variants, got: {warnings:?}"
+        );
     }
 }

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -824,10 +824,7 @@ impl Processor {
     where
         F: OutputFormat<Output = String>,
     {
-        if std::any::type_name::<F>() == std::any::type_name::<crate::render::html::Html>() {
-            return format!("<h2>{heading}</h2>\n\n");
-        }
-
-        format!("# {heading}\n\n")
+        let fmt = F::default();
+        fmt.finish(fmt.unnumbered_heading(2, fmt.text(heading)))
     }
 }

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -119,7 +119,7 @@ impl Processor {
     ///
     /// Used for grouping paths that only need IDs for selector matching — avoids
     /// the full PlainText render pass that `process_references` performs.
-    fn sorted_id_stubs(&self) -> Vec<ProcEntry> {
+    pub(super) fn sorted_id_stubs(&self) -> Vec<ProcEntry> {
         self.initialize_numeric_bibliography_numbers();
         self.sort_references(self.bibliography.values().collect())
             .into_iter()

--- a/crates/citum-engine/src/processor/bibliography/mod.rs
+++ b/crates/citum-engine/src/processor/bibliography/mod.rs
@@ -294,7 +294,7 @@ impl Processor {
             .filter(|bibliography| bibliography.groups_enabled)
             .and_then(|bibliography| bibliography.groups.as_ref())
         {
-            let all_entries = self.process_references().bibliography;
+            let all_entries = self.sorted_id_stubs();
             return self.render_with_custom_groups_filtered::<F>(
                 &all_entries,
                 groups,

--- a/crates/citum-engine/src/processor/document/pipeline.rs
+++ b/crates/citum-engine/src/processor/document/pipeline.rs
@@ -11,6 +11,7 @@ use super::output::{
     rewrite_document_markup_for_typst, stage_document_bibliography_blocks,
 };
 use super::{BibliographyBlock, CitationParser, DocumentFormat, ParsedDocument};
+use crate::error::ProcessorError;
 use crate::processor::Processor;
 
 /// Format a bibliography section heading for the trailing-bibliography path.
@@ -42,6 +43,11 @@ impl Processor {
     /// 1. Parses the source document using the provided adapter.
     /// 2. Resolves frontmatter overrides (integral-name policy, bibliography options).
     /// 3. Chooses a bibliography orchestration path based on frontmatter and document blocks.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ProcessorError::ParseError` when the document's frontmatter
+    /// fails to parse.
     #[allow(
         clippy::string_slice,
         reason = "parser-guaranteed boundaries and indices"
@@ -51,7 +57,7 @@ impl Processor {
         content: &str,
         parser: &P,
         format: DocumentFormat,
-    ) -> String
+    ) -> Result<String, ProcessorError>
     where
         P: CitationParser,
         F: crate::render::format::OutputFormat<Output = String>,
@@ -59,8 +65,10 @@ impl Processor {
         let mut parsed = parser.parse_document(content, &self.locale);
 
         if let Some(err) = &parsed.frontmatter_error {
-            eprintln!("citum: error: frontmatter parse error: {err}");
-            std::process::exit(1);
+            return Err(ProcessorError::ParseError(
+                "FRONTMATTER".to_string(),
+                err.clone(),
+            ));
         }
 
         // `options.*` fields take precedence over the legacy top-level fields.
@@ -103,21 +111,22 @@ impl Processor {
             .unwrap_or(self);
         let body = &content[parsed.body_start..];
         if let Some(groups) = parsed.frontmatter_groups.take() {
-            return processor.process_document_with_frontmatter_groups::<P, F>(
+            return Ok(processor.process_document_with_frontmatter_groups::<P, F>(
                 body, parsed, groups, parser, format,
-            );
+            ));
         }
 
         if !parsed.bibliography_blocks.is_empty() {
-            return processor.process_document_with_bibliography_blocks::<P, F>(
+            return Ok(processor.process_document_with_bibliography_blocks::<P, F>(
                 body,
                 std::mem::take(&mut parsed.bibliography_blocks),
                 parser,
                 format,
-            );
+            ));
         }
 
-        processor.process_document_with_default_bibliography::<P, F>(body, parsed, parser, format)
+        Ok(processor
+            .process_document_with_default_bibliography::<P, F>(body, parsed, parser, format))
     }
 
     /// Orchestrate document processing with custom frontmatter bibliography groups.

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -3,6 +3,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
+use crate::error::ProcessorError;
 use crate::processor::Processor;
 use crate::processor::document::{CitationParser, DocumentFormat, djot::DjotParser};
 use crate::reference::{Bibliography, Reference};
@@ -231,8 +232,9 @@ fn test_author_date_documents_still_render_inline() {
     let parser = DjotParser;
 
     let content = "Visible citation: [@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -247,8 +249,9 @@ fn test_note_style_prose_citation_generates_footnote() {
     let parser = DjotParser;
 
     let content = "Text [@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -263,8 +266,9 @@ fn test_manual_footnote_citations_render_in_place() {
     let parser = DjotParser;
 
     let content = "Text[^m1].\n\n[^m1]: See [@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -279,8 +283,9 @@ fn test_manual_footnote_definition_is_not_duplicated() {
     let parser = DjotParser;
 
     let content = "Text[^m1].\n\n[^m1]: See [@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -295,8 +300,9 @@ fn test_mixed_manual_and_auto_notes_share_sequence() {
     let parser = DjotParser;
 
     let content = "Manual[^m1]. Auto [@item2]. Later[^m2].\n\n[^m1]: First [@item1].\n\n[^m2]: Second [@item2].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -311,8 +317,9 @@ fn test_multiple_citations_in_manual_footnote_are_preserved() {
     let parser = DjotParser;
 
     let content = "Text[^m1].\n\n[^m1]: See [@item1]. Compare [@item2].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -327,8 +334,9 @@ fn test_multi_cite_prose_marker_produces_one_generated_note() {
     let parser = DjotParser;
 
     let content = "Text [@item1; @item2].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -343,8 +351,9 @@ fn test_note_style_preserves_surrounding_punctuation() {
     let parser = DjotParser;
 
     let content = "Sentence [@item1]. Next, [@item2] (see [@item1]).";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -359,8 +368,9 @@ fn test_note_style_default_rule_places_marker_after_period() {
     let parser = DjotParser;
 
     let content = "Sentence [@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -383,8 +393,9 @@ fn test_note_style_config_can_place_marker_before_period() {
     let parser = DjotParser;
 
     let content = "Sentence [@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -407,8 +418,9 @@ fn test_note_style_config_moves_marker_inside_quotes() {
     let parser = DjotParser;
 
     let content = "\"Quoted [@item1].\"";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -423,8 +435,9 @@ fn test_note_order_uses_manual_reference_order_not_definition_order() {
     let parser = DjotParser;
 
     let content = "Manual[^m1]. Later [@item1].\n\n[^m1]: See [@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -439,11 +452,9 @@ fn test_note_style_html_output_contains_footnotes() {
     let parser = DjotParser;
 
     let content = "Text [@item1].";
-    let result = processor.process_document::<_, crate::render::html::Html>(
-        content,
-        &parser,
-        DocumentFormat::Html,
-    );
+    let result = processor
+        .process_document::<_, crate::render::html::Html>(content, &parser, DocumentFormat::Html)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -462,8 +473,9 @@ fn test_note_style_integral_citation_keeps_prose_anchor() {
     let parser = DjotParser;
 
     let content = "Narrative [+@item1] continues.";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -540,8 +552,9 @@ fn test_repro_djot_rendering() {
     let parser = DjotParser;
 
     let content = "Integral: [+@item1]. SuppressAuthor: [-@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(result, "Integral: Doe (2020). SuppressAuthor: (2020).");
 }
@@ -557,8 +570,9 @@ fn test_real_chicago_note_style_generates_djot_footnotes() {
     let parser = DjotParser;
 
     let content = "Text [@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -587,8 +601,9 @@ bibliography:
 
 Some text [@item1]."#;
 
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     // Should have the frontmatter heading and bibliography groups rendered
     // Groups are rendered as H2 sub-headings under the H1 Bibliography heading.
@@ -605,8 +620,9 @@ fn test_document_without_bibliography_blocks_uses_default() {
     let parser = DjotParser;
 
     let content = "Text [@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     // Should have default bibliography heading
     assert_eq!(
@@ -622,7 +638,9 @@ fn test_document_without_bibliography_blocks_uses_typst_heading() {
     let parser = DjotParser;
 
     let content = "Text [@item1].";
-    let result = processor.process_document::<_, Typst>(content, &parser, DocumentFormat::Typst);
+    let result = processor
+        .process_document::<_, Typst>(content, &parser, DocumentFormat::Typst)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -640,8 +658,9 @@ fn test_document_with_inline_bibliography_block() {
     // that citation processing still works. Full inline block attribute parsing
     // would require the block to use proper djot syntax.
     let content = "Text [@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -670,7 +689,9 @@ bibliography:
 
 Some text [@item1]."#;
 
-    let result = processor.process_document::<_, Typst>(content, &parser, DocumentFormat::Typst);
+    let result = processor
+        .process_document::<_, Typst>(content, &parser, DocumentFormat::Typst)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -702,11 +723,9 @@ bibliography:
 
 Some text [@item1]."#;
 
-    let result = processor.process_document::<_, crate::render::html::Html>(
-        content,
-        &parser,
-        DocumentFormat::Html,
-    );
+    let result = processor
+        .process_document::<_, crate::render::html::Html>(content, &parser, DocumentFormat::Html)
+        .expect("document should render");
 
     // Group heading must be a pre-rendered HTML <h2>, not a Markdown ## that leaked through.
     assert!(
@@ -744,8 +763,9 @@ bibliography:
 
 Some text [@item1]."#;
 
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     // Empty "Cases" group must produce no heading or body.
     assert!(
@@ -772,8 +792,9 @@ fn test_integral_name_memory_full_then_short_in_one_document() {
     let parser = DjotParser;
 
     let content = "First [+@item1]. Later [+@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -794,8 +815,9 @@ fn test_suppress_author_counts_as_seen_for_later_integral_name_memory() {
     let parser = DjotParser;
 
     let content = "Hidden [-@item1]. Later [+@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -816,8 +838,9 @@ fn test_integral_name_memory_chapter_reset_uses_full_name_again() {
     let parser = DjotParser;
 
     let content = "# One\n\n[+@item1]. [+@item1].\n\n# Two\n\n[+@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -838,8 +861,9 @@ fn test_integral_name_memory_section_reset_uses_full_name_again() {
     let parser = DjotParser;
 
     let content = "## One\n\n[+@item1]. [+@item1].\n\n## Two\n\n[+@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -858,8 +882,9 @@ fn test_integral_name_memory_body_only_ignores_note_mentions() {
 
     let content =
         "Lead[^n1]. First body [+@item1]. Later body [+@item1].\n\n[^n1]: Note [+@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -880,8 +905,9 @@ fn test_integral_name_memory_body_and_notes_keeps_body_first_after_note_first() 
     let parser = DjotParser;
 
     let content = "Lead[^n1]. First body [+@item1].\n\n[^n1]: First note [+@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -902,8 +928,9 @@ fn test_integral_name_memory_repeated_note_then_body_transitions_correctly() {
     let parser = DjotParser;
 
     let content = "Lead[^n1] and again[^n2]. First body [+@item1]. Later[^n3].\n\n[^n1]: One [+@item1].\n\n[^n2]: Two [+@item1].\n\n[^n3]: Three [+@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -929,8 +956,9 @@ integral-name-memory:
 ---
 
 First [+@item1]. Later [+@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -963,7 +991,9 @@ integral-name-memory:
 # Two
 
 [+@item1].";
-    let result = processor.process_document::<_, Typst>(content, &parser, DocumentFormat::Typst);
+    let result = processor
+        .process_document::<_, Typst>(content, &parser, DocumentFormat::Typst)
+        .expect("document should render");
 
     assert_eq!(
         result,
@@ -999,8 +1029,9 @@ integral-name-memory:
 ---
 
 First [+@item1]. Later [+@item1]."#;
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     // Groups are H2 sub-headings. Unmatched refs (Jane Smith, not cited) are not
     // rendered — use an explicit catch-all group with `selector: {}` to capture them.
@@ -1008,6 +1039,26 @@ First [+@item1]. Later [+@item1]."#;
         result,
         "First John Doe. Later Doe.\n\n# Bibliography\n\n## Cited Works\n\nJohn Doe (2020)"
     );
+}
+
+#[test]
+fn test_document_frontmatter_parse_error_returns_err() {
+    let bib = make_test_bib();
+    let processor = Processor::new(make_author_date_style(), bib);
+    let parser = DjotParser;
+
+    // Malformed YAML (unclosed flow sequence) inside the frontmatter fence
+    // fails `serde_yaml` deserialization, which must surface as an `Err`
+    // rather than terminating the process.
+    let content = "---\noptions: [unclosed\n---\n\nText [@item1].";
+
+    let result =
+        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+
+    match result {
+        Err(ProcessorError::ParseError(name, _)) => assert_eq!(name, "FRONTMATTER"),
+        other => panic!("expected frontmatter ParseError, got {other:?}"),
+    }
 }
 
 /// Build `make_author_date_style` with a catch-all `bibliography.groups` entry so
@@ -1035,8 +1086,9 @@ fn test_grouped_style_document_with_no_citations_omits_bibliography() {
     let parser = DjotParser;
 
     let content = "Some text with no citations.";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(result, "Some text with no citations.");
 }
@@ -1051,8 +1103,9 @@ fn test_grouped_style_document_bibliography_contains_only_cited_references() {
 
     // item1 (Doe 2020) is cited; item2 (Smith 2010) must not appear.
     let content = "Text [@item1].";
-    let result =
-        processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
+    let result = processor
+        .process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain)
+        .expect("document should render");
 
     assert_eq!(
         result,

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -1258,18 +1258,19 @@ impl Renderer<'_> {
         }
     }
 
+    /// Term form used for the "no date" fallback, from `options.dates.no-date-form`
+    /// (default `short`).
     fn preferred_no_date_term_form(&self) -> citum_schema::locale::TermForm {
         match self
-            .style
-            .info
-            .source
+            .config
+            .dates
             .as_ref()
-            .map(|source| source.csl_id.as_str())
+            .and_then(|dates| dates.no_date_form)
         {
-            Some("http://www.zotero.org/styles/harvard-cite-them-right") => {
-                citum_schema::locale::TermForm::Long
+            Some(citum_schema::options::NoDateForm::Long) => citum_schema::locale::TermForm::Long,
+            Some(citum_schema::options::NoDateForm::Short) | None => {
+                citum_schema::locale::TermForm::Short
             }
-            _ => citum_schema::locale::TermForm::Short,
         }
     }
 

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -355,7 +355,7 @@ fn make_grouped_compound_selection_processor(leader_note: &str, sibling_note: &s
 }
 
 fn extract_selected_group_body(output: &str) -> String {
-    let heading = "# Selected\n\n";
+    let heading = "## Selected\n\n";
     let start = output
         .find(heading)
         .unwrap_or_else(|| panic!("missing selected heading in output: {output}"));
@@ -3118,7 +3118,7 @@ fn test_bibliography_per_group_disambiguation() {
     // Group 2 restarts the sequence (locally scoped) at a→"C title", b→"D title".
     assert_eq!(
         result,
-        "# Group 1\n\nKuhn, Thomas (1962a). _B title_\n\nKuhn, Thomas (1962b). _A title_\n\n# Group 2\n\nKuhn, Thomas (1962a). _C title_\n\nKuhn, Thomas (1962b). _D title_"
+        "## Group 1\n\nKuhn, Thomas (1962a). _B title_\n\nKuhn, Thomas (1962b). _A title_\n\n## Group 2\n\nKuhn, Thomas (1962a). _C title_\n\nKuhn, Thomas (1962b). _D title_"
     );
 }
 

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -977,6 +977,58 @@ fn test_parsed_style_no_date_terms_match_expected_variants() {
     );
 }
 
+/// Given a style whose `options.dates.no-date-form` is `long`, when a citation's
+/// issued date is missing, then the rendered "no date" term uses the long form;
+/// and given the same style without the option set, then it falls back to the
+/// short form. This is now a declarative option, not a hardcoded style-id check.
+#[test]
+fn given_no_date_form_option_when_issued_date_missing_then_term_form_matches_option() {
+    let mut bib = Bibliography::new();
+    bib.insert(
+        "undated".to_string(),
+        Reference::from(LegacyReference {
+            id: "undated".to_string(),
+            ref_type: "book".to_string(),
+            author: Some(vec![Name::new("Doe", "Jane")]),
+            title: Some("Untitled Work".to_string()),
+            ..Default::default()
+        }),
+    );
+    let citation = Citation {
+        id: Some("c1".into()),
+        items: vec![crate::reference::CitationItem {
+            id: "undated".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let mut long_style = make_style();
+    long_style.options = Some(Config {
+        dates: Some(citum_schema::options::DateConfig {
+            no_date_form: Some(citum_schema::options::NoDateForm::Long),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let long_rendered = Processor::new(long_style, bib.clone())
+        .process_citation(&citation)
+        .unwrap();
+    assert_eq!(
+        long_rendered, "(Doe, no date)",
+        "no-date-form: long should render the long no-date term"
+    );
+
+    let short_style = make_style();
+    let short_rendered = Processor::new(short_style, bib)
+        .process_citation(&citation)
+        .unwrap();
+    assert_eq!(
+        short_rendered, "(Doe, n.d.)",
+        "default no-date-form should render the short no-date term"
+    );
+}
+
 /// Tests the behavior of `test_render_bibliography`.
 #[test]
 fn test_render_bibliography() {

--- a/crates/citum-engine/src/render/djot.rs
+++ b/crates/citum-engine/src/render/djot.rs
@@ -28,6 +28,11 @@ impl OutputFormat for Djot {
         output
     }
 
+    fn heading(&self, level: u8, content: Self::Output) -> Self::Output {
+        let marks = "#".repeat(level.max(1) as usize);
+        format!("{marks} {content}\n\n")
+    }
+
     fn emph(&self, content: Self::Output) -> Self::Output {
         if content.is_empty() {
             return content;

--- a/crates/citum-engine/src/render/format.rs
+++ b/crates/citum-engine/src/render/format.rs
@@ -143,6 +143,16 @@ pub trait OutputFormat: Default + Clone {
         content
     }
 
+    /// Render an unnumbered heading at the given level.
+    ///
+    /// Used for generated section headings (e.g. bibliography group
+    /// headings) that must not participate in document section numbering.
+    /// Defaults to [`Self::heading`]; formats with numbered headings
+    /// (LaTeX) override this with their unnumbered variants.
+    fn unnumbered_heading(&self, level: u8, content: Self::Output) -> Self::Output {
+        self.heading(level, content)
+    }
+
     /// Render a fenced or indented code block with an optional language hint.
     ///
     /// `content` is the raw (unescaped) code text.

--- a/crates/citum-engine/src/render/html.rs
+++ b/crates/citum-engine/src/render/html.rs
@@ -58,6 +58,11 @@ impl OutputFormat for Html {
         output
     }
 
+    fn heading(&self, level: u8, content: Self::Output) -> Self::Output {
+        let level = level.clamp(1, 6);
+        format!("<h{level}>{content}</h{level}>\n\n")
+    }
+
     fn emph(&self, content: Self::Output) -> Self::Output {
         if content.is_empty() {
             return content;

--- a/crates/citum-engine/src/render/latex.rs
+++ b/crates/citum-engine/src/render/latex.rs
@@ -171,6 +171,16 @@ impl OutputFormat for Latex {
         format!("{cmd}{{{content}}}\n\n")
     }
 
+    fn unnumbered_heading(&self, level: u8, content: Self::Output) -> Self::Output {
+        let cmd = match level {
+            1 => "\\section*",
+            2 => "\\subsection*",
+            3 => "\\subsubsection*",
+            _ => "\\paragraph*",
+        };
+        format!("{cmd}{{{content}}}\n\n")
+    }
+
     fn code_block(&self, _lang: Option<&str>, content: Self::Output) -> Self::Output {
         format!("\\begin{{verbatim}}\n{content}\\end{{verbatim}}\n\n")
     }

--- a/crates/citum-engine/src/render/markdown.rs
+++ b/crates/citum-engine/src/render/markdown.rs
@@ -63,6 +63,12 @@ impl OutputFormat for Markdown {
         output
     }
 
+    /// Render a heading using ATX syntax (`#`, `##`, ...).
+    fn heading(&self, level: u8, content: Self::Output) -> Self::Output {
+        let marks = "#".repeat(level.max(1) as usize);
+        format!("{marks} {content}\n\n")
+    }
+
     /// Render emphasis as `*content*` (CommonMark italic).
     fn emph(&self, content: Self::Output) -> Self::Output {
         if content.is_empty() {

--- a/crates/citum-engine/src/render/org.rs
+++ b/crates/citum-engine/src/render/org.rs
@@ -27,6 +27,12 @@ impl OutputFormat for OrgOutputFormat {
         output
     }
 
+    /// Render a heading using org-mode stars (`*`, `**`, ...).
+    fn heading(&self, level: u8, content: Self::Output) -> Self::Output {
+        let marks = "*".repeat(level.max(1) as usize);
+        format!("{marks} {content}\n\n")
+    }
+
     /// Render content with emphasis (italics in org-mode: /text/).
     fn emph(&self, content: Self::Output) -> Self::Output {
         if content.is_empty() {

--- a/crates/citum-engine/src/render/plain.rs
+++ b/crates/citum-engine/src/render/plain.rs
@@ -27,6 +27,11 @@ impl OutputFormat for PlainText {
         output
     }
 
+    fn heading(&self, level: u8, content: Self::Output) -> Self::Output {
+        let marks = "#".repeat(level.max(1) as usize);
+        format!("{marks} {content}\n\n")
+    }
+
     fn emph(&self, content: Self::Output) -> Self::Output {
         if content.is_empty() {
             return content;

--- a/crates/citum-engine/src/render/test_formats.rs
+++ b/crates/citum-engine/src/render/test_formats.rs
@@ -26,6 +26,30 @@ mod tests {
     use citum_schema::{tc_contributor, tc_title, tc_variable};
 
     #[test]
+    fn test_heading_numbered_vs_unnumbered() {
+        // Group/bibliography headings must not participate in LaTeX section
+        // numbering, while document body headings keep numbered commands.
+        let latex = Latex;
+        assert_eq!(
+            latex.heading(2, "Sources".to_string()),
+            "\\subsection{Sources}\n\n"
+        );
+        assert_eq!(
+            latex.unnumbered_heading(2, "Sources".to_string()),
+            "\\subsection*{Sources}\n\n"
+        );
+        // Formats without heading numbering share both variants.
+        assert_eq!(
+            Html.unnumbered_heading(2, "Sources".to_string()),
+            Html.heading(2, "Sources".to_string())
+        );
+        assert_eq!(
+            Typst.unnumbered_heading(2, "Sources".to_string()),
+            Typst.heading(2, "Sources".to_string())
+        );
+    }
+
+    #[test]
     fn test_html_title() {
         let component = ProcTemplateComponent {
             template_component: tc_title!(Primary, emph = true),

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -375,7 +375,7 @@ options:
 
     assert_eq!(
         processor.render_grouped_bibliography_with_format::<PlainText>(),
-        "# Cyrillic\n\nБета\n\n# Latin\n\nAlpha\n\n# Han\n\n東京"
+        "## Cyrillic\n\nБета\n\n## Latin\n\nAlpha\n\n## Han\n\n東京"
     );
 }
 
@@ -449,7 +449,7 @@ fn language_partition_sections_reset_subsequent_author_substitution_per_section(
 
     assert_eq!(
         processor.render_grouped_bibliography_with_format::<PlainText>(),
-        "# Russian\n\nSmith, John. Alpha.\n\n———. Beta.\n\n# English\n\nSmith, John. Gamma."
+        "## Russian\n\nSmith, John. Alpha.\n\n———. Beta.\n\n## English\n\nSmith, John. Gamma."
     );
 }
 
@@ -4203,7 +4203,7 @@ groups:
 
     assert_eq!(
         rendered,
-        "# Primary Sources Section\n\nFirst Book\n\n# Secondary Sources Section\n\nAn Archival Manuscript"
+        "## Primary Sources Section\n\nFirst Book\n\n## Secondary Sources Section\n\nAn Archival Manuscript"
     );
 }
 

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -955,12 +955,12 @@ fn given_grouped_primary_and_secondary_sources_when_rendered_then_both_group_hea
 
     assert_output_has_line(
         &output,
-        "# Primary Sources",
+        "## Primary Sources",
         "grouped bibliography should include the primary heading",
     );
     assert_output_has_line(
         &output,
-        "# Secondary Sources",
+        "## Secondary Sources",
         "grouped bibliography should include the secondary heading",
     );
     assert_output_includes(
@@ -1016,12 +1016,12 @@ fn given_group_local_disambiguation_when_rendering_multilingual_groups_then_year
 
     // Split on the known group headings to get per-group bibliography text.
     let vi_block = output
-        .split("# Vietnamese Sources")
+        .split("## Vietnamese Sources")
         .nth(1)
-        .and_then(|s| s.split("# Western Sources").next())
+        .and_then(|s| s.split("## Western Sources").next())
         .unwrap_or_else(|| panic!("Vietnamese Sources section missing: {output}"));
     let en_block = output
-        .split("# Western Sources")
+        .split("## Western Sources")
         .nth(1)
         .unwrap_or_else(|| panic!("Western Sources section missing: {output}"));
 
@@ -1063,16 +1063,16 @@ fn given_juris_m_legal_grouping_when_rendered_then_headings_follow_the_expected_
         .expect("document should render");
 
     let cases = output
-        .find("# Cases")
+        .find("## Cases")
         .expect("missing cases heading in grouped bibliography");
     let statutes = output
-        .find("# Statutes")
+        .find("## Statutes")
         .expect("missing statutes heading in grouped bibliography");
     let treaties = output
-        .find("# Treaties and International Agreements")
+        .find("## Treaties and International Agreements")
         .expect("missing treaties heading in grouped bibliography");
     let secondary = output
-        .find("# Secondary Sources")
+        .find("## Secondary Sources")
         .expect("missing secondary heading in grouped bibliography");
 
     assert!(cases < statutes, "expected Cases before Statutes: {output}");
@@ -1110,12 +1110,12 @@ fn given_an_english_locale_variant_when_group_headings_are_localized_then_the_la
     // en-GB should fall back to the language tag (en).
     assert_output_has_line(
         &output,
-        "# Primary Sources",
+        "## Primary Sources",
         "English locale fallback should resolve the primary heading",
     );
     assert_output_has_line(
         &output,
-        "# Secondary Sources",
+        "## Secondary Sources",
         "English locale fallback should resolve the secondary heading",
     );
 }

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -142,11 +142,13 @@ fn given_simple_author_date_document_when_rendered_as_html_then_a_bibliography_h
 
     // Process document as HTML
     let parser = DjotParser;
-    let html_output = processor.process_document::<_, citum_engine::render::html::Html>(
-        document,
-        &parser,
-        DocumentFormat::Html,
-    );
+    let html_output = processor
+        .process_document::<_, citum_engine::render::html::Html>(
+            document,
+            &parser,
+            DocumentFormat::Html,
+        )
+        .expect("document should render");
 
     assert_output_includes(
         &html_output,
@@ -203,11 +205,13 @@ fn given_simple_author_date_document_when_rendered_as_djot_then_html_tags_are_no
 
     // Process as Djot format
     let parser = DjotParser;
-    let djot_output = processor.process_document::<_, citum_engine::render::djot::Djot>(
-        document,
-        &parser,
-        DocumentFormat::Djot,
-    );
+    let djot_output = processor
+        .process_document::<_, citum_engine::render::djot::Djot>(
+            document,
+            &parser,
+            DocumentFormat::Djot,
+        )
+        .expect("document should render");
 
     assert_output_has_line(
         &djot_output,
@@ -226,11 +230,13 @@ fn given_example_mla_document_when_rendered_as_html_then_citation_markup_is_not_
     let parser = DjotParser;
     let document = load_example_document("examples/document.djot");
 
-    let html_output = processor.process_document::<_, citum_engine::render::html::Html>(
-        &document,
-        &parser,
-        DocumentFormat::Html,
-    );
+    let html_output = processor
+        .process_document::<_, citum_engine::render::html::Html>(
+            &document,
+            &parser,
+            DocumentFormat::Html,
+        )
+        .expect("document should render");
 
     assert_output_includes(
         &html_output,
@@ -259,11 +265,13 @@ fn given_example_mla_document_when_rendered_as_plain_text_then_integral_name_mem
     let parser = DjotParser;
     let document = load_example_document("examples/document.djot");
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        &document,
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            &document,
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     assert_eq!(
         output,
@@ -330,11 +338,13 @@ fn given_two_authors_with_same_surname_when_both_cited_integrally_then_each_gets
     let parser = DjotParser;
     let doc = "[+@john-smith] wrote the first book. [+@jane-smith] wrote the second.";
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        doc,
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            doc,
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     // Both authors share surname "Smith" but are different people, so each
     // person's first integral mention should use the full given+family form.
@@ -387,11 +397,13 @@ fn given_org_with_short_name_when_org_abbreviation_memory_configured_and_cited_i
     // Two integral citations to the same org.
     let doc = "[+@who2020] released a report. Later, [+@who2020] followed up.";
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        doc,
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            doc,
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     // First integral mention: full name + abbreviation in parens.
     assert_output_includes(
@@ -414,11 +426,13 @@ fn given_example_apa_document_when_rendered_as_plain_text_then_integral_citation
     let parser = DjotParser;
     let document = load_example_document("examples/document.djot");
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        &document,
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            &document,
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     // APA abbreviates given names: "A. D. Smith" (Long form, first integral mention)
     assert_output_has_line(
@@ -455,11 +469,13 @@ fn given_example_chicago_note_document_when_rendered_as_plain_text_then_integral
     let parser = DjotParser;
     let document = load_example_document("examples/document.djot");
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        &document,
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            &document,
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     // Body anchors and note bodies are distinct rendered surfaces. Smith is
     // introduced first in the manual note, so later body anchors use the
@@ -509,11 +525,13 @@ fn given_chicago_note_flow_document_when_authored_ibid_appears_in_notes_then_anc
     let parser = DjotParser;
     let document = load_example_document("examples/document-citation-flow.djot");
 
-    let output = processor.process_document::<_, citum_engine::render::djot::Djot>(
-        &document,
-        &parser,
-        DocumentFormat::Djot,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::djot::Djot>(
+            &document,
+            &parser,
+            DocumentFormat::Djot,
+        )
+        .expect("document should render");
 
     let lowercase_output = output.to_lowercase();
     assert_output_includes(
@@ -559,11 +577,13 @@ fn given_chicago_note_locator_repeat_when_integral_ibid_is_rendered_then_anchor_
         "  - [+@brown1954, p. 12] also argues that...\n",
     );
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        document,
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            document,
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     assert_output_includes(
         &output,
@@ -596,11 +616,13 @@ fn given_page_labels_are_configured_when_integral_ibid_is_rendered_then_the_labe
         "  - [+@brown1954, p. 12] also argues that...\n",
     );
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        document,
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            document,
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     assert_output_includes(
         &output,
@@ -630,11 +652,13 @@ fn given_chapter_locator_repeat_when_integral_ibid_is_rendered_then_the_labeled_
         "  - [+@brown1954, chap. 3] also argues that...\n",
     );
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        document,
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            document,
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     assert_output_includes(
         &output,
@@ -668,11 +692,13 @@ fn given_locale_specific_ibid_term_when_the_style_has_no_ibid_override_then_the_
     let parser = DjotParser;
     let document = load_example_document("examples/document-citation-flow.djot");
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        &document,
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            &document,
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     assert_output_has_line(
         &output,
@@ -701,11 +727,13 @@ fn given_explicit_style_ibid_suffix_when_locale_also_defines_ibid_then_the_style
     let parser = DjotParser;
     let document = load_example_document("examples/document-citation-flow.djot");
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        &document,
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            &document,
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     assert_output_has_line(
         &output,
@@ -725,11 +753,13 @@ fn given_missing_note_anchor_when_integral_ibid_is_rendered_then_the_reduced_cit
         "  - [+@missingref, p. 12] also argues that...\n",
     );
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        document,
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            document,
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     assert_output_includes(
         &output.to_lowercase(),
@@ -749,11 +779,13 @@ fn given_chicago_note_flow_document_when_no_bibliography_entries_are_needed_then
     let parser = DjotParser;
     let document = load_example_document("examples/document-citation-flow.djot");
 
-    let output = processor.process_document::<_, citum_engine::render::djot::Djot>(
-        &document,
-        &parser,
-        DocumentFormat::Djot,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::djot::Djot>(
+            &document,
+            &parser,
+            DocumentFormat::Djot,
+        )
+        .expect("document should render");
 
     assert_output_lacks_line(
         &output,
@@ -761,11 +793,13 @@ fn given_chicago_note_flow_document_when_no_bibliography_entries_are_needed_then
         "empty bibliography should not emit Djot heading",
     );
 
-    let html_output = processor.process_document::<_, citum_engine::render::html::Html>(
-        &document,
-        &parser,
-        DocumentFormat::Html,
-    );
+    let html_output = processor
+        .process_document::<_, citum_engine::render::html::Html>(
+            &document,
+            &parser,
+            DocumentFormat::Html,
+        )
+        .expect("document should render");
     assert_output_excludes(
         &html_output,
         "<h1>Bibliography</h1>",
@@ -785,11 +819,13 @@ fn given_non_note_styles_when_rendering_the_note_flow_example_then_ibid_is_never
         let style = load_style(style_path);
         let processor = Processor::new(style, load_example_bibliography());
 
-        let output = processor.process_document::<_, citum_engine::render::djot::Djot>(
-            &document,
-            &parser,
-            DocumentFormat::Djot,
-        );
+        let output = processor
+            .process_document::<_, citum_engine::render::djot::Djot>(
+                &document,
+                &parser,
+                DocumentFormat::Djot,
+            )
+            .expect("document should render");
         assert_output_excludes(
             &output,
             "Ibid",
@@ -807,11 +843,13 @@ fn given_pandoc_markdown_author_date_syntax_when_rendered_then_integral_and_clus
         "Later work supports this [see @smith2010, p. 12; @kuhn1962, ch. 3].",
     );
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        document,
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            document,
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     assert_output_has_line(
         &output,
@@ -832,11 +870,13 @@ fn given_markdown_integral_note_citation_when_rendered_with_a_note_style_then_a_
     let parser = MarkdownParser;
     let document = "Narrative mention @smith2010 introduces the argument.";
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        document,
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            document,
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     assert_output_has_line(
         &output,
@@ -860,11 +900,13 @@ fn given_markdown_citation_inside_manual_footnote_when_rendered_with_note_style_
     let parser = MarkdownParser;
     let document = "See note[^1].\n\n[^1]: Early work [@kuhn1962] supports this.";
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        document,
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            document,
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     // The manual footnote anchor must appear in prose.
     assert_output_includes(
@@ -903,11 +945,13 @@ fn given_grouped_primary_and_secondary_sources_when_rendered_then_both_group_hea
 
     let processor = Processor::new(style, bibliography);
     let parser = DjotParser;
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        "Grouping check [@interview-1978; @ms-archive-1901; @journal-2021].",
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            "Grouping check [@interview-1978; @ms-archive-1901; @journal-2021].",
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     assert_output_has_line(
         &output,
@@ -962,11 +1006,13 @@ fn given_group_local_disambiguation_when_rendering_multilingual_groups_then_year
             .expect("multilingual grouping fixture should parse");
     let processor = Processor::new(style, bibliography);
     let parser = DjotParser;
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        "Disambiguation check [@vi-kuhn-a; @vi-kuhn-b; @en-kuhn-a; @en-kuhn-b].",
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            "Disambiguation check [@vi-kuhn-a; @vi-kuhn-b; @en-kuhn-a; @en-kuhn-b].",
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     // Split on the known group headings to get per-group bibliography text.
     let vi_block = output
@@ -1008,11 +1054,13 @@ fn given_juris_m_legal_grouping_when_rendered_then_headings_follow_the_expected_
 
     let processor = Processor::new(style, bibliography);
     let parser = DjotParser;
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        "Legal grouping [@brown1954; @civilrights1964; @versailles1919; @hart1994].",
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            "Legal grouping [@brown1954; @civilrights1964; @versailles1919; @hart1994].",
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     let cases = output
         .find("# Cases")
@@ -1050,11 +1098,13 @@ fn given_an_english_locale_variant_when_group_headings_are_localized_then_the_la
 
     let processor = Processor::with_locale(style, bibliography, locale);
     let parser = DjotParser;
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        "Locale fallback check [@interview-1978; @journal-2021].",
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            "Locale fallback check [@interview-1978; @journal-2021].",
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     // chicago-author-date headings are localized with en-US + en.
     // en-GB should fall back to the language tag (en).
@@ -1230,11 +1280,13 @@ fn given_markdown_document_with_pipe_table_when_rendered_as_markdown_then_body_p
     let document =
         format!("# Introduction\n\nAs argued in [@kuhn1962].\n\n{pipe_table}\n\n{code_block}\n");
 
-    let output = processor.process_document::<_, citum_engine::render::markdown::Markdown>(
-        &document,
-        &parser,
-        DocumentFormat::Markdown,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::markdown::Markdown>(
+            &document,
+            &parser,
+            DocumentFormat::Markdown,
+        )
+        .expect("document should render");
 
     // Pipe table lines must be unchanged.
     assert_output_includes_all(
@@ -1283,11 +1335,13 @@ fn given_note_style_markdown_document_when_rendered_as_markdown_then_commonmark_
     let parser = MarkdownParser;
     let document = "First claim [@kuhn1962]. Second claim [@smith2010].";
 
-    let output = processor.process_document::<_, citum_engine::render::markdown::Markdown>(
-        document,
-        &parser,
-        DocumentFormat::Markdown,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::markdown::Markdown>(
+            document,
+            &parser,
+            DocumentFormat::Markdown,
+        )
+        .expect("document should render");
 
     // Footnote anchors in prose.
     assert_output_has_line(
@@ -1378,11 +1432,13 @@ fn given_chicago_author_date_markdown_citation_when_rendered_then_no_spurious_sp
     let processor = example_document_processor("styles/embedded/chicago-author-date-18th.yaml");
     let parser = MarkdownParser;
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        "See [@kuhn1962, p. 5].",
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            "See [@kuhn1962, p. 5].",
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     // Chicago author-date should render the full sentence with author, year,
     // and locator, with no spurious space before the comma.
@@ -1397,11 +1453,13 @@ fn given_chicago_author_date_markdown_suppressed_citation_when_rendered_then_no_
     let processor = example_document_processor("styles/embedded/chicago-author-date-18th.yaml");
     let parser = MarkdownParser;
 
-    let output = processor.process_document::<_, citum_engine::render::plain::PlainText>(
-        "See [-@kuhn1962, p. 5].",
-        &parser,
-        DocumentFormat::Plain,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::plain::PlainText>(
+            "See [-@kuhn1962, p. 5].",
+            &parser,
+            DocumentFormat::Plain,
+        )
+        .expect("document should render");
 
     // Suppress-author form should render the full sentence with year and
     // locator only, with no author or spurious space before the comma.
@@ -1640,11 +1698,13 @@ fn given_markdown_block_quote_when_rendered_as_typst_then_quote_block_is_emitted
         "> and **strong** text. So is __this__.\n",
     );
 
-    let output = processor.process_document::<_, citum_engine::render::typst::Typst>(
-        document,
-        &parser,
-        DocumentFormat::Typst,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::typst::Typst>(
+            document,
+            &parser,
+            DocumentFormat::Typst,
+        )
+        .expect("document should render");
 
     assert_output_includes_all(
         &output,
@@ -1665,11 +1725,13 @@ fn given_djot_block_quote_when_rendered_as_typst_then_quote_block_is_emitted() {
         "> and *bold*.\n",
     );
 
-    let output = processor.process_document::<_, citum_engine::render::typst::Typst>(
-        document,
-        &parser,
-        DocumentFormat::Typst,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::typst::Typst>(
+            document,
+            &parser,
+            DocumentFormat::Typst,
+        )
+        .expect("document should render");
 
     assert_output_includes_all(
         &output,
@@ -1689,11 +1751,13 @@ fn given_djot_notice_with_nested_strong_when_rendered_as_typst_then_strong_marku
         "A later citation still resolves [@kuhn1962].\n",
     );
 
-    let output = processor.process_document::<_, citum_engine::render::typst::Typst>(
-        document,
-        &parser,
-        DocumentFormat::Typst,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::typst::Typst>(
+            document,
+            &parser,
+            DocumentFormat::Typst,
+        )
+        .expect("document should render");
 
     assert_output_includes(
         &output,
@@ -1727,11 +1791,13 @@ fn given_djot_notice_with_nested_strong_when_rendered_as_djot_then_source_markup
         "A later citation still resolves [@kuhn1962].\n",
     );
 
-    let output = processor.process_document::<_, citum_engine::render::djot::Djot>(
-        document,
-        &parser,
-        DocumentFormat::Djot,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::djot::Djot>(
+            document,
+            &parser,
+            DocumentFormat::Djot,
+        )
+        .expect("document should render");
 
     assert_output_includes(
         &output,
@@ -1763,11 +1829,13 @@ fn given_markdown_block_quote_when_rendered_as_latex_then_quote_environment_is_e
         "> and **strong** text.\n",
     );
 
-    let output = processor.process_document::<_, citum_engine::render::latex::Latex>(
-        document,
-        &parser,
-        DocumentFormat::Latex,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::latex::Latex>(
+            document,
+            &parser,
+            DocumentFormat::Latex,
+        )
+        .expect("document should render");
 
     assert_output_includes_all(
         &output,
@@ -1782,11 +1850,13 @@ fn given_markdown_citation_inside_prose_when_rendered_as_typst_then_citation_and
     let parser = MarkdownParser;
     let document = "A paragraph with *emphasis* and a citation [@kuhn1962].";
 
-    let output = processor.process_document::<_, citum_engine::render::typst::Typst>(
-        document,
-        &parser,
-        DocumentFormat::Typst,
-    );
+    let output = processor
+        .process_document::<_, citum_engine::render::typst::Typst>(
+            document,
+            &parser,
+            DocumentFormat::Typst,
+        )
+        .expect("document should render");
 
     assert_output_includes(
         &output,

--- a/crates/citum-schema-style/src/options/dates.rs
+++ b/crates/citum-schema-style/src/options/dates.rs
@@ -46,6 +46,18 @@ pub enum NegativeUnspecifiedYears {
     Fuzzy,
 }
 
+/// Term form for the "no date" fallback when `issued` is empty.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum NoDateForm {
+    /// Render the locale's short term (e.g. "n.d.").
+    #[default]
+    Short,
+    /// Render the locale's long term (e.g. "no date").
+    Long,
+}
+
 /// Date config: either a preset name or explicit configuration.
 ///
 /// Allows styles to write `dates: long` as shorthand, or provide
@@ -94,6 +106,11 @@ pub struct DateConfig {
     /// Marker for open-ended ranges (e.g., "–present"). None uses locale default.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub open_range_marker: Option<String>,
+    /// Locale term form used for the "no date" fallback when a template's
+    /// `issued` date is empty: `short` renders "n.d.", `long` renders
+    /// "no date". Defaults to short.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub no_date_form: Option<NoDateForm>,
     /// Custom user-defined fields for extensions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom: Option<HashMap<String, serde_json::Value>>,
@@ -136,6 +153,7 @@ impl Default for DateConfig {
             approximation_marker: Some("ca. ".to_string()),
             range_delimiter: default_range_delimiter(),
             open_range_marker: None,
+            no_date_form: None,
             custom: None,
             time_format: None,
             show_seconds: false,

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -27,7 +27,7 @@ pub use contributors::{
     DemoteNonDroppingParticle, DisplayAsSort, NameForm, RoleLabelPreset, RoleOptions,
     RoleOptionsEntry, RoleRendering, ShortenListOptions,
 };
-pub use dates::{DateConfig, DateConfigEntry};
+pub use dates::{DateConfig, DateConfigEntry, NoDateForm};
 pub use integral_name_memory::{
     IntegralNameContexts, IntegralNameMemoryConfig, IntegralNameScope, OrgAbbreviationMemoryConfig,
     ResolvedIntegralNameMemoryConfig, ResolvedOrgAbbreviationMemoryConfig, ShortNameDisplay,

--- a/docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md
+++ b/docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md
@@ -1,0 +1,287 @@
+# citum-engine Crate Review
+
+Date: 2026-07-03
+Branch: `audit/citum-engine-review-2026-07`
+Bean: `csl26-nj72`
+
+## Scope and Method
+
+Comprehensive code review of `crates/citum-engine` (~45k lines across 102
+files; ~29k lines of production code excluding test modules). Review criteria:
+[DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md) (especially §4 "Styles Are
+Declarative Contracts" and §9 "Rust Engineering Serves The Model"), the crate's
+own `CLAUDE.md` contract, and general Rust API/performance hygiene.
+
+Coverage:
+
+- **Fully read:** `lib.rs`, `error.rs`, all of `src/api/` (document, session,
+  types, style_input, refs_input, warnings, forward_compat), the processor
+  spine (`processor/mod.rs`, `setup.rs`, `citation.rs`, `note_context.rs`,
+  `matching.rs`, `disambiguation.rs`, `sorting.rs`, `labels.rs`,
+  `rendering/mod.rs`, `rendering/grouped/core.rs`, `bibliography/mod.rs`,
+  `bibliography/grouping.rs`, `document/pipeline.rs`), `ffi/mod.rs`,
+  `values/mod.rs`, `render/format.rs`, `grouping/sorting.rs`.
+- **Targeted scans crate-wide:** panic-path scan (`unwrap`/`expect`/`panic!`/
+  `unreachable!`/`todo!`/`unimplemented!` outside `#[cfg(test)]`), `unsafe`
+  scan, TODO/FIXME scan, `process::exit`/`eprintln!` scan.
+- **Not read line-by-line:** `values/` submodules (date, contributor, title,
+  number, locator, text_case), `render/` format backends, `document/`
+  markdown/notes/djot parsers, `rendering/grouped/` template_policy and
+  sentence_initial, `sort_partitioning.rs`. These were sampled and scanned
+  mechanically only; a follow-up pass could cover them.
+
+## Verification Baseline
+
+- `cargo clippy -p citum-engine --all-targets --all-features -- -D warnings`: **clean**.
+- `cargo nextest run -p citum-engine`: **846/846 passed**.
+- Zero `TODO`/`FIXME`/`HACK` markers in the crate.
+- No `unsafe` outside `src/ffi/` (which is `#![allow(unsafe_code)]` with
+  documented `# Safety` contracts on every entry point).
+- Exactly six panic-lint exceptions in production code, each carrying an
+  `#[allow(..., reason = ...)]` with a defensible rationale (ICU bootstrap ×2,
+  length-checked `first()` ×2, scan-loop `unreachable!` ×1, cache-hydration
+  `expect` ×1 — see Finding 7 for the last one).
+
+## Strengths
+
+- **Lint regime is exemplary.** The workspace denies `unwrap_used`,
+  `expect_used`, `panic`, `indexing_slicing`, `string_slice`, and
+  `allow_attributes_without_reason`, with every noise-lint `allow` documented
+  in `Cargo.toml`. The "no hidden panic paths" principle is mechanically
+  enforced, not aspirational.
+- **FFI is hardened.** The 2026-05-12 security audit's fixes hold: centralized
+  pointer/UTF-8 parsing, thread-local last-error, null-pointer tests, no
+  panics across the C ABI.
+- **Module architecture matches its documentation.** `Processor` really is a
+  thin facade; setup/citation/bibliography/note-context concerns are cleanly
+  separated; comments consistently record *constraints* (year-suffix ordering
+  vs. rendered sort order, wrap-capture semantics, borrow-release points)
+  rather than narrating code.
+- **Structured warnings are a real API.** `missing_ref`, `nocite_missing_ref`,
+  `locale_fallback`, `unknown_reference_class/field`, `unknown_enum_variant`
+  flow through one channel; forward-compat unknown-field walking
+  (`api/forward_compat.rs`) is thorough and path-addressed.
+- **Test posture is strong.** 846 tests, BDD naming, `rstest` parameterization,
+  oracle-backed sort/i18n/multilingual suites, and boundary tests (et-al
+  thresholds, label presets, ibid/locator positions).
+- **Multilingual handling is principled.** Holistic name-variant selection,
+  BCP 47 exact→prefix→fallback resolution, and script-aware display are data-
+  driven per §3 of the design principles.
+
+## Findings
+
+Ordered by severity. File references are to the audit branch at the review
+commit.
+
+### High
+
+**1. `std::process::exit(1)` inside a public library API.**
+`Processor::process_document` aborts the host process on a frontmatter parse
+error (`processor/document/pipeline.rs:61-64`), preceded by an `eprintln!`.
+Today the only external caller is `citum-cli`, so this is latent — but the
+crate contract is "one engine, multiple surfaces" and this method is the
+document entry point a server/FFI/WASM surface would adopt. `exit` is worse
+than a panic (no unwinding, destructors skipped, untrappable through the C
+ABI), and it violates DESIGN_PRINCIPLES §9. Related: `process_document`
+returns a bare `String` with no error/warning channel, and per-citation render
+errors silently fall back to source text (`pipeline.rs:369,395,423`).
+*Recommendation:* return `Result` (or thread the existing `Warning` channel);
+move exit-on-error behavior into the CLI.
+
+**2. Style-specific hardcoding in the engine.**
+`preferred_no_date_term_form` special-cases
+`csl_id == "http://www.zotero.org/styles/harvard-cite-them-right"` to select
+the long "no date" term form (`processor/rendering/grouped/core.rs:1261-1274`).
+This is precisely the "hidden processor magic" pattern DESIGN_PRINCIPLES §4
+names as the anti-example — behavior keyed to a specific style identity
+instead of declared in style data. Any style re-derived from that CSL id, or
+hand-authored equivalent without the id, silently behaves differently.
+*Recommendation:* promote to a typed style option (e.g.
+`options.dates.no-date-term-form: long|short`), set it in the style YAML, and
+delete the id match. Record the interim behavior in the divergence register if
+it must ship.
+
+### Medium
+
+**3. Grouped-bibliography headings bypass the `OutputFormat` abstraction.**
+`render_group_heading` compares `std::any::type_name::<F>()` to detect HTML
+and emits Markdown `# heading` for *every other format*
+(`processor/bibliography/grouping.rs:823-832`) — so LaTeX/Typst/Djot grouped
+bibliographies get Markdown heading syntax. The `OutputFormat` trait already
+defines `heading(level, content)` (`render/format.rs:142`). Heading policy now
+lives in three places: this type-name hack, the per-format
+`render_bibliography_section_heading` in `document/pipeline.rs:23-36`, and the
+unused trait method. *Recommendation:* implement `heading` in each backend and
+route both call sites through it.
+
+**4. Tier-1 / session pipeline duplication.**
+`DocumentSession::render_citations` (`api/session.rs:336-483`) duplicates
+~130 lines of `format_document_with_style` (`api/document.rs:214-406`): locale
+fallback warning, three warning scans, document-options application,
+missing-ref retention, nocite registration, and the six-way
+`OutputFormatKind` dispatch (which itself repeats five times across the two
+files). The duplication is self-acknowledged ("mirrors Tier 1 setup"). Drift
+here would produce batch-vs-interactive behavioral splits that are hard to
+test for. *Recommendation:* extract a shared `prepare_processor(request) →
+(Processor, Vec<Warning>, Vec<Citation>)` helper and a single format-dispatch
+helper (generic fn or macro).
+
+**5. Session mutations re-do all work.**
+Every `insert/update/delete/set_nocite` re-parses the refs input from the
+stored `RefsInput` (clone + `resolve_local()` — a full YAML/JSON parse),
+re-runs the warning scans, rebuilds the `Processor` (including disambiguation
+hint calculation over the whole bibliography), and re-renders every citation
+plus the bibliography (`api/session.rs:304-483`). For the interactive use case
+this API exists for, that is O(document) work per keystroke-level edit.
+*Recommendation:* cache the resolved `Bibliography` (invalidate on
+`put_references`), and consider caching the resolved style. Document the
+current cost either way.
+
+**6. `Processor` is an implicit state machine via `RefCell`.**
+`citation_numbers`, `cited_ids`, `first_note_by_id`, `compound_groups`, and
+three dynamic compound maps are interior-mutable (`processor/mod.rs:89-124`),
+so `&self` render methods are order-dependent and non-idempotent: bibliography
+output depends on which citations were processed first; processing the same
+citation list twice can differ (dynamic groups are first-occurrence-wins).
+This is by design (citeproc semantics) but the invariants live only in
+comments (e.g. "must be called before `track_cited_ids_and_init_numbers`",
+`processor/citation.rs:178-180`). It also makes `Processor` single-threaded.
+*Recommendation:* no immediate change; longer-term, consider an explicit
+per-run state object so a `Processor` can be reused/shared and the ordering
+contract is typed rather than commented.
+
+**7. Disambiguation cache keyed by reference pointer address.**
+`reference_cache_key` uses `std::ptr::from_ref(reference) as usize`
+(`processor/disambiguation.rs:1038-1040`) and `reference_data` `expect`s a hit
+(`:1054`). This is correct today only because the cache is built and consumed
+within one `calculate_hints` call over an unmoved `IndexMap`. The invariant is
+non-local: any future caller that passes a cloned reference, or mutates the
+bibliography between build and lookup, converts a logic change into a runtime
+panic. *Recommendation:* key by reference id (falling back to map index for
+id-less refs) and drop the `expect` exception.
+
+**8. Two parallel sorting stacks; the default one is uncached.**
+`Sorter` (`processor/sorting.rs`) recomputes `author_sort_key_opt` /
+`title_sort_key` — including leading-article stripping and collation
+normalization — for *both* operands on *every* comparison, i.e. O(n log n) key
+derivations. `GroupSorter` (`grouping/sorting.rs`) already implements the
+cached (Schwartzian) pattern with compiled keys. The two stacks also duplicate
+`compare_optional_years` verbatim. Additionally `SortKey::CitationNumber`
+compares as `Equal` — a silent no-op sort key (`processor/sorting.rs:124`).
+*Recommendation:* fold `Sorter` into `GroupSorter` (map config `SortKey` to
+group sort keys), and either implement or reject `citation-number` sorting
+explicitly.
+
+**9. Per-component `Config` clones in the render hot path.**
+Every rendered `ProcTemplateComponent` carries `config:
+Some(ctx.options.config.clone())` and a cloned `bibliography_config`
+(`processor/rendering/grouped/core.rs:1092-1093, 1138-1139`), and every
+`RenderOptions`/`Renderer` construction clones `BibliographyConfig`. For a
+bibliography of *n* entries × *m* components that is n×m deep clones of the
+full config tree per render pass. The crate has a benchmark
+(`benches/rendering.rs`); this is the first place to look if it regresses.
+*Recommendation:* borrow (`&'a Config`) or `Rc`/`Arc` the configs in
+`ProcTemplateComponent`.
+
+**10. Custom-groups bibliography path renders everything twice.**
+`render_selected_bibliography_with_format_and_annotations` path 1 calls
+`self.process_references()` — a full PlainText render of the entire
+bibliography — solely to obtain entry IDs for selector matching
+(`processor/bibliography/mod.rs:297`), while the sibling grouped path already
+uses `sorted_id_stubs()` for exactly this (`grouping.rs:622`). Separately,
+`render_document_bibliography` computes `content` and `entries` via two full
+render passes (`grouping.rs:576-599`); the doc comment justifies the
+consistency requirement, but one pass could produce both.
+*Recommendation:* use `sorted_id_stubs()` in path 1; consider a single-pass
+content+entries build later.
+
+**11. Forward-compat template scan misses sub-spec templates.**
+`unknown_enum_warnings` scans `style.templates`, `citation.template`, and
+`bibliography.template` (`api/warnings.rs:145-160`) but not
+`citation.integral/non_integral/subsequent/ibid` templates, `type-variants`
+templates, or locale-variant templates — unknown terms/roles/date-forms there
+are silently unreported, while `collect_unknown_field_paths` *does* recurse
+into those specs. *Recommendation:* reuse the `walk_citation_spec` recursion
+shape in the enum scanner.
+
+**12. `RefsInput::Path` documentation promises CBOR; implementation is YAML-only.**
+The variant docs say "YAML/JSON/CBOR extensions are loaded as native Citum
+refs" (`api/refs_input.rs:31-32`), but `resolve_local` reads bytes through
+`String::from_utf8_lossy` and parses YAML (JSON parses as a YAML subset; CBOR
+cannot). Non-UTF-8 input is silently mangled by the lossy conversion instead
+of erroring. *Recommendation:* correct the docs (or implement CBOR), and use
+`String::from_utf8` with a proper `RefsInputParse` error.
+
+### Low
+
+**13. Error-type inconsistency.** `FormatDocumentError` and
+`DocumentSessionError` hand-roll `Display`/`Error` impls
+(`api/document.rs:109-123`, `api/session.rs:83-93`) while the crate already
+depends on `thiserror` (used by `ProcessorError`). `ProcessorError` itself is
+stringly — compound-set validation abuses
+`ParseError("BIBLIOGRAPHY", ...)` (`processor/mod.rs:162-181`).
+
+**14. Known substitute key routed through the `Unknown` escape hatch.**
+Both `Matcher` and `Disambiguator` look up collection editors via
+`ContributorRole::Unknown("collection-editor".to_string())`
+(`processor/matching.rs:86`, `processor/disambiguation.rs:292-294`). If the
+schema role vocabulary lacks the variant, add it; using `Unknown` as a routine
+lookup allocates per call and defeats the tolerant-enum telemetry.
+
+**15. Variable-once keys derive from `Debug` formatting.**
+`get_variable_key` builds suppression keys with `{:?}` on schema enums
+(`processor/rendering/mod.rs:734-756`), so renaming an enum variant silently
+changes CSL variable-once dedup behavior. Prefer explicit serde names.
+
+**16. Silent compound-set fallback.** `with_compound_sets` discards invalid
+sets and builds a processor without them (`processor/setup.rs:117-122`) with
+no warning emitted, while `try_with_compound_sets` errors. Per §5 "warnings
+are API behavior", the lossy path should at least surface a structured
+warning. Also `sort_citation_number_order` and `sort_bibliography_number_order`
+are identical duplicates (`setup.rs:226-241`).
+
+**17. Session API loose ends.** `DocumentSession::new` takes an unused
+`_style_input: StyleInput` parameter (`api/session.rs:125`).
+`diff_formatted_citations` reports only added/changed citations — deletions
+are not represented in `affected_citations`, which adapters must infer from
+the full citation list.
+
+**18. `Renderer` exposes its internals.** `Renderer` is `pub` with all-public
+fields, including the `filtered_to_original_index: RefCell<...>` scratch state
+(`processor/rendering/mod.rs:29-60`). Pre-1.0 this is tolerable, but most
+fields could be `pub(crate)` today.
+
+**19. Crate documentation drift.** `crates/citum-engine/CLAUDE.md` references
+`src/ffi/biblatex.rs` and `BibRefContext` (now living in `citum-refs`), sizes
+`ffi/mod.rs` at ~570 lines (now 747), and the layout table names
+`src/render/citations.rs` (actual file: `src/render/citation.rs`).
+
+## Known Limitations (documented, not defects)
+
+- Non-en-US locales cannot be resolved inside the engine; `format_document`
+  emits a `locale_fallback` warning and renders en-US
+  (`api/document.rs:226-243`). Adapter-side locale resolution is the declared
+  follow-up.
+- Gendered role labels flow through legacy `roles:` pending the MF2
+  multi-selector follow-up (per crate `CLAUDE.md`).
+
+## Recommended Follow-ups (prioritized)
+
+1. Replace `process::exit` in `process_document` with an error return and move
+   abort behavior to the CLI (Finding 1) — small change, removes the only
+   process-fatal path in the crate.
+2. Promote the harvard-cite-them-right no-date behavior into style data
+   (Finding 2) — restores the declarative contract.
+3. Route all bibliography/section headings through `OutputFormat::heading`
+   (Finding 3) — fixes wrong markup for LaTeX/Typst/Djot grouped output.
+4. Extract the shared Tier-1/session preparation pipeline and format dispatch
+   (Finding 4).
+5. Unify the two sorting stacks with cached keys (Finding 8) and cache session
+   ref resolution (Finding 5).
+6. Sweep the remaining Medium/Low items as individual beans; none block
+   current fidelity work.
+
+A follow-up review pass over the unread submodules (`values/date`,
+`values/contributor`, render backends, document markdown/notes parsers) is
+worthwhile — this review's mechanical scans found nothing alarming there, but
+they contain the densest formatting logic in the crate.

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -4072,6 +4072,17 @@
             "null"
           ]
         },
+        "no-date-form": {
+          "description": "Locale term form used for the \"no date\" fallback when a template's\n`issued` date is empty: `short` renders \"n.d.\", `long` renders\n\"no date\". Defaults to short.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NoDateForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "custom": {
           "description": "Custom user-defined fields for extensions.",
           "type": [
@@ -4124,6 +4135,21 @@
         "long",
         "short",
         "numeric"
+      ]
+    },
+    "NoDateForm": {
+      "description": "Term form for the \"no date\" fallback when `issued` is empty.",
+      "oneOf": [
+        {
+          "description": "Render the locale's short term (e.g. \"n.d.\").",
+          "type": "string",
+          "const": "short"
+        },
+        {
+          "description": "Render the locale's long term (e.g. \"no date\").",
+          "type": "string",
+          "const": "long"
+        }
       ]
     },
     "TimeFormat": {

--- a/styles/harvard-cite-them-right.yaml
+++ b/styles/harvard-cite-them-right.yaml
@@ -54,6 +54,7 @@ options:
     uncertainty-marker: "?"
     approximation-marker: "ca. "
     range-delimiter: –
+    no-date-form: long
   titles:
     monograph:
       emph: true


### PR DESCRIPTION
## Summary

Comprehensive review of `citum-engine` plus fixes for its highest-impact
findings. The audit document
(`docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md`) records the
full triage: 2 high, 10 medium, 7 low findings against a clean baseline
(clippy `-D warnings`, 846/846 engine tests).

### Fixed here

- **High — `process::exit(1)` in a library API** (`fix(engine)!`):
  `Processor::process_document` now returns `Result<String, ProcessorError>`
  instead of printing to stderr and killing the host process on a frontmatter
  parse error. The CLI propagates the error to its existing top-level funnel
  (same message + nonzero exit for terminal users). Breaking API change,
  pre-1.0.
- **High — hidden per-style behavior**: the engine matched
  `csl_id == harvard-cite-them-right` to pick the long "no date" term. That is
  now a declarative option, `options.dates.no-date-form` (`short`|`long`,
  default `short`); the harvard style declares `long`, so rendered output is
  byte-identical. Schemas regenerated in the same commit.
- **Medium — heading dispatch**: grouped-bibliography headings routed through
  `OutputFormat::heading` instead of a `std::any::type_name` string compare.
  LaTeX/Typst grouped headings now emit `\subsection*{…}` / `== …` instead of
  literal Markdown. Deliberate byte change: markdown-family grouped headings
  go from `# X` to `## X`, matching the document pipeline's existing H2
  convention.
- **Medium — wasted render pass**: the custom-groups bibliography path used a
  full PlainText render of every entry just to read IDs; it now uses
  `sorted_id_stubs()`.
- **Medium — incomplete compat warnings**: `unknown_enum_warnings` now
  recurses into `integral`/`non-integral`/`subsequent`/`ibid` sub-specs,
  `type-variants`, and per-locale templates.
- **Medium — lossy refs input**: non-UTF-8 refs files now return
  `RefsInputParse` instead of being silently mangled by `from_utf8_lossy`;
  removed a false CBOR support claim from the docs.
- **Low — doc drift**: refreshed stale layout facts in the crate `CLAUDE.md`.

### Deferred to beans

Eight follow-up beans filed for the remaining findings: shared
tier-1/session pipeline extraction (`csl26-aawl`), session caching
(`csl26-54bk`), explicit render-run state design (`csl26-dog9`), id-keyed
disambiguation cache (`csl26-wj7z`), sorter unification (`csl26-b801`),
render-path config clone reduction (`csl26-qi7l`), thiserror consolidation
(`csl26-wfua`), low-severity cleanup batch (`csl26-dr0r`).

## Test plan

- Full gate per commit: `cargo fmt --check`, `cargo clippy --all-targets
  --all-features -- -D warnings`, `cargo nextest run` (1724 tests at HEAD,
  all passing; suite grew by 4 new tests: frontmatter error path,
  no-date-form option, sub-spec warning scan ×2, non-UTF-8 refs input).
- Guard tests for the harvard change pass unchanged
  (`test_harvard_cite_them_right_grouped_citations_render_cleanly`,
  `test_parsed_style_no_date_terms_match_expected_variants`).
- End-to-end CLI check: document with broken frontmatter now reports
  `Error: Parse error (FRONTMATTER): …` via the CLI funnel with exit 1;
  happy-path render unchanged.
- Core fidelity report re-run to confirm no style fidelity regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
