### PR TITLE
chore(tooling): use stable model aliases

### DIFF
--- a/.beans/csl26-7r5m--remove-stale-codex-model-version-pins.md
+++ b/.beans/csl26-7r5m--remove-stale-codex-model-version-pins.md
@@ -1,0 +1,17 @@
+---
+# csl26-7r5m
+title: Remove stale Codex model version pins
+status: in-progress
+type: task
+priority: normal
+created_at: 2026-07-08T21:08:30Z
+updated_at: 2026-07-08T21:09:03Z
+---
+
+Replace versioned Codex model IDs in repo-local agent contracts and launcher with stable aliases.
+
+- [x] Create stable model aliases in agent contracts
+- [x] Update scripts/codex fallback launcher
+- [x] Verify no stale gpt-5.x pins remain in Codex agent surfaces
+- [x] Run shell syntax and beans hygiene checks
+- [ ] Commit, push, and open draft PR

--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -17,7 +17,8 @@ Authoritative shared process docs:
 
 These files are intentionally thin host wrappers:
 - use the shared docs for process logic
-- keep only host-local purpose, model, scope, and output-contract metadata here
+- keep only host-local purpose, model preference, scope, and output-contract metadata here
+- use stable model aliases such as `default` and `default-mini`, not dated model IDs
 - do not duplicate the shared workflow loop in each agent file
 
 Runnable Codex fallback:

--- a/.codex/agents/docs-curator.md
+++ b/.codex/agents/docs-curator.md
@@ -8,7 +8,7 @@ use_when:
 do_not_use_when:
   - The task is primarily code implementation with no documentation impact.
   - The user needs a code-review style bug hunt instead of documentation work.
-default_model: gpt-5.4-mini
+default_model: default-mini
 default_reasoning_effort: low
 scope:
   - Write or refine docs under the repo's documented placement rules.

--- a/.codex/agents/migration-researcher.md
+++ b/.codex/agents/migration-researcher.md
@@ -9,7 +9,7 @@ do_not_use_when:
   - The task is a one-off style YAML fix.
   - The mismatch is clearly an engine rendering defect.
   - The change requires new schema design or broader architecture work.
-default_model: gpt-5.4-mini
+default_model: default-mini
 default_reasoning_effort: medium
 scope:
   - Primary write scope is `crates/citum_migrate/`

--- a/.codex/agents/rust-implementer.md
+++ b/.codex/agents/rust-implementer.md
@@ -9,7 +9,7 @@ do_not_use_when:
   - The main problem is still ambiguous and needs architectural clarification.
   - The task is purely documentation or style QA.
   - The requested change is primarily style-authoring rather than Rust implementation.
-default_model: gpt-5.4
+default_model: default
 default_reasoning_effort: medium
 scope:
   - Write scope is the smallest set of Rust and adjacent test files needed to complete the task.

--- a/.codex/agents/spec-planner.md
+++ b/.codex/agents/spec-planner.md
@@ -8,7 +8,7 @@ use_when:
 do_not_use_when:
   - The task is a small, obvious bug fix.
   - The implementation is already fully specified and just needs execution.
-default_model: gpt-5.4
+default_model: default
 default_reasoning_effort: high
 scope:
   - Read design docs, policies, specs, architecture notes, and relevant code paths.

--- a/.codex/agents/style-qa-reviewer.md
+++ b/.codex/agents/style-qa-reviewer.md
@@ -8,7 +8,7 @@ use_when:
 do_not_use_when:
   - The task is to implement a fix.
   - There is no concrete style, oracle, or report evidence to review.
-default_model: gpt-5.4-mini
+default_model: default-mini
 default_reasoning_effort: low
 scope:
   - Read-only review of style outputs, oracle results, reports, and affected docs or beans.

--- a/scripts/codex
+++ b/scripts/codex
@@ -117,10 +117,10 @@ EOF
 model_for_role() {
   case "$1" in
     rust-implementer|spec-planner|test-soundness-review)
-      echo "gpt-5.4"
+      echo "default"
       ;;
     *)
-      echo "gpt-5.4-mini"
+      echo "default-mini"
       ;;
   esac
 }


### PR DESCRIPTION
## Summary

- Replace versioned Codex agent model pins with stable aliases.
- Keep scripts/codex fallback model selection aligned with those aliases.
- Document that repo-local role contracts should avoid dated model IDs.

## Verification

- grep -RIn "gpt-5\.[0-9]" .codex/agents scripts/codex (no matches)
- bash -n scripts/codex
- bash .agents/skills/beans/bin/citum-bean hygiene
- pre-push hook: all alint rules passed; no Rust files changed, cargo gate skipped
