### PR TITLE
ci: retry flaky compat-report pages deploy step

### DIFF
--- a/.beans/archive/csl26-b4r4--fix-flaky-compat-report-deploy-step.md
+++ b/.beans/archive/csl26-b4r4--fix-flaky-compat-report-deploy-step.md
@@ -1,0 +1,15 @@
+---
+# csl26-b4r4
+title: Fix flaky Compat Report deploy step
+status: completed
+type: bug
+priority: normal
+created_at: 2026-07-06T14:52:15Z
+updated_at: 2026-07-06T14:52:42Z
+---
+
+Deploy to GitHub Pages step in compat-report.yml intermittently fails with 'Deployment failed, try again later' (transient GitHub Pages API error), requiring manual rerun. Wrap actions/deploy-pages with Wandalen/wretry.action for automatic retry.
+
+## Summary of Changes
+
+Wrapped the `Deploy to GitHub Pages` step in `.github/workflows/compat-report.yml` with `Wandalen/wretry.action@v3.8.0` (pinned SHA `e68c23e6309f2871ca8ae4763e7629b9c258e1ea`), retrying `actions/deploy-pages` up to 3 times with a 30s delay. Confirmed via `gh run list`/`gh run view --log-failed` across the last 100 runs that the Build Docs job always succeeds and only the deploy step's `actions/deploy-pages` call intermittently returns `Deployment failed, try again later.` — a transient GitHub Pages API error, not a build/content problem. Ruled out a concurrent-run race (no other Compat Report or Pages-deploying workflow was in flight at failure time).

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -106,4 +106,8 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
+        with:
+          action: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4
+          attempt_limit: 3
+          attempt_delay: 30000


### PR DESCRIPTION
## Summary

- The `Compat Report` workflow has been intermittently failing on `main`, requiring a manual re-run (e.g. [run 28799557058](https://github.com/citum/citum-core/actions/runs/28799557058)).
- Diagnosis: the `Build Docs` job always succeeds. Only the `Deploy to GitHub Pages` step (`actions/deploy-pages@v4`) intermittently fails with `Deployment failed, try again later.` — a transient error from GitHub's Pages deployment API, not a build/content problem. There's no concurrent-run race (only one `Compat Report` run was active at the failure time, and no other workflow targets the `github-pages` environment).
- Fix: wrap `actions/deploy-pages` with `Wandalen/wretry.action@v3.8.0` (pinned SHA), retrying up to 3 times with a 30s delay, so transient Pages API hiccups resolve automatically instead of requiring a manual "Re-run jobs" click.

A separate, unrelated cluster of 4 failures on 2026-06-30/07-01 was a missing `styles-legacy` submodule file at those commits — already resolved, not part of this fix.

## Test plan

- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Watch the next `main` push or a manual `gh workflow run compat-report.yml` to confirm the `deploy` job still completes and publishes to Pages normally
- [ ] Retry behavior itself can only be confirmed the next time GitHub's Pages API hiccups again — this is a mitigation for an upstream transient failure, not something reproducible on demand
