### PR TITLE
docs(migrate): crate review audit + design wave

### DIFF
--- a/.beans/csl26-21ep--migrate-compact-physics-form-title-suppression.md
+++ b/.beans/csl26-21ep--migrate-compact-physics-form-title-suppression.md
@@ -9,7 +9,7 @@ tags:
     - fidelity
     - style-family
 created_at: 2026-06-10T16:56:45Z
-updated_at: 2026-06-12T17:25:53Z
+updated_at: 2026-07-06T18:56:01Z
 parent: csl26-vmcr
 ---
 
@@ -18,3 +18,12 @@ Cluster C5 (small band, physics family) from docs/architecture/audits/2026-06-10
 Compact physics styles should suppress article titles and render page-only locators (`T. S. Kuhn, Philosophy of Science 37, 1 (1970)`). Migrated output includes the title and drops the page. Evidence: `springer-physics-author-date` (11/38).
 
 Next step: one bounded migrate-research pass that classifies the root cause before implementation.
+
+## Diagnosis Pointers (2026-07-06 review — hypothesis level, for the bounded classification pass)
+
+From the migrate crate review: the candidate machinery for half of this defect **already exists** — `measured_citation.rs` generates `article-journal-suppress-primary-title` (and title+doi-url combos) in the ArticleJournalSuppression family. Two likely reasons it never wins on the physics band:
+
+1. **The mutations are unpaired.** Compact physics needs title suppression AND page-locator restoration together (`T. S. Kuhn, Philosophy of Science 37, 1 (1970)`). A title-suppression-only candidate still misses the page tokens, so its Jaccard score may not clear candidate_beats against the incumbent; the win condition requires the paired form. The synthesis loop applies one mutation per round and only accepts strict improvements, so it cannot cross a two-defect valley.
+2. **The page drop is upstream of selection.** If pages are absent from the seed templates entirely (extractor/compiler drop), no bibliography mutation family reintroduces them — candidates only suppress or reshape existing components (suppress_matching_components sets suppress, nothing adds).
+
+The bounded pass should therefore check, on springer-physics-author-date: (a) does the XML-compiled seed contain the pages component? If not → extractor/compiler locus, fix there. (b) If present, do the suppress candidates score above the incumbent? Instrument with CITUM_MIGRATE_DEBUG_BIB_SELECTION=1. (c) Only if both look right, consider a paired 'compact-physics' patch (suppress title + page-only locator) as one CandidatePatchKind — precedent: the existing multi-matcher ArticleJournalSuppress combos.

--- a/.beans/csl26-6rjq--transliteration-aware-bibliography-sort-keys.md
+++ b/.beans/csl26-6rjq--transliteration-aware-bibliography-sort-keys.md
@@ -7,7 +7,7 @@ priority: normal
 tags:
     - multilingual
 created_at: 2026-05-01T11:32:10Z
-updated_at: 2026-05-16T12:48:56Z
+updated_at: 2026-07-06T18:47:52Z
 ---
 
 Support romanization/transliteration-based sort keys so Arabic, Cyrillic, CJK names can optionally sort under their romanized forms. Currently explicitly out of scope in the Unicode sorting spec — deferred by design.
@@ -20,3 +20,7 @@ Before implementing, three policy questions must be answered:
 - Is transliteration applied globally or only for specific scripts/locales?
 
 These choices affect both the data model and the user-visible bibliography output, so they warrant a spec before any implementation. Likely requires a new schema option (see csl26-xz2t) and possibly new reference data fields for pre-supplied romanized sort keys.
+
+## Recommended Design (2026-07-06)
+
+Answered jointly with csl26-xz2t — the full recommended design (schema sketch, three policy answers, phasing) is recorded there. Summary of this bean's part: primary mechanism is data-supplied `sort_as` keys on contributor names and titles (biblatex sortname/sorttitle prior art), hidden from rendered output, activated per-script via `options.sorting.multilingual: romanized`; generated transliteration deferred to a feature-gated phase 3. Remains draft pending sign-off on the policy answers in csl26-xz2t.

--- a/.beans/csl26-8hxp--fix-scoring-denominator-asymmetry-and-vestigial-to.md
+++ b/.beans/csl26-8hxp--fix-scoring-denominator-asymmetry-and-vestigial-to.md
@@ -1,0 +1,12 @@
+---
+# csl26-8hxp
+title: Fix scoring denominator asymmetry and vestigial tokenizer split
+status: todo
+type: task
+priority: low
+created_at: 2026-07-06T18:42:31Z
+updated_at: 2026-07-06T18:42:31Z
+parent: csl26-al39
+---
+
+Audit F5 (2026-07-06 migrate review): (1) score_bibliography_entries counts unmatched references AND unmatched rendered entries in items, while invalid_candidate_score counts only references — candidates compared on pass counts use different denominators. Unify or document. (2) tokenize is a pure alias of tokenize_normalized yet doc comments describe a distinct historical raw citation scorer; collapse token_jaccard/token_jaccard_normalized and fix the comments.

--- a/.beans/csl26-a001--investigate-re-grouping-flat-migrated-templates-in.md
+++ b/.beans/csl26-a001--investigate-re-grouping-flat-migrated-templates-in.md
@@ -1,7 +1,7 @@
 ---
 # csl26-a001
 title: Investigate re-grouping flat migrated templates into authored groups
-status: draft
+status: todo
 type: task
 priority: normal
 tags:
@@ -10,7 +10,7 @@ tags:
     - template
     - fidelity
 created_at: 2026-06-16T12:55:29Z
-updated_at: 2026-06-16T13:06:37Z
+updated_at: 2026-07-06T18:55:09Z
 ---
 
 Occurrence-compiler emits a flat union template; component groups (imprint = publisher+place, locator = volume+issue+pages) are mostly gone in migrated output (see ACME). Groups are the primary mechanism for conditional formatting: a group renders its delimiter, affixes, and punctuation only when at least one member produces output. Without groups, components render individually — a delimiter or label before an absent variable becomes a stray artifact. Regrouping flat templates is therefore essential for correct output, not just visual tidiness.
@@ -18,3 +18,18 @@ Occurrence-compiler emits a flat union template; component groups (imprint = pub
 GATE ON FIDELITY: confirm the engine renders identically before/after re-grouping. Flatness may be load-bearing for current pass rates. Draft until a safe grouping heuristic is validated.
 
 Authorability follow-up from ACME review (PR #932). Pre-existing; not a regression.
+
+## Design (2026-07-06)
+
+Verified mechanism: `template_compiler/compilation.rs` (~line 230 and duplicated ~line 300) preserves a source group only when (2-3 components AND delimiter in a whitelist of five AND no wrap) OR (wrap or Term present); everything else is flattened into occurrence order. The original CSL groups are available at that point — **regrouping should be provenance-guided (keep what the XML declared), not heuristically re-inferred downstream.**
+
+Plan, gated exactly as this bean requires:
+
+1. **Measurement first:** add a debug counter to the compiler reporting groups-preserved vs groups-flattened per style; run the seeded random-100 corpus to size the change before touching behavior.
+2. **Engine-equality gate, not oracle Jaccard:** for each style, render the full fixture corpus with the flat template and the group-preserving template through citum-engine and require **byte-identical** output to auto-accept. This is cheap (no citeproc), exact, and directly answers 'is flatness load-bearing'. Styles where output differs are the interesting cohort: diff them — if the grouped form drops stray delimiters before absent variables (the artifact this bean describes), that is a fidelity *improvement*, verify against citeproc via the existing synthesis scorer before accepting.
+3. **Widen preservation incrementally:** relax one criterion at a time (first the delimiter whitelist, then the 2-3 size cap), re-running the gate each step. Never introduce groups the source XML did not declare — synthesized grouping (imprint/locator taxonomies) stays out of scope.
+4. **Cleanup:** the two ~60-line group-collection blocks (citation vs bibliography) are near-verbatim duplicates — extract a shared helper in the same change.
+
+Interaction: inferred-path templates (no XML provenance) are untouched. Relates to csl26-na19 (variant encoding) — land this first; better groups shrink the diffs na19 operates on.
+
+Promote to todo: the investigation method is decided; step 1-2 are Sonnet-executable.

--- a/.beans/csl26-a0em--hoist-ref-type-title-category-tables-into-citum-sc.md
+++ b/.beans/csl26-a0em--hoist-ref-type-title-category-tables-into-citum-sc.md
@@ -1,0 +1,12 @@
+---
+# csl26-a0em
+title: Hoist ref-type title-category tables into citum-schema-style
+status: todo
+type: task
+priority: high
+created_at: 2026-07-06T18:42:06Z
+updated_at: 2026-07-06T18:42:06Z
+parent: csl26-al39
+---
+
+Audit F1 (2026-07-06 migrate review): passes/sqi_refinement.rs::effective_title_rendering re-implements the engine's ref-type→title-category mapping (citum-engine/src/values/type_class.rs: title_category, container_title_category, parent_serial_title_category — all pub(crate)). SQI pruning must be the exact inverse of engine defaulting; divergent tables silently change rendering after pruning. Fix: move the classification functions into citum-schema-style (next to TitleConfig), re-export for the engine, and have sqi_refinement consume the shared table. Add a cross-crate test asserting prune-then-render equals render-unpruned for every classified type.

--- a/.beans/csl26-ahxh--migrate-note-class-citation-component-order-and-af.md
+++ b/.beans/csl26-ahxh--migrate-note-class-citation-component-order-and-af.md
@@ -9,8 +9,35 @@ tags:
     - fidelity
     - note-styles
 created_at: 2026-06-14T11:21:02Z
-updated_at: 2026-06-14T11:49:29Z
+updated_at: 2026-07-06T18:43:28Z
 parent: csl26-vmcr
 ---
 
 Note-class styles in the sub-90 tail render bibliographic-prose citations with wrong component order/affixes vs citeproc. Example early-medieval-europe: oracle "J. Smith et al, 'Title', Journal of Climate Analytics 12.3 (2021), pp. 201–" vs citum "Smith et al, 2021, 205, '“Title”', Journal of Climate Analytics, 12, 3, accessed". Affects anabases, bulletin-de-correspondance-hellenique, the-journal-of-transport-history, histoire-at-politique. Converter-level: note citation template synthesis reorders components and leaks separators. Repro: node scripts/oracle.js styles-legacy/early-medieval-europe.csl --json --force-migrate
+
+## Root Cause (2026-07-06 review)
+
+Reproduced: `node scripts/oracle.js styles-legacy/early-medieval-europe.csl --json --force-migrate` → citations 18/20 passed, with entries like:
+
+- oracle: `T.S. Kuhn, 'The Structure of Scientific Revolutions', Chicago International Encyclopedia of Unified Science 2.2 (1962)`
+- citum:  `Kuhn, 1962, "The Structure of Scientific Revolutions", International Encyclopedia of Unified Science, 2, 2, accessed`
+- **match: true** — the per-item pass metric is bag-of-words Jaccard (`measured_citation.rs::token_jaccard`), which is order- and punctuation-blind, so this visibly wrong entry passes.
+
+Mechanism (three compounding converter defects, all on the citation seed for note-class styles):
+
+1. **Author-date-shaped seed order.** Note-class styles ride the same citation synthesis path as in-text styles (`synthesis/citation.rs`); the inferred seed places year after author (in-text convention) instead of the note layout's terminal `(year)`. Because the pass metric cannot see order, seed selection and mutation rounds neither penalize nor repair it (confirmed structurally futile to fix via scoring: docs/architecture/audits/2026-06-14_MIGRATE_ORDER_AWARE_FITNESS_NEGATIVE.md).
+2. **Separator/affix loss.** `volume.issue` (`2.2`) degrades to list-delimited `2, 2` — the vol/issue group delimiter from the XML layout is not preserved into the note citation template (grouping passes exist in `passes/grouping.rs` but target bibliography shapes).
+3. **Gating loss.** Bare `accessed` leaks where citeproc renders it only for web-only items — `fixups/gating.rs::gate_web_only_url_accessed` is not applied to citation templates. Name form is also wrong (`Kuhn` vs `T.S. Kuhn`): note first-references use the full/initialized form, but the citation contributor extraction emits the in-text short form.
+
+## Fix Design
+
+Fix the seed, not the scorer:
+
+1. **Route note-class citation seeds through the XML layout compilation with order preserved.** For `Processing::Note` styles, make `compile_citation_note` (template_compiler/mod.rs) the primary seed and bias `pick_seed` to it unless the inferred candidate strictly beats it on passes — the inferrer's citation fragments are in-text-shaped and structurally wrong for notes.
+2. **Apply the bibliography-side passes to note citation templates**: run `passes/grouping.rs` vol/issue grouping and `fixups/gating.rs` accessed/URL gating on the citation template when the style class is note (they currently run only on bibliography templates).
+3. **Contributor form:** for note-class citation templates, extract the first-reference name form from the note layout's `<names>` attributes (initialize-with / name-as-sort-order) instead of defaulting to the in-text short form.
+4. **Diagnostic only, not pass classification:** add an order-sensitive similarity column to the migrate debug/evidence output for note-class styles so regressions are visible, per the 2026-06-14 decision not to change the pass metric.
+
+Verify against the affected cohort: early-medieval-europe, anabases, bulletin-de-correspondance-hellenique, the-journal-of-transport-history, histoire-at-politique (`--force-migrate` reruns), plus the seeded random-100 scorecard to confirm no headline regression.
+
+Sizing: items 2-3 are Sonnet-executable; item 1 touches seed routing and should be reviewed against OUTPUT_DRIVEN_TEMPLATE_SYNTHESIS.md first.

--- a/.beans/csl26-al39--comprehensive-migrate-review-cleanup-wave.md
+++ b/.beans/csl26-al39--comprehensive-migrate-review-cleanup-wave.md
@@ -1,0 +1,18 @@
+---
+# csl26-al39
+title: Comprehensive migrate review cleanup wave
+status: in-progress
+type: epic
+priority: normal
+created_at: 2026-07-06T18:33:16Z
+updated_at: 2026-07-06T18:43:45Z
+---
+
+Parent epic for the citum-migrate code/architecture review wave (2026-07-06). Analogous to csl26-8m2p for the engine. Audit doc: docs/architecture/audits/2026-07-06_CITUM_MIGRATE_REVIEW.md. Findings triaged into child beans.
+
+## Progress 2026-07-06
+
+- [x] Audit doc: docs/architecture/audits/2026-07-06_CITUM_MIGRATE_REVIEW.md (F1-F8)
+- [x] Child beans: csl26-a0em (F1 high), csl26-xshm (F2+F7), csl26-awef (F3), csl26-oxai (F4), csl26-8hxp (F5), csl26-gea2 (F6)
+- [x] Root cause + fix design appended to csl26-vpae and csl26-ahxh
+- [ ] Work through child beans (post-Fable, per-fix commits per audit workflow)

--- a/.beans/csl26-awef--replace-global-panic-hook-swap-in-candidate-scorin.md
+++ b/.beans/csl26-awef--replace-global-panic-hook-swap-in-candidate-scorin.md
@@ -1,0 +1,11 @@
+---
+# csl26-awef
+title: Replace global panic-hook swap in candidate scoring
+status: todo
+type: task
+created_at: 2026-07-06T18:42:20Z
+updated_at: 2026-07-06T18:42:20Z
+parent: csl26-al39
+---
+
+Audit F3 (2026-07-06 migrate review): measured_citation.rs::catch_candidate_unwind swaps the process-global panic hook around every bibliography-candidate render. Latent race under any future parallelism, and the panic payload is discarded so engine bugs are indistinguishable from bad candidates (scored 0). Fix: install a silencing hook once via std::sync::Once, or keep catch_unwind and tracing::debug! the captured payload with the candidate name.

--- a/.beans/csl26-dog9--design-explicit-render-run-state-for-processor.md
+++ b/.beans/csl26-dog9--design-explicit-render-run-state-for-processor.md
@@ -8,7 +8,7 @@ tags:
     - state
     - rendering
 created_at: 2026-07-04T02:42:26Z
-updated_at: 2026-07-05T12:22:47Z
+updated_at: 2026-07-06T18:47:31Z
 parent: csl26-8m2p
 ---
 
@@ -36,3 +36,19 @@ Not planned as part of this bean's scope — recorded so it isn't lost. Only
 worth doing if a real workload shows single-threaded rendering as the
 bottleneck; the O(n×m) clone cost fixed by csl26-qi7l was the actual hot-path
 issue, not thread count.
+
+## Design (2026-07-06)
+
+Verified current state: `processor/mod.rs` holds seven `RefCell` fields (citation_numbers, cited_ids, compound_groups, dynamic_compound_set_by_ref, dynamic_compound_member_index, dynamic_compound_sets, first_note_by_id) mutated from `&self` render methods.
+
+**Shape: typestate run object, three mechanical phases.**
+
+1. `struct RunState` owns the seven maps (plain, no RefCell). `Processor` keeps only immutable style+references+locale and gains `fn begin_run(&self) -> RunState`.
+2. Registration phase: citation processing takes `&self, &mut RunState` — position assignment, citation numbers, first-note numbers, compound-set membership all happen here. Existing one-shot conveniences (`process_citation` on `&self`) remain as wrappers that create a throwaway run, preserving API compatibility for simple callers.
+3. Finalization typestate: `RunState::finalize(self) -> FinalizedRun`; bibliography rendering and any output that depends on cite order take `&FinalizedRun`. This makes the ordering contract a compile error instead of a comment: you cannot render a bibliography before registration is complete, and rendering is pure/idempotent over `&FinalizedRun`.
+4. FFI/WASM: the C handle becomes a boxed `(Processor, Option<RunState>, Option<FinalizedRun>)` session; existing entry points map onto begin/register/finalize internally, no ABI signature changes required in the first pass.
+5. Document/session pipeline (`api/document`, `api/session`) is the primary consumer and already runs in register-then-render order — it converts first.
+
+**Migration plan (each step green on its own):** (a) introduce RunState wrapping the existing RefCells and move the fields, callers unchanged; (b) change internal call chains to `&mut RunState` and delete the RefCells; (c) add the FinalizedRun typestate and convert bibliography entry points; (d) update FFI session plumbing. Step (a)-(b) are Sonnet-executable; (c)-(d) want a review pass.
+
+Post-finalize, the csl26-qi7l note applies: `FinalizedRun` is where Rc→Arc + rayon over `render_group_entries` becomes safe — out of scope here, gated on a real workload.

--- a/.beans/csl26-gea2--registry-reverse-template-index-and-tracing-based.md
+++ b/.beans/csl26-gea2--registry-reverse-template-index-and-tracing-based.md
@@ -1,0 +1,12 @@
+---
+# csl26-gea2
+title: Registry reverse-template index and tracing-based debug output
+status: todo
+type: task
+priority: low
+created_at: 2026-07-06T18:42:31Z
+updated_at: 2026-07-06T18:42:31Z
+parent: csl26-al39
+---
+
+Audit F6 (2026-07-06 migrate review): (1) discover_reverse_template_parent deserializes every embedded style per parentless migration and StyleRegistry::load_default() loads twice per resolve/promote — add a precomputed reverse-template index (or lazy static registry). (2) Debug output is split across five CITUM_MIGRATE_DEBUG* env vars plus eprintln! in synthesis modules while lineage.rs uses tracing — unify on tracing targets so RUST_LOG filtering works.

--- a/.beans/csl26-na19--reduce-type-variant-over-generation-via-minimal-de.md
+++ b/.beans/csl26-na19--reduce-type-variant-over-generation-via-minimal-de.md
@@ -1,7 +1,7 @@
 ---
 # csl26-na19
 title: Reduce type-variant over-generation via minimal default template
-status: draft
+status: todo
 type: task
 priority: normal
 tags:
@@ -9,7 +9,7 @@ tags:
     - authorability
     - template
 created_at: 2026-06-16T12:55:29Z
-updated_at: 2026-06-16T12:55:29Z
+updated_at: 2026-07-06T18:55:09Z
 ---
 
 Migration emits many type-variants that only 'remove' components (e.g. speech extends article-newspaper removing edition/section). Driven by maximal-default + diff-everything model.
@@ -19,3 +19,16 @@ Note: term: literals (edition/section labels) render regardless of data presence
 Large; converter-dominated tail (see crates/citum-migrate/CLAUDE.md). Draft.
 
 Authorability follow-up from ACME review (PR #932). Pre-existing; not a regression.
+
+## Design (2026-07-06)
+
+Confirmed model: assembly materializes per-type Full templates; `sqi_refinement.rs::encode_bibliography_type_variants` re-encodes them as diffs against the maximal default via `template_diff::build_type_variants`, so subtractive-heavy variants are a direct artifact of the maximal-union default.
+
+Recommended approach — **choose the default by minimizing total diff cost, not by inverting the union:**
+
+1. **Measurement:** script the per-corpus distribution of diff ops (adds vs removes vs modifies per type-variant) from migrated output; this quantifies over-generation and gives the acceptance metric (total ops, remove share).
+2. **Candidate defaults:** (a) current maximal union (baseline); (b) intersection of per-type templates (types only add); (c) the median/most-common per-type template. Compute total encoded diff cost for each candidate per style and pick the minimum — this is a pure re-encoding choice, **render-neutral by construction** (each type's resolved Full template is unchanged), so it needs no fidelity gate, only the existing `template_diff` engine round-trip validation.
+3. **Semantics guard:** term: literals render regardless of data presence, so removes of term-bearing components are semantically real (this bean's own note) — the encoder must keep those as explicit removes and never silently absorb them into a smaller default.
+4. **Follow-through:** re-baseline SQI after the encoding change; csl26-2uq2 (sprawl double-count) and csl26-7auw (diff readability) both interact with the same encoder and should ride the same wave.
+
+Sequencing: after csl26-a001 (provenance-preserved groups shrink diffs first). Promote to todo: approach decided, step 1-2 Sonnet-executable against template_diff.rs.

--- a/.beans/csl26-oxai--introduce-crate-level-migrateerror-replacing-resul.md
+++ b/.beans/csl26-oxai--introduce-crate-level-migrateerror-replacing-resul.md
@@ -1,0 +1,11 @@
+---
+# csl26-oxai
+title: Introduce crate-level MigrateError replacing Result<_, String>
+status: todo
+type: task
+created_at: 2026-07-06T18:42:20Z
+updated_at: 2026-07-06T18:42:20Z
+parent: csl26-al39
+---
+
+Audit F4 (2026-07-06 migrate review): lineage.rs has typed LineageError while synthesis/measured-selection/js_runtime thread Result<_, String> through 23 signatures. Add a crate-level MigrateError enum (Lineage, Runtime, Fixture, Render, Parse variants), migrate the String signatures, and convert the two assembly.rs XML-fallback expect()s into error returns. Keep display text identical where callers print it.

--- a/.beans/csl26-ucg3--chicago-notes-legaltreaty-note-flow-bluebook.md
+++ b/.beans/csl26-ucg3--chicago-notes-legaltreaty-note-flow-bluebook.md
@@ -5,7 +5,7 @@ status: todo
 type: bug
 priority: normal
 created_at: 2026-06-21T11:49:07Z
-updated_at: 2026-06-21T11:49:07Z
+updated_at: 2026-07-06T18:55:29Z
 ---
 
 Chicago notes (`chicago-notes-18th.yaml`) legal/treaty note-flow defects found
@@ -30,3 +30,15 @@ the maintainer before changing.
 
 Note: the chicago-notes *bibliography* is intentionally empty (notes-only style;
 citeproc `chicago-notes.json` also emits `bibliography: []`) — not in scope here.
+
+## Mechanical Diagnosis (2026-07-06 — content decisions still yours, per this bean's rule)
+
+Read against crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml (extends chicago-18-base):
+
+1. **Stray leading comma (Brown v. Board):** the `legal-case` note variant opens with `contributor: author` followed by `title: primary, prefix: \", \"`. US case references carry no author, so the author component renders empty and the title's component-local prefix is emitted with nothing before it. The note-flow path has no leading-affix trimming (the bibliography cleanup pass would have caught \" ,\"-style artifacts; notes flow does not run it). **Mechanical fix candidates:** (a) engine: suppress a component prefix when no visible output precedes it in the entry — general rule, benefits all note styles; (b) style: give the title `render-when: field-absent: author` twin components. (a) is the right locus if we confirm citeproc behaves that way; it belongs with the csl26-ztxq/zfqr punctuation family.
+2. **Treaty double fields (U.S.T. 14 (1963): 1313, in U.S.T., vol. 14…):** there is **no `treaty:` type-variant** in chicago-notes-18th.yaml at all — treaty falls through to the default note template, which renders the container/volume/year/pages group, while reporter-style fields also render from the generic components. The fix is necessarily a new Bluebook treaty variant — pure content decision (Bluebook R21: name, parties, vol, source abbrev, page, date).
+3. **Conference double year/pages:** the `paper-conference` variant is an `extends`/remove-diff; its removes do not cover the year+pages group the base renders *before* the 'in Proceedings' group, so both the component-level and container-level renderings survive. Needs either wider removes or a Full variant — decide alongside the intended Chicago 18 conference-paper note shape.
+
+**Decisions needed from you before implementation:** intended Bluebook output strings for (2) treaty and (3) conference-paper notes; for (1), confirm citeproc suppresses the leading separator so the engine-level fix is fidelity-correct.
+
+Repro unchanged: render CITATIONS / references-expanded.json against chicago-notes-18th.

--- a/.beans/csl26-vpae--migrate-delta-based-extraction-to-fix-eager-disamb.md
+++ b/.beans/csl26-vpae--migrate-delta-based-extraction-to-fix-eager-disamb.md
@@ -5,7 +5,27 @@ status: todo
 type: bug
 priority: normal
 created_at: 2026-06-20T18:51:16Z
-updated_at: 2026-06-20T18:51:16Z
+updated_at: 2026-07-06T18:43:05Z
 ---
 
 The migrate options-extractor eagerly materializes disambiguation defaults (e.g. year_suffix: unwrap_or(true)) before comparing against named Processing presets, so fold_to_named_processing can never match. Fix: leave unset CSL attributes as None and record only explicit overrides that differ from the preset — the same delta philosophy as extends:. Design decisions captured in docs/reference/PROCESSING_MIGRATION.md (csl26-1861); implementation deferred from that bean's doc-only scope.
+
+## Root Cause (2026-07-06 review)
+
+The original `year_suffix: unwrap_or(true)` sites are gone; `options_extractor/processing.rs` now seeds from the class preset and applies only explicit attributes (lines 88-97). Two residual defects keep materialization eager:
+
+1. **Unconditional `givenname_rule` assignment** (`processing.rs:98-104`): the `_ => GivennameRule::default()` arm overwrites the seeded preset value even when the CSL attribute is absent. Harmless while `default() == ByCite` (the author-date presets' rule), but it is a fold-breaker the moment any preset uses a different rule (`AuthorDateFull` already uses `PrimaryName`; a style folding toward it via explicit attrs gets clobbered back to default).
+2. **All-or-nothing folding** (`fold_to_named_processing`): the derived config is compared for exact equality against each named preset's `config()`. Any single divergence — most commonly an explicit non-preset `sort` — fails every candidate and falls to `Processing::Custom(custom)`, whose serialization dumps the **entire** materialized `ProcessingCustom`, including disambiguation defaults the CSL never stated. That is the eager-materialization symptom in emitted YAML.
+
+## Fix Design
+
+Delta philosophy per docs/reference/PROCESSING_MIGRATION.md, two layers:
+
+1. **Migrate-side sparse extraction (no schema change, do first):**
+   - Introduce a local `ProcessingOverrides { sort, group, disamb_names, disamb_add_givenname, disamb_year_suffix, givenname_rule }` with all-`Option` fields populated only from explicit CSL attributes. Fix defect 1 by assigning `givenname_rule` only when the attribute is present.
+   - Fold per facet, not whole-struct: pick the disambiguation-nearest named preset from the folding table (bare→author-date, +givenname→author-date-givenname, +names→author-date-names, both→author-date-full), then check whether the remaining overrides (sort/group) also match that preset's config. If yes → named preset. If only sort/group diverge → emit `Custom` with the explicit sort/group but `disambiguate` set to the preset's value ONLY if it differs from what resolution would produce; today Custom has no default-resolution, so keep the materialized disambiguation but add a serializer skip for values equal to the class default once layer 2 lands.
+2. **Schema-side custom-as-delta (preferred end state, separate commit):** allow `ProcessingCustom` to carry an optional `base: Processing` (named presets only); resolution overlays the sparse fields onto `base.config()`. YAML reads `processing: { base: author-date, sort: ... }` — the same philosophy as `extends:`. Serializer omits fields equal to the base config. Touches citum-schema-style (serde + resolution) and engine call sites of `.config()`; schema regen required (`just schema-gen`).
+
+Tests: rstest over the folding table in PROCESSING_MIGRATION.md (each row → expected emitted YAML), plus a regression asserting a style with explicit non-preset sort no longer emits materialized disambiguation defaults.
+
+Sizing: layer 1 is Sonnet-executable against this design; layer 2 needs a schema review pass first.

--- a/.beans/csl26-xshm--remove-or-wire-dead-migrationoutputplan-embedded-r.md
+++ b/.beans/csl26-xshm--remove-or-wire-dead-migrationoutputplan-embedded-r.md
@@ -1,0 +1,11 @@
+---
+# csl26-xshm
+title: Remove or wire dead MigrationOutputPlan embedded-root variants
+status: todo
+type: task
+created_at: 2026-07-06T18:42:20Z
+updated_at: 2026-07-06T18:42:20Z
+parent: csl26-al39
+---
+
+Audit F2+F7 (2026-07-06 migrate review): MigrationOutputPlan::CreateEmbeddedRootAndWrapper / UpgradeEmbeddedRootAndWrapper and requires_multi_artifact_write() are constructed nowhere in the repo; output_plan() can only return Standalone or ExistingWrapper. Either wire them to the embedded-root+wrapper workflow they anticipate or delete them until it exists. Also (F7): document in the lineage.rs module header that diff_value cannot express deletions (a wrapper silently inherits parent keys the standalone form lacked) and add a debug-log when a child drops a parent key.

--- a/.beans/csl26-xz2t--public-schema-options-for-multilingual-sort-policy.md
+++ b/.beans/csl26-xz2t--public-schema-options-for-multilingual-sort-policy.md
@@ -7,7 +7,35 @@ priority: normal
 tags:
     - multilingual
 created_at: 2026-05-01T11:32:12Z
-updated_at: 2026-05-16T12:48:56Z
+updated_at: 2026-07-06T18:47:52Z
 ---
 
 Expose schema/style configuration for multilingual bibliography sort behavior once multiple modes exist (e.g. single-locale, per-script, transliterated). Currently all sort policy is hardcoded. Depends on per-script partitioning and/or transliteration features being implemented first. Deferred by design per UNICODE_BIBLIOGRAPHY_SORTING.md.
+
+## Recommended Design (2026-07-06, joint with csl26-6rjq — needs policy sign-off)
+
+Decide the two beans together; csl26-6rjq's data-model answer determines this bean's schema surface.
+
+Proposed schema (options.sorting, style-level with bibliography-level override):
+
+    sorting:
+      locale: auto | <bcp47>          # collator locale; default auto = effective bibliography locale
+      multilingual: uniform | romanized | per-script
+      # uniform    = today's single-collator pass (default, no behavior change)
+      # romanized  = sort under supplied/generated romanized keys, render original script
+      # per-script = partition by script, order partitions per locale convention (later phase)
+
+Recommended answers to csl26-6rjq's three policy questions:
+
+1. **Standard:** do not pick one globally. Primary mechanism is **data-supplied sort keys** (biblatex prior art: sortname/sortkey/sorttitle): add optional `sort_as` to contributor names and titles in the reference schema. Generated transliteration (ALA-LC for Cyrillic, Pinyin for Han) is a later, feature-gated fallback only where a deterministic Rust implementation exists.
+2. **Visibility:** hidden sort key — sort under the romanized form, render the original script unchanged. Matches library/archival expectation and biblatex behavior.
+3. **Scope:** per-script via the `multilingual` mode, never a global text transform.
+
+**Phasing (unblocks archival users without a transliteration engine):**
+- Phase 1: reference-data `sort_as` fields + engine consumes them when present under `multilingual: romanized`; absent keys fall back to UCA collation (UNICODE_BIBLIOGRAPHY_SORTING.md unchanged). Small, self-contained.
+- Phase 2: `per-script` partition mode (partition order = locale convention, spec addendum needed).
+- Phase 3: generated transliteration behind a cargo feature.
+
+Schema change ⇒ `just schema-gen` in the implementing commit; spec doc in docs/specs/ superseding the out-of-scope declarations in UNICODE_BIBLIOGRAPHY_SORTING.md §Scope.
+
+**Left in draft deliberately:** the three policy answers above are recommendations; promote to todo after Bruce confirms them.

--- a/.beans/csl26-zfqr--structured-title-delimiter-suppression-after-termi.md
+++ b/.beans/csl26-zfqr--structured-title-delimiter-suppression-after-termi.md
@@ -8,7 +8,7 @@ tags:
     - punctuation
     - rendering
 created_at: 2026-07-05T17:18:48Z
-updated_at: 2026-07-05T17:18:48Z
+updated_at: 2026-07-06T18:45:57Z
 ---
 
 Follow-up from GitHub issue #1010 / csl26-01jy.
@@ -25,3 +25,17 @@ structured-title delimiters across locales.
 - [ ] Amend the title or punctuation spec with terminal-punctuation delimiter suppression rules
 - [ ] Add structured-title tests for `?`, `!`, and other agreed terminal punctuation
 - [ ] Implement delimiter suppression without breaking configurable `primary-delimiter` / `subtitle-delimiter` behavior
+
+## Root Cause (2026-07-06 review)
+
+`crates/citum-engine/src/values/title.rs::render_structured_title` (line 255) appends `primary_delimiter` unconditionally between the rendered main part and the subtitle group. Delimiters resolve in `structured_title_delimiters` (line 330): explicit `rendering.primary_delimiter` override, else `locale.grammar_options.title_subtitle_delimiter`. Nothing inspects the main part's terminal character, so `Main title?` + `: ` → `Main title?: And a subtitle`.
+
+## Fix Design
+
+Key simplification: the check is **semantic, not presentational** — test the terminal character of the *source* main-part text (`st.main` / the short-form variant) before `render_part_with_case` runs, not the rendered fragment. That avoids any markup-stripping dependency and decouples this bean from csl26-ztxq entirely (text-case transforms do not alter terminal punctuation; quote-wrapped mains are source text too, so mirror the quote-aware lookback in `ends_with_sentence_ending_visible_punctuation`, bibliography.rs:61).
+
+1. **Spec first** (per todo): amend the title/punctuation spec with the suppression rule — when the main part ends in a suppressing terminal mark, the punctuation core of the configured primary delimiter is dropped and only its trailing whitespace is emitted. Recommended mark set: `?`, `!`, `…` (and `.` only when the delimiter core is itself `.`); encode the set in `locale.grammar_options` (new field, default "?!…") so inflected locales can override. Suppression applies to explicit style-level `primary_delimiter` overrides too, matching citeproc-js's global punctuation dedupe.
+2. **Implementation:** in `render_structured_title`, split `primary_delimiter` into (punctuation core, whitespace tail); if the main part's last non-quote char is in the locale's suppressing set, push only the whitespace tail. `subtitle_delimiter` joins between multiple subtitles need the same rule (a subtitle can also end in `?`).
+3. **Tests:** rstest matrix over ?/!/…/. mains × default and overridden delimiters × long/short forms × quoted mains, plus one multi-subtitle case, in values/tests.rs. Oracle spot-check on a style exercising structured titles (GitHub issue #1010 example).
+
+Sizing: Sonnet-executable once the spec decision (mark set + locale field name) is confirmed.

--- a/.beans/csl26-ztxq--format-aware-punctuation-boundary-detection.md
+++ b/.beans/csl26-ztxq--format-aware-punctuation-boundary-detection.md
@@ -3,12 +3,26 @@
 title: Format-aware punctuation boundary detection
 status: todo
 type: task
+priority: normal
 tags:
     - punctuation
     - rendering
-parent: csl26-8m2p
 created_at: 2026-07-04T17:11:33Z
-updated_at: 2026-07-04T17:49:02Z
+updated_at: 2026-07-06T18:45:57Z
+parent: csl26-8m2p
 ---
 
 visible_text strips only HTML tags, so separator/dedup logic misfires for LaTeX/Typst/Markdown (\emph{Title.} ends in }, producing 'Title.. Next'), violating the backends-differ-only-in-markup rule. cleanup_dangling_punctuation also runs global find/replace over full marked-up entries including attributes. Add a visible-text/logical-last-char hook to OutputFormat (or track logical boundaries in ProcTemplateComponent) and constrain the cleanup pass to text outside markup. docs/architecture/audits/2026-07-04_CITUM_ENGINE_REVIEW_PART2.md finding 13.
+
+## Root Cause (2026-07-06 review)
+
+Confirmed at source: `render/bibliography.rs::visible_text` (line 26) strips only HTML `<...>` tags. All punctuation-boundary helpers (`first_visible_char`, `last_visible_non_space_char`, `ends_with_sentence_ending_visible_punctuation`) build on it, so for LaTeX/Typst/Markdown/Djot fragments the 'last visible char' is markup (`}`, `_`, `*`), and separator/dedup decisions misfire (\emph{Title.} → 'Title.. Next'). Independently, `cleanup_dangling_punctuation` (line 386) runs a fixed-point global find/replace over the fully marked-up entry, so patterns like \" ,\" / '  ' can rewrite inside markup, attributes, and URLs.
+
+## Fix Design
+
+1. **OutputFormat hook:** add `fn visible_text<'a>(&self, fragment: &'a str) -> Cow<'a, str>` to the `OutputFormat` trait with per-backend implementations: HTML = current tag strip; PlainText = passthrough; LaTeX = strip \\command tokens and brace delimiters (keep brace contents); Typst = strip `#func[...]` wrappers and emphasis markers; Markdown/Djot = strip emphasis/strong markers and link syntax keeping link text. Default impl = passthrough so third-party formats degrade safely.
+2. **Thread the format through** the boundary helpers in bibliography.rs (they become generic over F like their callers already are) and any citation.rs users of the same pattern.
+3. **Constrain the cleanup pass:** rewrite `cleanup_dangling_punctuation` to operate per visible segment — lex the fragment with the backend's markup boundaries (reuse the visible_text lexer, but map spans instead of discarding them) and apply the pattern table only inside visible runs. If span-mapping is too invasive for a first commit, an acceptable intermediate is: apply the pass only for PlainText/HTML (current behavior) and skip it for LaTeX/Typst/Markdown until spans land — that converts silent corruption into a known, documented gap.
+4. **Tests:** per-backend rstest matrix (same entry rendered via each format asserts identical `visible_text` output — the backends-differ-only-in-markup rule from DESIGN_PRINCIPLES), plus regression cases from engine review part2 finding 13 ('Title.. Next' in LaTeX, marker-terminated Typst emphasis, URL containing ', .').
+
+Note: csl26-zfqr no longer depends on this work — its check moved to source text (see that bean). Sizing: item 1-2 Sonnet-executable; item 3 span-mapping needs a review pass.

--- a/docs/architecture/audits/2026-07-06_CITUM_MIGRATE_REVIEW.md
+++ b/docs/architecture/audits/2026-07-06_CITUM_MIGRATE_REVIEW.md
@@ -1,0 +1,187 @@
+# citum-migrate Crate Review
+
+Date: 2026-07-06
+Branch: `audit/citum-migrate-review`
+Bean: `csl26-al39`
+
+## Scope and Method
+
+Comprehensive code review of `crates/citum-migrate` (~25.3k lines across 47
+files; ~19k lines of production code excluding test modules). Review criteria:
+[DESIGN_PRINCIPLES.md](../DESIGN_PRINCIPLES.md), the crate's own `CLAUDE.md`
+contract (template-authority split, locus-before-fixup), and the
+2026-06 migrate audit series (fidelity locus classification, order-aware
+fitness negative result).
+
+Coverage:
+
+- **Fully read:** `measured_citation.rs`, `lineage.rs`,
+  `passes/sqi_refinement.rs` (production portion), `synthesis/citation.rs`,
+  `options_extractor/processing.rs`; module outlines for `assembly.rs`,
+  `template_resolver.rs`, `synthesis/core.rs`, `synthesis/operators.rs`,
+  `template_compiler/mod.rs`, `evidence.rs`, `js_runtime.rs`, `lib.rs`,
+  `runtime.rs`, `ir.rs`.
+- **Targeted scans crate-wide:** panic-path scan (`unwrap`/`expect`/`panic!`/
+  `unreachable!` outside `#[cfg(test)]`), `unsafe` scan, TODO/FIXME scan,
+  `process::exit`/env-var scan, `Result<_, String>` census, threading scan.
+- **Not read line-by-line:** `template_diff.rs`, `upsampler/`, `fixups/`
+  internals, `base_detector.rs`, `bib_postprocess.rs`, `template_compiler/`
+  submodules, remaining `options_extractor/` modules, `analysis/`,
+  `output_plan.rs`, `main.rs`. These were sampled via outlines and scans only.
+
+## Overall Assessment
+
+The crate is in notably good hygiene for a transitional converter: **zero
+`unsafe`, zero TODO/FIXME debt, and only two production panic sites** (both
+invariant-carrying `expect`s in `assembly.rs`). Module documentation is
+strong — `measured_citation.rs` and `lineage.rs` open with genuinely useful
+contracts, and the synthesis loop is bounded by explicit budgets
+(`CandidateBudget`) with an evidence sidecar for every selection. Test style
+follows the BDD naming convention. The architecture matches the documented
+template-authority split (synthesis authoritative, XML compilation a seed,
+options extraction permanent).
+
+The findings below are therefore mostly structural: semantic tables duplicated
+against the engine, a dead output-plan surface, an inconsistent error-handling
+strategy, and process-global state in candidate scoring.
+
+## Findings
+
+### F1 (High) — Duplicated ref-type → title-category tables vs the engine
+
+`passes/sqi_refinement.rs::effective_title_rendering` hardcodes the
+ref-type → title-category fallback mapping (periodical/serial/monograph/
+component, including literal type lists like `"article-journal" |
+"article-magazine" | …`) to decide which explicit rendering fields are
+redundant and can be pruned. The engine owns the authoritative version of this
+mapping in `citum-engine/src/values/type_class.rs` (`title_category`,
+`container_title_category`, `parent_serial_title_category`), but those are
+`pub(crate)`, so migrate re-implemented them.
+
+Pruning is only sound when it is the **exact inverse** of engine defaulting:
+if the two tables ever disagree for a type, SQI refinement deletes an explicit
+rendering that the engine then defaults differently — a silent fidelity
+regression attributable to neither crate. The engine table already encodes
+subtleties migrate's copy may not track (e.g. broadcast is serial-not-
+periodical for parent-serial in the engine's tests, while migrate's
+container-title arm lists broadcast among periodicals).
+
+**Recommendation:** hoist the type-classification table into
+`citum-schema-style` (next to `TitleConfig`, which both crates already
+consume) and have both the engine and SQI refinement call the shared
+functions. Follow-up bean: `csl26-a0em`.
+
+### F2 (Medium) — Dead `MigrationOutputPlan` variants
+
+`lineage.rs` defines `MigrationOutputPlan::CreateEmbeddedRootAndWrapper` and
+`UpgradeEmbeddedRootAndWrapper` plus `requires_multi_artifact_write()`, but no
+code path in the repository constructs either variant — `output_plan()` can
+only return `Standalone` or `ExistingWrapper`, and a repo-wide search finds no
+other constructor. This is speculative API: match arms and tests carry the
+variants without behavior behind them. Either wire them to the embedded-root
+workflow they anticipate or remove them until that workflow exists.
+Follow-up bean: `csl26-xshm`.
+
+### F3 (Medium) — Process-global panic-hook swap during candidate scoring
+
+`measured_citation.rs::catch_candidate_unwind` calls
+`std::panic::take_hook`/`set_hook` around every bibliography-candidate render
+to silence panic output. The hook is process-global: any future parallelism
+(or a panic on another thread during the window) races the swap and can
+permanently install the silent hook or misroute another thread's panic
+report. It also discards the panic payload, so an engine bug that panics on a
+candidate is indistinguishable from a legitimately bad candidate (scored 0).
+The crate is single-threaded today, so this is latent, not active.
+
+**Recommendation:** install a silencing hook once (`std::sync::Once`) or keep
+`catch_unwind` but log the captured payload via `tracing::debug!` instead of
+suppressing it. Follow-up bean: `csl26-awef`.
+
+### F4 (Medium) — Two error-handling regimes: typed vs `String`
+
+`lineage.rs` defines a proper `LineageError` enum, while the synthesis /
+measured-selection / js-runtime half of the crate threads `Result<_, String>`
+through 23 signatures. String errors preclude programmatic handling, make
+"treat as keep-inferred" decisions stringly-typed, and leak formatting
+concerns into logic. A small crate-level `MigrateError` (wrapping
+`LineageError`, runtime, fixture, and render failure cases) would unify the
+two regimes. The two `assembly.rs` `expect`s on the XML-fallback invariant
+should become error returns at the same time. Follow-up bean: `csl26-oxai`.
+
+### F5 (Low) — Scoring bookkeeping asymmetries and a vestigial tokenizer split
+
+- `score_bibliography_entries` counts unmatched references **and** unmatched
+  rendered entries in `items`, while `invalid_candidate_score` counts only
+  references — candidates that fail to render are scored against a smaller
+  denominator than candidates that render extra entries. Pass counts are
+  compared across candidates, so denominators should be identical or the
+  discrepancy documented.
+- `tokenize` is a pure alias of `tokenize_normalized`, yet the doc comments
+  describe citation selection keeping a "historical raw scorer" distinct from
+  the normalized one. The distinction is vestigial; `token_jaccard` and
+  `token_jaccard_normalized` are the same function modulo the `normalize_text`
+  the caller applies. Collapse them and fix the comments.
+
+Follow-up bean: `csl26-8hxp`.
+
+### F6 (Low) — Registry scans and debug plumbing
+
+- `discover_reverse_template_parent` deserializes **every embedded style** on
+  each migration that lacks a parent link; `StyleRegistry::load_default()` is
+  also loaded twice per resolve/promote cycle. A precomputed reverse-template
+  index on the registry (or a lazy static) removes the O(corpus) YAML parse.
+- Debug output is split across five `CITUM_MIGRATE_DEBUG*` env vars plus
+  `eprintln!` in the synthesis modules, while `lineage.rs` already uses
+  `tracing`. Unify on `tracing` with targets so `RUST_LOG` filtering works.
+
+Follow-up bean: `csl26-gea2`.
+
+### F7 (Info) — Diff wrappers cannot express deletions
+
+`lineage.rs::diff_value` emits child-side additions and changes but has no
+representation for "parent has this key, child must not". A migrated wrapper
+therefore silently inherits any parent field the standalone form lacked.
+This matches current YAML semantics (no null-delete in the schema), but it is
+an invisible constraint on wrapper fidelity — worth a doc note in the module
+header and a debug-log when the child drops a parent key. Folded into
+`csl26-xshm`.
+
+### F8 (Info) — Note-class citations ride an in-text-shaped pipeline
+
+The citation synthesis path (seeds, mutation candidates, and the
+bag-of-words pass metric) was built for short in-text citations. For
+note-class styles the citation is bibliographic prose, and the order- and
+punctuation-blind Jaccard metric **passes** visibly wrong output (the
+`early-medieval-europe` repro renders author-date-shaped order, `2, 2,`
+instead of `2.2`, and a leaked `accessed` — and still scores `match: true`,
+18/20 passes). Per the 2026-06-14 order-aware-fitness negative result, the
+fix belongs in the note-citation **seed/template**, not in scoring. Root
+cause and fix design recorded on `csl26-ahxh`.
+
+### Hardcoded fixture-coupled type lists (accepted)
+
+`LOCAL_DEFAULT_TYPES` / `MEDIA_FULL_DATE_TYPES` in `measured_citation.rs`
+couple candidate generation to the current fixture corpus. They are
+documented and bounded; acceptable while the fixture set is stable, but any
+fixture-corpus change must revisit them. No action.
+
+## Positive Patterns Worth Keeping
+
+- Bounded search everywhere: `CandidateBudget`, `MAX_SYNTHESIS_ROUNDS`,
+  held-out rejection gate with explicit fallback ordering.
+- Evidence sidecars (`MigrationEvidence`) capture selection provenance,
+  minimization decisions, and discovered parents — this is the model for any
+  future automated pipeline in the workspace.
+- The regime guard (`apply_regime_guard`) documents its exact firing
+  conditions in the doc comment, including what it deliberately does not do.
+- `#[allow]` attributes carry `reason =` strings consistently.
+
+## Related Open Work
+
+- `csl26-hxhx` — XML layout compiler removal gate (unchanged by this review;
+  the seed still wins selections).
+- `csl26-vpae` — processing-fold materialization; root cause narrowed and fix
+  design recorded on the bean during this review.
+- `csl26-ahxh` — note-class citation divergence (F8).
+- `csl26-4wec`, `csl26-h0rt`, `csl26-na19` — pre-existing extractor/synthesis
+  beans; none are duplicated by the findings above.


### PR DESCRIPTION
## Summary

Docs/beans-only branch from the 2026-07-06 review wave (epic `csl26-al39`, the citum-migrate analogue of `csl26-8m2p`).

- **Audit doc:** `docs/architecture/audits/2026-07-06_CITUM_MIGRATE_REVIEW.md` — comprehensive review of `crates/citum-migrate` (~25.3k LOC), findings F1–F8 with severity and per-finding follow-up beans. Headline: F1 (high) — SQI refinement duplicates the engine's ref-type → title-category tables from `values/type_class.rs`; pruning must be the exact inverse of engine defaulting, and the tables already diverge on `broadcast`.
- **Six new child beans** under `csl26-al39`: `csl26-a0em` (F1), `csl26-xshm` (F2+F7 dead output-plan variants / diff-deletion gap), `csl26-awef` (F3 global panic-hook swap), `csl26-oxai` (F4 typed-vs-String errors), `csl26-8hxp` (F5 scoring bookkeeping), `csl26-gea2` (F6 registry scan + debug plumbing).
- **Root-cause + fix designs** appended to existing bugs: `csl26-vpae` (processing-fold materialization), `csl26-ahxh` (note-class citation divergence, reproduced on early-medieval-europe), `csl26-zfqr` (structured-title delimiter — decoupled from ztxq via source-text check), `csl26-ztxq` (OutputFormat visible-text hook), `csl26-ucg3` (Bluebook note-flow mechanical diagnosis), `csl26-21ep` (classification-pass pointers).
- **Design resolutions:** `csl26-dog9` (typestate RunState/FinalizedRun for the Processor RefCells), `csl26-a001` + `csl26-na19` (promoted draft → todo with gated designs), `csl26-xz2t` + `csl26-6rjq` (joint multilingual-sort recommendation, left in draft pending policy sign-off).

## Evidence

- Panic-path/unsafe/TODO scans: zero `unsafe`, zero TODOs, two production `expect`s (documented in F4).
- `csl26-ahxh` repro: `node scripts/oracle.js styles-legacy/early-medieval-europe.csl --json --force-migrate` → order-blind Jaccard passes visibly wrong note citations (18/20, `match: true` on author-date-shaped output).
- Dead-variant claim (F2): repo-wide grep — `CreateEmbeddedRootAndWrapper`/`UpgradeEmbeddedRootAndWrapper` constructed nowhere.

No Rust changes; docs and `.beans/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
