### PR TITLE
fix(ci): replace wretry.action with manual deploy-pages retry

### DIFF
--- a/.beans/archive/csl26-cn0x--fix-compat-report-deploy-wretryaction-fails-sha-pi.md
+++ b/.beans/archive/csl26-cn0x--fix-compat-report-deploy-wretryaction-fails-sha-pi.md
@@ -1,0 +1,15 @@
+---
+# csl26-cn0x
+title: 'Fix compat-report deploy: wretry.action fails SHA-pin policy'
+status: completed
+type: bug
+priority: normal
+created_at: 2026-07-06T18:14:22Z
+updated_at: 2026-07-06T18:14:59Z
+---
+
+PR #1018 wrapped actions/deploy-pages with Wandalen/wretry.action, but wretry.action internally re-invokes itself via a version tag (Wandalen/wretry.action@v3.8.0_js_action) rather than a SHA when wrapping a JS action. Org policy requires all actions pinned to full-length commit SHA, so the workflow run fails with 'action ... is not allowed'. Need a retry mechanism that doesn't depend on wretry.action's internal tag-based self-reference.
+
+## Summary of Changes
+
+Replaced the `Wandalen/wretry.action` wrapper around `actions/deploy-pages` with three sequential, SHA-pinned `actions/deploy-pages` steps (30s sleep between attempts), gated with `continue-on-error`/`if: steps.*.outcome == 'failure'`. The `environment.url` now falls back across `steps.deployment1/2/3.outputs.page_url`. This avoids wretry.action's internal behavior of re-invoking itself via a version tag (`Wandalen/wretry.action@v3.8.0_js_action`) when wrapping a JS action, which the org's "actions must be pinned to a full-length commit SHA" policy rejects (confirmed via the PR #1018 run log: https://github.com/citum/citum-core/actions/runs/28801493973/job/85408025295).

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -99,15 +99,36 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment1.outputs.page_url || steps.deployment2.outputs.page_url || steps.deployment3.outputs.page_url }}
     permissions:
       pages: write
       id-token: write
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
-        with:
-          action: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4
-          attempt_limit: 3
-          attempt_delay: 30000
+      # actions/deploy-pages intermittently fails with a transient "Deployment
+      # failed, try again later" GitHub Pages API error. Wandalen/wretry.action
+      # can't wrap it here: it re-invokes itself via a version tag
+      # (Wandalen/wretry.action@<tag>_js_action) rather than a SHA, which this
+      # org's SHA-pin policy rejects. Retry manually instead.
+      - name: Deploy to GitHub Pages (attempt 1)
+        id: deployment1
+        continue-on-error: true
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4
+
+      - name: Wait before retry
+        if: steps.deployment1.outcome == 'failure'
+        run: sleep 30
+
+      - name: Deploy to GitHub Pages (attempt 2)
+        id: deployment2
+        if: steps.deployment1.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4
+
+      - name: Wait before retry
+        if: steps.deployment1.outcome == 'failure' && steps.deployment2.outcome == 'failure'
+        run: sleep 30
+
+      - name: Deploy to GitHub Pages (attempt 3)
+        id: deployment3
+        if: steps.deployment1.outcome == 'failure' && steps.deployment2.outcome == 'failure'
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4


### PR DESCRIPTION
## Summary
- PR #1018 wrapped `actions/deploy-pages` with `Wandalen/wretry.action` to retry a transient "Deployment failed, try again later" Pages API error.
- That workflow run then failed: `The action wandalen/wretry.action@v3.8.0_js_action is not allowed in citum/citum-core because all actions must be pinned to a full-length commit SHA.` — `wretry.action` internally re-invokes itself via a version tag (not a SHA) when wrapping a JS action, which trips this org's SHA-pin policy even though the outer call was already pinned.
- Replaces the wrapper with three sequential, SHA-pinned `actions/deploy-pages` attempts (30s sleep between retries), gated with `continue-on-error`/`outcome == 'failure'` checks. `environment.url` falls back across each attempt's `page_url` output.

Ref: https://github.com/citum/citum-core/actions/runs/28801493973/job/85408025295

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/compat-report.yml'))"` — YAML parses
- [ ] CI run on this PR's `build` job passes (deploy job only runs on push, not PR, per `if: github.event_name != 'pull_request'`)
- [ ] Manually confirm the deploy job succeeds on next push to main
