### PR TITLE
fix(engine): unify range formatting

### DIFF
--- a/.beans/archive/csl26-2ubj--unify-pagelocator-range-formats-fix-cmos-rule.md
+++ b/.beans/archive/csl26-2ubj--unify-pagelocator-range-formats-fix-cmos-rule.md
@@ -1,14 +1,19 @@
 ---
 # csl26-2ubj
 title: Unify page/locator range formats; fix CMOS rule
-status: todo
+status: completed
 type: task
+priority: normal
 tags:
     - numbers
     - rendering
-parent: csl26-8m2p
 created_at: 2026-07-04T17:11:33Z
-updated_at: 2026-07-04T17:49:02Z
+updated_at: 2026-07-04T18:33:49Z
+parent: csl26-8m2p
 ---
 
 Three defects: format_chicago renders 101-108 as 101–08 where CMOS 17/citeproc-js give 101–8; locator apply_range_format implements Minimal as strip-only-when-already-abbreviated and Chicago falls through to expanded, so the same option formats pages and locators differently; labeled locator segments hardcode Expanded, ignoring config range_format. Share one range-format implementation between number.rs and locator.rs. docs/architecture/audits/2026-07-04_CITUM_ENGINE_REVIEW_PART2.md finding 11.
+
+## Summary of Changes
+
+Unified page and locator range formatting on the engine shared page-range formatter. Implemented the newer Chicago page-range abbreviation rules, and added unit coverage for Chicago table examples plus labeled/unlabeled locator range-format precedence.

--- a/crates/citum-engine/src/values/locator.rs
+++ b/crates/citum-engine/src/values/locator.rs
@@ -81,14 +81,19 @@ fn render_with_pattern(
                 let form = kind_cfg
                     .and_then(|cfg| cfg.label_form)
                     .unwrap_or(config.default_label_form);
-                render_segment_with_label(seg, kind_cfg, form, config.strip_label_periods, locale)
+                render_segment_with_label(
+                    seg,
+                    kind_cfg,
+                    form,
+                    config,
+                    config.strip_label_periods,
+                    locale,
+                )
             } else {
-                let kind_range_fmt = kind_cfg
-                    .and_then(|k| k.range_format.clone())
-                    .unwrap_or_else(|| config.range_format.clone());
-                apply_range_format(
+                let range_format = effective_range_format(kind_cfg, config);
+                crate::values::number::format_page_range(
                     seg.value.value_str(),
-                    kind_range_fmt,
+                    Some(&range_format),
                     locale.grammar_options.page_range_delimiter.as_str(),
                 )
             };
@@ -104,12 +109,10 @@ fn render_with_pattern(
         let form = kind_cfg
             .and_then(|cfg| cfg.label_form)
             .unwrap_or(config.default_label_form);
-        let kind_range_fmt = kind_cfg
-            .and_then(|k| k.range_format.clone())
-            .unwrap_or_else(|| config.range_format.clone());
-        let value_str = apply_range_format(
+        let range_format = effective_range_format(kind_cfg, config);
+        let value_str = crate::values::number::format_page_range(
             seg.value.value_str(),
-            kind_range_fmt,
+            Some(&range_format),
             locale.grammar_options.page_range_delimiter.as_str(),
         );
         let rendered_segment = if matches!(form, LabelForm::None) {
@@ -141,16 +144,21 @@ fn render_default(segments: &[LocatorSegment], config: &LocatorConfig, locale: &
             .unwrap_or(config.default_label_form);
 
         let rendered_segment = if matches!(form, LabelForm::None) {
-            let kind_range_fmt = kind_cfg
-                .and_then(|k| k.range_format.clone())
-                .unwrap_or_else(|| config.range_format.clone());
-            apply_range_format(
+            let range_format = effective_range_format(kind_cfg, config);
+            crate::values::number::format_page_range(
                 seg.value.value_str(),
-                kind_range_fmt,
+                Some(&range_format),
                 locale.grammar_options.page_range_delimiter.as_str(),
             )
         } else {
-            render_segment_with_label(seg, kind_cfg, form, config.strip_label_periods, locale)
+            render_segment_with_label(
+                seg,
+                kind_cfg,
+                form,
+                config,
+                config.strip_label_periods,
+                locale,
+            )
         };
 
         rendered.push(rendered_segment);
@@ -164,15 +172,14 @@ fn render_segment_with_label(
     seg: &LocatorSegment,
     kind_cfg: Option<&citum_schema::options::LocatorKindConfig>,
     form: LabelForm,
+    config: &LocatorConfig,
     global_strip: Option<bool>,
     locale: &Locale,
 ) -> String {
-    let kind_range_fmt = kind_cfg
-        .and_then(|k| k.range_format.clone())
-        .unwrap_or(PageRangeFormat::Expanded);
-    let value_str = apply_range_format(
+    let range_format = effective_range_format(kind_cfg, config);
+    let value_str = crate::values::number::format_page_range(
         seg.value.value_str(),
-        kind_range_fmt,
+        Some(&range_format),
         locale.grammar_options.page_range_delimiter.as_str(),
     );
     render_segment_with_label_str(seg, kind_cfg, form, &value_str, global_strip, locale)
@@ -214,71 +221,14 @@ fn render_segment_with_label_str(
     }
 }
 
-/// Apply range format to a value string containing a range separator.
-fn apply_range_format(value: &str, format: PageRangeFormat, delimiter: &str) -> String {
-    // Only act on values containing a range separator
-    let sep_pos = value.find(['-', '–', '—']);
-    let Some(pos) = sep_pos else {
-        return value.to_string();
-    };
-    #[allow(clippy::string_slice, reason = "index from find()")]
-    let start = &value[..pos];
-    // Find end of separator (handle multi-byte em/en-dash)
-    #[allow(clippy::string_slice, reason = "index from find()")]
-    let sep_end = value[pos..]
-        .chars()
-        .next()
-        .map_or(pos + 1, |c| pos + c.len_utf8());
-    #[allow(clippy::string_slice, reason = "index from find() + char len")]
-    let end = value[sep_end..].trim_start();
-    match format {
-        PageRangeFormat::Expanded => {
-            // Expand abbreviated end: "33-5" → "33-35", "100-3" → "100-103"
-            let expanded_end = expand_range_end(start.trim(), end);
-            format!("{start}{delimiter}{expanded_end}")
-        }
-        PageRangeFormat::Minimal => {
-            // Minimal: trim shared prefix from end
-            let minimal_end = minimal_range_end(start.trim(), end);
-            format!("{start}{delimiter}{minimal_end}")
-        }
-        PageRangeFormat::MinimalTwo => {
-            // MinimalTwo: keep at least 2 digits on end
-            let minimal_end = minimal_range_end(start.trim(), end);
-            format!("{start}{delimiter}{minimal_end}")
-        }
-        PageRangeFormat::Chicago | PageRangeFormat::Chicago16 | _ => {
-            // Chicago rules (simplified: same as expanded for now)
-            let expanded_end = expand_range_end(start.trim(), end);
-            format!("{start}{delimiter}{expanded_end}")
-        }
-    }
-}
-
-/// Expand an abbreviated range end relative to start.
-fn expand_range_end(start: &str, end: &str) -> String {
-    if end.len() >= start.len() {
-        return end.to_string();
-    }
-    #[allow(clippy::string_slice, reason = "length checked")]
-    let prefix = &start[..start.len() - end.len()];
-    format!("{prefix}{end}")
-}
-
-/// Compute minimal range end (drop shared leading digits).
-fn minimal_range_end(start: &str, end: &str) -> String {
-    if end.len() >= start.len() {
-        return end.to_string();
-    }
-    // Find how many leading chars are shared
-    let shared = start
-        .chars()
-        .zip(end.chars())
-        .take_while(|(a, b)| a == b)
-        .count();
-    #[allow(clippy::string_slice, reason = "shared is a character boundary")]
-    let result = end[shared..].to_string();
-    result
+/// Resolve the effective range format for a locator segment.
+fn effective_range_format(
+    kind_cfg: Option<&citum_schema::options::LocatorKindConfig>,
+    config: &LocatorConfig,
+) -> PageRangeFormat {
+    kind_cfg
+        .and_then(|k| k.range_format.clone())
+        .unwrap_or_else(|| config.range_format.clone())
 }
 
 /// Check if a reference type matches a TypeClass.
@@ -413,6 +363,99 @@ mod tests {
         assert!(
             !result.contains("p."),
             "label period should be stripped: {result}"
+        );
+    }
+
+    #[test]
+    fn test_render_global_range_format_applies_to_labeled_and_unlabeled_locators() {
+        let config = LocatorConfig {
+            default_label_form: LabelForm::Short,
+            range_format: PageRangeFormat::Chicago,
+            ..Default::default()
+        };
+        let locale = Locale::from_yaml_str(
+            r#"
+locale: en-US
+locators:
+  page:
+    short:
+      singular: "page"
+      plural: "page"
+"#,
+        )
+        .expect("custom locale should parse");
+        let locator = CitationLocator::Single(LocatorSegment {
+            label: LocatorType::Page,
+            value: LocatorValue::Text("3-10".to_string()),
+        });
+
+        assert_eq!(
+            render_locator(&locator, "book", &config, &locale),
+            "page 3–10"
+        );
+
+        let unlabeled_config = LocatorConfig {
+            default_label_form: LabelForm::None,
+            range_format: PageRangeFormat::Chicago,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            render_locator(&locator, "book", &unlabeled_config, &locale),
+            "3–10"
+        );
+    }
+
+    #[test]
+    fn test_render_kind_range_override_applies_to_labeled_and_unlabeled_locators() {
+        let mut kinds = std::collections::HashMap::new();
+        kinds.insert(
+            LocatorType::Page,
+            citum_schema::options::LocatorKindConfig {
+                range_format: Some(PageRangeFormat::Chicago),
+                ..Default::default()
+            },
+        );
+        let config = LocatorConfig {
+            default_label_form: LabelForm::Short,
+            range_format: PageRangeFormat::Expanded,
+            kinds,
+            ..Default::default()
+        };
+        let locale = Locale::from_yaml_str(
+            r#"
+locale: en-US
+locators:
+  page:
+    short:
+      singular: "page"
+      plural: "page"
+"#,
+        )
+        .expect("custom locale should parse");
+        let labeled = CitationLocator::Single(LocatorSegment {
+            label: LocatorType::Page,
+            value: LocatorValue::Text("505-517".to_string()),
+        });
+        let unlabeled = CitationLocator::Single(LocatorSegment {
+            label: LocatorType::Page,
+            value: LocatorValue::Text("1002-1006".to_string()),
+        });
+
+        assert_eq!(
+            render_locator(&labeled, "book", &config, &locale),
+            "page 505–17"
+        );
+
+        let unlabeled_config = LocatorConfig {
+            default_label_form: LabelForm::None,
+            range_format: PageRangeFormat::Expanded,
+            kinds: config.kinds.clone(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render_locator(&unlabeled, "book", &unlabeled_config, &locale),
+            "1002–6"
         );
     }
 

--- a/crates/citum-engine/src/values/number.rs
+++ b/crates/citum-engine/src/values/number.rs
@@ -294,7 +294,9 @@ pub fn format_page_range(
                 PageRangeFormat::Expanded => end.to_string(),
                 PageRangeFormat::Minimal => format_minimal(start, end, 1),
                 PageRangeFormat::MinimalTwo => format_minimal(start, end, 2),
-                PageRangeFormat::Chicago | PageRangeFormat::Chicago16 => format_chicago(s, e),
+                PageRangeFormat::Chicago | PageRangeFormat::Chicago16 => {
+                    format_chicago_page_range_end(s, e)
+                }
                 _ => end.to_string(), // Future variants: default to expanded
             };
             format!("{start}{delimiter}{formatted_end}")
@@ -331,35 +333,45 @@ pub fn format_minimal(start: &str, end: &str, min_digits: usize) -> String {
         .collect()
 }
 
-/// Chicago Manual of Style page range format
+/// Format the second number in a Chicago Manual of Style page range.
 #[must_use]
-pub fn format_chicago(start: u32, end: u32) -> String {
-    // Chicago rules (simplified from CMOS 17th):
-    // - Under 100: use all digits (3–10, 71–72, 96–117)
-    // - 100+, same hundreds: use changed part only for 2+ digits (107–8, 321–28, 1536–38)
-    // - Different hundreds: use all digits (107–108, 321–328 if change of hundreds)
+fn format_chicago_page_range_end(start: u32, end: u32) -> String {
+    // Chicago rules:
+    // - start < 100: use all digits
+    // - start exact multiple of 100: use all digits
+    // - start % 100 is 1..=9: use the changed part only and trim any leading
+    //   zero from that suffix (1002–6, 505–17, 107–8)
+    // - otherwise: keep at least two digits unless more are needed to show the
+    //   changed part (321–25, 1087–89, 1496–500, 13792–803)
 
-    if start < 100 || end < 100 {
+    if start < 100 || start.is_multiple_of(100) {
         return end.to_string();
     }
 
     let start_str = start.to_string();
     let end_str = end.to_string();
+    let changed_end_part = if start % 100 <= 9 {
+        format_minimal(&start_str, &end_str, 1)
+    } else {
+        format_minimal(&start_str, &end_str, 2)
+    };
 
-    if start_str.len() != end_str.len() {
-        return end_str;
+    if changed_end_part.len() > 1 && changed_end_part.starts_with('0') {
+        let trimmed = changed_end_part.trim_start_matches('0');
+        if trimmed.is_empty() {
+            "0".to_string()
+        } else {
+            trimmed.to_string()
+        }
+    } else {
+        changed_end_part
     }
+}
 
-    // Check if same hundreds
-    let start_prefix = start / 100;
-    let end_prefix = end / 100;
-
-    if start_prefix != end_prefix {
-        return end_str; // Different hundreds, use full number
-    }
-
-    // Same hundreds: use minimal-two style
-    format_minimal(&start_str, &end_str, 2)
+/// Format a Chicago Manual of Style page range end.
+#[must_use]
+pub fn format_chicago(start: u32, end: u32) -> String {
+    format_chicago_page_range_end(start, end)
 }
 
 #[cfg(test)]
@@ -379,18 +391,24 @@ mod tests {
     use citum_schema::options::PageRangeFormat;
 
     #[test]
-    fn test_format_chicago() {
+    fn test_format_chicago_page_range_end() {
         for (start, end, expected) in [
             (3, 10, "10"),
             (71, 72, "72"),
-            (96, 117, "117"),
-            (107, 108, "08"),
-            (321, 328, "28"),
-            (1536, 1538, "38"),
-            (107, 208, "208"),
-            (321, 428, "428"),
+            (92, 113, "113"),
+            (100, 104, "104"),
+            (600, 613, "613"),
+            (107, 108, "8"),
+            (505, 517, "17"),
+            (1002, 1006, "6"),
+            (321, 325, "25"),
+            (415, 532, "532"),
+            (1087, 1089, "89"),
+            (1496, 1500, "500"),
+            (13792, 13803, "803"),
+            (12991, 13001, "3001"),
         ] {
-            assert_eq!(format_chicago(start, end), expected);
+            assert_eq!(format_chicago_page_range_end(start, end), expected);
         }
     }
 
@@ -420,11 +438,38 @@ mod tests {
             ("321-328", None, "321–328"),
             ("10-15", Some(PageRangeFormat::Expanded), "10–15"),
             ("42-45", Some(PageRangeFormat::Expanded), "42–45"),
-            ("107-108", Some(PageRangeFormat::Chicago), "107–08"),
+            ("3-10", Some(PageRangeFormat::Chicago), "3–10"),
             ("71-72", Some(PageRangeFormat::Chicago), "71–72"),
-            ("321-328", Some(PageRangeFormat::Chicago), "321–28"),
-            ("321-428", Some(PageRangeFormat::Chicago), "321–428"),
-            ("1536-1538", Some(PageRangeFormat::Chicago), "1536–38"),
+            ("92-113", Some(PageRangeFormat::Chicago), "92–113"),
+            ("100-104", Some(PageRangeFormat::Chicago), "100–104"),
+            ("600-613", Some(PageRangeFormat::Chicago), "600–613"),
+            ("107-108", Some(PageRangeFormat::Chicago), "107–8"),
+            ("505-517", Some(PageRangeFormat::Chicago), "505–17"),
+            ("1002-1006", Some(PageRangeFormat::Chicago), "1002–6"),
+            ("321-325", Some(PageRangeFormat::Chicago), "321–25"),
+            ("415-532", Some(PageRangeFormat::Chicago), "415–532"),
+            ("1087-1089", Some(PageRangeFormat::Chicago), "1087–89"),
+            ("1496-1500", Some(PageRangeFormat::Chicago), "1496–500"),
+            ("13792-13803", Some(PageRangeFormat::Chicago), "13792–803"),
+            ("12991-13001", Some(PageRangeFormat::Chicago), "12991–3001"),
+            ("3-10", Some(PageRangeFormat::Chicago16), "3–10"),
+            ("71-72", Some(PageRangeFormat::Chicago16), "71–72"),
+            ("92-113", Some(PageRangeFormat::Chicago16), "92–113"),
+            ("100-104", Some(PageRangeFormat::Chicago16), "100–104"),
+            ("600-613", Some(PageRangeFormat::Chicago16), "600–613"),
+            ("107-108", Some(PageRangeFormat::Chicago16), "107–8"),
+            ("505-517", Some(PageRangeFormat::Chicago16), "505–17"),
+            ("1002-1006", Some(PageRangeFormat::Chicago16), "1002–6"),
+            ("321-325", Some(PageRangeFormat::Chicago16), "321–25"),
+            ("415-532", Some(PageRangeFormat::Chicago16), "415–532"),
+            ("1087-1089", Some(PageRangeFormat::Chicago16), "1087–89"),
+            ("1496-1500", Some(PageRangeFormat::Chicago16), "1496–500"),
+            ("13792-13803", Some(PageRangeFormat::Chicago16), "13792–803"),
+            (
+                "12991-13001",
+                Some(PageRangeFormat::Chicago16),
+                "12991–3001",
+            ),
             ("100-105", Some(PageRangeFormat::Minimal), "100–5"),
             ("321-328", Some(PageRangeFormat::Minimal), "321–8"),
             ("42-45", Some(PageRangeFormat::Minimal), "42–5"),


### PR DESCRIPTION
Summary:
- Unify page and locator range formatting through the shared engine formatter.
- Implement the newer Chicago page-range abbreviation table.
- Complete and archive csl26-2ubj from the engine review cleanup epic.

Scope:
- Touches citum-engine range rendering in values/number.rs and values/locator.rs.
- No schema, YAML, or external API changes.

Validation:
- cargo test -p citum-engine test_format_page_range -- --nocapture
- cargo test -p citum-engine test_format_chicago -- --nocapture
- cargo test -p citum-engine range_format -- --nocapture
- cargo test -p citum-engine kind_range_override -- --nocapture
- python3 scripts/audit-rust-review-smells.py --changed
- just pre-commit
- pre-push Rust gate: 1744 tests passed

Risk:
- Low behavioral risk; changes are limited to page/locator range formatting.
- Added direct unit coverage for Chicago examples and locator precedence.

Follow-ups:
- Continue remaining csl26-8m2p child beans in separate focused PRs.
