### PR TITLE
fix(engine): type engine error variants

### DIFF
--- a/.beans/archive/csl26-wfua--consolidate-engine-error-types-on-thiserror.md
+++ b/.beans/archive/csl26-wfua--consolidate-engine-error-types-on-thiserror.md
@@ -1,14 +1,19 @@
 ---
 # csl26-wfua
 title: Consolidate engine error types on thiserror
-status: todo
+status: completed
 type: task
+priority: normal
 tags:
     - errors
     - types
-parent: csl26-8m2p
 created_at: 2026-07-04T02:42:26Z
-updated_at: 2026-07-04T17:49:02Z
+updated_at: 2026-07-04T19:51:21Z
+parent: csl26-8m2p
 ---
 
 FormatDocumentError and DocumentSessionError hand-roll Display/Error despite thiserror being a dependency; ProcessorError variants are stringly (ParseError("BIBLIOGRAPHY"/"FRONTMATTER", ...) used for validation and frontmatter). Add typed variants and derive consistently. docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md finding 13.
+
+## Summary of Changes
+
+Typed citum-engine parse errors into frontmatter, compound-set validation, and named reference parse variants; moved document/session API errors onto thiserror derives; updated engine and citum-io call sites plus tests for the new public error shape.

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -88,44 +88,29 @@ pub struct FormatDocumentResult {
 }
 
 /// Errors that can occur during document formatting.
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum FormatDocumentError {
     /// The style ID or URI requires a resolver chain not available in the engine.
+    #[error("Unresolved style input: {0}")]
     UnresolvedInput(String),
     /// Failed to parse the style YAML.
+    #[error("Style parse error: {0}")]
     StyleParse(String),
     /// Failed to read or locate the style file.
+    #[error("Style path error: {0}")]
     StylePath(String),
     /// Failed to read a local refs input path.
+    #[error("Refs input path error: {0}")]
     RefsInputPath(String),
     /// Failed to parse refs input data.
+    #[error("Refs input parse error: {0}")]
     RefsInputParse(String),
     /// The processor encountered an error during rendering.
-    Processing(ProcessorError),
+    #[error("Processing error: {0}")]
+    Processing(#[from] ProcessorError),
     /// Style inheritance (`extends`) could not be resolved.
+    #[error("Style resolution error: {0}")]
     StyleResolution(String),
-}
-
-impl std::fmt::Display for FormatDocumentError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::UnresolvedInput(msg) => write!(f, "Unresolved style input: {}", msg),
-            Self::StyleParse(msg) => write!(f, "Style parse error: {}", msg),
-            Self::StylePath(msg) => write!(f, "Style path error: {}", msg),
-            Self::RefsInputPath(msg) => write!(f, "Refs input path error: {}", msg),
-            Self::RefsInputParse(msg) => write!(f, "Refs input parse error: {}", msg),
-            Self::Processing(err) => write!(f, "Processing error: {}", err),
-            Self::StyleResolution(msg) => write!(f, "Style resolution error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for FormatDocumentError {}
-
-impl From<ProcessorError> for FormatDocumentError {
-    fn from(err: ProcessorError) -> Self {
-        Self::Processing(err)
-    }
 }
 
 /// Parse a partial-style overlay (YAML or JSON) and merge it over `style` in place.

--- a/crates/citum-engine/src/api/session.rs
+++ b/crates/citum-engine/src/api/session.rs
@@ -70,32 +70,17 @@ pub struct PreviewCitationResult {
 }
 
 /// Errors returned by the stateful session API.
-#[derive(Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum DocumentSessionError {
     /// The requested citation does not exist in the session.
+    #[error("citation not found: {0}")]
     CitationNotFound(String),
     /// The requested insertion position is invalid.
+    #[error("invalid citation position: {0}")]
     InvalidPosition(String),
     /// Rendering failed while recomputing session output.
-    Format(FormatDocumentError),
-}
-
-impl std::fmt::Display for DocumentSessionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::CitationNotFound(id) => write!(f, "citation not found: {id}"),
-            Self::InvalidPosition(msg) => write!(f, "invalid citation position: {msg}"),
-            Self::Format(err) => write!(f, "{err}"),
-        }
-    }
-}
-
-impl std::error::Error for DocumentSessionError {}
-
-impl From<FormatDocumentError> for DocumentSessionError {
-    fn from(err: FormatDocumentError) -> Self {
-        Self::Format(err)
-    }
+    #[error(transparent)]
+    Format(#[from] FormatDocumentError),
 }
 
 /// Stateful facade over whole-document citation rendering.

--- a/crates/citum-engine/src/error.rs
+++ b/crates/citum-engine/src/error.rs
@@ -28,16 +28,31 @@ pub enum ProcessorError {
     #[error("File I/O error: {0}")]
     FileIO(#[from] std::io::Error),
 
-    /// Parsing a named input failed with a message describing the problem.
-    #[error("Parse error ({0}): {1}")]
-    ParseError(String, String),
+    /// Frontmatter parsing failed for a document input.
+    #[error("Frontmatter parse error: {0}")]
+    FrontmatterParse(String),
+
+    /// Compound-set validation failed for a bibliography input.
+    #[error("Compound set validation error: {0}")]
+    CompoundSetValidation(String),
+
+    /// Parsing a named reference input failed with a message describing the problem.
+    #[error("Parse error ({name}): {message}")]
+    RefsParse {
+        /// Name of the input format or source that failed to parse.
+        name: String,
+        /// Human-readable parser message.
+        message: String,
+    },
 }
 
 impl From<citum_refs::RefsError> for ProcessorError {
     fn from(e: citum_refs::RefsError) -> Self {
         match e {
             citum_refs::RefsError::FileIO(io) => ProcessorError::FileIO(io),
-            citum_refs::RefsError::ParseError(name, msg) => ProcessorError::ParseError(name, msg),
+            citum_refs::RefsError::ParseError(name, message) => {
+                ProcessorError::RefsParse { name, message }
+            }
         }
     }
 }

--- a/crates/citum-engine/src/processor/document/pipeline.rs
+++ b/crates/citum-engine/src/processor/document/pipeline.rs
@@ -46,8 +46,8 @@ impl Processor {
     ///
     /// # Errors
     ///
-    /// Returns `ProcessorError::ParseError` when the document's frontmatter
-    /// fails to parse.
+    /// Returns `ProcessorError::FrontmatterParse` when the document's
+    /// frontmatter fails to parse.
     #[allow(
         clippy::string_slice,
         reason = "parser-guaranteed boundaries and indices"
@@ -65,10 +65,7 @@ impl Processor {
         let mut parsed = parser.parse_document(content, &self.locale);
 
         if let Some(err) = &parsed.frontmatter_error {
-            return Err(ProcessorError::ParseError(
-                "FRONTMATTER".to_string(),
-                err.clone(),
-            ));
+            return Err(ProcessorError::FrontmatterParse(err.clone()));
         }
 
         // `options.*` fields take precedence over the legacy top-level fields.

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -1058,8 +1058,8 @@ fn test_document_frontmatter_parse_error_returns_err() {
         processor.process_document::<_, PlainText>(content, &parser, DocumentFormat::Plain);
 
     match result {
-        Err(ProcessorError::ParseError(name, _)) => assert_eq!(name, "FRONTMATTER"),
-        other => panic!("expected frontmatter ParseError, got {other:?}"),
+        Err(ProcessorError::FrontmatterParse(_)) => {}
+        other => panic!("expected frontmatter parse error, got {other:?}"),
     }
 }
 

--- a/crates/citum-engine/src/processor/mod.rs
+++ b/crates/citum-engine/src/processor/mod.rs
@@ -159,22 +159,19 @@ pub fn validate_compound_sets(
         let mut seen_in_set: std::collections::HashSet<String> = std::collections::HashSet::new();
         for member in members {
             if !seen_in_set.insert(member.clone()) {
-                return Err(crate::error::ProcessorError::ParseError(
-                    "BIBLIOGRAPHY".to_string(),
+                return Err(crate::error::ProcessorError::CompoundSetValidation(
                     format!(
                         "reference '{member}' appears more than once in compound set '{set_id}'"
                     ),
                 ));
             }
             if !bibliography.contains_key(member) {
-                return Err(crate::error::ProcessorError::ParseError(
-                    "BIBLIOGRAPHY".to_string(),
+                return Err(crate::error::ProcessorError::CompoundSetValidation(
                     format!("compound set '{set_id}' references unknown id '{member}'"),
                 ));
             }
             if let Some(existing) = member_owner.insert(member.clone(), set_id.clone()) {
-                return Err(crate::error::ProcessorError::ParseError(
-                    "BIBLIOGRAPHY".to_string(),
+                return Err(crate::error::ProcessorError::CompoundSetValidation(
                     format!(
                         "reference '{member}' appears in both compound sets '{existing}' and '{set_id}'"
                     ),

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -4,7 +4,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use super::*;
-use crate::{Bibliography, Citation, CitationItem, Reference};
+use crate::{Bibliography, Citation, CitationItem, ProcessorError, Reference};
 use citum_schema::BibliographyOptions;
 use citum_schema::options::{
     AndOptions, ContributorConfig, DisplayAsSort, GivennameRule, LabelConfig, LabelPreset,
@@ -5003,11 +5003,13 @@ fn given_duplicate_compound_membership_when_using_checked_constructors_then_an_e
     sets.insert("group-2".to_string(), vec!["ref-a".to_string()]);
 
     let err = Processor::try_with_compound_sets(style, bib, sets).expect_err("must reject sets");
-    assert!(
-        err.to_string()
-            .contains("appears in both compound sets 'group-1' and 'group-2'"),
-        "unexpected error: {err}"
-    );
+    match err {
+        ProcessorError::CompoundSetValidation(msg) => assert!(
+            msg.contains("appears in both compound sets 'group-1' and 'group-2'"),
+            "unexpected error: {msg}"
+        ),
+        other => panic!("unexpected error: {other:?}"),
+    }
 }
 
 /// Verifies forgiving constructors drop invalid compound sets while checked ones error.
@@ -5045,11 +5047,13 @@ fn given_invalid_compound_sets_when_using_forgiving_constructors_then_they_fall_
 
     let err = Processor::try_with_locale_and_compound_sets(style, bib, Locale::en_us(), sets)
         .expect_err("checked constructor must reject invalid sets");
-    assert!(
-        err.to_string()
-            .contains("appears in both compound sets 'group-1' and 'group-2'"),
-        "unexpected error: {err}"
-    );
+    match err {
+        ProcessorError::CompoundSetValidation(msg) => assert!(
+            msg.contains("appears in both compound sets 'group-1' and 'group-2'"),
+            "unexpected error: {msg}"
+        ),
+        other => panic!("unexpected error: {other:?}"),
+    }
 }
 
 /// Tests that grouped integral citations with an explicit integral template

--- a/crates/citum-io/src/formats/biblatex.rs
+++ b/crates/citum-io/src/formats/biblatex.rs
@@ -16,6 +16,8 @@ use citum_schema::InputBibliography;
 ///
 /// Returns an error when the file cannot be read or parsed as BibLaTeX.
 pub(crate) fn load_biblatex_bibliography(path: &Path) -> Result<InputBibliography, ProcessorError> {
-    citum_refs::formats::biblatex::load_biblatex(path)
-        .map_err(|e| ProcessorError::ParseError("BibLaTeX".to_string(), e.to_string()))
+    citum_refs::formats::biblatex::load_biblatex(path).map_err(|e| ProcessorError::RefsParse {
+        name: "BibLaTeX".to_string(),
+        message: e.to_string(),
+    })
 }

--- a/crates/citum-io/src/formats/native.rs
+++ b/crates/citum-io/src/formats/native.rs
@@ -17,19 +17,30 @@ pub(crate) fn serialize_any<T: serde::Serialize>(
     match ext {
         "yaml" | "yml" => serde_yaml::to_string(obj)
             .map(String::into_bytes)
-            .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string())),
+            .map_err(|e| ProcessorError::RefsParse {
+                name: "YAML".to_string(),
+                message: e.to_string(),
+            }),
         "json" => serde_json::to_string_pretty(obj)
             .map(String::into_bytes)
-            .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string())),
+            .map_err(|e| ProcessorError::RefsParse {
+                name: "JSON".to_string(),
+                message: e.to_string(),
+            }),
         "cbor" => {
             let mut buf = Vec::new();
-            ciborium::ser::into_writer(obj, &mut buf)
-                .map_err(|e| ProcessorError::ParseError("CBOR".to_string(), e.to_string()))?;
+            ciborium::ser::into_writer(obj, &mut buf).map_err(|e| ProcessorError::RefsParse {
+                name: "CBOR".to_string(),
+                message: e.to_string(),
+            })?;
             Ok(buf)
         }
         _ => serde_yaml::to_string(obj)
             .map(String::into_bytes)
-            .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string())),
+            .map_err(|e| ProcessorError::RefsParse {
+                name: "YAML".to_string(),
+                message: e.to_string(),
+            }),
     }
 }
 

--- a/crates/citum-io/src/lib.rs
+++ b/crates/citum-io/src/lib.rs
@@ -54,33 +54,39 @@ pub fn load_citations(path: &Path) -> Result<Vec<Citation>, ProcessorError> {
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
 
     if ext == "json" {
-        let _: serde_json::Value = serde_json::from_slice(&bytes)
-            .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
+        let _: serde_json::Value =
+            serde_json::from_slice(&bytes).map_err(|e| ProcessorError::RefsParse {
+                name: "JSON".to_string(),
+                message: e.to_string(),
+            })?;
 
         if let Ok(citations) = serde_json::from_slice::<Vec<Citation>>(&bytes) {
             return Ok(citations);
         }
         match serde_json::from_slice::<Citation>(&bytes) {
             Ok(citation) => Ok(vec![citation]),
-            Err(e) => Err(ProcessorError::ParseError(
-                "JSON".to_string(),
-                e.to_string(),
-            )),
+            Err(e) => Err(ProcessorError::RefsParse {
+                name: "JSON".to_string(),
+                message: e.to_string(),
+            }),
         }
     } else {
         let content = String::from_utf8_lossy(&bytes);
-        let _: serde_yaml::Value = serde_yaml::from_str(&content)
-            .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string()))?;
+        let _: serde_yaml::Value =
+            serde_yaml::from_str(&content).map_err(|e| ProcessorError::RefsParse {
+                name: "YAML".to_string(),
+                message: e.to_string(),
+            })?;
 
         if let Ok(citations) = serde_yaml::from_str::<Vec<Citation>>(&content) {
             return Ok(citations);
         }
         match serde_yaml::from_str::<Citation>(&content) {
             Ok(citation) => Ok(vec![citation]),
-            Err(e) => Err(ProcessorError::ParseError(
-                "YAML".to_string(),
-                e.to_string(),
-            )),
+            Err(e) => Err(ProcessorError::RefsParse {
+                name: "YAML".to_string(),
+                message: e.to_string(),
+            }),
         }
     }
 }
@@ -98,18 +104,32 @@ pub fn load_annotations(path: &Path) -> Result<HashMap<String, String>, Processo
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
 
     if ext == "json" {
-        let _: serde_json::Value = serde_json::from_slice(&bytes)
-            .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
+        let _: serde_json::Value =
+            serde_json::from_slice(&bytes).map_err(|e| ProcessorError::RefsParse {
+                name: "JSON".to_string(),
+                message: e.to_string(),
+            })?;
 
-        serde_json::from_slice::<HashMap<String, String>>(&bytes)
-            .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))
+        serde_json::from_slice::<HashMap<String, String>>(&bytes).map_err(|e| {
+            ProcessorError::RefsParse {
+                name: "JSON".to_string(),
+                message: e.to_string(),
+            }
+        })
     } else {
         let content = String::from_utf8_lossy(&bytes);
-        let _: serde_yaml::Value = serde_yaml::from_str(&content)
-            .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string()))?;
+        let _: serde_yaml::Value =
+            serde_yaml::from_str(&content).map_err(|e| ProcessorError::RefsParse {
+                name: "YAML".to_string(),
+                message: e.to_string(),
+            })?;
 
-        serde_yaml::from_str::<HashMap<String, String>>(&content)
-            .map_err(|e| ProcessorError::ParseError("YAML".to_string(), e.to_string()))
+        serde_yaml::from_str::<HashMap<String, String>>(&content).map_err(|e| {
+            ProcessorError::RefsParse {
+                name: "YAML".to_string(),
+                message: e.to_string(),
+            }
+        })
     }
 }
 
@@ -219,8 +239,11 @@ pub fn write_output_bibliography(
                 .iter()
                 .map(formats::input_reference_to_csl_json)
                 .collect();
-            let json = serde_json::to_string_pretty(&refs)
-                .map_err(|e| ProcessorError::ParseError("JSON".to_string(), e.to_string()))?;
+            let json =
+                serde_json::to_string_pretty(&refs).map_err(|e| ProcessorError::RefsParse {
+                    name: "JSON".to_string(),
+                    message: e.to_string(),
+                })?;
             fs::write(path, json)?;
         }
         RefsFormat::Biblatex => {


### PR DESCRIPTION
Replace stringly processor parse buckets with typed variants. Derive API errors with thiserror.

Closes csl26-wfua.