### PR TITLE
refactor(engine): relocate sorter to crate root

### DIFF
--- a/.beans/archive/csl26-ximb--relocate-groupsorter-out-of-grouping-module.md
+++ b/.beans/archive/csl26-ximb--relocate-groupsorter-out-of-grouping-module.md
@@ -1,10 +1,11 @@
 ---
 # csl26-ximb
 title: Relocate GroupSorter out of grouping module
-status: todo
+status: completed
 type: task
+priority: normal
 created_at: 2026-07-06T17:26:16Z
-updated_at: 2026-07-06T17:26:16Z
+updated_at: 2026-07-06T17:59:17Z
 ---
 
 Follow-up to csl26-b801 (PR #1019). GroupSorter in crates/citum-engine/src/grouping/sorting.rs is now the engine's single sorting stack — its callers are mostly not grouping-related (processor/setup.rs bibliography + citation-item sorting, processor/disambiguation.rs), so both the file location and the type name are historical.
@@ -14,3 +15,7 @@ Scope (engine-side only, mechanical):
 - Rename GroupSorter → ReferenceSorter (or Sorter; the name is free again). Update the pub use in grouping/mod.rs and all call sites.
 
 Out of scope, decide separately: renaming the serde-facing schema types (citum_schema::grouping::GroupSort/GroupSortKey) — they touch the style schema surface and docs/schemas, and the mismatch predates csl26-b801 (bibliography.sort already resolves to a GroupSort).
+
+## Summary of Changes
+
+Moved crates/citum-engine/src/grouping/sorting.rs to crates/citum-engine/src/sorting.rs (crate root, beside sort_support.rs / sort_partitioning.rs) and renamed GroupSorter to ReferenceSorter. lib.rs now declares `pub mod sorting;` and re-exports ReferenceSorter at the crate root; grouping/mod.rs no longer owns sorting. Updated all consumers (processor/setup.rs, processor/disambiguation.rs, processor/bibliography/grouping.rs, benches/rendering.rs incl. the benchmark-group label). Schema types (citum_schema::grouping::GroupSort/GroupSortKey) untouched per scope. Pure move+rename: 1814/1814 tests, clippy clean, apa.csl fidelity unchanged.

--- a/crates/citum-engine/benches/rendering.rs
+++ b/crates/citum-engine/benches/rendering.rs
@@ -16,9 +16,9 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
     reason = "Panicking is acceptable and often desired in test, benchmark, and example code."
 )]
 
-use citum_engine::grouping::GroupSorter;
 use citum_engine::processor::disambiguation::Disambiguator;
 use citum_engine::render::plain::PlainText;
+use citum_engine::sorting::ReferenceSorter;
 use citum_engine::{
     Bibliography, Citation, CitationItem, Contributor, EdtfString, Locale, Monograph,
     MonographType, MultilingualString, Processor, Reference, StructuredName, Title,
@@ -337,7 +337,7 @@ where
 
 fn bench_group_sorting(c: &mut Criterion) {
     let locale = Locale::en_us();
-    let sorter = GroupSorter::new(&locale);
+    let sorter = ReferenceSorter::new(&locale);
     let bibliography = make_group_sort_bibliography();
     let references: Vec<&Reference> = bibliography.values().collect();
     let sort_spec = GroupSort {
@@ -367,7 +367,7 @@ fn bench_group_sorting(c: &mut Criterion) {
         ],
     };
 
-    let mut bench_group = c.benchmark_group("GroupSorter::sort_references");
+    let mut bench_group = c.benchmark_group("ReferenceSorter::sort_references");
     bench_group.bench_function("Explicit type order + author", |b| {
         b.iter_batched(
             || references.clone(),

--- a/crates/citum-engine/src/grouping/mod.rs
+++ b/crates/citum-engine/src/grouping/mod.rs
@@ -6,10 +6,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! Bibliography grouping support.
 //!
 //! This module provides functionality for dividing bibliographies into
-//! labeled groups with distinct sorting rules.
+//! labeled groups via selector evaluation.
 
 pub mod selector;
-pub mod sorting;
 
 pub use selector::SelectorEvaluator;
-pub use sorting::GroupSorter;

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -106,6 +106,8 @@ pub mod reference;
 pub mod render;
 mod sort_partitioning;
 mod sort_support;
+/// Bibliography and citation reference sorting.
+pub mod sorting;
 /// Template value resolution and formatting helpers.
 pub mod values;
 
@@ -133,6 +135,7 @@ pub use processor::document::DocumentFormat;
 pub use processor::{ProcessedReferences, Processor};
 pub use reference::{Bibliography, Citation, CitationItem, Reference};
 pub use render::{ProcTemplate, ProcTemplateComponent, citation_to_string, refs_to_string};
+pub use sorting::ReferenceSorter;
 pub use values::{ComponentValues, ProcHints, ProcValues, RenderContext, RenderOptions};
 
 // Re-export Locale from citum_schema for convenience

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -7,13 +7,14 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 use super::RenderedBibliographyGroup;
 use crate::api::AnnotationStyle;
-use crate::grouping::{GroupSorter, SelectorEvaluator};
+use crate::grouping::SelectorEvaluator;
 use crate::processor::Processor;
 use crate::processor::disambiguation::Disambiguator;
 use crate::processor::rendering::{CompoundRenderData, Renderer, RendererResources};
 use crate::reference::{Bibliography, Reference};
 use crate::render::ProcEntry;
 use crate::render::format::{OutputFormat, ProcEntryMetadata};
+use crate::sorting::ReferenceSorter;
 use crate::values::{
     ProcHints, RenderContext, RenderOptions, format_contributors_short, resolve_multilingual_name,
     resolve_multilingual_string,
@@ -392,7 +393,7 @@ impl Processor {
         let fmt = F::default();
         let cited_ids = self.cited_ids.borrow();
         let evaluator = SelectorEvaluator::new(&cited_ids);
-        let sorter = GroupSorter::new(&self.locale);
+        let sorter = ReferenceSorter::new(&self.locale);
 
         let mut assigned = HashSet::new();
         let mut result = String::new();
@@ -685,7 +686,7 @@ impl Processor {
         let bibliography = self.sorted_id_stubs();
         let cited_ids = self.cited_ids.borrow();
         let evaluator = SelectorEvaluator::new(&cited_ids);
-        let sorter = GroupSorter::new(&self.locale);
+        let sorter = ReferenceSorter::new(&self.locale);
 
         let matching_refs =
             self.collect_matching_group_refs(&bibliography, assigned, &evaluator, group);

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -9,7 +9,7 @@ use citum_schema::options::{Config, GivennameRule};
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 
-use crate::grouping::GroupSorter;
+use crate::sorting::ReferenceSorter;
 use citum_schema::grouping::GroupSort;
 use citum_schema::locale::Locale;
 use citum_schema::options::{Substitute, SubstituteKey};
@@ -703,10 +703,10 @@ impl<'a> Disambiguator<'a> {
         group: &[&'b CachedReference<'b>],
     ) -> Vec<&'b CachedReference<'b>> {
         if let Some(sort_spec) = self.group_sort {
-            let sorter = GroupSorter::new(self.locale);
+            let sorter = ReferenceSorter::new(self.locale);
             // Pre-sort by title_key so that entries which compare equal under the primary
             // sort_spec retain a stable, deterministic order (title ascending as tiebreaker).
-            // GroupSorter::sort_references uses sort_by (stable), so the pre-sort order is
+            // ReferenceSorter::sort_references uses sort_by (stable), so the pre-sort order is
             // preserved for entries that compare equal under the primary key.
             let mut pre_sorted: Vec<&CachedReference<'_>> = group.to_vec();
             pre_sorted.sort_by(|a, b| {

--- a/crates/citum-engine/src/processor/setup.rs
+++ b/crates/citum-engine/src/processor/setup.rs
@@ -485,11 +485,11 @@ impl Processor {
     pub fn sort_references<'a>(&self, references: Vec<&'a Reference>) -> Vec<&'a Reference> {
         let mut sorted_refs = match self.resolved_bibliography_sort() {
             Some((sort_spec, true)) => {
-                let sorter = crate::grouping::GroupSorter::new(&self.locale);
+                let sorter = crate::sorting::ReferenceSorter::new(&self.locale);
                 sorter.sort_references_with_id_tiebreak(references, &sort_spec)
             }
             Some((sort_spec, false)) => {
-                let sorter = crate::grouping::GroupSorter::new(&self.locale);
+                let sorter = crate::sorting::ReferenceSorter::new(&self.locale);
                 sorter.sort_references(references, &sort_spec)
             }
             None => references,
@@ -526,7 +526,7 @@ impl Processor {
                 .collect();
 
             let resolved_sort = sort_spec.resolve();
-            let sorter = crate::grouping::GroupSorter::new(&self.locale);
+            let sorter = crate::sorting::ReferenceSorter::new(&self.locale);
             items_with_refs.sort_by(|left, right| {
                 for sort_key in &resolved_sort.template {
                     let cmp = sorter.compare_by_key(left.1, right.1, sort_key);

--- a/crates/citum-engine/src/sorting.rs
+++ b/crates/citum-engine/src/sorting.rs
@@ -5,7 +5,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 //! Reference sorting for bibliographies, groups, and citations.
 //!
-//! `GroupSorter` is the engine's single sorting stack: bibliography sorts
+//! `ReferenceSorter` is the engine's single sorting stack: bibliography sorts
 //! (explicit `bibliography.sort`, processing presets, and config-level
 //! `sort:` mapped via `Sort::group_sort()`), per-group sorting, citation-item
 //! ordering, and disambiguation all route through it. Sort keys are compiled
@@ -35,7 +35,7 @@ fn compare_optional_years(a_year: Option<i32>, b_year: Option<i32>) -> std::cmp:
 }
 
 /// Sorts grouped bibliography entries using group-specific sort rules.
-pub struct GroupSorter<'a> {
+pub struct ReferenceSorter<'a> {
     locale: &'a Locale,
     text_collator: TextCollator,
 }
@@ -45,7 +45,7 @@ struct CachedReference<'a> {
     sort_values: Vec<CachedSortValue>,
     /// Reference ID, cached once per reference so the ID tiebreak does not
     /// re-derive it on every pairwise comparison. Populated only when sorting
-    /// via [`GroupSorter::sort_references_with_id_tiebreak`]; `None` otherwise
+    /// via [`ReferenceSorter::sort_references_with_id_tiebreak`]; `None` otherwise
     /// to keep ID-less sorts allocation-free.
     id: Option<String>,
 }
@@ -78,7 +78,7 @@ enum CompiledSortKey<'a> {
     },
 }
 
-impl<'a> GroupSorter<'a> {
+impl<'a> ReferenceSorter<'a> {
     /// Create a sorter that uses `locale` for locale-sensitive comparisons.
     #[must_use]
     pub fn new(locale: &'a Locale) -> Self {
@@ -110,7 +110,7 @@ impl<'a> GroupSorter<'a> {
     ///
     /// References without an ID sort after references with one. The tiebreak
     /// makes config-driven bibliography sorts fully deterministic, and is
-    /// opt-in because most `GroupSorter` call sites (grouping/render paths)
+    /// opt-in because most `ReferenceSorter` call sites (grouping/render paths)
     /// rely on stable-sort/registry order for equal keys instead.
     ///
     /// An empty sort template is a no-op: with no keys to compare, references
@@ -493,7 +493,7 @@ mod tests {
     #[test]
     fn test_type_order_sorting() {
         let locale = make_locale();
-        let sorter = GroupSorter::new(&locale);
+        let sorter = ReferenceSorter::new(&locale);
 
         // Use standard CSL JSON types for testing
         let journal = make_reference("r1", "article-journal", "Smith", "Title J", 1990);
@@ -528,7 +528,7 @@ mod tests {
     #[test]
     fn test_author_family_given_order() {
         let locale = make_locale();
-        let sorter = GroupSorter::new(&locale);
+        let sorter = ReferenceSorter::new(&locale);
 
         let smith = make_reference("r1", "book", "Smith", "Title", 2000);
         let jones = make_reference("r2", "book", "Jones", "Title", 2000);
@@ -557,7 +557,7 @@ mod tests {
     #[cfg(feature = "icu")]
     fn test_author_sort_uses_unicode_collation_for_accented_names() {
         let locale = make_locale();
-        let sorter = GroupSorter::new(&locale);
+        let sorter = ReferenceSorter::new(&locale);
 
         let celik = make_reference("r1", "book", "Çelik", "Title", 2000);
         let zimring = make_reference("r2", "book", "Zimring", "Title", 2000);
@@ -585,7 +585,7 @@ mod tests {
     #[cfg(feature = "icu")]
     fn test_title_sort_uses_unicode_collation_for_accented_titles() {
         let locale = make_locale();
-        let sorter = GroupSorter::new(&locale);
+        let sorter = ReferenceSorter::new(&locale);
 
         let accent = make_reference_no_author("r1", "book", "Órbitas del sur", 2000);
         let plain = make_reference_no_author("r2", "book", "Origins of Theory", 2000);
@@ -612,7 +612,7 @@ mod tests {
     #[test]
     fn test_issued_descending() {
         let locale = make_locale();
-        let sorter = GroupSorter::new(&locale);
+        let sorter = ReferenceSorter::new(&locale);
 
         let old = make_reference("r1", "book", "Smith", "Title", 1990);
         let new = make_reference("r2", "book", "Jones", "Title", 2020);
@@ -640,7 +640,7 @@ mod tests {
     #[test]
     fn test_issued_ascending_places_undated_last() {
         let locale = make_locale();
-        let sorter = GroupSorter::new(&locale);
+        let sorter = ReferenceSorter::new(&locale);
 
         let dated_early = make_reference("r1", "book", "Smith", "Book D", 1999);
         let dated_late = make_reference("r2", "book", "Jones", "Book B", 2000);
@@ -670,7 +670,7 @@ mod tests {
     #[test]
     fn test_issued_sort_uses_created_when_issued_is_missing() {
         let locale = make_locale();
-        let sorter = GroupSorter::new(&locale);
+        let sorter = ReferenceSorter::new(&locale);
 
         let dated = make_reference("r1", "book", "Smith", "Book D", 1999);
         let mut created_only = make_reference("r2", "book", "Jones", "Book C", 2000);
@@ -699,7 +699,7 @@ mod tests {
     #[test]
     fn test_composite_sort() {
         let locale = make_locale();
-        let sorter = GroupSorter::new(&locale);
+        let sorter = ReferenceSorter::new(&locale);
 
         let smith2020 = make_reference("r1", "book", "Smith", "Title", 2020);
         let smith2010 = make_reference("r2", "book", "Smith", "Title", 2010);
@@ -735,7 +735,7 @@ mod tests {
     #[test]
     fn test_author_sort_falls_back_to_title_for_missing_names() {
         let locale = make_locale();
-        let sorter = GroupSorter::new(&locale);
+        let sorter = ReferenceSorter::new(&locale);
 
         let no_author = make_reference_no_author("r1", "legal-case", "Brown v. Board", 1954);
         let brown = make_reference("r2", "book", "Brown", "Title", 2000);
@@ -762,7 +762,7 @@ mod tests {
     #[test]
     fn test_legal_citation_sort() {
         let locale = make_locale();
-        let sorter = GroupSorter::new(&locale);
+        let sorter = ReferenceSorter::new(&locale);
 
         let case_a = make_reference("r1", "legal-case", "", "Doe v. Smith", 1990);
         let case_b = make_reference("r2", "legal-case", "", "Brown v. Board", 1954);
@@ -793,7 +793,7 @@ mod tests {
     #[test]
     fn test_legal_hierarchy_sort() {
         let locale = make_locale();
-        let sorter = GroupSorter::new(&locale);
+        let sorter = ReferenceSorter::new(&locale);
 
         let statute = make_reference("r1", "statute", "", "Clean Air Act", 1970);
         let case = make_reference("r2", "legal-case", "", "Roe v. Wade", 1973);
@@ -827,7 +827,7 @@ mod tests {
     #[test]
     fn test_id_tiebreak_orders_equal_keys_by_id() {
         let locale = make_locale();
-        let sorter = GroupSorter::new(&locale);
+        let sorter = ReferenceSorter::new(&locale);
 
         let c = make_reference("r-c", "book", "Smith", "Same Title", 2000);
         let a = make_reference("r-a", "book", "Smith", "Same Title", 2000);
@@ -856,7 +856,7 @@ mod tests {
     #[test]
     fn test_id_tiebreak_places_missing_id_last() {
         let locale = make_locale();
-        let sorter = GroupSorter::new(&locale);
+        let sorter = ReferenceSorter::new(&locale);
 
         let with_id = make_reference("r1", "book", "Smith", "Same Title", 2000);
         let mut no_id = make_reference("r2", "book", "Smith", "Same Title", 2000);
@@ -886,7 +886,7 @@ mod tests {
     #[test]
     fn test_id_tiebreak_with_empty_template_keeps_registry_order() {
         let locale = make_locale();
-        let sorter = GroupSorter::new(&locale);
+        let sorter = ReferenceSorter::new(&locale);
 
         let c = make_reference("r-c", "book", "Smith", "Title C", 2000);
         let a = make_reference("r-a", "book", "Jones", "Title A", 2001);


### PR DESCRIPTION
## Summary

Follow-up to #1019 (bean `csl26-ximb`). Since the `csl26-b801` unification, `GroupSorter` is the engine's single sorting stack, but most of its callers are not grouping-related (bibliography and citation-item sorting in `processor/setup.rs`, disambiguation) — the file location and type name were historical.

- Move `crates/citum-engine/src/grouping/sorting.rs` → `crates/citum-engine/src/sorting.rs` (crate root, beside `sort_support.rs` / `sort_partitioning.rs`)
- Rename `GroupSorter` → `ReferenceSorter`; re-export at the crate root
- Update all consumers (`processor/setup.rs`, `processor/disambiguation.rs`, `processor/bibliography/grouping.rs`, `benches/rendering.rs` including the benchmark-group label)

**Out of scope** (per the bean): renaming the serde-facing schema types `citum_schema::grouping::GroupSort` / `GroupSortKey` — they touch the style schema surface, and the mismatch predates csl26-b801.

Pure move + rename; no behavior change.

## Test plan

- `just pre-commit`: fmt clean, clippy `-D warnings` clean, 1814/1814 nextest
- `grep -rn "GroupSorter\|grouping::sorting" crates/` → empty
- `./scripts/workflow-test.sh styles-legacy/apa.csl`: 20/20 citations, 45/46 bibliography (identical to main baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
