### PR TITLE
feat: processing custom-as-delta base field

### DIFF
--- a/.beans/archive/csl26-kuwj--add-processingcustombase-schema-field-for-custom-a.md
+++ b/.beans/archive/csl26-kuwj--add-processingcustombase-schema-field-for-custom-a.md
@@ -1,11 +1,11 @@
 ---
 # csl26-kuwj
 title: Add ProcessingCustom.base schema field for custom-as-delta processing
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-07-06T23:39:03Z
-updated_at: 2026-07-07T01:18:38Z
+updated_at: 2026-07-07T01:38:29Z
 parent: csl26-al39
 ---
 
@@ -29,6 +29,16 @@ Needs a schema review pass first (deferred from csl26-vpae per its own sizing no
 ## Todo
 
 - [x] feat(schema): ProcessingBase enum, ProcessingCustom.base, resolved() overlay, delegation, deserializer, tests, schema-gen
-- [ ] feat(migrate): fold_to_named_processing emits base+delta; update regression tests
-- [ ] docs/reference/PROCESSING_MIGRATION.md: Custom-as-delta section
-- [ ] just pre-commit green; end-to-end style verification; PR + CI
+- [x] feat(migrate): fold_to_named_processing emits base+delta; update regression tests
+- [x] docs/reference/PROCESSING_MIGRATION.md: Custom-as-delta section
+- [x] just pre-commit green; end-to-end style verification; PR + CI
+
+## Summary of Changes
+
+Implemented both layers of the custom-as-delta design per the confirmed decisions:
+
+**feat(schema)**: Added `ProcessingBase` enum (named presets only — nesting impossible by construction) and `ProcessingCustom.base`. `ProcessingCustom::resolved()` overlays present fields wholesale onto the base preset's config; `Processing::config()` now resolves Custom through it, so all engine call sites pick the overlay up for free. `regime_family()` / `is_author_date_family()` delegate to the base; `default_bibliography_sort()` delegates only when no explicit sort overrides it (preserving the entry-ID-tiebreak path). Deserializer accepts `base:` in the bare custom map; schemas regenerated (docs/schemas/style.json).
+
+**feat(migrate)**: `fold_to_named_processing` now emits the Custom fallback as `base: <preset>` plus only the diverging fields — emitted YAML no longer materializes disambiguation defaults the CSL never stated. Documented in PROCESSING_MIGRATION.md ('Custom as Delta').
+
+Verified end-to-end on acta-botanica-croatica.csl (year-first citation sort): emits `base: author-date-full` + sort/group only; workflow-test fidelity identical to main (18/20 citations, 47/47 bibliography). Full suite: 1832 tests green.

--- a/.beans/csl26-kuwj--add-processingcustombase-schema-field-for-custom-a.md
+++ b/.beans/csl26-kuwj--add-processingcustombase-schema-field-for-custom-a.md
@@ -1,11 +1,11 @@
 ---
 # csl26-kuwj
 title: Add ProcessingCustom.base schema field for custom-as-delta processing
-status: draft
+status: in-progress
 type: task
 priority: normal
 created_at: 2026-07-06T23:39:03Z
-updated_at: 2026-07-06T23:39:07Z
+updated_at: 2026-07-07T01:18:38Z
 parent: csl26-al39
 ---
 
@@ -18,3 +18,17 @@ extends:. Touches citum-schema-style (serde + resolution) and citum-engine call 
 of Processing::config(); requires just schema-gen in the same commit.
 
 Needs a schema review pass first (deferred from csl26-vpae per its own sizing note).
+
+## Confirmed Design Decisions (2026-07-06, Bruce)
+
+1. **Base type**: dedicated `ProcessingBase` enum (author-date, author-date-givenname, author-date-names, author-date-full, numeric, note, label) — nesting impossible by construction; label maps to `Label(LabelConfig::default())`.
+2. **Overlay depth**: whole-field — each present field (sort/group/disambiguate) replaces the base's value wholesale; no sparse Disambiguation sub-merge.
+3. **Base semantics**: delegate — `regime_family()` and `is_author_date_family()` follow the base; `default_bibliography_sort()` delegates only when `custom.sort` is None (explicit sort keeps the custom entry-ID-tiebreak path). Base with zero overrides behaves identically to the bare preset.
+4. **Scope**: one PR, two commits — feat(schema) field+resolution+delegation+schema-gen, then feat(migrate) base+delta emission on Custom fallback.
+
+## Todo
+
+- [x] feat(schema): ProcessingBase enum, ProcessingCustom.base, resolved() overlay, delegation, deserializer, tests, schema-gen
+- [ ] feat(migrate): fold_to_named_processing emits base+delta; update regression tests
+- [ ] docs/reference/PROCESSING_MIGRATION.md: Custom-as-delta section
+- [ ] just pre-commit green; end-to-end style verification; PR + CI

--- a/crates/citum-engine/benches/rendering.rs
+++ b/crates/citum-engine/benches/rendering.rs
@@ -118,6 +118,7 @@ fn bench_disambiguation(c: &mut Criterion) {
     };
     let default_title_sort_config = Config {
         processing: Some(Processing::Custom(ProcessingCustom {
+            base: None,
             disambiguate: Some(Disambiguation {
                 names: false,
                 add_givenname: false,
@@ -167,6 +168,7 @@ fn bench_disambiguation(c: &mut Criterion) {
 fn make_custom_config(names: bool, add_givenname: bool, year_suffix: bool) -> Config {
     Config {
         processing: Some(Processing::Custom(ProcessingCustom {
+            base: None,
             sort: Some(SortEntry::Explicit(Sort {
                 shorten_names: false,
                 render_substitutions: false,

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -1185,6 +1185,7 @@ mod tests {
         let style = make_author_date_style(
             Config {
                 processing: Some(Processing::Custom(ProcessingCustom {
+                    base: None,
                     disambiguate: Some(Disambiguation {
                         names: false,
                         add_givenname: false,
@@ -1283,6 +1284,7 @@ mod tests {
 
         let config = Config {
             processing: Some(Processing::Custom(ProcessingCustom {
+                base: None,
                 disambiguate: Some(Disambiguation {
                     names: false,
                     add_givenname: true,
@@ -1315,6 +1317,7 @@ mod tests {
         let style = make_author_date_style(
             Config {
                 processing: Some(Processing::Custom(ProcessingCustom {
+                    base: None,
                     disambiguate: Some(Disambiguation {
                         names: false,
                         add_givenname: true,
@@ -1386,6 +1389,7 @@ mod tests {
 
         let config = Config {
             processing: Some(Processing::Custom(ProcessingCustom {
+                base: None,
                 disambiguate: Some(Disambiguation {
                     names: true,
                     add_givenname: true,
@@ -1465,6 +1469,7 @@ mod tests {
 
         let disabled_config = Config {
             processing: Some(Processing::Custom(ProcessingCustom {
+                base: None,
                 disambiguate: Some(Disambiguation {
                     names: false,
                     add_givenname: true,
@@ -1487,6 +1492,7 @@ mod tests {
 
         let enabled_config = Config {
             processing: Some(Processing::Custom(ProcessingCustom {
+                base: None,
                 disambiguate: Some(Disambiguation {
                     names: false,
                     add_givenname: false,
@@ -1550,6 +1556,7 @@ mod tests {
         let locale = Locale::en_us();
         let config = Config {
             processing: Some(Processing::Custom(ProcessingCustom {
+                base: None,
                 disambiguate: Some(Disambiguation {
                     names: true,
                     add_givenname: true,
@@ -1602,6 +1609,7 @@ mod tests {
 
         let config = Config {
             processing: Some(Processing::Custom(ProcessingCustom {
+                base: None,
                 disambiguate: Some(Disambiguation {
                     names: true,
                     add_givenname: false,

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -1190,6 +1190,7 @@ fn test_disambiguation_givenname() {
     let mut style = make_style();
     style.options = Some(Config {
         processing: Some(Processing::Custom(ProcessingCustom {
+            base: None,
             sort: Some(citum_schema::options::SortEntry::Explicit(Sort {
                 shorten_names: false,
                 render_substitutions: false,
@@ -1289,6 +1290,7 @@ fn test_disambiguation_add_names() {
     let mut style = make_style();
     style.options = Some(Config {
         processing: Some(Processing::Custom(ProcessingCustom {
+            base: None,
             sort: Some(citum_schema::options::SortEntry::Explicit(Sort {
                 shorten_names: false,
                 render_substitutions: false,
@@ -1409,6 +1411,7 @@ fn test_disambiguation_combined_expansion() {
     let mut style = make_style();
     style.options = Some(Config {
         processing: Some(Processing::Custom(ProcessingCustom {
+            base: None,
             sort: Some(citum_schema::options::SortEntry::Explicit(Sort {
                 shorten_names: false,
                 render_substitutions: false,
@@ -3100,6 +3103,7 @@ fn test_bibliography_per_group_disambiguation() {
     // Ensure year-suffix is enabled in style
     style.options.as_mut().unwrap().processing = Some(citum_schema::options::Processing::Custom(
         citum_schema::options::ProcessingCustom {
+            base: None,
             disambiguate: Some(citum_schema::options::Disambiguation {
                 year_suffix: true,
                 ..Default::default()
@@ -5708,6 +5712,7 @@ fn test_disambiguation_givenname_primary_only_flag() {
         let mut style = make_style();
         style.options = Some(Config {
             processing: Some(Processing::Custom(ProcessingCustom {
+                base: None,
                 sort: Some(citum_schema::options::SortEntry::Explicit(Sort {
                     shorten_names: false,
                     render_substitutions: false,
@@ -5839,6 +5844,7 @@ fn test_disambiguation_givenname_primary_only_rendered() {
         let mut style = make_style();
         style.options = Some(Config {
             processing: Some(Processing::Custom(ProcessingCustom {
+                base: None,
                 sort: Some(citum_schema::options::SortEntry::Explicit(Sort {
                     shorten_names: false,
                     render_substitutions: false,

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -92,6 +92,7 @@ fn build_sorted_style(sort: Vec<SortSpec>) -> Style {
         },
         options: Some(Config {
             processing: Some(Processing::Custom(ProcessingCustom {
+                base: None,
                 sort: Some(citum_schema::options::SortEntry::Explicit(Sort {
                     template: sort,
                     shorten_names: false,
@@ -148,6 +149,7 @@ fn build_title_year_sorted_style(sort: Vec<SortSpec>) -> Style {
         },
         options: Some(Config {
             processing: Some(Processing::Custom(ProcessingCustom {
+                base: None,
                 sort: Some(citum_schema::options::SortEntry::Explicit(Sort {
                     template: sort,
                     shorten_names: false,
@@ -1706,6 +1708,7 @@ fn make_name_particle_style(display_as_sort: DisplayAsSort) -> Style {
         },
         options: Some(Config {
             processing: Some(Processing::Custom(ProcessingCustom {
+                base: None,
                 sort: Some(citum_schema::options::SortEntry::Explicit(Sort {
                     template: vec![SortSpec {
                         key: SortKey::Author,

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -464,6 +464,7 @@ fn disambiguation_two_level_author_collisions_get_distinct_suffixes() {
     let mut style = build_author_date_style(true, true, false, Some(3), Some(1));
     style.options = Some(Config {
         processing: Some(Processing::Custom(ProcessingCustom {
+            base: None,
             disambiguate: Some(citum_schema::options::Disambiguation {
                 year_suffix: true,
                 names: true,
@@ -1008,6 +1009,7 @@ fn subsequent_et_al_thresholds_shorten_the_repeat_citation() {
         },
         options: Some(Config {
             processing: Some(Processing::Custom(ProcessingCustom {
+                base: None,
                 disambiguate: Some(Disambiguation {
                     year_suffix: false,
                     names: false,

--- a/crates/citum-engine/tests/common/mod.rs
+++ b/crates/citum-engine/tests/common/mod.rs
@@ -361,6 +361,7 @@ pub fn build_author_date_style(
         },
         options: Some(Config {
             processing: Some(Processing::Custom(ProcessingCustom {
+                base: None,
                 disambiguate,
                 ..Default::default()
             })),

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -982,6 +982,7 @@ fn given_group_local_disambiguation_when_rendering_multilingual_groups_then_year
         .options
         .get_or_insert_with(Default::default)
         .processing = Some(Processing::Custom(ProcessingCustom {
+        base: None,
         disambiguate: Some(Disambiguation {
             year_suffix: false,
             ..Default::default()
@@ -994,6 +995,7 @@ fn given_group_local_disambiguation_when_rendering_multilingual_groups_then_year
         .options
         .get_or_insert_with(Default::default)
         .processing = Some(Processing::Custom(ProcessingCustom {
+        base: None,
         disambiguate: Some(Disambiguation {
             year_suffix: true,
             ..Default::default()

--- a/crates/citum-migrate/src/options_extractor/processing.rs
+++ b/crates/citum-migrate/src/options_extractor/processing.rs
@@ -4,8 +4,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 */
 
 use citum_schema::options::{
-    GivennameRule, Group, LabelConfig, LabelPreset, Processing, ProcessingCustom, Sort, SortEntry,
-    SortKey, SortSpec,
+    GivennameRule, Group, LabelConfig, LabelPreset, Processing, ProcessingBase, ProcessingCustom,
+    Sort, SortEntry, SortKey, SortSpec,
 };
 use citum_schema::presets::SortPreset;
 use csl_legacy::model::{CslNode, Style};
@@ -131,15 +131,15 @@ impl ProcessingOverrides {
     /// Disambiguation-nearest named author-date preset for the explicit
     /// names/given-name signal, per the folding table in
     /// `docs/reference/PROCESSING_MIGRATION.md`.
-    fn author_date_preset(&self) -> Processing {
+    fn author_date_preset(&self) -> ProcessingBase {
         match (
             self.disamb_names.unwrap_or(false),
             self.disamb_add_givenname.unwrap_or(false),
         ) {
-            (false, false) => Processing::AuthorDate,
-            (false, true) => Processing::AuthorDateGivenname,
-            (true, false) => Processing::AuthorDateNames,
-            (true, true) => Processing::AuthorDateFull,
+            (false, false) => ProcessingBase::AuthorDate,
+            (false, true) => ProcessingBase::AuthorDateGivenname,
+            (true, false) => ProcessingBase::AuthorDateNames,
+            (true, true) => ProcessingBase::AuthorDateFull,
         }
     }
 
@@ -170,16 +170,32 @@ impl ProcessingOverrides {
 /// preset, falling back to `Processing::Custom` only when the remaining
 /// overrides (sort/group/year-suffix/givenname-rule) diverge from that
 /// preset's canonical config. Keeps the migrated YAML idiomatic
-/// (`processing: author-date`) instead of dumping a `!custom` block for
+/// (`processing: author-date`) instead of dumping a custom block for
 /// styles that never stated a divergent attribute.
+///
+/// The custom fallback is emitted as a delta: `base:` names the chosen
+/// preset and only the fields that diverge from its config are written,
+/// so the YAML never materializes defaults the CSL never stated.
 fn fold_to_named_processing(overrides: &ProcessingOverrides) -> Processing {
-    let preset = overrides.author_date_preset();
-    let custom = overrides.apply(preset.config());
-    if custom == preset.config() {
-        preset
-    } else {
-        Processing::Custom(custom)
+    let base = overrides.author_date_preset();
+    let preset = base.processing();
+    let base_config = preset.config();
+    let custom = overrides.apply(base_config.clone());
+    if custom == base_config {
+        return preset;
     }
+    Processing::Custom(ProcessingCustom {
+        base: Some(base),
+        sort: (custom.sort != base_config.sort)
+            .then_some(custom.sort)
+            .flatten(),
+        group: (custom.group != base_config.group)
+            .then_some(custom.group)
+            .flatten(),
+        disambiguate: (custom.disambiguate != base_config.disambiguate)
+            .then_some(custom.disambiguate)
+            .flatten(),
+    })
 }
 
 fn nodes_have_author_date_signal(
@@ -497,16 +513,52 @@ mod tests {
         // when processing mode is detected
         let mode = detect_processing_mode(&style);
 
-        // then it falls to Custom for the divergent sort, but the
-        // disambiguation portion still matches the AuthorDate preset exactly
-        // rather than being eagerly materialized from scratch
+        // then it falls to a Custom delta on the author-date base carrying
+        // only the divergent sort (and its derived group): disambiguation is
+        // not materialized in the emitted config at all
         let Some(Processing::Custom(custom)) = mode else {
             panic!("expected Processing::Custom, got: {mode:?}");
         };
+        assert_eq!(custom.base, Some(ProcessingBase::AuthorDate));
+        assert_eq!(custom.disambiguate, None);
         assert_eq!(
-            custom.disambiguate,
+            custom.group,
+            Some(Group {
+                template: vec![SortKey::Title]
+            })
+        );
+        assert_ne!(custom.sort, None);
+        assert_ne!(custom.sort, Processing::AuthorDate.config().sort);
+
+        // and the resolved config still inherits the preset's disambiguation
+        assert_eq!(
+            custom.resolved().disambiguate,
             Processing::AuthorDate.config().disambiguate
         );
-        assert_ne!(custom.sort, Processing::AuthorDate.config().sort);
+    }
+
+    #[test]
+    #[allow(clippy::panic, reason = "Panicking is acceptable in tests.")]
+    fn explicit_year_suffix_false_emits_base_delta_with_disambiguation_only() {
+        // given an author-date style that contradicts the class default with
+        // an explicit disambiguate-add-year-suffix="false"
+        let style = author_date_style(r#"disambiguate-add-year-suffix="false""#, "");
+
+        // when processing mode is detected
+        let mode = detect_processing_mode(&style);
+
+        // then it emits a delta on the author-date base whose only override
+        // is the diverging disambiguation block; sort/group stay inherited
+        let Some(Processing::Custom(custom)) = mode else {
+            panic!("expected Processing::Custom, got: {mode:?}");
+        };
+        assert_eq!(custom.base, Some(ProcessingBase::AuthorDate));
+        assert_eq!(custom.sort, None);
+        assert_eq!(custom.group, None);
+        let disamb = custom
+            .disambiguate
+            .as_ref()
+            .unwrap_or_else(|| panic!("expected diverging disambiguation override"));
+        assert!(!disamb.year_suffix);
     }
 }

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -45,7 +45,8 @@ pub use multilingual::{
 };
 pub use processing::{
     CitationSortPolicy, Disambiguation, GivennameRule, Group, LabelConfig, LabelParams,
-    LabelPreset, Processing, ProcessingCustom, RegimeFamily, Sort, SortEntry, SortKey, SortSpec,
+    LabelPreset, Processing, ProcessingBase, ProcessingCustom, RegimeFamily, Sort, SortEntry,
+    SortKey, SortSpec,
 };
 pub use scoped::{
     BibliographyLabelMode, BibliographyLabelWrap, CitationGroupDelimiter, DatePosition, LabelWrap,

--- a/crates/citum-schema-style/src/options/processing.rs
+++ b/crates/citum-schema-style/src/options/processing.rs
@@ -180,14 +180,63 @@ pub enum CitationSortPolicy {
     ExplicitOnly,
 }
 
+/// Named processing preset usable as the base of a custom delta.
+///
+/// Restricting `ProcessingCustom::base` to this enum makes nested custom
+/// configurations impossible by construction: a base is always one of the
+/// named presets, never another custom block.
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum ProcessingBase {
+    /// Delta base equivalent to `Processing::AuthorDate`.
+    AuthorDate,
+    /// Delta base equivalent to `Processing::AuthorDateGivenname`.
+    AuthorDateGivenname,
+    /// Delta base equivalent to `Processing::AuthorDateNames`.
+    AuthorDateNames,
+    /// Delta base equivalent to `Processing::AuthorDateFull`.
+    AuthorDateFull,
+    /// Delta base equivalent to `Processing::Numeric`.
+    Numeric,
+    /// Delta base equivalent to `Processing::Note`.
+    Note,
+    /// Delta base equivalent to `Processing::Label` with default label config.
+    Label,
+}
+
+impl ProcessingBase {
+    /// The named `Processing` variant this base stands for.
+    ///
+    /// `Label` maps to `Processing::Label(LabelConfig::default())`; all other
+    /// variants map to their unit counterparts.
+    pub fn processing(&self) -> Processing {
+        match self {
+            Self::AuthorDate => Processing::AuthorDate,
+            Self::AuthorDateGivenname => Processing::AuthorDateGivenname,
+            Self::AuthorDateNames => Processing::AuthorDateNames,
+            Self::AuthorDateFull => Processing::AuthorDateFull,
+            Self::Numeric => Processing::Numeric,
+            Self::Note => Processing::Note,
+            Self::Label => Processing::Label(LabelConfig::default()),
+        }
+    }
+}
+
 /// Custom processing configuration.
 ///
-/// Allows explicit specification of sorting, grouping, and disambiguation rules
-/// without relying on preset defaults.
+/// Allows explicit specification of sorting, grouping, and disambiguation rules.
+/// With a `base`, the block is a *delta*: present fields override the named
+/// preset's configuration wholesale and absent fields inherit from it (the same
+/// philosophy as style `extends:`). Without a `base`, present fields stand alone.
 #[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub struct ProcessingCustom {
+    /// Named preset whose configuration seeds unset fields (optional).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base: Option<ProcessingBase>,
     /// Bibliography sorting configuration (optional).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<SortEntry>,
@@ -197,6 +246,34 @@ pub struct ProcessingCustom {
     /// Disambiguation settings (optional).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disambiguate: Option<Disambiguation>,
+}
+
+impl ProcessingCustom {
+    /// Resolve the effective configuration by overlaying present fields onto
+    /// the base preset's config.
+    ///
+    /// Each present field (`sort`, `group`, `disambiguate`) replaces the base's
+    /// value wholesale; absent fields inherit the base's. Without a `base`,
+    /// returns the stored fields as-is. The result carries no `base` — it is
+    /// fully materialized.
+    #[must_use]
+    pub fn resolved(&self) -> ProcessingCustom {
+        let mut config = match self.base {
+            Some(base) => base.processing().config(),
+            None => ProcessingCustom::default(),
+        };
+        config.base = None;
+        if self.sort.is_some() {
+            config.sort = self.sort.clone();
+        }
+        if self.group.is_some() {
+            config.group = self.group.clone();
+        }
+        if self.disambiguate.is_some() {
+            config.disambiguate = self.disambiguate.clone();
+        }
+        config
+    }
 }
 
 /// Coarse citation regime family for cross-regime compatibility checks.
@@ -228,6 +305,7 @@ fn author_date_config(
     givenname_rule: GivennameRule,
 ) -> ProcessingCustom {
     ProcessingCustom {
+        base: None,
         sort: Some(SortEntry::Preset(SortPreset::AuthorDateTitle)),
         group: Some(Group {
             template: vec![SortKey::Author, SortKey::Year],
@@ -247,7 +325,10 @@ impl Processing {
     /// Returns the standard bibliography sort order for the processing mode:
     /// - `AuthorDate` / `Label`: author, year, title
     /// - `Note`: author, title, year
-    /// - `Numeric` / `Custom`: None (no automatic sort)
+    /// - `Numeric`: None (no automatic sort)
+    /// - `Custom`: the base preset's default when a `base` is set and no
+    ///   explicit `sort` overrides it; otherwise None (an explicit custom sort
+    ///   resolves through `config()` instead, keeping the entry-ID tiebreak)
     pub fn default_bibliography_sort(&self) -> Option<SortPreset> {
         match self {
             Processing::AuthorDate
@@ -257,22 +338,21 @@ impl Processing {
             Processing::Numeric => None,
             Processing::Note => Some(SortPreset::AuthorTitleDate),
             Processing::Label(_) => Some(SortPreset::AuthorDateTitle),
-            Processing::Custom(_) => None,
+            Processing::Custom(custom) => match (custom.base, custom.sort.as_ref()) {
+                (Some(base), None) => base.processing().default_bibliography_sort(),
+                _ => None,
+            },
         }
     }
 
     /// Returns `true` for all author-date family variants.
     ///
+    /// A `Custom` delta whose `base` is an author-date preset counts as
+    /// author-date: a delta on author-date is still an author-date style.
     /// Centralizes the author-date family check so new variants don't require
     /// updating scattered `matches!` blocks across the codebase.
     pub fn is_author_date_family(&self) -> bool {
-        matches!(
-            self,
-            Self::AuthorDate
-                | Self::AuthorDateGivenname
-                | Self::AuthorDateNames
-                | Self::AuthorDateFull
-        )
+        self.regime_family() == RegimeFamily::AuthorDate
     }
 
     /// Coarse citation regime family for cross-regime compatibility checks.
@@ -281,8 +361,10 @@ impl Processing {
     /// citation-mode sub-specs (integral, non-integral) belong to a different
     /// regime and should be reset when the child supplies its own base template.
     ///
-    /// `Custom` is its own family and never triggers automatic sub-spec resets,
-    /// preserving fully-custom authored styles.
+    /// A base-less `Custom` is its own family and never triggers automatic
+    /// sub-spec resets, preserving fully-custom authored styles. A `Custom`
+    /// delta with a `base` belongs to its base's family: a delta on
+    /// author-date is still an author-date style.
     ///
     /// See `docs/specs/CITATION_REGIME.md` for the full invariant.
     pub fn regime_family(&self) -> RegimeFamily {
@@ -294,7 +376,10 @@ impl Processing {
             Self::Numeric => RegimeFamily::Numeric,
             Self::Note => RegimeFamily::Note,
             Self::Label(_) => RegimeFamily::Label,
-            Self::Custom(_) => RegimeFamily::Custom,
+            Self::Custom(custom) => match custom.base {
+                Some(base) => base.processing().regime_family(),
+                None => RegimeFamily::Custom,
+            },
         }
     }
 
@@ -326,12 +411,9 @@ impl Processing {
             Processing::AuthorDateFull => {
                 author_date_config(true, true, GivennameRule::PrimaryName)
             }
-            Processing::Numeric => ProcessingCustom {
-                sort: None,
-                group: None,
-                disambiguate: None,
-            },
+            Processing::Numeric => ProcessingCustom::default(),
             Processing::Note => ProcessingCustom {
+                base: None,
                 sort: Some(SortEntry::Preset(SortPreset::AuthorTitleDate)),
                 group: None,
                 disambiguate: Some(Disambiguation {
@@ -342,6 +424,7 @@ impl Processing {
                 }),
             },
             Processing::Label(_) => ProcessingCustom {
+                base: None,
                 sort: Some(SortEntry::Preset(SortPreset::AuthorDateTitle)),
                 group: None,
                 disambiguate: Some(Disambiguation {
@@ -351,7 +434,7 @@ impl Processing {
                     year_suffix: true,
                 }),
             },
-            Processing::Custom(custom) => custom.clone(),
+            Processing::Custom(custom) => custom.resolved(),
         }
     }
 }
@@ -434,24 +517,30 @@ impl<'de> Deserialize<'de> for Processing {
                         let config: LabelConfig = map.next_value()?;
                         Ok(Processing::Label(config))
                     }
-                    "sort" | "group" | "disambiguate" => {
+                    "base" | "sort" | "group" | "disambiguate" => {
                         // This is a custom processing config
                         // We need to deserialize the whole map as ProcessingCustom
                         // Unfortunately we can't easily re-parse from the middle of map access.
                         // Instead, collect fields and build manually
+                        let mut base = None;
                         let mut sort = None;
                         let mut group = None;
                         let mut disambiguate = None;
 
+                        // Values deserialize as `Option<_>` so an explicit
+                        // null (`base: ~`) reads as absent, matching derived
+                        // serde semantics and the JSON schema contract.
+
                         // Handle the first key we already read
                         match key.as_str() {
-                            "sort" => sort = Some(map.next_value()?),
-                            "group" => group = Some(map.next_value()?),
-                            "disambiguate" => disambiguate = Some(map.next_value()?),
+                            "base" => base = map.next_value()?,
+                            "sort" => sort = map.next_value()?,
+                            "group" => group = map.next_value()?,
+                            "disambiguate" => disambiguate = map.next_value()?,
                             _ => {
                                 return Err(de::Error::unknown_field(
                                     &key,
-                                    &["sort", "group", "disambiguate"],
+                                    &["base", "sort", "group", "disambiguate"],
                                 ));
                             }
                         }
@@ -459,19 +548,21 @@ impl<'de> Deserialize<'de> for Processing {
                         // Read remaining keys
                         while let Some(k) = map.next_key::<String>()? {
                             match k.as_str() {
-                                "sort" => sort = Some(map.next_value()?),
-                                "group" => group = Some(map.next_value()?),
-                                "disambiguate" => disambiguate = Some(map.next_value()?),
+                                "base" => base = map.next_value()?,
+                                "sort" => sort = map.next_value()?,
+                                "group" => group = map.next_value()?,
+                                "disambiguate" => disambiguate = map.next_value()?,
                                 other => {
                                     return Err(de::Error::unknown_field(
                                         other,
-                                        &["sort", "group", "disambiguate"],
+                                        &["base", "sort", "group", "disambiguate"],
                                     ));
                                 }
                             }
                         }
 
                         Ok(Processing::Custom(ProcessingCustom {
+                            base,
                             sort,
                             group,
                             disambiguate,
@@ -479,7 +570,7 @@ impl<'de> Deserialize<'de> for Processing {
                     }
                     other => Err(de::Error::unknown_field(
                         other,
-                        &["label", "sort", "group", "disambiguate"],
+                        &["label", "base", "sort", "group", "disambiguate"],
                     )),
                 }
             }
@@ -885,6 +976,171 @@ mod tests {
             let deserialized: Processing = serde_yaml::from_str(name).unwrap();
             assert_eq!(deserialized, processing);
         }
+    }
+
+    /// Test that a custom map with `base:` and an explicit sort round-trips
+    /// through YAML preserving the sparse delta shape.
+    #[test]
+    fn test_processing_custom_base_round_trip() {
+        // given: a custom delta on author-date with only an explicit sort
+        let processing = Processing::Custom(ProcessingCustom {
+            base: Some(ProcessingBase::AuthorDate),
+            sort: Some(SortEntry::Preset(SortPreset::AuthorTitleDate)),
+            group: None,
+            disambiguate: None,
+        });
+
+        // when: serialized to YAML and parsed back
+        let yaml = serde_yaml::to_string(&processing).unwrap();
+        let parsed: Processing = serde_yaml::from_str(&yaml).unwrap();
+
+        // then: the YAML stays sparse (base + sort only) and round-trips
+        assert_eq!(yaml.trim(), "base: author-date\nsort: author-title-date");
+        assert_eq!(parsed, processing);
+    }
+
+    /// Test that a map with only `base:` parses and resolves to the bare
+    /// preset's config.
+    #[test]
+    fn test_processing_custom_base_only_resolves_to_preset_config() {
+        // given: YAML declaring only a base
+        let parsed: Processing = serde_yaml::from_str("base: author-date-full").unwrap();
+
+        // then: it parses as Custom with the base and no overrides
+        assert_eq!(
+            parsed,
+            Processing::Custom(ProcessingCustom {
+                base: Some(ProcessingBase::AuthorDateFull),
+                sort: None,
+                group: None,
+                disambiguate: None,
+            })
+        );
+
+        // and: config() matches the bare preset's config
+        assert_eq!(parsed.config(), Processing::AuthorDateFull.config());
+    }
+
+    /// Test that resolved() overlays present fields wholesale and inherits
+    /// absent fields from the base preset.
+    #[test]
+    fn test_processing_custom_resolved_overlay_semantics() {
+        // given: a delta on author-date overriding only the sort
+        let custom = ProcessingCustom {
+            base: Some(ProcessingBase::AuthorDate),
+            sort: Some(SortEntry::Preset(SortPreset::AuthorTitleDate)),
+            group: None,
+            disambiguate: None,
+        };
+
+        // when: resolved against the base
+        let resolved = custom.resolved();
+
+        // then: the explicit sort wins; group/disambiguate inherit; no base remains
+        let base_config = Processing::AuthorDate.config();
+        assert_eq!(resolved.base, None);
+        assert_eq!(
+            resolved.sort,
+            Some(SortEntry::Preset(SortPreset::AuthorTitleDate))
+        );
+        assert_eq!(resolved.group, base_config.group);
+        assert_eq!(resolved.disambiguate, base_config.disambiguate);
+    }
+
+    /// Test that resolved() without a base returns the stored fields as-is.
+    #[test]
+    fn test_processing_custom_resolved_without_base_is_identity() {
+        let custom = ProcessingCustom {
+            base: None,
+            sort: Some(SortEntry::Preset(SortPreset::AuthorDateTitle)),
+            group: None,
+            disambiguate: None,
+        };
+
+        assert_eq!(custom.resolved(), custom);
+    }
+
+    /// Test that regime_family and is_author_date_family delegate to the base
+    /// when present and stay Custom without one.
+    #[test]
+    fn test_processing_custom_base_family_delegation() {
+        // given: a delta on author-date and a base-less custom
+        let with_base = Processing::Custom(ProcessingCustom {
+            base: Some(ProcessingBase::AuthorDate),
+            ..Default::default()
+        });
+        let without_base = Processing::Custom(ProcessingCustom::default());
+
+        // then: family checks follow the base only when one is set
+        assert_eq!(with_base.regime_family(), RegimeFamily::AuthorDate);
+        assert!(with_base.is_author_date_family());
+        assert_eq!(without_base.regime_family(), RegimeFamily::Custom);
+        assert!(!without_base.is_author_date_family());
+
+        // and: a numeric base maps to the numeric family
+        let numeric_base = Processing::Custom(ProcessingCustom {
+            base: Some(ProcessingBase::Numeric),
+            ..Default::default()
+        });
+        assert_eq!(numeric_base.regime_family(), RegimeFamily::Numeric);
+        assert!(!numeric_base.is_author_date_family());
+    }
+
+    /// Test that default_bibliography_sort delegates to the base only when the
+    /// custom carries no explicit sort.
+    #[test]
+    fn test_processing_custom_base_default_bibliography_sort() {
+        // given: a base-carrying custom without an explicit sort
+        let inherited = Processing::Custom(ProcessingCustom {
+            base: Some(ProcessingBase::AuthorDate),
+            ..Default::default()
+        });
+        // then: the base's preset default applies
+        assert_eq!(
+            inherited.default_bibliography_sort(),
+            Some(SortPreset::AuthorDateTitle)
+        );
+
+        // given: the same base with an explicit sort override
+        let overridden = Processing::Custom(ProcessingCustom {
+            base: Some(ProcessingBase::AuthorDate),
+            sort: Some(SortEntry::Preset(SortPreset::AuthorTitleDate)),
+            ..Default::default()
+        });
+        // then: no preset default — the explicit sort resolves via config()
+        assert_eq!(overridden.default_bibliography_sort(), None);
+    }
+
+    /// Test that explicit null values in a custom map read as absent fields,
+    /// matching derived-serde `Option` semantics and the JSON schema.
+    #[test]
+    fn test_processing_custom_map_accepts_explicit_nulls() {
+        // given: a custom map with explicit nulls alongside a real field
+        let parsed: Processing =
+            serde_yaml::from_str("base: ~\nsort: author-title-date\ndisambiguate: null").unwrap();
+
+        // then: null fields are absent, the real field is kept
+        assert_eq!(
+            parsed,
+            Processing::Custom(ProcessingCustom {
+                base: None,
+                sort: Some(SortEntry::Preset(SortPreset::AuthorTitleDate)),
+                group: None,
+                disambiguate: None,
+            })
+        );
+    }
+
+    /// Test that invalid `base:` values are rejected at parse time.
+    #[test]
+    fn test_processing_custom_base_rejects_invalid_values() {
+        // given: a nested map and an unknown preset name as base
+        let nested = serde_yaml::from_str::<Processing>("base: { sort: author-date-title }");
+        let unknown = serde_yaml::from_str::<Processing>("base: fancy-date");
+
+        // then: both fail to parse
+        assert!(nested.is_err());
+        assert!(unknown.is_err());
     }
 
     /// Test that Disambiguation defaults have correct values.

--- a/docs/reference/PROCESSING_MIGRATION.md
+++ b/docs/reference/PROCESSING_MIGRATION.md
@@ -65,3 +65,30 @@ CSL disambiguation attributes, and compares the result with named presets:
 `givenname-disambiguation-rule` defaults to `by-cite` when omitted. An explicit
 non-default rule is preserved in custom processing unless the full configuration
 still exactly matches a named preset.
+
+## Custom as Delta
+
+When folding cannot reach a named preset, migration emits custom processing as
+a *delta* on the disambiguation-nearest preset rather than a fully materialized
+block. The `base:` field names the preset and only fields that diverge from its
+configuration are written:
+
+```yaml
+processing:
+  base: author-date
+  sort:
+    template:
+      - key: title
+```
+
+Resolution overlays present fields onto the base preset's configuration
+**wholesale** — a present `sort`, `group`, or `disambiguate` replaces the
+base's value entirely; absent fields inherit from the base. There is no
+sub-field merge: overriding one disambiguation flag requires restating the
+whole `disambiguate` block.
+
+A custom block with a `base` also belongs to the base's processing family:
+`regime_family()` and `is_author_date_family()` delegate to the base, and the
+default bibliography sort follows the base when no explicit `sort` overrides
+it. A `base:` with zero overrides behaves identically to the bare preset.
+Base-less custom blocks keep their previous fully-explicit semantics.

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -3325,9 +3325,20 @@
       ]
     },
     "ProcessingCustom": {
-      "description": "Custom processing configuration.\n\nAllows explicit specification of sorting, grouping, and disambiguation rules\nwithout relying on preset defaults.",
+      "description": "Custom processing configuration.\n\nAllows explicit specification of sorting, grouping, and disambiguation rules.\nWith a `base`, the block is a *delta*: present fields override the named\npreset's configuration wholesale and absent fields inherit from it (the same\nphilosophy as style `extends:`). Without a `base`, present fields stand alone.",
       "type": "object",
       "properties": {
+        "base": {
+          "description": "Named preset whose configuration seeds unset fields (optional).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProcessingBase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "sort": {
           "description": "Bibliography sorting configuration (optional).",
           "anyOf": [
@@ -3362,6 +3373,46 @@
           ]
         }
       }
+    },
+    "ProcessingBase": {
+      "description": "Named processing preset usable as the base of a custom delta.\n\nRestricting `ProcessingCustom::base` to this enum makes nested custom\nconfigurations impossible by construction: a base is always one of the\nnamed presets, never another custom block.",
+      "oneOf": [
+        {
+          "description": "Delta base equivalent to `Processing::AuthorDate`.",
+          "type": "string",
+          "const": "author-date"
+        },
+        {
+          "description": "Delta base equivalent to `Processing::AuthorDateGivenname`.",
+          "type": "string",
+          "const": "author-date-givenname"
+        },
+        {
+          "description": "Delta base equivalent to `Processing::AuthorDateNames`.",
+          "type": "string",
+          "const": "author-date-names"
+        },
+        {
+          "description": "Delta base equivalent to `Processing::AuthorDateFull`.",
+          "type": "string",
+          "const": "author-date-full"
+        },
+        {
+          "description": "Delta base equivalent to `Processing::Numeric`.",
+          "type": "string",
+          "const": "numeric"
+        },
+        {
+          "description": "Delta base equivalent to `Processing::Note`.",
+          "type": "string",
+          "const": "note"
+        },
+        {
+          "description": "Delta base equivalent to `Processing::Label` with default label config.",
+          "type": "string",
+          "const": "label"
+        }
+      ]
     },
     "SortEntry": {
       "description": "Sort configuration: either a preset name or explicit configuration.\n\nCan be a preset name like `author-date-title` or a full `Sort` struct with explicit settings.",


### PR DESCRIPTION
Layer 2 of the delta-based processing design ([PROCESSING_MIGRATION.md](docs/reference/PROCESSING_MIGRATION.md); layer 1 landed in csl26-vpae). Closes bean **csl26-kuwj**.

## What

Custom processing blocks can now be a *delta on a named preset* — the same philosophy as `extends:`:

```yaml
processing:
  base: author-date
  sort: { template: [ { key: title } ] }
```

**`feat(schema)`** — new `ProcessingBase` enum (named presets only; nested custom blocks impossible by construction) and `ProcessingCustom.base`. `resolved()` overlays present fields wholesale onto the base's config; `Processing::config()` routes Custom through it, so all engine call sites inherit the behavior. Schemas regenerated.

**`feat(migrate)`** — when folding can't reach a named preset, the Custom fallback is emitted as `base:` + only the diverging fields. Emitted YAML no longer materializes disambiguation defaults the source CSL never stated.

## Design decisions (confirmed 2026-07-06)

1. **Base type**: dedicated `ProcessingBase` enum, not `Box<Processing>` + validation — type-level nesting guard, self-documenting JSON schema.
2. **Overlay depth**: whole-field — a present `sort`/`group`/`disambiguate` replaces the base's value entirely; no sparse sub-field merge.
3. **Base semantics**: delegate — `regime_family()` / `is_author_date_family()` follow the base; `default_bibliography_sort()` delegates only when no explicit sort overrides it (preserving the entry-ID-tiebreak path for custom sorts). `base:` with zero overrides ≡ the bare preset.
4. **Scope**: schema + migrate emission in one PR so the regression coverage asserts the real end-state YAML.

## Evidence

- Full suite: 1832 tests green (`just pre-commit`).
- End-to-end on `acta-botanica-croatica.csl` (year-first citation sort): emits `base: author-date-full` + sort/group only; workflow-test fidelity identical to main (citations 18/20, bibliography 47/47).
- New coverage: serde round-trips (sparse shape preserved), overlay semantics, family/sort delegation, invalid-base rejection, and migrate regressions for divergent-sort and explicit `year-suffix="false"` deltas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
