### PR TITLE
Configure structured title delimiters

### DIFF
--- a/.beans/archive/csl26-01jy--configurable-structured-title-delimiters.md
+++ b/.beans/archive/csl26-01jy--configurable-structured-title-delimiters.md
@@ -1,0 +1,39 @@
+---
+# csl26-01jy
+title: Configurable structured title delimiters
+status: completed
+type: feature
+priority: normal
+created_at: 2026-07-05T17:08:53Z
+updated_at: 2026-07-05T17:23:17Z
+---
+
+Related: https://github.com/citum/citum-core/issues/1010
+Specs: docs/specs/TITLE_TEXT_CASE.md, docs/specs/LOCALE_MESSAGES.md
+
+- [x] Amend structured title delimiter spec
+- [x] Add style-level title delimiter options
+- [x] Add locale grammar defaults for structured title delimiters
+- [x] Render structured titles with primary/subtitle delimiters
+- [x] Add tests for default, custom, locale override, and short form
+- [x] Regenerate schemas and pass pre-commit
+
+## Summary of Changes
+
+Implemented locale-backed structured title delimiters for GitHub issue #1010.
+Added locale `grammar-options.title-subtitle-delimiter` for the
+main-title-to-subtitle-group boundary and `grammar-options.subtitle-delimiter`
+for subtitle-to-subtitle boundaries, while keeping style-level
+`primary-delimiter` and `subtitle-delimiter` as explicit overrides. The
+fallback defaults are `: ` for main-to-subtitle and `; ` for subtitle lists,
+with behavior documented in `docs/specs/TITLE_TEXT_CASE.md` and
+`docs/specs/LOCALE_MESSAGES.md`. Regenerated `docs/schemas/style.json` and
+added renderer/schema tests.
+
+Validation:
+- `just schema-gen`
+- `cargo test -p citum-schema-style test_title_locale_overrides_deserialization`
+- `cargo test -p citum-engine structured_title`
+- `just pre-commit` (1779 tests passed)
+
+Follow-up punctuation suppression is tracked in `csl26-zfqr`.

--- a/.beans/csl26-zfqr--structured-title-delimiter-suppression-after-termi.md
+++ b/.beans/csl26-zfqr--structured-title-delimiter-suppression-after-termi.md
@@ -1,0 +1,27 @@
+---
+# csl26-zfqr
+title: Structured title delimiter suppression after terminal punctuation
+status: todo
+type: bug
+priority: normal
+tags:
+    - punctuation
+    - rendering
+created_at: 2026-07-05T17:18:48Z
+updated_at: 2026-07-05T17:18:48Z
+---
+
+Follow-up from GitHub issue #1010 / csl26-01jy.
+
+When a structured title main part ends with significant terminal punctuation,
+rendering should avoid blindly inserting the configured primary delimiter.
+Example desired behavior: `Main title? And a subtitle`, not
+`Main title?: And a subtitle`.
+
+This likely belongs with broader punctuation-boundary work (`csl26-ztxq`) and
+needs a spec decision for which terminal marks suppress or replace configured
+structured-title delimiters across locales.
+
+- [ ] Amend the title or punctuation spec with terminal-punctuation delimiter suppression rules
+- [ ] Add structured-title tests for `?`, `!`, and other agreed terminal punctuation
+- [ ] Implement delimiter suppression without breaking configurable `primary-delimiter` / `subtitle-delimiter` behavior

--- a/crates/citum-engine/src/render/component.rs
+++ b/crates/citum-engine/src/render/component.rs
@@ -3,7 +3,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
-use citum_schema::options::{Config, bibliography::BibliographyConfig};
+use citum_schema::options::{Config, bibliography::BibliographyConfig, titles::TitleRendering};
 use citum_schema::template::{Rendering, TemplateComponent, TitleType};
 use std::rc::Rc;
 
@@ -282,6 +282,21 @@ pub fn get_title_category_rendering(
     language: Option<&str>,
     config: &Config,
 ) -> Option<Rendering> {
+    get_title_category_title_rendering(title_type, ref_type, language, config)
+        .map(|rendering| rendering.to_rendering())
+}
+
+/// Resolve title-category-specific title rendering options for a title component.
+///
+/// The returned rendering reflects title type, mapped reference category, and
+/// optional language-specific overrides from the style configuration.
+#[must_use]
+pub fn get_title_category_title_rendering(
+    title_type: &TitleType,
+    ref_type: Option<&str>,
+    language: Option<&str>,
+    config: &Config,
+) -> Option<TitleRendering> {
     let titles_config = config.titles.as_ref()?;
 
     // Use type_mapping if available to resolve category
@@ -360,9 +375,9 @@ pub fn get_title_category_rendering(
     };
 
     let selected = rendering.or(titles_config.default.as_ref())?;
-    let mut effective = selected.to_rendering();
+    let mut effective = selected.clone();
     if let Some(override_rendering) = selected.locale_override(language) {
-        effective.merge(&override_rendering.to_rendering());
+        effective.merge(override_rendering);
     }
     Some(effective)
 }

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -4085,6 +4085,60 @@ fn title_value_with_config(title_str: &str, ref_type: &str, config: &Config) -> 
         .value
 }
 
+fn structured_title_value_with_config(
+    title: citum_schema::reference::types::StructuredTitle,
+    config: &Config,
+    language: Option<&str>,
+    form: Option<TitleForm>,
+) -> String {
+    let locale = make_locale();
+    structured_title_value_with_config_and_locale(title, config, &locale, language, form)
+}
+
+fn structured_title_value_with_config_and_locale(
+    title: citum_schema::reference::types::StructuredTitle,
+    config: &Config,
+    locale: &Locale,
+    language: Option<&str>,
+    form: Option<TitleForm>,
+) -> String {
+    let options = RenderOptions {
+        config: Rc::new(config.clone()),
+        bibliography_config: None,
+        locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+        abbreviation_map: None,
+    };
+    let hints = ProcHints::default();
+
+    let mut reference = Reference::from(LegacyReference {
+        id: "structured-delimiter".to_string(),
+        ref_type: "book".to_string(),
+        title: Some("placeholder".to_string()),
+        language: language.map(Into::into),
+        ..Default::default()
+    });
+    if let ClassExtension::Monograph(monograph) = reference.extension_mut() {
+        monograph.title = Some(Title::Structured(title));
+    }
+
+    let component = TemplateTitle {
+        title: TitleType::Primary,
+        form,
+        ..Default::default()
+    };
+    component
+        .values::<PlainText>(&reference, &hints, &options)
+        .unwrap()
+        .value
+}
+
 #[test]
 fn test_text_case_sentence_apa_basic() {
     use citum_schema::options::titles::{TextCase, TitleRendering, TitlesConfig};
@@ -4259,8 +4313,195 @@ fn test_text_case_structured_title_sentence_apa() {
     // APA: first word of main + each subtitle capitalized
     assert_eq!(
         values.value,
-        "Understanding citation systems: History and practice: A comparative view"
+        "Understanding citation systems: History and practice; A comparative view"
     );
+}
+
+#[test]
+fn test_structured_title_default_delimiters_use_locale_grammar_options() {
+    use citum_schema::reference::types::{StructuredTitle, Subtitle};
+
+    let result = structured_title_value_with_config(
+        StructuredTitle {
+            full: None,
+            main: "Main title".to_string(),
+            sub: Subtitle::Vector(vec!["Subtitle one".to_string(), "Subtitle two".to_string()]),
+        },
+        &Config::default(),
+        None,
+        None,
+    );
+
+    assert_eq!(result, "Main title: Subtitle one; Subtitle two");
+}
+
+#[test]
+fn test_structured_title_locale_grammar_options_provide_fallback_delimiters() {
+    use citum_schema::reference::types::{StructuredTitle, Subtitle};
+
+    let mut locale = make_locale();
+    locale.grammar_options.title_subtitle_delimiter = " — ".to_string();
+    locale.grammar_options.subtitle_delimiter = " / ".to_string();
+
+    let result = structured_title_value_with_config_and_locale(
+        StructuredTitle {
+            full: None,
+            main: "Main title".to_string(),
+            sub: Subtitle::Vector(vec!["Subtitle one".to_string(), "Subtitle two".to_string()]),
+        },
+        &Config::default(),
+        &locale,
+        None,
+        None,
+    );
+
+    assert_eq!(result, "Main title — Subtitle one / Subtitle two");
+}
+
+#[test]
+fn test_structured_title_primary_delimiter_separates_main_from_subtitle() {
+    use citum_schema::options::titles::{TitleRendering, TitlesConfig};
+    use citum_schema::reference::types::{StructuredTitle, Subtitle};
+
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            primary_delimiter: Some(". ".to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let result = structured_title_value_with_config(
+        StructuredTitle {
+            full: None,
+            main: "Main title".to_string(),
+            sub: Subtitle::String("Subtitle".to_string()),
+        },
+        &config,
+        None,
+        None,
+    );
+
+    assert_eq!(result, "Main title. Subtitle");
+}
+
+#[test]
+fn test_structured_title_subtitle_delimiter_separates_subtitle_parts() {
+    use citum_schema::options::titles::{TitleRendering, TitlesConfig};
+    use citum_schema::reference::types::{StructuredTitle, Subtitle};
+
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            primary_delimiter: Some(": ".to_string()),
+            subtitle_delimiter: Some(". ".to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let result = structured_title_value_with_config(
+        StructuredTitle {
+            full: None,
+            main: "Main title".to_string(),
+            sub: Subtitle::Vector(vec!["Subtitle one".to_string(), "Subtitle two".to_string()]),
+        },
+        &config,
+        None,
+        None,
+    );
+
+    assert_eq!(result, "Main title: Subtitle one. Subtitle two");
+}
+
+#[test]
+fn test_structured_title_default_title_options_apply_delimiters_to_all_categories() {
+    use citum_schema::options::titles::{TitleRendering, TitlesConfig};
+    use citum_schema::reference::types::{StructuredTitle, Subtitle};
+
+    let config = make_config_with_titles(TitlesConfig {
+        default: Some(TitleRendering {
+            primary_delimiter: Some(". ".to_string()),
+            subtitle_delimiter: Some(" / ".to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let result = structured_title_value_with_config(
+        StructuredTitle {
+            full: None,
+            main: "Main title".to_string(),
+            sub: Subtitle::Vector(vec!["Subtitle one".to_string(), "Subtitle two".to_string()]),
+        },
+        &config,
+        None,
+        None,
+    );
+
+    assert_eq!(result, "Main title. Subtitle one / Subtitle two");
+}
+
+#[test]
+fn test_structured_title_locale_override_can_change_delimiters() {
+    use citum_schema::options::titles::{TitleRendering, TitlesConfig};
+    use citum_schema::reference::types::{StructuredTitle, Subtitle};
+    use std::collections::HashMap;
+
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            primary_delimiter: Some(": ".to_string()),
+            subtitle_delimiter: Some(": ".to_string()),
+            locale_overrides: Some(HashMap::from([(
+                "de".to_string(),
+                TitleRendering {
+                    primary_delimiter: Some(". ".to_string()),
+                    subtitle_delimiter: Some("; ".to_string()),
+                    ..Default::default()
+                },
+            )])),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let result = structured_title_value_with_config(
+        StructuredTitle {
+            full: None,
+            main: "Haupttitel".to_string(),
+            sub: Subtitle::Vector(vec![
+                "Untertitel eins".to_string(),
+                "Untertitel zwei".to_string(),
+            ]),
+        },
+        &config,
+        Some("de-DE"),
+        None,
+    );
+
+    assert_eq!(result, "Haupttitel. Untertitel eins; Untertitel zwei");
+}
+
+#[test]
+fn test_structured_title_form_short_ignores_configured_delimiters() {
+    use citum_schema::options::titles::{TitleRendering, TitlesConfig};
+    use citum_schema::reference::types::{StructuredTitle, Subtitle};
+
+    let config = make_config_with_titles(TitlesConfig {
+        monograph: Some(TitleRendering {
+            primary_delimiter: Some(". ".to_string()),
+            subtitle_delimiter: Some("; ".to_string()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    let result = structured_title_value_with_config(
+        StructuredTitle {
+            full: None,
+            main: "Main title".to_string(),
+            sub: Subtitle::Vector(vec!["Subtitle one".to_string(), "Subtitle two".to_string()]),
+        },
+        &config,
+        None,
+        Some(TitleForm::Short),
+    );
+
+    assert_eq!(result, "Main title");
 }
 
 #[test]
@@ -4470,7 +4711,7 @@ fn test_structured_title_form_short_returns_main_only() {
         .unwrap();
     assert_eq!(
         full.value,
-        "Homeland Security Act of 2002: Hearings on H.R. 5005: Day 3"
+        "Homeland Security Act of 2002: Hearings on H.R. 5005; Day 3"
     );
 
     // With form: short — main only, subtitles suppressed

--- a/crates/citum-engine/src/values/title.rs
+++ b/crates/citum-engine/src/values/title.rs
@@ -15,7 +15,8 @@ use crate::values::text_case::{self, apply_text_case, capitalize_first_word};
 use crate::values::{
     ComponentValues, ProcHints, ProcValues, RenderOptions, effective_component_language,
 };
-use citum_schema::options::titles::TextCase;
+use citum_schema::locale::Locale;
+use citum_schema::options::titles::{TextCase, TitleRendering};
 use citum_schema::reference::ClassExtension;
 use citum_schema::reference::types::{StructuredTitle, Subtitle, Title};
 use citum_schema::template::{TemplateComponent, TemplateTitle, TitleForm, TitleType};
@@ -219,6 +220,8 @@ fn render_structured_title<F: crate::render::format::OutputFormat<Output = Strin
     case: Option<TextCase>,
     short: bool,
     quote_depth: usize,
+    primary_delimiter: &str,
+    subtitle_delimiter: &str,
 ) -> (String, bool) {
     let (main_rendered, has_link) = render_part_with_case(&st.main, fmt, case, quote_depth);
     if short {
@@ -230,21 +233,29 @@ fn render_structured_title<F: crate::render::format::OutputFormat<Output = Strin
         other => other,
     });
 
-    let mut parts = vec![main_rendered];
     let mut has_link = has_link;
 
     let subs: Vec<&str> = match &st.sub {
         Subtitle::String(s) => vec![s.as_str()],
         Subtitle::Vector(v) => v.iter().map(std::string::String::as_str).collect(),
     };
+    if subs.is_empty() {
+        return (main_rendered, has_link);
+    }
 
+    let mut rendered_subtitles = Vec::with_capacity(subs.len());
     for sub in subs {
         let (sub_rendered, sub_link) = render_part_with_case(sub, fmt, subtitle_case, quote_depth);
         has_link |= sub_link;
-        parts.push(sub_rendered);
+        rendered_subtitles.push(sub_rendered);
     }
+    let subtitle_group = rendered_subtitles.join(subtitle_delimiter);
 
-    (parts.join(": "), has_link)
+    let mut rendered = main_rendered;
+    rendered.push_str(primary_delimiter);
+    rendered.push_str(&subtitle_group);
+
+    (rendered, has_link)
 }
 
 /// Resolve the effective text-case for this title component.
@@ -298,6 +309,35 @@ pub(crate) fn resolve_substitute_text_case(
     )?;
     let tc = rendering.text_case?;
     Some(apply_language_fallback(tc, reference))
+}
+
+fn resolve_effective_title_rendering(
+    template: &TemplateTitle,
+    reference: &Reference,
+    options: &RenderOptions<'_>,
+) -> Option<TitleRendering> {
+    let component = TemplateComponent::Title(template.clone());
+    let item_language = effective_component_language(reference, &component);
+    let ref_type = reference.ref_type();
+    crate::render::component::get_title_category_title_rendering(
+        &template.title,
+        Some(&ref_type),
+        item_language.as_deref(),
+        &options.config,
+    )
+}
+
+fn structured_title_delimiters<'a>(
+    rendering: Option<&'a TitleRendering>,
+    locale: &'a Locale,
+) -> (&'a str, &'a str) {
+    let primary_delimiter = rendering
+        .and_then(|rendering| rendering.primary_delimiter.as_deref())
+        .unwrap_or(locale.grammar_options.title_subtitle_delimiter.as_str());
+    let subtitle_delimiter = rendering
+        .and_then(|rendering| rendering.subtitle_delimiter.as_deref())
+        .unwrap_or(locale.grammar_options.subtitle_delimiter.as_str());
+    (primary_delimiter, subtitle_delimiter)
 }
 
 fn effective_title_quote_depth(
@@ -370,10 +410,12 @@ impl ComponentValues for TemplateTitle {
 
         let title = resolve_primary_title(reference, &self.title)?;
         let effective_case = resolve_effective_text_case(self, reference, options);
+        let effective_title_rendering = resolve_effective_title_rendering(self, reference, options);
         let (value, has_explicit_link, pre_formatted) = render_title_variant::<F>(
             &title,
             self.form.as_ref(),
             effective_case,
+            effective_title_rendering.as_ref(),
             options,
             quote_depth,
         );
@@ -432,6 +474,7 @@ fn render_title_variant<F: crate::render::format::OutputFormat<Output = String>>
     title: &Title,
     form: Option<&TitleForm>,
     effective_case: Option<TextCase>,
+    effective_title_rendering: Option<&TitleRendering>,
     options: &RenderOptions<'_>,
     quote_depth: usize,
 ) -> (String, bool, bool) {
@@ -439,8 +482,17 @@ fn render_title_variant<F: crate::render::format::OutputFormat<Output = String>>
     match title {
         Title::Structured(st) => {
             let short = matches!(form, Some(TitleForm::Short));
-            let (value, has_link) =
-                render_structured_title(st, &fmt, effective_case, short, quote_depth);
+            let (primary_delimiter, subtitle_delimiter) =
+                structured_title_delimiters(effective_title_rendering, options.locale);
+            let (value, has_link) = render_structured_title(
+                st,
+                &fmt,
+                effective_case,
+                short,
+                quote_depth,
+                primary_delimiter,
+                subtitle_delimiter,
+            );
             let pre_formatted = if short {
                 looks_like_djot_markup(&st.main)
             } else {

--- a/crates/citum-schema-style/embedded/locales/de-DE.yaml
+++ b/crates/citum-schema-style/embedded/locales/de-DE.yaml
@@ -806,6 +806,8 @@ grammar-options:
   close-inner-quote: "'"
   serial-comma: false
   page-range-delimiter: "–"
+  title-subtitle-delimiter: ": "
+  subtitle-delimiter: ", "
 
 legacy-term-aliases:
   page: term.page-label

--- a/crates/citum-schema-style/embedded/locales/en-US.yaml
+++ b/crates/citum-schema-style/embedded/locales/en-US.yaml
@@ -965,6 +965,8 @@ grammar-options:
   close-inner-quote: "’"
   serial-comma: true
   page-range-delimiter: "–"
+  title-subtitle-delimiter: ": "
+  subtitle-delimiter: "; "
 
 legacy-term-aliases:
   page: term.page-label

--- a/crates/citum-schema-style/embedded/locales/es-ES.yaml
+++ b/crates/citum-schema-style/embedded/locales/es-ES.yaml
@@ -336,6 +336,8 @@ grammar-options:
   close-inner-quote: "”"
   serial-comma: false
   page-range-delimiter: "–"
+  title-subtitle-delimiter: ": "
+  subtitle-delimiter: "; "
 
 legacy-term-aliases:
   page: term.page-label

--- a/crates/citum-schema-style/embedded/locales/eu-ES.yaml
+++ b/crates/citum-schema-style/embedded/locales/eu-ES.yaml
@@ -135,6 +135,8 @@ grammar-options:
   close-inner-quote: "”"
   serial-comma: false
   page-range-delimiter: "–"
+  title-subtitle-delimiter: ": "
+  subtitle-delimiter: "; "
 
 legacy-term-aliases:
   page: term.page-label

--- a/crates/citum-schema-style/embedded/locales/fr-FR.yaml
+++ b/crates/citum-schema-style/embedded/locales/fr-FR.yaml
@@ -916,6 +916,8 @@ grammar-options:
   close-inner-quote: "”"
   serial-comma: false
   page-range-delimiter: "‑"
+  title-subtitle-delimiter: " : "
+  subtitle-delimiter: " ; "
 
 legacy-term-aliases:
   page: term.page-label

--- a/crates/citum-schema-style/embedded/locales/overrides/de-DE-chicago.yaml
+++ b/crates/citum-schema-style/embedded/locales/overrides/de-DE-chicago.yaml
@@ -25,6 +25,8 @@ grammar-options:
   delimiter-precedes-last: never
   # Chicago German uses no serial (Oxford) comma
   serial-comma: false
+  title-subtitle-delimiter: ": "
+  subtitle-delimiter: "; "
 
 messages:
   # Chicago-German chapter entries introduce the container by adjacency; the

--- a/crates/citum-schema-style/embedded/locales/overrides/en-US-chicago.yaml
+++ b/crates/citum-schema-style/embedded/locales/overrides/en-US-chicago.yaml
@@ -17,4 +17,6 @@ grammar-options:
   nbsp-before-colon: false
   serial-comma: true
   page-range-delimiter: "\u2013"
+  title-subtitle-delimiter: ": "
+  subtitle-delimiter: "; "
 legacy-term-aliases: {}

--- a/crates/citum-schema-style/embedded/locales/tr-TR.yaml
+++ b/crates/citum-schema-style/embedded/locales/tr-TR.yaml
@@ -803,6 +803,8 @@ grammar-options:
   close-inner-quote: "'"
   serial-comma: false
   page-range-delimiter: "-"
+  title-subtitle-delimiter: ": "
+  subtitle-delimiter: "; "
 
 legacy-term-aliases:
   page: term.page-label

--- a/crates/citum-schema-style/src/locale/types.rs
+++ b/crates/citum-schema-style/src/locale/types.rs
@@ -470,6 +470,12 @@ pub struct GrammarOptions {
     /// Delimiter between page range endpoints.
     #[serde(default = "default_page_range_delimiter")]
     pub page_range_delimiter: String,
+    /// Delimiter between a structured title's main title and subtitle group.
+    #[serde(default = "default_title_subtitle_delimiter")]
+    pub title_subtitle_delimiter: String,
+    /// Delimiter between subtitle parts inside a structured title.
+    #[serde(default = "default_subtitle_delimiter")]
+    pub subtitle_delimiter: String,
 }
 
 impl Default for GrammarOptions {
@@ -483,6 +489,8 @@ impl Default for GrammarOptions {
             close_inner_quote: default_close_inner_quote(),
             serial_comma: false,
             page_range_delimiter: default_page_range_delimiter(),
+            title_subtitle_delimiter: default_title_subtitle_delimiter(),
+            subtitle_delimiter: default_subtitle_delimiter(),
         }
     }
 }
@@ -505,6 +513,14 @@ fn default_close_inner_quote() -> String {
 
 fn default_page_range_delimiter() -> String {
     "\u{2013}".into()
+}
+
+fn default_title_subtitle_delimiter() -> String {
+    ": ".into()
+}
+
+fn default_subtitle_delimiter() -> String {
+    "; ".into()
 }
 
 /// Message syntax variant active in a locale file.

--- a/crates/citum-schema-style/src/options/titles.rs
+++ b/crates/citum-schema-style/src/options/titles.rs
@@ -117,6 +117,12 @@ pub struct TitleRendering {
     /// Text-case transform to apply to this title category.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text_case: Option<TextCase>,
+    /// Delimiter between the main title and the first subtitle.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary_delimiter: Option<String>,
+    /// Delimiter between subtitle parts when a title has multiple subtitles.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subtitle_delimiter: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub emph: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -144,6 +150,8 @@ pub struct TitleRendering {
 }
 
 impl TitleRendering {
+    /// Convert title rendering fields shared by generic components into a
+    /// template rendering configuration.
     pub fn to_rendering(&self) -> crate::template::Rendering {
         crate::template::Rendering {
             text_case: self.text_case,
@@ -157,6 +165,27 @@ impl TitleRendering {
         }
     }
 
+    /// Merge another title rendering configuration into this one.
+    ///
+    /// The other rendering takes precedence, overwriting any fields that are present.
+    pub fn merge(&mut self, other: &TitleRendering) {
+        crate::merge_options!(
+            self,
+            other,
+            text_case,
+            primary_delimiter,
+            subtitle_delimiter,
+            emph,
+            quote,
+            strong,
+            small_caps,
+            prefix,
+            suffix,
+            locale_overrides,
+        );
+    }
+
+    /// Return the most specific language override for a language tag.
     pub fn locale_override(&self, language: Option<&str>) -> Option<&TitleRendering> {
         let overrides = self.locale_overrides.as_ref()?;
         let language = language?;

--- a/crates/citum-schema-style/src/reference_multilingual_tests.rs
+++ b/crates/citum-schema-style/src/reference_multilingual_tests.rs
@@ -16,6 +16,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
     reason = "Panicking is acceptable and often desired in tests."
 )]
 mod tests {
+    use crate::locale::Locale;
     use crate::options::{Config, MultilingualMode};
     use crate::reference::contributor::MultilingualName;
     use crate::reference::types::{Monograph, Title};
@@ -113,18 +114,52 @@ translations:
 titles:
   component:
     quote: true
+    primary-delimiter: ". "
+    subtitle-delimiter: "; "
     locale-overrides:
       de:
         emph: true
+        primary-delimiter: ": "
       en-US:
         quote: false
+        subtitle-delimiter: ". "
 "#;
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         let titles = config.titles.unwrap();
         let component = titles.component.unwrap();
+        assert_eq!(component.primary_delimiter.as_deref(), Some(". "));
+        assert_eq!(component.subtitle_delimiter.as_deref(), Some("; "));
         let overrides = component.locale_overrides.unwrap();
         assert_eq!(overrides.get("de").unwrap().emph, Some(true));
+        assert_eq!(
+            overrides.get("de").unwrap().primary_delimiter.as_deref(),
+            Some(": ")
+        );
         assert_eq!(overrides.get("en-US").unwrap().quote, Some(false));
+        assert_eq!(
+            overrides
+                .get("en-US")
+                .unwrap()
+                .subtitle_delimiter
+                .as_deref(),
+            Some(". ")
+        );
+    }
+
+    #[test]
+    fn test_locale_title_delimiters_deserialization() {
+        let yaml = r#"
+locale: x-test
+grammar-options:
+  title-subtitle-delimiter: " — "
+  subtitle-delimiter: " / "
+"#;
+        let locale = Locale::from_yaml_str(yaml).unwrap();
+        assert_eq!(
+            locale.grammar_options.title_subtitle_delimiter.as_str(),
+            " — "
+        );
+        assert_eq!(locale.grammar_options.subtitle_delimiter.as_str(), " / ");
     }
 
     #[test]

--- a/docs/schemas/locale.json
+++ b/docs/schemas/locale.json
@@ -586,6 +586,16 @@
           "description": "Delimiter between page range endpoints.",
           "type": "string",
           "default": "–"
+        },
+        "title-subtitle-delimiter": {
+          "description": "Delimiter between a structured title's main title and subtitle group.",
+          "type": "string",
+          "default": ": "
+        },
+        "subtitle-delimiter": {
+          "description": "Delimiter between subtitle parts inside a structured title.",
+          "type": "string",
+          "default": "; "
         }
       }
     },

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -4500,6 +4500,20 @@
             }
           ]
         },
+        "primary-delimiter": {
+          "description": "Delimiter between the main title and the first subtitle.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "subtitle-delimiter": {
+          "description": "Delimiter between subtitle parts when a title has multiple subtitles.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "emph": {
           "type": [
             "boolean",

--- a/docs/specs/LOCALE_MESSAGES.md
+++ b/docs/specs/LOCALE_MESSAGES.md
@@ -571,6 +571,8 @@ grammar-options:
   close-inner-quote:    "\u2019"
   serial-comma:         true
   page-range-delimiter: "\u2013"
+  title-subtitle-delimiter: ": "
+  subtitle-delimiter:   "; "
 
 legacy-term-aliases:
   page:          term.page-label
@@ -648,6 +650,8 @@ grammar-options:
   close-inner-quote:    "\u2018"
   serial-comma:         false
   page-range-delimiter: "\u2013"
+  title-subtitle-delimiter: ": "
+  subtitle-delimiter:   "; "
 ```
 
 The same message IDs (`term.page-label`, `role.editor.verb`) carry
@@ -663,6 +667,8 @@ language-specific realizations without any change to the style YAML.
 | `open-inner-quote` / `close-inner-quote` | `string` | Nested quotation marks. |
 | `serial-comma` | `bool` | Oxford comma before final list conjunction. |
 | `page-range-delimiter` | `string` | Default separator between page range endpoints. |
+| `title-subtitle-delimiter` | `string` | Default separator between a structured title's main title and subtitle group. |
+| `subtitle-delimiter` | `string` | Default separator between subtitle parts inside a structured title. |
 
 ---
 
@@ -863,6 +869,8 @@ pub struct RawGrammarOptions {
     pub close_inner_quote: Option<String>,
     pub serial_comma: Option<bool>,
     pub page_range_delimiter: Option<String>,
+    pub title_subtitle_delimiter: Option<String>,
+    pub subtitle_delimiter: Option<String>,
 }
 ```
 

--- a/docs/specs/TITLE_TEXT_CASE.md
+++ b/docs/specs/TITLE_TEXT_CASE.md
@@ -1,10 +1,12 @@
 # Title Text-Case Semantics Specification
 
 **Status:** Active
-**Version:** 1.0
-**Date:** 2026-03-11
+**Version:** 1.2
+**Date:** 2026-07-05
 **Supersedes:** none
-**Related:** `csl26-wv5o`, `csl26-suz3`, `docs/specs/DJOT_RICH_TEXT.md`
+**Related:** `csl26-wv5o`, `csl26-suz3`, `csl26-01jy`, GitHub issue
+[#1010](https://github.com/citum/citum-core/issues/1010),
+`docs/specs/DJOT_RICH_TEXT.md`
 
 ## Purpose
 
@@ -119,6 +121,61 @@ recognize at least these punctuation boundaries:
 
 Semicolon does not create a subtitle boundary by default.
 
+### Structured Title Delimiters
+
+Structured title rendering must distinguish the delimiter between the main
+title and the subtitle group from the delimiter between subtitle parts.
+
+Normative rules:
+
+- Locale `grammar-options.title-subtitle-delimiter` joins the main title to
+  the subtitle group.
+- Locale `grammar-options.subtitle-delimiter` joins subtitle parts to each
+  other and is repeated for each additional subtitle part.
+- Locale defaults are `": "` for `title-subtitle-delimiter` and `"; "` for
+  `subtitle-delimiter`.
+- `options.titles.<category>.primary-delimiter` overrides the locale main
+  title to subtitle delimiter for that title category.
+- `options.titles.<category>.subtitle-delimiter` overrides the locale
+  subtitle-to-subtitle delimiter for that title category.
+- `options.titles.default` applies delimiter overrides to all title categories
+  that do not have a more specific category entry.
+- A style may set only one delimiter; the unset delimiter keeps the locale
+  default.
+- Empty strings are valid explicit delimiter values.
+- `form: short` renders only the main title and ignores both delimiter options.
+- Delimiter defaults are locale-owned. Style delimiter keys express
+  style-specific overrides; they are not the default source of language
+  punctuation. This spec does not require an MF2 message path for structured
+  title assembly.
+
+For example:
+
+```yaml
+options:
+  titles:
+    monograph:
+      primary-delimiter: ": "
+      subtitle-delimiter: ". "
+```
+
+renders a structured title as:
+
+```text
+Main title: subtitle 1. subtitle 2
+```
+
+To set the same delimiter overrides for all title categories, author them under
+`options.titles.default`:
+
+```yaml
+options:
+  titles:
+    default:
+      primary-delimiter: ". "
+      subtitle-delimiter: "; "
+```
+
 ### Case Protection
 
 Citum must define an internal case-protection concept that all case transforms
@@ -228,6 +285,8 @@ capabilities are required, even if the final YAML or Rust surface differs:
 - a way to carry semantic span roles where they are useful
 - a way to model explicit main-title and subtitle structure, including multiple
   subtitles
+- a style-level way to configure the main-title-to-subtitle delimiter and the
+  delimiter repeated between subtitle parts
 - a way to declare when a field intentionally deviates from the sentence-case
   default assumption
 
@@ -341,6 +400,8 @@ direction. The remaining disagreements or unresolved choices are:
       compatible with Djot spans, CSL `.nocase`, and BibTeX-style protection
 - [ ] The specification states that structured title parts, including multiple
       subtitles, are the normative rendering model
+- [ ] The specification defines style-owned structured-title delimiters for
+      the main/subtitle boundary and subtitle/subtitle boundaries
 - [ ] The specification distinguishes generic protected spans from richer
       semantic span roles
 - [ ] The specification adopts sentence case as the default portability
@@ -355,6 +416,8 @@ direction. The remaining disagreements or unresolved choices are:
 - v1.0 (2026-03-11): Initial draft synthesized from `perplexity.md` and
   `gem.md`.
 - v1.1 (2026-03-12): Implementation notes added.
+- v1.2 (2026-07-05): Added style-owned structured title delimiters for
+  main/subtitle and subtitle/subtitle boundaries.
 
 ## Deferred Behavior
 


### PR DESCRIPTION
## Summary

Adds style-level structured title delimiter configuration for GitHub issue #1010.

- Adds `primary-delimiter` for the main-title-to-first-subtitle boundary.
- Adds `subtitle-delimiter` for boundaries between multiple subtitle parts.
- Preserves the existing `": "` default behavior when neither option is set.
- Allows existing title `locale-overrides` to override either delimiter.
- Documents the behavior in `docs/specs/TITLE_TEXT_CASE.md` and regenerates `docs/schemas/style.json`.
- Tracks terminal-punctuation delimiter suppression as follow-up bean `csl26-zfqr`.

## Scope

Touches title rendering configuration and structured title rendering only. Does not add per-template title delimiter overrides and does not introduce an MF2 locale-message path for title assembly.

## Validation

- `just schema-gen`
- `cargo test -p citum-schema-style test_title_locale_overrides_deserialization`
- `cargo test -p citum-engine structured_title`
- `just pre-commit` (1779 tests passed)
- pre-push gate reran fmt, clippy, and nextest (1779 tests passed)

## Risk

Low. Defaults preserve existing structured title output, and new behavior is opt-in via style title config. The main open edge case is significant terminal punctuation before a subtitle delimiter, tracked separately in `csl26-zfqr`.

Closes #1010
