### PR TITLE
Feat/engine explicit render run state

### DIFF
--- a/.beans/archive/csl26-dog9--design-explicit-render-run-state-for-processor.md
+++ b/.beans/archive/csl26-dog9--design-explicit-render-run-state-for-processor.md
@@ -1,14 +1,14 @@
 ---
 # csl26-dog9
 title: 'Design: explicit render-run state for Processor'
-status: in-progress
+status: completed
 type: task
 priority: normal
 tags:
     - state
     - rendering
 created_at: 2026-07-04T02:42:26Z
-updated_at: 2026-07-09T11:49:55Z
+updated_at: 2026-07-09T13:00:15Z
 parent: csl26-8m2p
 ---
 
@@ -55,15 +55,32 @@ Post-finalize, the csl26-qi7l note applies: `FinalizedRun` is where Rc→Arc + r
 
 ## Implementation Checklist (2026-07-09)
 
-- [ ] (0) Spec: docs/specs/EXPLICIT_RENDER_RUN_STATE.md (Draft)
-- [ ] (a) Introduce RunState wrapping existing RefCells, callers unchanged
-- [ ] (b) Thread &mut RunState through registration; delete transitional field; add begin_run
-- [ ] (c) Add FinalizedRun typestate; convert bibliography/render entry points
-- [ ] (d) FFI/WASM session plumbing (opaque handle swap)
-- [ ] Idempotency test: same citations through one reused Processor + two begin_run calls -> identical output
-- [ ] just pre-commit green at each phase
-- [ ] workflow-test + report-core fidelity check (no regression)
-- [ ] Spec Draft -> Active in the typestate-landing commit
-- [ ] File follow-up bean for Rc->Arc/rayon (csl26-qi7l note), out of scope here
+- [x] (0) Spec: docs/specs/EXPLICIT_RENDER_RUN_STATE.md (Active)
+- [x] (a) Introduce RunState wrapping existing RefCells, callers unchanged
+- [x] (b)+(c) combined: Thread &mut RunState/&FinalizedRun through registration and rendering; RunState fully external to Processor (see spec's Implementation Notes for why (b)/(c) could not split — Rust borrow-checker rejects self.method(&mut self.field))
+- [x] (d) FFI/WASM session plumbing (FfiSession opaque handle, ABI-preserving)
+- [x] Idempotency test: test_processor_is_reusable_across_independent_runs (two begin_run calls -> identical output)
+- [x] just pre-commit green (fmt + clippy -D warnings + 1854 tests, --all-features, whole workspace)
+- [x] workflow-test fidelity check: apa.csl + apa-numeric-superscript.csl match byte-for-byte vs git-stash pre-refactor baseline
+- [x] Spec Draft -> Active
+- [x] File follow-up bean for Rc->Arc/rayon: csl26-nitz
 
 **Spec:** docs/specs/EXPLICIT_RENDER_RUN_STATE.md (Draft, 2026-07-09)
+
+## Summary of Changes
+
+Implemented the full explicit render-run state refactor:
+
+- `crates/citum-engine/src/processor/run_state.rs` (new): `RunState` (registration-phase, `&mut`) and `FinalizedRun` (render-phase, `&`) typestate. `citation_numbers`/`first_note_by_id` stay `RefCell`-wrapped inside `RunState` (lazy numeric assignment during render); the other five fields (`cited_ids`, `compound_groups`, three dynamic compound maps) are plain, mutated only via `&mut RunState`.
+- `Processor` no longer owns any of the seven former `RefCell` fields. `Processor::begin_run(&self) -> RunState` is the new entry point.
+- Registration (citation.rs, note_context.rs, setup.rs) takes `&mut RunState`; bibliography rendering (bibliography/{mod,grouping,compound}.rs) takes `&FinalizedRun`.
+- One-shot convenience wrappers preserve the pre-refactor zero-argument call shape where no cross-call continuity is needed: `process_citation`/`process_citations` (pre-existing names, now throwaway-run), plus a new `*_standalone` family for the bibliography methods (`render_bibliography_with_format_standalone`, `render_selected_bibliography_with_format_and_annotations_standalone`, etc.) — begins a throwaway run internally.
+- FFI (`ffi/mod.rs`): opaque `FfiSession { processor, run }` replaces the bare `*mut Processor` pointee; C ABI signatures unchanged. Bibliography renders clone-and-finalize a snapshot of the session's run so citation registration can continue afterward.
+- `api/document.rs`, `api/session.rs`: thread one `begin_run`/`finalize` per document/render instead of relying on implicit per-`Processor` state; `DocumentSession::render_citations` no longer needs the per-render style/bibliography clone workaround.
+- Updated every downstream consumer to compile against the new signatures: `citum-cli`, `citum-server`, `citum-bindings`, `citum-migrate`, plus the engine's own unit/integration tests, benches, and examples.
+- Fixed two latent test bugs the refactor surfaced: `test_dynamic_group_first_occurrence_wins` and `test_dynamic_group_ungrouped_first_occurrence_wins" relied on `process_citation`'s (now-throwaway-run) cross-call accumulation for dynamic compound-group state; both now thread one explicit `RunState` across their two citations.
+- Added `test_processor_is_reusable_across_independent_runs`: the headline idempotency property this refactor makes both expressible and true.
+
+**Verification:** `just pre-commit` green (fmt + clippy `-D warnings` + 1854 tests) across the whole workspace with `--all-features`. `just workflow-test` on an author-date style (apa.csl) and a numeric/compound style (apa-numeric-superscript.csl) both match byte-for-byte against a `git stash`-isolated pre-refactor baseline — no fidelity regression.
+
+**Follow-up filed:** csl26-nitz (Rc→Arc + rayon parallelization, deferred, gated on a real workload).

--- a/.beans/csl26-dog9--design-explicit-render-run-state-for-processor.md
+++ b/.beans/csl26-dog9--design-explicit-render-run-state-for-processor.md
@@ -1,14 +1,14 @@
 ---
 # csl26-dog9
 title: 'Design: explicit render-run state for Processor'
-status: todo
+status: in-progress
 type: task
 priority: normal
 tags:
     - state
     - rendering
 created_at: 2026-07-04T02:42:26Z
-updated_at: 2026-07-06T18:47:31Z
+updated_at: 2026-07-09T11:49:55Z
 parent: csl26-8m2p
 ---
 
@@ -52,3 +52,18 @@ Verified current state: `processor/mod.rs` holds seven `RefCell` fields (citatio
 **Migration plan (each step green on its own):** (a) introduce RunState wrapping the existing RefCells and move the fields, callers unchanged; (b) change internal call chains to `&mut RunState` and delete the RefCells; (c) add the FinalizedRun typestate and convert bibliography entry points; (d) update FFI session plumbing. Step (a)-(b) are Sonnet-executable; (c)-(d) want a review pass.
 
 Post-finalize, the csl26-qi7l note applies: `FinalizedRun` is where Rc→Arc + rayon over `render_group_entries` becomes safe — out of scope here, gated on a real workload.
+
+## Implementation Checklist (2026-07-09)
+
+- [ ] (0) Spec: docs/specs/EXPLICIT_RENDER_RUN_STATE.md (Draft)
+- [ ] (a) Introduce RunState wrapping existing RefCells, callers unchanged
+- [ ] (b) Thread &mut RunState through registration; delete transitional field; add begin_run
+- [ ] (c) Add FinalizedRun typestate; convert bibliography/render entry points
+- [ ] (d) FFI/WASM session plumbing (opaque handle swap)
+- [ ] Idempotency test: same citations through one reused Processor + two begin_run calls -> identical output
+- [ ] just pre-commit green at each phase
+- [ ] workflow-test + report-core fidelity check (no regression)
+- [ ] Spec Draft -> Active in the typestate-landing commit
+- [ ] File follow-up bean for Rc->Arc/rayon (csl26-qi7l note), out of scope here
+
+**Spec:** docs/specs/EXPLICIT_RENDER_RUN_STATE.md (Draft, 2026-07-09)

--- a/.beans/csl26-nitz--consider-rcarc-rayon-parallelization-for-bibliogra.md
+++ b/.beans/csl26-nitz--consider-rcarc-rayon-parallelization-for-bibliogra.md
@@ -1,0 +1,12 @@
+---
+# csl26-nitz
+title: Consider Rc→Arc + rayon parallelization for bibliography rendering
+status: todo
+type: task
+priority: deferred
+created_at: 2026-07-09T12:59:36Z
+updated_at: 2026-07-09T12:59:36Z
+parent: csl26-8m2p
+---
+
+Once csl26-dog9's FinalizedRun typestate lands (done), Rc<Config>/Rc<BibliographyConfig> (introduced in csl26-qi7l) could become Arc, and Renderer::process_bibliography_entry/render_group_entries could parallelize with rayon, since FinalizedRun makes the read-only-before-render contract typed rather than comment-documented. Out of scope for csl26-dog9 itself. Only worth doing if a real workload shows single-threaded rendering as the bottleneck — the O(n×m) clone cost fixed by csl26-qi7l was the actual hot-path issue, not thread count. See docs/specs/EXPLICIT_RENDER_RUN_STATE.md and the csl26-qi7l follow-up note recorded in csl26-dog9's body.

--- a/crates/citum-bindings/src/lib.rs
+++ b/crates/citum-bindings/src/lib.rs
@@ -221,8 +221,9 @@ pub fn render_citation(
         citation.mode = m_enum;
     }
     let processor = Processor::new(style, refs);
+    let mut run = processor.begin_run();
     processor
-        .process_citation_with_format::<HtmlRenderer>(&citation)
+        .process_citation_with_format::<HtmlRenderer>(&citation, &mut run)
         .map_err(|e| format!("Render error: {e}"))
 }
 
@@ -240,7 +241,7 @@ pub fn render_bibliography(style_yaml: &str, refs_json: &str) -> Result<String, 
     ensure_style_has_templates(&mut style);
     let refs = parse_references(refs_json)?;
     let processor = Processor::new(style, refs);
-    Ok(processor.render_bibliography_with_format::<HtmlRenderer>())
+    Ok(processor.render_bibliography_with_format_standalone::<HtmlRenderer>())
 }
 
 /// Validate a Citum style string.

--- a/crates/citum-cli/src/commands/render/human.rs
+++ b/crates/citum-cli/src/commands/render/human.rs
@@ -107,7 +107,11 @@ fn render_citations_section<F>(
                 mode: citum_schema::citation::CitationMode::NonIntegral,
                 ..Default::default()
             };
-            match ctx.processor.process_citation_with_format::<F>(&citation) {
+            let mut run = ctx.processor.begin_run();
+            match ctx
+                .processor
+                .process_citation_with_format::<F>(&citation, &mut run)
+            {
                 Ok(text) => {
                     if show_keys {
                         let _ = writeln!(output, "  [{id}] {text}");
@@ -133,7 +137,11 @@ fn render_citations_section<F>(
                 mode: citum_schema::citation::CitationMode::Integral,
                 ..Default::default()
             };
-            match ctx.processor.process_citation_with_format::<F>(&citation) {
+            let mut run = ctx.processor.begin_run();
+            match ctx
+                .processor
+                .process_citation_with_format::<F>(&citation, &mut run)
+            {
                 Ok(text) => {
                     if show_keys {
                         let _ = writeln!(output, "  [{id}] {text}");
@@ -184,7 +192,7 @@ where
         // We use render_selected_bibliography_with_format_and_annotations to respect the CLI's item_ids filter and propagate annotations.
         let rendered = ctx
             .processor
-            .render_selected_bibliography_with_format_and_annotations::<F, _>(
+            .render_selected_bibliography_with_format_and_annotations_standalone::<F, _>(
                 ctx.item_ids.to_vec(),
                 ctx.annotations,
                 Some(ctx.annotation_style),
@@ -212,8 +220,9 @@ where
         .is_some_and(|processing| matches!(processing, Processing::Numeric));
 
     if is_numeric {
+        let mut run = processor.begin_run();
         processor
-            .process_citations_with_format::<F>(citations)
+            .process_citations_with_format::<F>(citations, &mut run)
             .unwrap_or_else(|_| render_citation_file_entries_one_by_one::<F>(processor, citations))
     } else {
         render_citation_file_entries_one_by_one::<F>(processor, citations)
@@ -235,8 +244,9 @@ where
     citations
         .iter()
         .map(|citation| {
+            let mut run = processor.begin_run();
             processor
-                .process_citation_with_format::<F>(citation)
+                .process_citation_with_format::<F>(citation, &mut run)
                 .unwrap_or_else(format_citation_file_render_error)
         })
         .collect()

--- a/crates/citum-cli/src/commands/render/json.rs
+++ b/crates/citum-cli/src/commands/render/json.rs
@@ -65,10 +65,11 @@ where
                         mode: citum_schema::citation::CitationMode::NonIntegral,
                         ..Default::default()
                     };
+                    let mut run = ctx.processor.begin_run();
                     json!({
                         "id": id,
                         "text": ctx.processor
-                            .process_citation_with_format::<F>(&citation)
+                            .process_citation_with_format::<F>(&citation, &mut run)
                             .unwrap_or_else(|e| e.to_string())
                     })
                 })
@@ -87,10 +88,11 @@ where
                         mode: citum_schema::citation::CitationMode::Integral,
                         ..Default::default()
                     };
+                    let mut run = ctx.processor.begin_run();
                     json!({
                         "id": id,
                         "text": ctx.processor
-                            .process_citation_with_format::<F>(&citation)
+                            .process_citation_with_format::<F>(&citation, &mut run)
                             .unwrap_or_else(|e| e.to_string())
                     })
                 })

--- a/crates/citum-engine/benches/rendering.rs
+++ b/crates/citum-engine/benches/rendering.rs
@@ -389,11 +389,14 @@ fn bench_bibliography_type_variants(c: &mut Criterion) {
         .bibliography
         .get("article-no-pages")
         .expect("type-variant benchmark reference should exist");
+    let run = processor.begin_run().finalize();
 
     let mut bench_group = c.benchmark_group("Renderer::process_bibliography_entry");
     bench_group.bench_function("Type variant + article-journal fallback", |b| {
         b.iter(|| {
-            black_box(processor.process_bibliography_entry_with_format::<PlainText>(reference, 1));
+            black_box(
+                processor.process_bibliography_entry_with_format::<PlainText>(reference, 1, &run),
+            );
         });
     });
     bench_group.finish();
@@ -405,11 +408,12 @@ fn bench_compound_bibliography(c: &mut Criterion) {
         make_compound_bibliography(),
         make_compound_sets(),
     );
+    let run = processor.begin_run().finalize();
 
     let mut bench_group = c.benchmark_group("Processor::render_bibliography_with_format");
     bench_group.bench_function("Compound bibliography merge", |b| {
         b.iter(|| {
-            black_box(processor.render_bibliography_with_format::<PlainText>());
+            black_box(processor.render_bibliography_with_format::<PlainText>(&run));
         });
     });
     bench_group.finish();

--- a/crates/citum-engine/examples/test_cite.rs
+++ b/crates/citum-engine/examples/test_cite.rs
@@ -53,7 +53,8 @@ fn main() {
         }],
     };
 
-    match processor.process_citation_with_format::<Latex>(&cite) {
+    let mut run = processor.begin_run();
+    match processor.process_citation_with_format::<Latex>(&cite, &mut run) {
         Ok(res) => tracing::debug!("CITATION: {res}"),
         Err(e) => tracing::debug!("ERROR: {e:?}"),
     }
@@ -64,7 +65,7 @@ fn main() {
         suppress_author: true,
         ..cite.clone()
     };
-    match processor.process_citation_with_format::<Latex>(&cite_sa) {
+    match processor.process_citation_with_format::<Latex>(&cite_sa, &mut run) {
         Ok(res) => tracing::debug!("CITATION SA: {res}"),
         Err(e) => tracing::debug!("ERROR: {e:?}"),
     }

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -282,14 +282,19 @@ pub fn format_document_with_style(
     // document scope). Safe no-op when no memory config is present.
     processor.annotate_flat_integral_name_states(&mut citations);
 
+    // One run threads registration (citation numbers, cite-order, dynamic
+    // compound groups, first-note tracking) across citations and nocite
+    // registration below, then finalizes once for bibliography rendering.
+    let mut run = processor.begin_run();
+
     // Process citations
     let formatted_citations = match request.output_format {
-        OutputFormatKind::Plain => format_by_kind::<PlainText>(&processor, &citations)?,
-        OutputFormatKind::Html => format_by_kind::<Html>(&processor, &citations)?,
-        OutputFormatKind::Djot => format_by_kind::<Djot>(&processor, &citations)?,
-        OutputFormatKind::Latex => format_by_kind::<Latex>(&processor, &citations)?,
-        OutputFormatKind::Typst => format_by_kind::<Typst>(&processor, &citations)?,
-        OutputFormatKind::Markdown => format_by_kind::<Markdown>(&processor, &citations)?,
+        OutputFormatKind::Plain => format_by_kind::<PlainText>(&processor, &citations, &mut run)?,
+        OutputFormatKind::Html => format_by_kind::<Html>(&processor, &citations, &mut run)?,
+        OutputFormatKind::Djot => format_by_kind::<Djot>(&processor, &citations, &mut run)?,
+        OutputFormatKind::Latex => format_by_kind::<Latex>(&processor, &citations, &mut run)?,
+        OutputFormatKind::Typst => format_by_kind::<Typst>(&processor, &citations, &mut run)?,
+        OutputFormatKind::Markdown => format_by_kind::<Markdown>(&processor, &citations, &mut run)?,
     };
 
     // Register nocite IDs: validate against bibliography, warn on missing, then add
@@ -312,7 +317,11 @@ pub fn format_document_with_style(
             }
         })
         .collect();
-    processor.register_nocite_ids(nocite_ids);
+    processor.register_nocite_ids(nocite_ids, &mut run);
+
+    // Registration is complete: finalize so bibliography rendering below sees
+    // the full cite-order state from every citation processed above.
+    let run = run.finalize();
 
     // Process bibliography
     let bibliography = match request.output_format {
@@ -320,31 +329,37 @@ pub fn format_document_with_style(
             &processor,
             request.output_format,
             request.document_options.as_ref(),
+            &run,
         )?,
         OutputFormatKind::Html => format_bibliography::<Html>(
             &processor,
             request.output_format,
             request.document_options.as_ref(),
+            &run,
         )?,
         OutputFormatKind::Djot => format_bibliography::<Djot>(
             &processor,
             request.output_format,
             request.document_options.as_ref(),
+            &run,
         )?,
         OutputFormatKind::Latex => format_bibliography::<Latex>(
             &processor,
             request.output_format,
             request.document_options.as_ref(),
+            &run,
         )?,
         OutputFormatKind::Typst => format_bibliography::<Typst>(
             &processor,
             request.output_format,
             request.document_options.as_ref(),
+            &run,
         )?,
         OutputFormatKind::Markdown => format_bibliography::<Markdown>(
             &processor,
             request.output_format,
             request.document_options.as_ref(),
+            &run,
         )?,
     };
 
@@ -354,31 +369,37 @@ pub fn format_document_with_style(
             &processor,
             &request.bibliography_blocks,
             request.document_options.as_ref(),
+            &run,
         )?,
         OutputFormatKind::Html => format_bibliography_blocks::<Html>(
             &processor,
             &request.bibliography_blocks,
             request.document_options.as_ref(),
+            &run,
         )?,
         OutputFormatKind::Djot => format_bibliography_blocks::<Djot>(
             &processor,
             &request.bibliography_blocks,
             request.document_options.as_ref(),
+            &run,
         )?,
         OutputFormatKind::Latex => format_bibliography_blocks::<Latex>(
             &processor,
             &request.bibliography_blocks,
             request.document_options.as_ref(),
+            &run,
         )?,
         OutputFormatKind::Typst => format_bibliography_blocks::<Typst>(
             &processor,
             &request.bibliography_blocks,
             request.document_options.as_ref(),
+            &run,
         )?,
         OutputFormatKind::Markdown => format_bibliography_blocks::<Markdown>(
             &processor,
             &request.bibliography_blocks,
             request.document_options.as_ref(),
+            &run,
         )?,
     };
 
@@ -394,11 +415,12 @@ pub fn format_document_with_style(
 pub(crate) fn format_by_kind<F>(
     processor: &Processor,
     citations: &[Citation],
+    run: &mut crate::processor::RunState,
 ) -> Result<Vec<FormattedCitation>, FormatDocumentError>
 where
     F: OutputFormat<Output = String>,
 {
-    let texts = processor.process_citations_with_format::<F>(citations)?;
+    let texts = processor.process_citations_with_format::<F>(citations, run)?;
 
     let formatted = citations
         .iter()
@@ -427,6 +449,7 @@ pub(crate) fn format_bibliography<F>(
     processor: &Processor,
     format_kind: OutputFormatKind,
     doc_opts: Option<&DocumentOptions>,
+    run: &crate::processor::FinalizedRun,
 ) -> Result<FormattedBibliography, FormatDocumentError>
 where
     F: OutputFormat<Output = String>,
@@ -440,6 +463,7 @@ where
             Some(&annotations)
         },
         annotation_style.as_ref(),
+        run,
     );
     let entries = doc_bib
         .entries
@@ -471,6 +495,7 @@ pub(crate) fn format_bibliography_blocks<F>(
     processor: &Processor,
     requests: &[super::BibliographyBlockRequest],
     doc_opts: Option<&DocumentOptions>,
+    run: &crate::processor::FinalizedRun,
 ) -> Result<Vec<super::FormattedBibliographyBlock>, FormatDocumentError>
 where
     F: OutputFormat<Output = String>,
@@ -489,6 +514,7 @@ where
             Some(&annotations)
         },
         annotation_style.as_ref(),
+        run,
     );
 
     Ok(requests

--- a/crates/citum-engine/src/api/session.rs
+++ b/crates/citum-engine/src/api/session.rs
@@ -433,50 +433,69 @@ impl DocumentSession {
                 }
             })
             .collect();
-        processor.register_nocite_ids(nocite_ids);
+
+        // One run threads registration across citations and nocite
+        // registration, then finalizes once for bibliography rendering.
+        let mut run = processor.begin_run();
 
         let formatted_citations = match self.output_format {
             OutputFormatKind::Plain => {
-                format_by_kind::<PlainText>(&processor, &processor_citations)?
+                format_by_kind::<PlainText>(&processor, &processor_citations, &mut run)?
             }
-            OutputFormatKind::Html => format_by_kind::<Html>(&processor, &processor_citations)?,
-            OutputFormatKind::Djot => format_by_kind::<Djot>(&processor, &processor_citations)?,
-            OutputFormatKind::Latex => format_by_kind::<Latex>(&processor, &processor_citations)?,
-            OutputFormatKind::Typst => format_by_kind::<Typst>(&processor, &processor_citations)?,
+            OutputFormatKind::Html => {
+                format_by_kind::<Html>(&processor, &processor_citations, &mut run)?
+            }
+            OutputFormatKind::Djot => {
+                format_by_kind::<Djot>(&processor, &processor_citations, &mut run)?
+            }
+            OutputFormatKind::Latex => {
+                format_by_kind::<Latex>(&processor, &processor_citations, &mut run)?
+            }
+            OutputFormatKind::Typst => {
+                format_by_kind::<Typst>(&processor, &processor_citations, &mut run)?
+            }
             OutputFormatKind::Markdown => {
-                format_by_kind::<Markdown>(&processor, &processor_citations)?
+                format_by_kind::<Markdown>(&processor, &processor_citations, &mut run)?
             }
         };
+        processor.register_nocite_ids(nocite_ids, &mut run);
+        let run = run.finalize();
         let bibliography = match self.output_format {
             OutputFormatKind::Plain => format_bibliography::<PlainText>(
                 &processor,
                 self.output_format,
                 self.document_options.as_ref(),
+                &run,
             )?,
             OutputFormatKind::Html => format_bibliography::<Html>(
                 &processor,
                 self.output_format,
                 self.document_options.as_ref(),
+                &run,
             )?,
             OutputFormatKind::Djot => format_bibliography::<Djot>(
                 &processor,
                 self.output_format,
                 self.document_options.as_ref(),
+                &run,
             )?,
             OutputFormatKind::Latex => format_bibliography::<Latex>(
                 &processor,
                 self.output_format,
                 self.document_options.as_ref(),
+                &run,
             )?,
             OutputFormatKind::Typst => format_bibliography::<Typst>(
                 &processor,
                 self.output_format,
                 self.document_options.as_ref(),
+                &run,
             )?,
             OutputFormatKind::Markdown => format_bibliography::<Markdown>(
                 &processor,
                 self.output_format,
                 self.document_options.as_ref(),
+                &run,
             )?,
         };
 

--- a/crates/citum-engine/src/ffi/mod.rs
+++ b/crates/citum-engine/src/ffi/mod.rs
@@ -10,7 +10,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 #![allow(unsafe_code, reason = "FFI interface")]
 
-use crate::processor::Processor;
+use crate::processor::{Processor, RunState};
 use crate::reference::{Bibliography, Citation, Reference};
 use crate::render::djot::Djot;
 use crate::render::html::Html;
@@ -28,6 +28,32 @@ use std::ptr;
 
 thread_local! {
     static LAST_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+/// Opaque per-handle FFI session: an owned [`Processor`] plus its current
+/// render-run state.
+///
+/// `pub` only so the `pub extern "C"` functions below may name it in their
+/// signatures (Rust's private-interface lint); its fields stay private, so
+/// it should be treated as an opaque handle by every caller exactly as
+/// `Processor` was before this type existed, even though `citum_engine::ffi`
+/// is itself a public module. This replaces the implicit per-`Processor`
+/// mutable state with an explicit [`RunState`] per
+/// docs/specs/EXPLICIT_RENDER_RUN_STATE.md.
+/// Citation-rendering calls (`citum_render_citation_*`) register into `run`
+/// via `&mut`; bibliography calls (`citum_render_bibliography_*`) render
+/// from a cloned, finalized snapshot of `run` so accumulation across calls
+/// on one handle is preserved without pausing further citation registration.
+pub struct FfiSession {
+    processor: Processor,
+    run: RunState,
+}
+
+impl FfiSession {
+    fn new(processor: Processor) -> Self {
+        let run = processor.begin_run();
+        Self { processor, run }
+    }
 }
 
 /// Set the last error message.
@@ -155,7 +181,7 @@ pub unsafe extern "C" fn citum_get_last_error() -> *mut c_char {
 pub unsafe extern "C" fn citum_processor_new(
     style_json: *const c_char,
     bib_json: *const c_char,
-) -> *mut Processor {
+) -> *mut FfiSession {
     let Ok(style_str) = (unsafe { parse_c_str(style_json, "style_json") }) else {
         return ptr::null_mut();
     };
@@ -179,8 +205,8 @@ pub unsafe extern "C" fn citum_processor_new(
         }
     };
 
-    let processor = Box::new(Processor::new(style, bib));
-    Box::into_raw(processor)
+    let session = Box::new(FfiSession::new(Processor::new(style, bib)));
+    Box::into_raw(session)
 }
 
 /// Create a new processor instance with a specific locale.
@@ -192,7 +218,7 @@ pub unsafe extern "C" fn citum_processor_new_with_locale(
     style_json: *const c_char,
     bib_json: *const c_char,
     locale_json: *const c_char,
-) -> *mut Processor {
+) -> *mut FfiSession {
     let Ok(style_str) = (unsafe { parse_c_str(style_json, "style_json") }) else {
         return ptr::null_mut();
     };
@@ -227,8 +253,8 @@ pub unsafe extern "C" fn citum_processor_new_with_locale(
         }
     };
 
-    let processor = Box::new(Processor::with_locale(style, bib, locale));
-    Box::into_raw(processor)
+    let session = Box::new(FfiSession::new(Processor::with_locale(style, bib, locale)));
+    Box::into_raw(session)
 }
 
 /// Create a new processor instance from YAML strings with default English locale.
@@ -241,7 +267,7 @@ pub unsafe extern "C" fn citum_processor_new_with_locale(
 pub unsafe extern "C" fn citum_processor_new_from_yaml(
     style_yaml: *const c_char,
     bib_yaml: *const c_char,
-) -> *mut Processor {
+) -> *mut FfiSession {
     let Ok(style_str) = (unsafe { parse_c_str(style_yaml, "style_yaml") }) else {
         return ptr::null_mut();
     };
@@ -265,8 +291,8 @@ pub unsafe extern "C" fn citum_processor_new_from_yaml(
         }
     };
 
-    let processor = Box::new(Processor::new(style, bib));
-    Box::into_raw(processor)
+    let session = Box::new(FfiSession::new(Processor::new(style, bib)));
+    Box::into_raw(session)
 }
 
 /// Create a new processor instance with a specific locale from YAML strings.
@@ -279,7 +305,7 @@ pub unsafe extern "C" fn citum_processor_new_with_locale_from_yaml(
     style_yaml: *const c_char,
     bib_yaml: *const c_char,
     locale_yaml: *const c_char,
-) -> *mut Processor {
+) -> *mut FfiSession {
     let Ok(style_str) = (unsafe { parse_c_str(style_yaml, "style_yaml") }) else {
         return ptr::null_mut();
     };
@@ -314,8 +340,8 @@ pub unsafe extern "C" fn citum_processor_new_with_locale_from_yaml(
         }
     };
 
-    let processor = Box::new(Processor::with_locale(style, bib, locale));
-    Box::into_raw(processor)
+    let session = Box::new(FfiSession::new(Processor::with_locale(style, bib, locale)));
+    Box::into_raw(session)
 }
 
 /// Free a processor instance.
@@ -325,14 +351,14 @@ pub unsafe extern "C" fn citum_processor_new_with_locale_from_yaml(
 /// Passing the same pointer more than once, or passing a pointer allocated by
 /// any other API, is undefined behavior.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn citum_processor_free(processor: *mut Processor) {
+pub unsafe extern "C" fn citum_processor_free(processor: *mut FfiSession) {
     if !processor.is_null() {
         let _ = unsafe { Box::from_raw(processor) };
     }
 }
 
 /// Helper to render a citation to a string using a specific format.
-unsafe fn render_citation<F>(processor: *mut Processor, cite_json: *const c_char) -> *mut c_char
+unsafe fn render_citation<F>(processor: *mut FfiSession, cite_json: *const c_char) -> *mut c_char
 where
     F: crate::render::format::OutputFormat<Output = String>,
 {
@@ -341,7 +367,7 @@ where
         return ptr::null_mut();
     }
 
-    let processor = unsafe { &*processor };
+    let session = unsafe { &mut *processor };
     let Ok(cite_str) = (unsafe { parse_c_str(cite_json, "cite_json") }) else {
         return ptr::null_mut();
     };
@@ -354,7 +380,10 @@ where
         }
     };
 
-    match processor.process_citation_with_format::<F>(&citation) {
+    match session
+        .processor
+        .process_citation_with_format::<F>(&citation, &mut session.run)
+    {
         Ok(rendered) => safe_c_string(rendered),
         Err(e) => {
             set_error(format!("Rendering error: {e}"));
@@ -371,7 +400,7 @@ where
 /// string must be freed with `citum_string_free`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn citum_render_citation_latex(
-    processor: *mut Processor,
+    processor: *mut FfiSession,
     cite_json: *const c_char,
 ) -> *mut c_char {
     unsafe { render_citation::<Latex>(processor, cite_json) }
@@ -385,7 +414,7 @@ pub unsafe extern "C" fn citum_render_citation_latex(
 /// string must be freed with `citum_string_free`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn citum_render_citation_html(
-    processor: *mut Processor,
+    processor: *mut FfiSession,
     cite_json: *const c_char,
 ) -> *mut c_char {
     unsafe { render_citation::<Html>(processor, cite_json) }
@@ -399,7 +428,7 @@ pub unsafe extern "C" fn citum_render_citation_html(
 /// string must be freed with `citum_string_free`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn citum_render_citation_plain(
-    processor: *mut Processor,
+    processor: *mut FfiSession,
     cite_json: *const c_char,
 ) -> *mut c_char {
     unsafe { render_citation::<PlainText>(processor, cite_json) }
@@ -411,7 +440,7 @@ pub unsafe extern "C" fn citum_render_citation_plain(
 /// See `citum_render_citation_html`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn citum_render_citation_djot(
-    processor: *mut Processor,
+    processor: *mut FfiSession,
     cite_json: *const c_char,
 ) -> *mut c_char {
     unsafe { render_citation::<Djot>(processor, cite_json) }
@@ -423,14 +452,18 @@ pub unsafe extern "C" fn citum_render_citation_djot(
 /// See `citum_render_citation_html`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn citum_render_citation_typst(
-    processor: *mut Processor,
+    processor: *mut FfiSession,
     cite_json: *const c_char,
 ) -> *mut c_char {
     unsafe { render_citation::<Typst>(processor, cite_json) }
 }
 
 /// Helper to render the bibliography to a string using a specific format.
-unsafe fn render_bibliography<F>(processor: *mut Processor) -> *mut c_char
+///
+/// Renders from a cloned, finalized snapshot of the session's current run so
+/// citation registration on the original `session.run` is unaffected — the
+/// handle can keep accumulating citations after this call.
+unsafe fn render_bibliography<F>(processor: *mut FfiSession) -> *mut c_char
 where
     F: crate::render::format::OutputFormat<Output = String>,
 {
@@ -439,8 +472,9 @@ where
         return ptr::null_mut();
     }
 
-    let processor = unsafe { &*processor };
-    let rendered = processor.render_bibliography_with_format::<F>();
+    let session = unsafe { &*processor };
+    let run = session.run.clone().finalize();
+    let rendered = session.processor.render_bibliography_with_format::<F>(&run);
     safe_c_string(rendered)
 }
 
@@ -450,7 +484,9 @@ where
 /// The caller must ensure that `processor` is a valid pointer.
 /// The returned string must be freed with `citum_string_free`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn citum_render_bibliography_latex(processor: *mut Processor) -> *mut c_char {
+pub unsafe extern "C" fn citum_render_bibliography_latex(
+    processor: *mut FfiSession,
+) -> *mut c_char {
     unsafe { render_bibliography::<Latex>(processor) }
 }
 
@@ -460,7 +496,7 @@ pub unsafe extern "C" fn citum_render_bibliography_latex(processor: *mut Process
 /// The caller must ensure that `processor` is a valid pointer.
 /// The returned string must be freed with `citum_string_free`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn citum_render_bibliography_html(processor: *mut Processor) -> *mut c_char {
+pub unsafe extern "C" fn citum_render_bibliography_html(processor: *mut FfiSession) -> *mut c_char {
     unsafe { render_bibliography::<Html>(processor) }
 }
 
@@ -470,7 +506,9 @@ pub unsafe extern "C" fn citum_render_bibliography_html(processor: *mut Processo
 /// The caller must ensure that `processor` is a valid pointer.
 /// The returned string must be freed with `citum_string_free`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn citum_render_bibliography_plain(processor: *mut Processor) -> *mut c_char {
+pub unsafe extern "C" fn citum_render_bibliography_plain(
+    processor: *mut FfiSession,
+) -> *mut c_char {
     unsafe { render_bibliography::<PlainText>(processor) }
 }
 
@@ -479,7 +517,7 @@ pub unsafe extern "C" fn citum_render_bibliography_plain(processor: *mut Process
 /// # Safety
 /// See `citum_render_bibliography_html`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn citum_render_bibliography_djot(processor: *mut Processor) -> *mut c_char {
+pub unsafe extern "C" fn citum_render_bibliography_djot(processor: *mut FfiSession) -> *mut c_char {
     unsafe { render_bibliography::<Djot>(processor) }
 }
 
@@ -488,12 +526,17 @@ pub unsafe extern "C" fn citum_render_bibliography_djot(processor: *mut Processo
 /// # Safety
 /// See `citum_render_bibliography_html`.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn citum_render_bibliography_typst(processor: *mut Processor) -> *mut c_char {
+pub unsafe extern "C" fn citum_render_bibliography_typst(
+    processor: *mut FfiSession,
+) -> *mut c_char {
     unsafe { render_bibliography::<Typst>(processor) }
 }
 
 /// Helper to render the grouped bibliography to a string using a specific format.
-unsafe fn render_grouped_bibliography<F>(processor: *mut Processor) -> *mut c_char
+///
+/// See `render_bibliography` for why this clones-and-finalizes a snapshot
+/// rather than consuming the session's own run.
+unsafe fn render_grouped_bibliography<F>(processor: *mut FfiSession) -> *mut c_char
 where
     F: crate::render::format::OutputFormat<Output = String>,
 {
@@ -502,8 +545,11 @@ where
         return ptr::null_mut();
     }
 
-    let processor = unsafe { &*processor };
-    let rendered = processor.render_grouped_bibliography_with_format::<F>();
+    let session = unsafe { &*processor };
+    let run = session.run.clone().finalize();
+    let rendered = session
+        .processor
+        .render_grouped_bibliography_with_format::<F>(&run);
     safe_c_string(rendered)
 }
 
@@ -513,7 +559,7 @@ where
 /// See `citum_render_bibliography_html`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn citum_render_bibliography_grouped_html(
-    processor: *mut Processor,
+    processor: *mut FfiSession,
 ) -> *mut c_char {
     unsafe { render_grouped_bibliography::<Html>(processor) }
 }
@@ -524,7 +570,7 @@ pub unsafe extern "C" fn citum_render_bibliography_grouped_html(
 /// See `citum_render_bibliography_html`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn citum_render_bibliography_grouped_plain(
-    processor: *mut Processor,
+    processor: *mut FfiSession,
 ) -> *mut c_char {
     unsafe { render_grouped_bibliography::<PlainText>(processor) }
 }
@@ -536,7 +582,7 @@ pub unsafe extern "C" fn citum_render_bibliography_grouped_plain(
 /// The returned JSON string must be freed with `citum_string_free`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn citum_render_citations_json(
-    processor: *mut Processor,
+    processor: *mut FfiSession,
     citations_json: *const c_char,
     format: *const c_char,
 ) -> *mut c_char {
@@ -545,7 +591,7 @@ pub unsafe extern "C" fn citum_render_citations_json(
         return ptr::null_mut();
     }
 
-    let processor = unsafe { &*processor };
+    let session = unsafe { &mut *processor };
     let Ok(citations_str) = (unsafe { parse_c_str(citations_json, "citations_json") }) else {
         return ptr::null_mut();
     };
@@ -563,13 +609,15 @@ pub unsafe extern "C" fn citum_render_citations_json(
         return ptr::null_mut();
     };
 
+    let processor = &session.processor;
+    let run = &mut session.run;
     let result = match format_str {
-        "html" => processor.process_citations_with_format::<Html>(&citations),
-        "latex" => processor.process_citations_with_format::<Latex>(&citations),
-        "djot" => processor.process_citations_with_format::<Djot>(&citations),
-        "typst" => processor.process_citations_with_format::<Typst>(&citations),
-        "markdown" => processor.process_citations_with_format::<Markdown>(&citations),
-        _ => processor.process_citations_with_format::<PlainText>(&citations),
+        "html" => processor.process_citations_with_format::<Html>(&citations, run),
+        "latex" => processor.process_citations_with_format::<Latex>(&citations, run),
+        "djot" => processor.process_citations_with_format::<Djot>(&citations, run),
+        "typst" => processor.process_citations_with_format::<Typst>(&citations, run),
+        "markdown" => processor.process_citations_with_format::<Markdown>(&citations, run),
+        _ => processor.process_citations_with_format::<PlainText>(&citations, run),
     };
 
     match result {
@@ -628,7 +676,7 @@ mod tests {
         CString::new(value).expect("test string has no interior NUL")
     }
 
-    fn processor() -> *mut Processor {
+    fn processor() -> *mut FfiSession {
         let style = serde_json::to_string(&Style::default()).expect("style serializes");
         let bibliography = "{}";
         unsafe { citum_processor_new(c_string(&style).as_ptr(), c_string(bibliography).as_ptr()) }

--- a/crates/citum-engine/src/processor/bibliography/compound.rs
+++ b/crates/citum-engine/src/processor/bibliography/compound.rs
@@ -6,6 +6,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! Compound-entry merging for numeric bibliography styles.
 
 use super::Processor;
+use crate::processor::FinalizedRun;
 use crate::render::ProcEntry;
 use crate::render::bibliography::render_entry_body_components_with_format;
 use crate::render::component::ProcTemplateComponent;
@@ -144,11 +145,15 @@ impl Processor {
         }
     }
 
-    pub(super) fn merge_compound_entries<F>(&self, entries: Vec<ProcEntry>) -> Vec<ProcEntry>
+    pub(super) fn merge_compound_entries<F>(
+        &self,
+        entries: Vec<ProcEntry>,
+        run: &FinalizedRun,
+    ) -> Vec<ProcEntry>
     where
         F: OutputFormat<Output = String>,
     {
-        let compound_groups = self.run_state.compound_groups.borrow();
+        let compound_groups = &run.state().compound_groups;
         if compound_groups.is_empty() {
             return entries;
         }
@@ -157,7 +162,7 @@ impl Processor {
             return entries;
         };
 
-        let ref_to_group = Self::build_compound_group_lookup(&compound_groups);
+        let ref_to_group = Self::build_compound_group_lookup(compound_groups);
         if ref_to_group.is_empty() {
             return entries;
         }

--- a/crates/citum-engine/src/processor/bibliography/compound.rs
+++ b/crates/citum-engine/src/processor/bibliography/compound.rs
@@ -148,7 +148,7 @@ impl Processor {
     where
         F: OutputFormat<Output = String>,
     {
-        let compound_groups = self.compound_groups.borrow();
+        let compound_groups = self.run_state.compound_groups.borrow();
         if compound_groups.is_empty() {
             return entries;
         }

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -8,6 +8,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use super::RenderedBibliographyGroup;
 use crate::api::AnnotationStyle;
 use crate::grouping::SelectorEvaluator;
+use crate::processor::FinalizedRun;
 use crate::processor::Processor;
 use crate::processor::disambiguation::Disambiguator;
 use crate::processor::rendering::{CompoundRenderData, Renderer, RendererResources};
@@ -122,7 +123,8 @@ impl Processor {
     /// Used for grouping paths that only need IDs for selector matching — avoids
     /// the full PlainText render pass that `process_references` performs.
     pub(super) fn sorted_id_stubs(&self) -> Vec<ProcEntry> {
-        self.initialize_numeric_bibliography_numbers();
+        // Numeric citation numbers are already populated by `Processor::begin_run`,
+        // which every `FinalizedRun` this module consumes was produced from.
         self.sort_references(self.bibliography.values().collect())
             .into_iter()
             .filter_map(|r| {
@@ -206,6 +208,7 @@ impl Processor {
         sorted_refs: Vec<&Reference>,
         group: &BibliographyGroup,
         local_hints: Option<&HashMap<String, ProcHints>>,
+        run: &FinalizedRun,
     ) -> Vec<ProcEntry>
     where
         F: OutputFormat<Output = String>,
@@ -227,7 +230,7 @@ impl Processor {
                 first_note_by_id: None,
             },
             hints,
-            &self.run_state.citation_numbers,
+            &run.state().citation_numbers,
             CompoundRenderData {
                 set_by_ref: &self.compound_set_by_ref,
                 member_index: &self.compound_member_index,
@@ -243,8 +246,8 @@ impl Processor {
 
         for (index, reference) in sorted_refs.into_iter().enumerate() {
             let ref_id = reference.id().unwrap_or_default().to_string();
-            let entry_number = self
-                .run_state
+            let entry_number = run
+                .state()
                 .citation_numbers
                 .borrow()
                 .get(&ref_id)
@@ -343,6 +346,7 @@ impl Processor {
         partitioning: &BibliographySortPartitioning,
         annotations: Option<&HashMap<String, String>>,
         annotation_style: Option<&AnnotationStyle>,
+        run: &FinalizedRun,
     ) -> String
     where
         F: OutputFormat<Output = String>,
@@ -356,12 +360,20 @@ impl Processor {
             let heading = partition_key
                 .as_ref()
                 .and_then(|key| partitioning.headings.get(key));
-            let entries = self.merge_compound_entries::<F>(self.process_sorted_refs::<_, F>(
-                references.into_iter(),
-                |reference, entry_number| {
-                    self.process_bibliography_entry_with_format::<F>(reference, entry_number)
-                },
-            ));
+            let entries = self.merge_compound_entries::<F>(
+                self.process_sorted_refs::<_, F>(
+                    references.into_iter(),
+                    |reference, entry_number| {
+                        self.process_bibliography_entry_with_format::<F>(
+                            reference,
+                            entry_number,
+                            run,
+                        )
+                    },
+                    run,
+                ),
+                run,
+            );
             self.append_rendered_partition::<F>(
                 &mut result,
                 heading,
@@ -387,13 +399,14 @@ impl Processor {
         selected: &HashSet<String>,
         annotations: Option<&HashMap<String, String>>,
         annotation_style: Option<&AnnotationStyle>,
+        run: &FinalizedRun,
     ) -> String
     where
         F: OutputFormat<Output = String>,
     {
         let fmt = F::default();
-        let cited_ids = self.run_state.cited_ids.borrow();
-        let evaluator = SelectorEvaluator::new(&cited_ids);
+        let cited_ids = &run.state().cited_ids;
+        let evaluator = SelectorEvaluator::new(cited_ids);
         let bibliography_config = self.get_bibliography_config();
         let sorter = ReferenceSorter::with_bibliography_config(&self.locale, &bibliography_config);
 
@@ -424,12 +437,16 @@ impl Processor {
                 matching_refs
             };
             let local_hints = self.build_group_local_hints(&sorted_refs, group);
-            let entries = self.merge_compound_entries::<F>(self.render_group_entries::<F>(
-                all_entries,
-                sorted_refs,
-                group,
-                local_hints.as_ref(),
-            ));
+            let entries = self.merge_compound_entries::<F>(
+                self.render_group_entries::<F>(
+                    all_entries,
+                    sorted_refs,
+                    group,
+                    local_hints.as_ref(),
+                    run,
+                ),
+                run,
+            );
 
             populated_groups.push((group, entries));
         }
@@ -462,11 +479,16 @@ impl Processor {
             selected,
             annotations,
             annotation_style,
+            run,
         );
         fmt.finish(result)
     }
 
     /// Append unassigned bibliography entries to the output string.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "internal helper, all params load-bearing"
+    )]
     fn append_unassigned_entries_filtered<F>(
         &self,
         result: &mut String,
@@ -475,6 +497,7 @@ impl Processor {
         selected: &HashSet<String>,
         annotations: Option<&HashMap<String, String>>,
         annotation_style: Option<&AnnotationStyle>,
+        run: &FinalizedRun,
     ) where
         F: OutputFormat<Output = String>,
     {
@@ -490,12 +513,16 @@ impl Processor {
 
         // Re-process references to ensure correct author substitution and disambiguation
         // within the unassigned subset.
-        let unassigned = self.merge_compound_entries::<F>(self.process_sorted_refs::<_, F>(
-            unassigned_refs.into_iter(),
-            |reference, entry_number| {
-                self.process_bibliography_entry_with_format::<F>(reference, entry_number)
-            },
-        ));
+        let unassigned = self.merge_compound_entries::<F>(
+            self.process_sorted_refs::<_, F>(
+                unassigned_refs.into_iter(),
+                |reference, entry_number| {
+                    self.process_bibliography_entry_with_format::<F>(reference, entry_number, run)
+                },
+                run,
+            ),
+            run,
+        );
 
         if !result.is_empty() {
             result.push_str("\n\n");
@@ -514,12 +541,13 @@ impl Processor {
         bibliography: &[ProcEntry],
         annotations: Option<&HashMap<String, String>>,
         annotation_style: Option<&AnnotationStyle>,
+        run: &FinalizedRun,
     ) -> String
     where
         F: OutputFormat<Output = String>,
     {
         let fmt = F::default();
-        let cited_ids = self.run_state.cited_ids.borrow();
+        let cited_ids = &run.state().cited_ids;
         let cited_entries: Vec<ProcEntry> = bibliography
             .iter()
             .filter(|entry| cited_ids.contains(&entry.id))
@@ -545,11 +573,11 @@ impl Processor {
     /// before compound numeric rows are merged, so each rendered group only
     /// includes the members that matched its selector. Otherwise, falls back to
     /// hardcoded cited/uncited grouping for backward compatibility.
-    pub fn render_grouped_bibliography_with_format<F>(&self) -> String
+    pub fn render_grouped_bibliography_with_format<F>(&self, run: &FinalizedRun) -> String
     where
         F: OutputFormat<Output = String>,
     {
-        self.render_grouped_bibliography_with_format_and_annotations::<F>(None, None)
+        self.render_grouped_bibliography_with_format_and_annotations::<F>(None, None, run)
     }
 
     /// Render the bibliography with grouping and annotations.
@@ -557,11 +585,41 @@ impl Processor {
         &self,
         annotations: Option<&HashMap<String, String>>,
         annotation_style: Option<&AnnotationStyle>,
+        run: &FinalizedRun,
     ) -> String
     where
         F: OutputFormat<Output = String>,
     {
-        self.render_grouped_bibliography_inner::<F>(false, annotations, annotation_style)
+        self.render_grouped_bibliography_inner::<F>(false, annotations, annotation_style, run)
+    }
+
+    /// One-shot convenience for [`Processor::render_grouped_bibliography_with_format`]:
+    /// begins a throwaway run internally.
+    pub fn render_grouped_bibliography_with_format_standalone<F>(&self) -> String
+    where
+        F: OutputFormat<Output = String>,
+    {
+        let run = self.begin_run().finalize();
+        self.render_grouped_bibliography_with_format::<F>(&run)
+    }
+
+    /// One-shot convenience for
+    /// [`Processor::render_grouped_bibliography_with_format_and_annotations`]:
+    /// begins a throwaway run internally.
+    pub fn render_grouped_bibliography_with_format_and_annotations_standalone<F>(
+        &self,
+        annotations: Option<&HashMap<String, String>>,
+        annotation_style: Option<&AnnotationStyle>,
+    ) -> String
+    where
+        F: OutputFormat<Output = String>,
+    {
+        let run = self.begin_run().finalize();
+        self.render_grouped_bibliography_with_format_and_annotations::<F>(
+            annotations,
+            annotation_style,
+            &run,
+        )
     }
 
     /// Unified document bibliography facade — returns content and per-entry data together.
@@ -571,7 +629,7 @@ impl Processor {
     /// document-string (`process_document`) path all funnel through here.
     ///
     /// When `restrict_to_cited` is `true` (the document case), only references present
-    /// in `self.run_state.cited_ids` — cited in-text or registered via `nocite` — are included.
+    /// in `run`'s `cited_ids` — cited in-text or registered via `nocite` — are included.
     /// When `false`, all loaded references are eligible; this hook is reserved for the
     /// `allrefs` escape hatch (csl26-f9ri) and is not yet exposed publicly.
     ///
@@ -582,6 +640,7 @@ impl Processor {
         restrict_to_cited: bool,
         annotations: Option<&HashMap<String, String>>,
         annotation_style: Option<&AnnotationStyle>,
+        run: &FinalizedRun,
     ) -> super::DocumentBibliography
     where
         F: OutputFormat<Output = String>,
@@ -590,14 +649,14 @@ impl Processor {
             restrict_to_cited,
             annotations,
             annotation_style,
+            run,
         );
-        // Collect IDs before calling process_* so the RefCell borrow is released.
-        let cited_ids: Vec<String> = self.run_state.cited_ids.borrow().iter().cloned().collect();
+        let cited_ids: Vec<String> = run.state().cited_ids.iter().cloned().collect();
         let entries = if restrict_to_cited {
-            self.process_selected_references_with_format::<F, _>(cited_ids)
+            self.process_selected_references_with_format::<F, _>(cited_ids, run)
                 .bibliography
         } else {
-            self.process_references_with_format::<F>().bibliography
+            self.process_references_with_format::<F>(run).bibliography
         };
         super::DocumentBibliography { content, entries }
     }
@@ -605,7 +664,7 @@ impl Processor {
     /// Shared implementation for grouped bibliography rendering.
     ///
     /// When `restrict_to_cited` is `true`, each branch limits its candidate
-    /// set to references present in `self.run_state.cited_ids`. When `false`, all
+    /// set to references present in `run`'s `cited_ids`. When `false`, all
     /// loaded references are eligible (the original all-refs behaviour used
     /// by standalone `render refs`, FFI, and tests).
     fn render_grouped_bibliography_inner<F>(
@@ -613,6 +672,7 @@ impl Processor {
         restrict_to_cited: bool,
         annotations: Option<&HashMap<String, String>>,
         annotation_style: Option<&AnnotationStyle>,
+        run: &FinalizedRun,
     ) -> String
     where
         F: OutputFormat<Output = String>,
@@ -625,7 +685,7 @@ impl Processor {
         {
             let id_stubs = self.sorted_id_stubs();
             let selected = if restrict_to_cited {
-                let cited = self.run_state.cited_ids.borrow();
+                let cited = &run.state().cited_ids;
                 id_stubs
                     .iter()
                     .filter(|e| cited.contains(&e.id))
@@ -643,6 +703,7 @@ impl Processor {
                 &selected,
                 annotations,
                 annotation_style,
+                run,
             );
         }
 
@@ -650,10 +711,9 @@ impl Processor {
         if let Some(partitioning) = bibliography_options.sort_partitioning.as_ref()
             && crate::sort_partitioning::should_render_sections(partitioning)
         {
-            self.initialize_numeric_bibliography_numbers();
             let mut refs: Vec<&Reference> = self.bibliography.values().collect();
             if restrict_to_cited {
-                let cited = self.run_state.cited_ids.borrow();
+                let cited = &run.state().cited_ids;
                 refs.retain(|r| r.id().as_deref().is_some_and(|id| cited.contains(id)));
             }
             let sorted_refs = self.sort_references(refs);
@@ -662,14 +722,16 @@ impl Processor {
                 partitioning,
                 annotations,
                 annotation_style,
+                run,
             );
         }
 
-        let all_entries = self.process_references_with_format::<F>().bibliography;
+        let all_entries = self.process_references_with_format::<F>(run).bibliography;
         self.render_with_legacy_grouping::<F>(
-            &self.merge_compound_entries::<F>(all_entries),
+            &self.merge_compound_entries::<F>(all_entries, run),
             annotations,
             annotation_style,
+            run,
         )
     }
 
@@ -681,13 +743,14 @@ impl Processor {
         &self,
         group: &BibliographyGroup,
         assigned: &mut HashSet<String>,
+        run: &FinalizedRun,
     ) -> Vec<crate::render::ProcEntry>
     where
         F: OutputFormat<Output = String>,
     {
         let bibliography = self.sorted_id_stubs();
-        let cited_ids = self.run_state.cited_ids.borrow();
-        let evaluator = SelectorEvaluator::new(&cited_ids);
+        let cited_ids = &run.state().cited_ids;
+        let evaluator = SelectorEvaluator::new(cited_ids);
         let bibliography_config = self.get_bibliography_config();
         let sorter = ReferenceSorter::with_bibliography_config(&self.locale, &bibliography_config);
 
@@ -706,24 +769,33 @@ impl Processor {
         };
 
         let local_hints = self.build_group_local_hints(&sorted_refs, group);
-        self.merge_compound_entries::<F>(self.render_group_entries::<F>(
-            &bibliography,
-            sorted_refs,
-            group,
-            local_hints.as_ref(),
-        ))
+        self.merge_compound_entries::<F>(
+            self.render_group_entries::<F>(
+                &bibliography,
+                sorted_refs,
+                group,
+                local_hints.as_ref(),
+                run,
+            ),
+            run,
+        )
     }
 
     /// Render one bibliography block for document output.
     ///
     /// Returns heading and body separately so callers can insert headings
     /// in their own output format.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "internal helper, all params load-bearing"
+    )]
     pub(crate) fn render_document_bibliography_block<F>(
         &self,
         group: &BibliographyGroup,
         assigned: &mut HashSet<String>,
         annotations: Option<&HashMap<String, String>>,
         annotation_style: Option<&AnnotationStyle>,
+        run: &FinalizedRun,
     ) -> RenderedBibliographyGroup
     where
         F: OutputFormat<Output = String>,
@@ -734,7 +806,7 @@ impl Processor {
             .take()
             .and_then(|group_heading| self.resolve_group_heading(&group_heading));
 
-        let entries = self.entries_for_bibliography_group::<F>(&headingless, assigned);
+        let entries = self.entries_for_bibliography_group::<F>(&headingless, assigned, run);
         let body = crate::render::refs_to_string_slice_with_format::<F>(
             &entries,
             annotations,
@@ -757,6 +829,7 @@ impl Processor {
         groups: &[BibliographyGroup],
         annotations: Option<&HashMap<String, String>>,
         annotation_style: Option<&AnnotationStyle>,
+        run: &FinalizedRun,
     ) -> Vec<RenderedBibliographyGroup>
     where
         F: OutputFormat<Output = String>,
@@ -770,6 +843,7 @@ impl Processor {
                     &mut assigned,
                     annotations,
                     annotation_style,
+                    run,
                 )
             })
             .collect()

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -227,7 +227,7 @@ impl Processor {
                 first_note_by_id: None,
             },
             hints,
-            &self.citation_numbers,
+            &self.run_state.citation_numbers,
             CompoundRenderData {
                 set_by_ref: &self.compound_set_by_ref,
                 member_index: &self.compound_member_index,
@@ -244,6 +244,7 @@ impl Processor {
         for (index, reference) in sorted_refs.into_iter().enumerate() {
             let ref_id = reference.id().unwrap_or_default().to_string();
             let entry_number = self
+                .run_state
                 .citation_numbers
                 .borrow()
                 .get(&ref_id)
@@ -391,7 +392,7 @@ impl Processor {
         F: OutputFormat<Output = String>,
     {
         let fmt = F::default();
-        let cited_ids = self.cited_ids.borrow();
+        let cited_ids = self.run_state.cited_ids.borrow();
         let evaluator = SelectorEvaluator::new(&cited_ids);
         let bibliography_config = self.get_bibliography_config();
         let sorter = ReferenceSorter::with_bibliography_config(&self.locale, &bibliography_config);
@@ -518,7 +519,7 @@ impl Processor {
         F: OutputFormat<Output = String>,
     {
         let fmt = F::default();
-        let cited_ids = self.cited_ids.borrow();
+        let cited_ids = self.run_state.cited_ids.borrow();
         let cited_entries: Vec<ProcEntry> = bibliography
             .iter()
             .filter(|entry| cited_ids.contains(&entry.id))
@@ -570,7 +571,7 @@ impl Processor {
     /// document-string (`process_document`) path all funnel through here.
     ///
     /// When `restrict_to_cited` is `true` (the document case), only references present
-    /// in `self.cited_ids` — cited in-text or registered via `nocite` — are included.
+    /// in `self.run_state.cited_ids` — cited in-text or registered via `nocite` — are included.
     /// When `false`, all loaded references are eligible; this hook is reserved for the
     /// `allrefs` escape hatch (csl26-f9ri) and is not yet exposed publicly.
     ///
@@ -591,7 +592,7 @@ impl Processor {
             annotation_style,
         );
         // Collect IDs before calling process_* so the RefCell borrow is released.
-        let cited_ids: Vec<String> = self.cited_ids.borrow().iter().cloned().collect();
+        let cited_ids: Vec<String> = self.run_state.cited_ids.borrow().iter().cloned().collect();
         let entries = if restrict_to_cited {
             self.process_selected_references_with_format::<F, _>(cited_ids)
                 .bibliography
@@ -604,7 +605,7 @@ impl Processor {
     /// Shared implementation for grouped bibliography rendering.
     ///
     /// When `restrict_to_cited` is `true`, each branch limits its candidate
-    /// set to references present in `self.cited_ids`. When `false`, all
+    /// set to references present in `self.run_state.cited_ids`. When `false`, all
     /// loaded references are eligible (the original all-refs behaviour used
     /// by standalone `render refs`, FFI, and tests).
     fn render_grouped_bibliography_inner<F>(
@@ -624,7 +625,7 @@ impl Processor {
         {
             let id_stubs = self.sorted_id_stubs();
             let selected = if restrict_to_cited {
-                let cited = self.cited_ids.borrow();
+                let cited = self.run_state.cited_ids.borrow();
                 id_stubs
                     .iter()
                     .filter(|e| cited.contains(&e.id))
@@ -652,7 +653,7 @@ impl Processor {
             self.initialize_numeric_bibliography_numbers();
             let mut refs: Vec<&Reference> = self.bibliography.values().collect();
             if restrict_to_cited {
-                let cited = self.cited_ids.borrow();
+                let cited = self.run_state.cited_ids.borrow();
                 refs.retain(|r| r.id().as_deref().is_some_and(|id| cited.contains(id)));
             }
             let sorted_refs = self.sort_references(refs);
@@ -685,7 +686,7 @@ impl Processor {
         F: OutputFormat<Output = String>,
     {
         let bibliography = self.sorted_id_stubs();
-        let cited_ids = self.cited_ids.borrow();
+        let cited_ids = self.run_state.cited_ids.borrow();
         let evaluator = SelectorEvaluator::new(&cited_ids);
         let bibliography_config = self.get_bibliography_config();
         let sorter = ReferenceSorter::with_bibliography_config(&self.locale, &bibliography_config);

--- a/crates/citum-engine/src/processor/bibliography/mod.rs
+++ b/crates/citum-engine/src/processor/bibliography/mod.rs
@@ -14,6 +14,7 @@ mod grouping;
 
 use super::matching::Matcher;
 use super::rendering::{CompoundRenderData, Renderer, RendererResources};
+use super::run_state::FinalizedRun;
 use super::{ProcessedReferences, Processor};
 use crate::api::AnnotationStyle;
 use crate::reference::Reference;
@@ -49,7 +50,11 @@ pub(crate) struct DocumentBibliography {
 
 impl Processor {
     /// Create a bibliography renderer with effective shared and bibliography-only config.
-    fn with_bibliography_renderer<T>(&self, render: impl FnOnce(Renderer<'_>) -> T) -> T {
+    fn with_bibliography_renderer<T>(
+        &self,
+        run: &FinalizedRun,
+        render: impl FnOnce(Renderer<'_>) -> T,
+    ) -> T {
         let bibliography_shared_config = self.get_bibliography_config();
         let bibliography_config = self.get_bibliography_options().into_owned();
         let renderer = Renderer::new(
@@ -62,7 +67,7 @@ impl Processor {
                 first_note_by_id: None,
             },
             &self.hints,
-            &self.run_state.citation_numbers,
+            &run.state().citation_numbers,
             CompoundRenderData {
                 set_by_ref: &self.compound_set_by_ref,
                 member_index: &self.compound_member_index,
@@ -86,6 +91,7 @@ impl Processor {
         &self,
         sorted_refs: I,
         process_fn: impl Fn(&Reference, usize) -> Option<ProcTemplate>,
+        run: &FinalizedRun,
     ) -> Vec<ProcEntry>
     where
         I: Iterator<Item = &'a Reference>,
@@ -99,8 +105,8 @@ impl Processor {
 
         for (index, reference) in sorted_refs.enumerate() {
             let ref_id = reference.id().unwrap_or_default().to_string();
-            let entry_number = self
-                .run_state
+            let entry_number = run
+                .state()
                 .citation_numbers
                 .borrow()
                 .get(&ref_id)
@@ -112,7 +118,7 @@ impl Processor {
                     && let Some(previous) = previous_reference
                     && self.contributors_match(previous, reference)
                 {
-                    self.with_bibliography_renderer(|renderer| {
+                    self.with_bibliography_renderer(run, |renderer| {
                         renderer.apply_author_substitution_with_format::<F>(
                             &mut processed,
                             substitute_string,
@@ -134,26 +140,36 @@ impl Processor {
 
     /// Process all bibliography references and render them.
     ///
-    /// Returns sorted and formatted bibliography entries. For numeric styles,
-    /// citations must have been processed first to assign citation numbers.
+    /// This is a one-shot convenience wrapper: it begins a throwaway
+    /// [`super::run_state::RunState`] internally, so it has no continuity
+    /// with any citations processed elsewhere. Use
+    /// [`Processor::process_references_with_format`] with an explicit,
+    /// shared `FinalizedRun` to render a bibliography that reflects prior
+    /// citation registration in the same document.
     pub fn process_references(&self) -> ProcessedReferences {
-        self.process_references_with_format::<crate::render::plain::PlainText>()
+        let run = self.begin_run().finalize();
+        self.process_references_with_format::<crate::render::plain::PlainText>(&run)
     }
 
     /// Process all bibliography references using the requested output format.
     ///
     /// This preserves format-specific inline markup in per-entry API output.
-    pub fn process_references_with_format<F>(&self) -> ProcessedReferences
+    /// `run` should reflect all citations already processed for this
+    /// document (or be a fresh [`Processor::begin_run`] for a standalone
+    /// bibliography with no citations); see
+    /// [`Processor::process_references_with_format_standalone`] for a
+    /// one-shot convenience.
+    pub fn process_references_with_format<F>(&self, run: &FinalizedRun) -> ProcessedReferences
     where
         F: OutputFormat<Output = String>,
     {
-        self.initialize_numeric_bibliography_numbers();
         let sorted_refs = self.sort_references(self.bibliography.values().collect());
         let bibliography = self.process_sorted_refs::<_, F>(
             sorted_refs.iter().copied(),
             |reference, entry_number| {
-                self.process_bibliography_entry_with_format::<F>(reference, entry_number)
+                self.process_bibliography_entry_with_format::<F>(reference, entry_number, run)
             },
+            run,
         );
         ProcessedReferences {
             bibliography,
@@ -172,12 +188,12 @@ impl Processor {
     pub(crate) fn process_selected_references_with_format<F, I>(
         &self,
         item_ids: I,
+        run: &FinalizedRun,
     ) -> ProcessedReferences
     where
         F: OutputFormat<Output = String>,
         I: IntoIterator<Item = String>,
     {
-        self.initialize_numeric_bibliography_numbers();
         let selected: HashSet<String> = item_ids.into_iter().collect();
         let sorted_refs = self.sort_references(self.bibliography.values().collect());
         let bibliography = self.process_sorted_refs::<_, F>(
@@ -186,8 +202,9 @@ impl Processor {
                 .filter(|r| r.id().as_deref().is_some_and(|id| selected.contains(id)))
                 .copied(),
             |reference, entry_number| {
-                self.process_bibliography_entry_with_format::<F>(reference, entry_number)
+                self.process_bibliography_entry_with_format::<F>(reference, entry_number, run)
             },
+            run,
         );
         ProcessedReferences {
             bibliography,
@@ -200,8 +217,9 @@ impl Processor {
         &self,
         reference: &Reference,
         entry_number: usize,
+        run: &FinalizedRun,
     ) -> Option<ProcTemplate> {
-        self.with_bibliography_renderer(|renderer| {
+        self.with_bibliography_renderer(run, |renderer| {
             renderer.process_bibliography_entry(reference, entry_number)
         })
     }
@@ -211,11 +229,12 @@ impl Processor {
         &self,
         reference: &Reference,
         entry_number: usize,
+        run: &FinalizedRun,
     ) -> Option<ProcTemplate>
     where
         F: OutputFormat<Output = String>,
     {
-        self.with_bibliography_renderer(|renderer| {
+        self.with_bibliography_renderer(run, |renderer| {
             renderer.process_bibliography_entry_with_format::<F>(reference, entry_number)
         })
     }
@@ -228,21 +247,12 @@ impl Processor {
         matcher.contributors_match(prev, current)
     }
 
-    /// Replace the primary contributor with a substitution string.
-    ///
-    /// Used for subsequent author substitution (e.g., "———").
-    pub fn apply_author_substitution(&self, proc: &mut ProcTemplate, substitute: &str) {
-        self.with_bibliography_renderer(|renderer| {
-            renderer.apply_author_substitution(proc, substitute);
-        });
-    }
-
     /// Render the bibliography to a string using a specific format.
-    pub fn render_bibliography_with_format<F>(&self) -> String
+    pub fn render_bibliography_with_format<F>(&self, run: &FinalizedRun) -> String
     where
         F: OutputFormat<Output = String>,
     {
-        self.render_bibliography_with_format_and_annotations::<F>(None, None)
+        self.render_bibliography_with_format_and_annotations::<F>(None, None, run)
     }
 
     /// Render the bibliography to a string with annotations.
@@ -250,6 +260,7 @@ impl Processor {
         &self,
         annotations: Option<&HashMap<String, String>>,
         annotation_style: Option<&AnnotationStyle>,
+        run: &FinalizedRun,
     ) -> String
     where
         F: OutputFormat<Output = String>,
@@ -258,16 +269,23 @@ impl Processor {
             self.bibliography.keys().cloned().collect::<Vec<_>>(),
             annotations,
             annotation_style,
+            run,
         )
     }
 
     /// Render a selected bibliography subset to a string using a specific format.
-    pub fn render_selected_bibliography_with_format<F, I>(&self, item_ids: I) -> String
+    pub fn render_selected_bibliography_with_format<F, I>(
+        &self,
+        item_ids: I,
+        run: &FinalizedRun,
+    ) -> String
     where
         F: OutputFormat<Output = String>,
         I: IntoIterator<Item = String>,
     {
-        self.render_selected_bibliography_with_format_and_annotations::<F, _>(item_ids, None, None)
+        self.render_selected_bibliography_with_format_and_annotations::<F, _>(
+            item_ids, None, None, run,
+        )
     }
 
     /// Render a selected bibliography subset to a string with annotations.
@@ -281,6 +299,7 @@ impl Processor {
         item_ids: I,
         annotations: Option<&HashMap<String, String>>,
         annotation_style: Option<&AnnotationStyle>,
+        run: &FinalizedRun,
     ) -> String
     where
         F: OutputFormat<Output = String>,
@@ -303,6 +322,7 @@ impl Processor {
                 &selected,
                 annotations,
                 annotation_style,
+                run,
             );
         }
 
@@ -311,7 +331,6 @@ impl Processor {
         if let Some(partitioning) = bibliography_options.sort_partitioning.as_ref()
             && crate::sort_partitioning::should_render_sections(partitioning)
         {
-            self.initialize_numeric_bibliography_numbers();
             let all_sorted = self.sort_references(self.bibliography.values().collect());
             let selected_sorted: Vec<&Reference> = all_sorted
                 .into_iter()
@@ -322,11 +341,11 @@ impl Processor {
                 partitioning,
                 annotations,
                 annotation_style,
+                run,
             );
         }
 
         // 3. Fallback to flat rendering
-        self.initialize_numeric_bibliography_numbers();
         let sorted_refs = self.sort_references(self.bibliography.values().collect());
 
         let bibliography = self.process_sorted_refs::<_, F>(
@@ -335,16 +354,121 @@ impl Processor {
                 .filter(|r| r.id().as_deref().is_some_and(|id| selected.contains(id)))
                 .copied(),
             |reference, entry_number| {
-                self.process_bibliography_entry_with_format::<F>(reference, entry_number)
+                self.process_bibliography_entry_with_format::<F>(reference, entry_number, run)
             },
+            run,
         );
 
-        let bibliography = self.merge_compound_entries::<F>(bibliography);
+        let bibliography = self.merge_compound_entries::<F>(bibliography, run);
         crate::render::refs_to_string_with_format::<F>(bibliography, annotations, annotation_style)
     }
 
     /// Render the entire bibliography to a formatted string.
+    ///
+    /// One-shot convenience wrapper: begins a throwaway run internally, so
+    /// it has no continuity with any citations processed elsewhere. Use
+    /// [`Processor::render_bibliography_with_format`] with an explicit,
+    /// shared `FinalizedRun` for a bibliography that reflects prior citation
+    /// registration.
     pub fn render_bibliography(&self) -> String {
-        self.render_bibliography_with_format::<crate::render::plain::PlainText>()
+        let run = self.begin_run().finalize();
+        self.render_bibliography_with_format::<crate::render::plain::PlainText>(&run)
+    }
+
+    /// One-shot convenience for [`Processor::process_references_with_format`]:
+    /// begins a throwaway run internally.
+    pub fn process_references_with_format_standalone<F>(&self) -> ProcessedReferences
+    where
+        F: OutputFormat<Output = String>,
+    {
+        let run = self.begin_run().finalize();
+        self.process_references_with_format::<F>(&run)
+    }
+
+    /// One-shot convenience for [`Processor::process_bibliography_entry`]:
+    /// begins a throwaway run internally.
+    pub fn process_bibliography_entry_standalone(
+        &self,
+        reference: &Reference,
+        entry_number: usize,
+    ) -> Option<ProcTemplate> {
+        let run = self.begin_run().finalize();
+        self.process_bibliography_entry(reference, entry_number, &run)
+    }
+
+    /// One-shot convenience for [`Processor::process_bibliography_entry_with_format`]:
+    /// begins a throwaway run internally.
+    pub fn process_bibliography_entry_with_format_standalone<F>(
+        &self,
+        reference: &Reference,
+        entry_number: usize,
+    ) -> Option<ProcTemplate>
+    where
+        F: OutputFormat<Output = String>,
+    {
+        let run = self.begin_run().finalize();
+        self.process_bibliography_entry_with_format::<F>(reference, entry_number, &run)
+    }
+
+    /// One-shot convenience for [`Processor::render_bibliography_with_format`]:
+    /// begins a throwaway run internally.
+    pub fn render_bibliography_with_format_standalone<F>(&self) -> String
+    where
+        F: OutputFormat<Output = String>,
+    {
+        let run = self.begin_run().finalize();
+        self.render_bibliography_with_format::<F>(&run)
+    }
+
+    /// One-shot convenience for
+    /// [`Processor::render_bibliography_with_format_and_annotations`]:
+    /// begins a throwaway run internally.
+    pub fn render_bibliography_with_format_and_annotations_standalone<F>(
+        &self,
+        annotations: Option<&HashMap<String, String>>,
+        annotation_style: Option<&AnnotationStyle>,
+    ) -> String
+    where
+        F: OutputFormat<Output = String>,
+    {
+        let run = self.begin_run().finalize();
+        self.render_bibliography_with_format_and_annotations::<F>(
+            annotations,
+            annotation_style,
+            &run,
+        )
+    }
+
+    /// One-shot convenience for [`Processor::render_selected_bibliography_with_format`]:
+    /// begins a throwaway run internally.
+    pub fn render_selected_bibliography_with_format_standalone<F, I>(&self, item_ids: I) -> String
+    where
+        F: OutputFormat<Output = String>,
+        I: IntoIterator<Item = String>,
+    {
+        let run = self.begin_run().finalize();
+        self.render_selected_bibliography_with_format::<F, I>(item_ids, &run)
+    }
+
+    /// One-shot convenience for
+    /// [`Processor::render_selected_bibliography_with_format_and_annotations`]:
+    /// begins a throwaway run internally.
+    pub fn render_selected_bibliography_with_format_and_annotations_standalone<F, I>(
+        &self,
+        item_ids: I,
+        annotations: Option<&HashMap<String, String>>,
+        annotation_style: Option<&AnnotationStyle>,
+    ) -> String
+    where
+        F: OutputFormat<Output = String>,
+        I: IntoIterator<Item = String>,
+    {
+        let run = self.begin_run().finalize();
+        self.render_selected_bibliography_with_format_and_annotations::<F, I>(
+            item_ids,
+            annotations,
+            annotation_style,
+            &run,
+        )
     }
 }

--- a/crates/citum-engine/src/processor/bibliography/mod.rs
+++ b/crates/citum-engine/src/processor/bibliography/mod.rs
@@ -62,7 +62,7 @@ impl Processor {
                 first_note_by_id: None,
             },
             &self.hints,
-            &self.citation_numbers,
+            &self.run_state.citation_numbers,
             CompoundRenderData {
                 set_by_ref: &self.compound_set_by_ref,
                 member_index: &self.compound_member_index,
@@ -100,6 +100,7 @@ impl Processor {
         for (index, reference) in sorted_refs.enumerate() {
             let ref_id = reference.id().unwrap_or_default().to_string();
             let entry_number = self
+                .run_state
                 .citation_numbers
                 .borrow()
                 .get(&ref_id)

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -111,7 +111,7 @@ impl Processor {
     /// IDs that are absent from `self.bibliography` are silently ignored here;
     /// callers are responsible for emitting `nocite_missing_ref` warnings first.
     pub fn register_nocite_ids(&self, ids: impl IntoIterator<Item = String>) {
-        let mut cited_ids = self.cited_ids.borrow_mut();
+        let mut cited_ids = self.run_state.cited_ids.borrow_mut();
         for id in ids {
             cited_ids.insert(id);
         }
@@ -123,7 +123,7 @@ impl Processor {
     /// that numeric styles have a stable numbering map.
     fn track_cited_ids_and_init_numbers(&self, citation: &Citation) {
         self.initialize_numeric_citation_numbers();
-        let mut cited_ids = self.cited_ids.borrow_mut();
+        let mut cited_ids = self.run_state.cited_ids.borrow_mut();
         for item in &citation.items {
             cited_ids.insert(item.id.clone());
         }
@@ -207,8 +207,8 @@ impl Processor {
         // Because this method is called before cited_ids is updated for the current
         // citation, `cited_ids` contains only references from earlier citations.
         {
-            let dyn_set = self.dynamic_compound_set_by_ref.borrow();
-            let cited = self.cited_ids.borrow();
+            let dyn_set = self.run_state.dynamic_compound_set_by_ref.borrow();
+            let cited = self.run_state.cited_ids.borrow();
 
             if dyn_set.contains_key(head_id.as_str()) || cited.contains(head_id.as_str()) {
                 return;
@@ -221,7 +221,7 @@ impl Processor {
         }
 
         let head_number = {
-            let numbers = self.citation_numbers.borrow();
+            let numbers = self.run_state.citation_numbers.borrow();
             let Some(&n) = numbers.get(head_id.as_str()) else {
                 return;
             };
@@ -230,7 +230,7 @@ impl Processor {
 
         // Assign all tails the same citation number as the head.
         {
-            let mut numbers = self.citation_numbers.borrow_mut();
+            let mut numbers = self.run_state.citation_numbers.borrow_mut();
             for tail in &tail_ids {
                 numbers.insert(tail.clone(), head_number);
             }
@@ -243,8 +243,8 @@ impl Processor {
 
         // Populate dynamic index maps so the renderer can assign sub-labels.
         {
-            let mut dyn_set = self.dynamic_compound_set_by_ref.borrow_mut();
-            let mut dyn_idx = self.dynamic_compound_member_index.borrow_mut();
+            let mut dyn_set = self.run_state.dynamic_compound_set_by_ref.borrow_mut();
+            let mut dyn_idx = self.run_state.dynamic_compound_member_index.borrow_mut();
             for (idx, member) in all_members.iter().enumerate() {
                 dyn_set.insert(member.clone(), head_id.clone());
                 dyn_idx.insert(member.clone(), idx);
@@ -253,7 +253,7 @@ impl Processor {
 
         // Inject into compound_groups for bibliography rendering.
         {
-            let mut groups = self.compound_groups.borrow_mut();
+            let mut groups = self.run_state.compound_groups.borrow_mut();
             let members = groups
                 .entry(head_number)
                 .or_insert_with(|| vec![head_id.clone()]);
@@ -265,7 +265,8 @@ impl Processor {
         }
 
         // Register dynamic set so citation_sub_label_for_ref can find members.
-        self.dynamic_compound_sets
+        self.run_state
+            .dynamic_compound_sets
             .borrow_mut()
             .insert(head_id.clone(), all_members);
     }
@@ -340,25 +341,30 @@ impl Processor {
         Option<HashMap<String, usize>>,
         Option<IndexMap<String, Vec<String>>>,
     ) {
-        if self.dynamic_compound_set_by_ref.borrow().is_empty() {
+        if self
+            .run_state
+            .dynamic_compound_set_by_ref
+            .borrow()
+            .is_empty()
+        {
             return (None, None, None);
         }
         let merged_set: HashMap<String, String> = self
             .compound_set_by_ref
             .iter()
-            .chain(self.dynamic_compound_set_by_ref.borrow().iter())
+            .chain(self.run_state.dynamic_compound_set_by_ref.borrow().iter())
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
         let merged_idx: HashMap<String, usize> = self
             .compound_member_index
             .iter()
-            .chain(self.dynamic_compound_member_index.borrow().iter())
+            .chain(self.run_state.dynamic_compound_member_index.borrow().iter())
             .map(|(k, v)| (k.clone(), *v))
             .collect();
         let merged_sets: IndexMap<String, Vec<String>> = self
             .compound_sets
             .iter()
-            .chain(self.dynamic_compound_sets.borrow().iter())
+            .chain(self.run_state.dynamic_compound_sets.borrow().iter())
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
         (Some(merged_set), Some(merged_idx), Some(merged_sets))
@@ -415,10 +421,10 @@ impl Processor {
                 locale: &self.locale,
                 config: citation_config.clone(),
                 bibliography_config: Some(Rc::new(self.get_bibliography_options().into_owned())),
-                first_note_by_id: Some(&self.first_note_by_id),
+                first_note_by_id: Some(&self.run_state.first_note_by_id),
             },
             renderer_hints,
-            &self.citation_numbers,
+            &self.run_state.citation_numbers,
             CompoundRenderData {
                 set_by_ref: effective_set_by_ref,
                 member_index: effective_member_index,

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -8,10 +8,21 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! This module resolves the effective citation spec for each citation, prepares
 //! renderer delimiters and affixes. Template-level rendering, including
 //! sentence-initial note-start handling, lives in `rendering`.
+//!
+//! Registration (`&mut RunState`) and rendering (`&RunState`) are interleaved
+//! per citation, in document order: each citation's disambiguation,
+//! position, and dynamic grouping depend on the cumulative state left by
+//! every citation processed before it, and citation numbers may be assigned
+//! lazily during one citation's render that a later citation's registration
+//! then reads. This is why citation processing takes `&mut RunState`
+//! end-to-end rather than the `&FinalizedRun` used by bibliography
+//! rendering, which requires the complete, final state from all citations.
+//! See `docs/specs/EXPLICIT_RENDER_RUN_STATE.md`.
 
 use super::Processor;
 use super::disambiguation::Disambiguator;
 use super::rendering::{CompoundRenderData, GroupRenderParams, Renderer, RendererResources};
+use super::run_state::RunState;
 use crate::error::ProcessorError;
 use crate::reference::Citation;
 use crate::values::ProcHints;
@@ -110,10 +121,9 @@ impl Processor {
     ///
     /// IDs that are absent from `self.bibliography` are silently ignored here;
     /// callers are responsible for emitting `nocite_missing_ref` warnings first.
-    pub fn register_nocite_ids(&self, ids: impl IntoIterator<Item = String>) {
-        let mut cited_ids = self.run_state.cited_ids.borrow_mut();
+    pub fn register_nocite_ids(&self, ids: impl IntoIterator<Item = String>, run: &mut RunState) {
         for id in ids {
-            cited_ids.insert(id);
+            run.cited_ids.insert(id);
         }
     }
 
@@ -121,11 +131,10 @@ impl Processor {
     ///
     /// This maintains the set of all references cited in the document and ensures
     /// that numeric styles have a stable numbering map.
-    fn track_cited_ids_and_init_numbers(&self, citation: &Citation) {
-        self.initialize_numeric_citation_numbers();
-        let mut cited_ids = self.run_state.cited_ids.borrow_mut();
+    fn track_cited_ids_and_init_numbers(&self, citation: &Citation, run: &mut RunState) {
+        self.initialize_numeric_citation_numbers(run);
         for item in &citation.items {
-            cited_ids.insert(item.id.clone());
+            run.cited_ids.insert(item.id.clone());
         }
     }
 
@@ -178,7 +187,7 @@ impl Processor {
     ///
     /// This method must be called before `track_cited_ids_and_init_numbers` so that
     /// `cited_ids` reflects only references from prior citations, not the current one.
-    fn resolve_dynamic_group(&self, citation: &Citation) {
+    fn resolve_dynamic_group(&self, citation: &Citation, run: &mut RunState) {
         if self.get_bibliography_options().compound_numeric.is_none() {
             return;
         }
@@ -206,22 +215,23 @@ impl Processor {
         // context — whether via a prior dynamic group or a previous ungrouped citation.
         // Because this method is called before cited_ids is updated for the current
         // citation, `cited_ids` contains only references from earlier citations.
+        if run
+            .dynamic_compound_set_by_ref
+            .contains_key(head_id.as_str())
+            || run.cited_ids.contains(head_id.as_str())
         {
-            let dyn_set = self.run_state.dynamic_compound_set_by_ref.borrow();
-            let cited = self.run_state.cited_ids.borrow();
-
-            if dyn_set.contains_key(head_id.as_str()) || cited.contains(head_id.as_str()) {
+            return;
+        }
+        for tail in &tail_ids {
+            if run.dynamic_compound_set_by_ref.contains_key(tail.as_str())
+                || run.cited_ids.contains(tail.as_str())
+            {
                 return;
-            }
-            for tail in &tail_ids {
-                if dyn_set.contains_key(tail.as_str()) || cited.contains(tail.as_str()) {
-                    return;
-                }
             }
         }
 
         let head_number = {
-            let numbers = self.run_state.citation_numbers.borrow();
+            let numbers = run.citation_numbers.borrow();
             let Some(&n) = numbers.get(head_id.as_str()) else {
                 return;
             };
@@ -230,7 +240,7 @@ impl Processor {
 
         // Assign all tails the same citation number as the head.
         {
-            let mut numbers = self.run_state.citation_numbers.borrow_mut();
+            let mut numbers = run.citation_numbers.borrow_mut();
             for tail in &tail_ids {
                 numbers.insert(tail.clone(), head_number);
             }
@@ -242,19 +252,17 @@ impl Processor {
             .collect();
 
         // Populate dynamic index maps so the renderer can assign sub-labels.
-        {
-            let mut dyn_set = self.run_state.dynamic_compound_set_by_ref.borrow_mut();
-            let mut dyn_idx = self.run_state.dynamic_compound_member_index.borrow_mut();
-            for (idx, member) in all_members.iter().enumerate() {
-                dyn_set.insert(member.clone(), head_id.clone());
-                dyn_idx.insert(member.clone(), idx);
-            }
+        for (idx, member) in all_members.iter().enumerate() {
+            run.dynamic_compound_set_by_ref
+                .insert(member.clone(), head_id.clone());
+            run.dynamic_compound_member_index
+                .insert(member.clone(), idx);
         }
 
         // Inject into compound_groups for bibliography rendering.
         {
-            let mut groups = self.run_state.compound_groups.borrow_mut();
-            let members = groups
+            let members = run
+                .compound_groups
                 .entry(head_number)
                 .or_insert_with(|| vec![head_id.clone()]);
             for tail in &tail_ids {
@@ -265,9 +273,7 @@ impl Processor {
         }
 
         // Register dynamic set so citation_sub_label_for_ref can find members.
-        self.run_state
-            .dynamic_compound_sets
-            .borrow_mut()
+        run.dynamic_compound_sets
             .insert(head_id.clone(), all_members);
     }
 
@@ -336,35 +342,31 @@ impl Processor {
     /// at least one dynamic group is registered.
     fn merged_compound_data(
         &self,
+        run: &RunState,
     ) -> (
         Option<HashMap<String, String>>,
         Option<HashMap<String, usize>>,
         Option<IndexMap<String, Vec<String>>>,
     ) {
-        if self
-            .run_state
-            .dynamic_compound_set_by_ref
-            .borrow()
-            .is_empty()
-        {
+        if run.dynamic_compound_set_by_ref.is_empty() {
             return (None, None, None);
         }
         let merged_set: HashMap<String, String> = self
             .compound_set_by_ref
             .iter()
-            .chain(self.run_state.dynamic_compound_set_by_ref.borrow().iter())
+            .chain(run.dynamic_compound_set_by_ref.iter())
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
         let merged_idx: HashMap<String, usize> = self
             .compound_member_index
             .iter()
-            .chain(self.run_state.dynamic_compound_member_index.borrow().iter())
+            .chain(run.dynamic_compound_member_index.iter())
             .map(|(k, v)| (k.clone(), *v))
             .collect();
         let merged_sets: IndexMap<String, Vec<String>> = self
             .compound_sets
             .iter()
-            .chain(self.run_state.dynamic_compound_sets.borrow().iter())
+            .chain(run.dynamic_compound_sets.iter())
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
         (Some(merged_set), Some(merged_idx), Some(merged_sets))
@@ -381,6 +383,7 @@ impl Processor {
         renderer_delimiter: &str,
         renderer_inter_delimiter: &str,
         note_start_text_case: Option<NoteStartTextCase>,
+        run: &RunState,
     ) -> Result<String, ProcessorError>
     where
         F: crate::render::format::OutputFormat<Output = String>,
@@ -395,7 +398,7 @@ impl Processor {
 
         // Build merged compound lookup maps (static + dynamic).
         // Return owned maps only when dynamic groups exist; otherwise use static maps directly.
-        let (dyn_set_owned, dyn_idx_owned, dyn_sets_owned) = self.merged_compound_data();
+        let (dyn_set_owned, dyn_idx_owned, dyn_sets_owned) = self.merged_compound_data(run);
         let effective_set_by_ref = dyn_set_owned.as_ref().unwrap_or(&self.compound_set_by_ref);
         let effective_member_index = dyn_idx_owned
             .as_ref()
@@ -421,10 +424,10 @@ impl Processor {
                 locale: &self.locale,
                 config: citation_config.clone(),
                 bibliography_config: Some(Rc::new(self.get_bibliography_options().into_owned())),
-                first_note_by_id: Some(&self.run_state.first_note_by_id),
+                first_note_by_id: Some(&run.first_note_by_id),
             },
             renderer_hints,
-            &self.run_state.citation_numbers,
+            &run.citation_numbers,
             CompoundRenderData {
                 set_by_ref: effective_set_by_ref,
                 member_index: effective_member_index,
@@ -567,25 +570,30 @@ impl Processor {
 
     /// Render a single citation to plain text.
     ///
-    /// This is the primary entry point for citation processing. It handles:
-    /// 1. Looking up references in the bibliography.
-    /// 2. Annotating positions (ibid, subsequent, etc.).
-    /// 3. Resolving disambiguation (name expansion, year suffixes).
-    /// 4. Applying the style's citation template.
-    ///
-    /// Returns the formatted citation string or an error if processing fails.
+    /// This is a one-shot convenience wrapper: it begins a throwaway
+    /// [`RunState`] internally, so it has no continuity with any other call.
+    /// Use [`Processor::process_citations`] (or the run-threaded
+    /// `_with_format` variants with an explicit, shared `RunState`) to render
+    /// multiple citations from one document with correct cumulative
+    /// numbering, cite-order tracking, and dynamic compound grouping.
     ///
     /// # Errors
     ///
     /// Returns an error when referenced items are missing or rendering fails.
     pub fn process_citation(&self, citation: &Citation) -> Result<String, ProcessorError> {
-        self.process_citation_with_format::<crate::render::plain::PlainText>(citation)
+        let mut run = self.begin_run();
+        self.process_citation_with_format::<crate::render::plain::PlainText>(citation, &mut run)
     }
 
     /// Render a citation to a string using a specific output format.
     ///
     /// This resolves the effective citation spec for the citation's mode and
-    /// position, renders the citation body, and applies input and style affixes.
+    /// position, renders the citation body, and applies input and style
+    /// affixes. `run` accumulates cite-order state (citation numbers, cited
+    /// IDs, dynamic compound groups) across calls; pass the same `RunState`
+    /// for every citation in one document to get correct cumulative
+    /// behavior, or a fresh one (via [`Processor::begin_run`]) for an
+    /// isolated, one-off render.
     ///
     /// # Errors
     ///
@@ -593,6 +601,7 @@ impl Processor {
     pub fn process_citation_with_format<F>(
         &self,
         citation: &Citation,
+        run: &mut RunState,
     ) -> Result<String, ProcessorError>
     where
         F: crate::render::format::OutputFormat<Output = String>,
@@ -603,11 +612,11 @@ impl Processor {
         // cited_ids with the current citation's items. This ensures the first-occurrence
         // check in resolve_dynamic_group sees only references from prior citations.
         if citation.grouped {
-            self.initialize_numeric_citation_numbers();
-            self.resolve_dynamic_group(citation);
+            self.initialize_numeric_citation_numbers(run);
+            self.resolve_dynamic_group(citation, run);
         }
 
-        self.track_cited_ids_and_init_numbers(citation);
+        self.track_cited_ids_and_init_numbers(citation, run);
 
         let effective_spec = self.resolve_effective_citation_spec(citation);
         let note_start_text_case =
@@ -620,6 +629,7 @@ impl Processor {
             renderer_delimiter,
             renderer_inter_delimiter,
             note_start_text_case,
+            run,
         )?;
         let output = self.apply_citation_input_affixes(citation, content, &fmt);
         let wrapped = self.apply_spec_wrap_and_affixes(citation, &effective_spec, output, &fmt);
@@ -643,16 +653,27 @@ impl Processor {
 
     /// Render multiple citations in document order.
     ///
-    /// For note-based styles, normalizes context and assigns citation positions.
+    /// For note-based styles, normalizes context and assigns citation
+    /// positions. This is a one-shot convenience wrapper: it begins a
+    /// throwaway [`RunState`] internally, shared across all citations in
+    /// `citations` (so cumulative numbering/grouping within this call is
+    /// correct) but not shared with any other call.
     ///
     /// # Errors
     ///
     /// Returns an error when any citation in the sequence fails to render.
     pub fn process_citations(&self, citations: &[Citation]) -> Result<Vec<String>, ProcessorError> {
-        self.process_citations_with_format::<crate::render::plain::PlainText>(citations)
+        let mut run = self.begin_run();
+        self.process_citations_with_format::<crate::render::plain::PlainText>(citations, &mut run)
     }
 
     /// Render multiple citations with a custom output format.
+    ///
+    /// `run` is threaded through every citation in `citations`, in order, so
+    /// numbering/cite-order/dynamic-grouping state accumulates correctly
+    /// across the whole batch. Pass the same `run` on to bibliography
+    /// rendering (after [`RunState::finalize`]) to render a consistent
+    /// document.
     ///
     /// # Errors
     ///
@@ -660,15 +681,16 @@ impl Processor {
     pub fn process_citations_with_format<F>(
         &self,
         citations: &[Citation],
+        run: &mut RunState,
     ) -> Result<Vec<String>, ProcessorError>
     where
         F: crate::render::format::OutputFormat<Output = String>,
     {
-        let mut normalized = self.normalize_note_context(citations);
+        let mut normalized = self.normalize_note_context(citations, run);
         self.annotate_positions(&mut normalized);
         normalized
             .iter()
-            .map(|citation| self.process_citation_with_format::<F>(citation))
+            .map(|citation| self.process_citation_with_format::<F>(citation, run))
             .collect()
     }
 }

--- a/crates/citum-engine/src/processor/document/integral_names.rs
+++ b/crates/citum-engine/src/processor/document/integral_names.rs
@@ -19,6 +19,7 @@ use super::{
     CitationPlacement, CitationStructure, DocumentIntegralNameOverride, DocumentOptionsOverride,
     DocumentOrgAbbreviationOverride, ParsedDocument,
 };
+use crate::processor::run_state::RunState;
 use crate::reference::{CitationItem, Contributor};
 use crate::{Citation, Processor};
 use citum_schema::citation::{CitationMode, IntegralNameState};
@@ -58,6 +59,7 @@ impl Processor {
     pub(super) fn normalize_integral_name_citations(
         &self,
         parsed: &ParsedDocument,
+        run: &mut RunState,
     ) -> Vec<Citation> {
         let mut normalized: Vec<Citation> = parsed
             .citations
@@ -92,7 +94,7 @@ impl Processor {
         for (citation, index) in ordered_citations.into_iter().zip(ordered_indices) {
             normalized[index] = citation;
         }
-        self.normalize_note_context(&normalized)
+        self.normalize_note_context(&normalized, run)
     }
 
     /// Annotate integral-name First/Subsequent state across a flat, ordered

--- a/crates/citum-engine/src/processor/document/notes.rs
+++ b/crates/citum-engine/src/processor/document/notes.rs
@@ -423,10 +423,10 @@ impl Processor {
                 locale: &self.locale,
                 config: Rc::new(self.get_config().clone()),
                 bibliography_config: Some(Rc::new(self.get_bibliography_options().into_owned())),
-                first_note_by_id: Some(&self.first_note_by_id),
+                first_note_by_id: Some(&self.run_state.first_note_by_id),
             },
             &self.hints,
-            &self.citation_numbers,
+            &self.run_state.citation_numbers,
             CompoundRenderData {
                 set_by_ref: &self.compound_set_by_ref,
                 member_index: &self.compound_member_index,

--- a/crates/citum-engine/src/processor/document/notes.rs
+++ b/crates/citum-engine/src/processor/document/notes.rs
@@ -18,6 +18,7 @@ use super::{CitationPlacement, ParsedDocument};
 use crate::Citation;
 use crate::processor::Processor;
 use crate::processor::rendering::{CompoundRenderData, Renderer, RendererResources};
+use crate::processor::run_state::RunState;
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -47,11 +48,16 @@ impl NoteOutputSink for HtmlNoteSink<'_> {
 }
 
 impl Processor {
-    pub(super) fn process_note_document<F>(&self, content: &str, parsed: ParsedDocument) -> String
+    pub(super) fn process_note_document<F>(
+        &self,
+        content: &str,
+        parsed: ParsedDocument,
+        run: &mut RunState,
+    ) -> String
     where
         F: crate::render::format::OutputFormat<Output = String>,
     {
-        self.render_note_document::<F, _>(content, parsed, &mut PlainNoteSink)
+        self.render_note_document::<F, _>(content, parsed, &mut PlainNoteSink, run)
     }
 
     pub(super) fn process_note_document_html(
@@ -59,11 +65,13 @@ impl Processor {
         content: &str,
         parsed: ParsedDocument,
         placeholders: &mut HtmlPlaceholderRegistry,
+        run: &mut RunState,
     ) -> String {
         self.render_note_document::<crate::render::html::Html, _>(
             content,
             parsed,
             &mut HtmlNoteSink { placeholders },
+            run,
         )
     }
 
@@ -77,13 +85,14 @@ impl Processor {
         content: &str,
         mut parsed: ParsedDocument,
         sink: &mut S,
+        run: &mut RunState,
     ) -> String
     where
         F: crate::render::format::OutputFormat<Output = String>,
         S: NoteOutputSink,
     {
         let (generated_notes, rendered_notes) =
-            self.prepare_note_citations::<F, S>(content, &mut parsed, sink);
+            self.prepare_note_citations::<F, S>(content, &mut parsed, sink, run);
         let generated_note_by_index: HashMap<usize, &GeneratedNote> = generated_notes
             .iter()
             .map(|note| (note.citation_index, note))
@@ -108,9 +117,10 @@ impl Processor {
                         if matches!(
                             parsed_citation.citation.mode,
                             citum_schema::citation::CitationMode::Integral
-                        ) && let Ok(anchor) = self
-                            .render_note_integral_anchor_with_format::<F>(&parsed_citation.citation)
-                        {
+                        ) && let Ok(anchor) = self.render_note_integral_anchor_with_format::<F>(
+                            &parsed_citation.citation,
+                            run,
+                        ) {
                             result.push_str(&sink.finalize(anchor));
                         }
                         let consumed_right = render_note_reference_in_prose(
@@ -148,10 +158,11 @@ impl Processor {
     fn prepare_note_citation_state(
         &self,
         parsed: &mut ParsedDocument,
+        run: &mut RunState,
     ) -> (Vec<GeneratedNote>, HashMap<String, Vec<usize>>) {
         let (note_occurrences, manual_citations) = collect_note_occurrences(parsed);
         let generated_notes = assign_note_numbers(parsed, &note_occurrences, &manual_citations);
-        self.apply_note_citation_annotations(parsed, &note_occurrences, &manual_citations);
+        self.apply_note_citation_annotations(parsed, &note_occurrences, &manual_citations, run);
         (generated_notes, manual_citations)
     }
 
@@ -164,12 +175,13 @@ impl Processor {
         parsed: &mut ParsedDocument,
         note_occurrences: &[NoteOccurrence],
         manual_citations: &HashMap<String, Vec<usize>>,
+        run: &mut RunState,
     ) {
         let ordered_indices = build_note_order_indices(note_occurrences, manual_citations);
         let (mut ordered_citations, ordered_contexts) =
             ordered_note_citations_and_contexts(parsed, &ordered_indices);
         self.annotate_integral_name_states(&mut ordered_citations, &ordered_contexts);
-        ordered_citations = self.normalize_note_context(&ordered_citations);
+        ordered_citations = self.normalize_note_context(&ordered_citations, run);
         self.annotate_positions(&mut ordered_citations);
 
         for (citation, index) in ordered_citations.into_iter().zip(ordered_indices) {
@@ -187,12 +199,13 @@ impl Processor {
         content: &str,
         parsed: &mut ParsedDocument,
         sink: &mut S,
+        run: &mut RunState,
     ) -> (Vec<GeneratedNote>, HashMap<usize, String>)
     where
         F: crate::render::format::OutputFormat<Output = String>,
         S: NoteOutputSink,
     {
-        let (generated_notes, manual_citations) = self.prepare_note_citation_state(parsed);
+        let (generated_notes, manual_citations) = self.prepare_note_citation_state(parsed, run);
         let mut rendered_notes: HashMap<usize, String> = HashMap::new();
 
         for generated in &generated_notes {
@@ -200,7 +213,7 @@ impl Processor {
                 &parsed.citations[generated.citation_index].citation,
             );
             let rendered = self
-                .process_citation_with_format::<F>(&note_citation)
+                .process_citation_with_format::<F>(&note_citation, run)
                 .unwrap_or_else(|_| {
                     content[parsed.citations[generated.citation_index].start
                         ..parsed.citations[generated.citation_index].end]
@@ -214,6 +227,7 @@ impl Processor {
                 let rendered = self
                     .render_manual_note_citation_with_format::<F>(
                         &parsed.citations[*index].citation,
+                        run,
                     )
                     .unwrap_or_else(|_| {
                         content[parsed.citations[*index].start..parsed.citations[*index].end]
@@ -233,16 +247,17 @@ impl Processor {
     fn render_manual_note_citation_with_format<F>(
         &self,
         citation: &Citation,
+        run: &mut RunState,
     ) -> Result<String, crate::error::ProcessorError>
     where
         F: crate::render::format::OutputFormat<Output = String>,
     {
         if self.should_compose_integral_ibid_in_manual_notes(citation) {
             return self
-                .render_manual_note_integral_ibid_with_format::<F>(citation)
-                .or_else(|_| self.process_citation_with_format::<F>(citation));
+                .render_manual_note_integral_ibid_with_format::<F>(citation, run)
+                .or_else(|_| self.process_citation_with_format::<F>(citation, run));
         }
-        self.process_citation_with_format::<F>(citation)
+        self.process_citation_with_format::<F>(citation, run)
     }
 
     fn should_compose_integral_ibid_in_manual_notes(&self, citation: &Citation) -> bool {
@@ -291,12 +306,13 @@ impl Processor {
     fn render_manual_note_integral_ibid_with_format<F>(
         &self,
         citation: &Citation,
+        run: &RunState,
     ) -> Result<String, crate::error::ProcessorError>
     where
         F: crate::render::format::OutputFormat<Output = String>,
     {
         let anchor = self
-            .render_note_integral_anchor_with_format::<F>(citation)
+            .render_note_integral_anchor_with_format::<F>(citation, run)
             .unwrap_or_default();
         let reduced = self.render_default_note_ibid_text_with_format::<F>(citation)?;
         if anchor.trim().is_empty() {
@@ -392,6 +408,7 @@ impl Processor {
     fn render_note_integral_anchor_with_format<F>(
         &self,
         citation: &Citation,
+        run: &RunState,
     ) -> Result<String, crate::error::ProcessorError>
     where
         F: crate::render::format::OutputFormat<Output = String>,
@@ -423,10 +440,10 @@ impl Processor {
                 locale: &self.locale,
                 config: Rc::new(self.get_config().clone()),
                 bibliography_config: Some(Rc::new(self.get_bibliography_options().into_owned())),
-                first_note_by_id: Some(&self.run_state.first_note_by_id),
+                first_note_by_id: Some(&run.first_note_by_id),
             },
             &self.hints,
-            &self.run_state.citation_numbers,
+            &run.citation_numbers,
             CompoundRenderData {
                 set_by_ref: &self.compound_set_by_ref,
                 member_index: &self.compound_member_index,

--- a/crates/citum-engine/src/processor/document/pipeline.rs
+++ b/crates/citum-engine/src/processor/document/pipeline.rs
@@ -13,6 +13,7 @@ use super::output::{
 use super::{BibliographyBlock, CitationParser, DocumentFormat, ParsedDocument};
 use crate::error::ProcessorError;
 use crate::processor::Processor;
+use crate::processor::run_state::{FinalizedRun, RunState};
 
 /// Format a bibliography section heading for the trailing-bibliography path.
 ///
@@ -106,10 +107,11 @@ impl Processor {
             .or(owned_org.as_ref())
             .or(owned_integral.as_ref())
             .unwrap_or(self);
+        let run = processor.begin_run();
         let body = &content[parsed.body_start..];
         if let Some(groups) = parsed.frontmatter_groups.take() {
             return Ok(processor.process_document_with_frontmatter_groups::<P, F>(
-                body, parsed, groups, parser, format,
+                body, parsed, groups, parser, format, run,
             ));
         }
 
@@ -119,11 +121,12 @@ impl Processor {
                 std::mem::take(&mut parsed.bibliography_blocks),
                 parser,
                 format,
+                run,
             ));
         }
 
         Ok(processor
-            .process_document_with_default_bibliography::<P, F>(body, parsed, parser, format))
+            .process_document_with_default_bibliography::<P, F>(body, parsed, parser, format, run))
     }
 
     /// Orchestrate document processing with custom frontmatter bibliography groups.
@@ -135,6 +138,10 @@ impl Processor {
     /// silently; references not matched by any group selector are not rendered
     /// (use a catch-all group with `selector: {}` or a `not:` negation to
     /// capture unmatched entries).
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "internal helper, all params load-bearing"
+    )]
     fn process_document_with_frontmatter_groups<P, F>(
         &self,
         body: &str,
@@ -142,6 +149,7 @@ impl Processor {
         groups: Vec<citum_schema::grouping::BibliographyGroup>,
         parser: &P,
         format: DocumentFormat,
+        run: RunState,
     ) -> String
     where
         P: CitationParser,
@@ -152,9 +160,10 @@ impl Processor {
             parsed,
             parser,
             format,
-            |processor| {
+            run,
+            |processor, run| {
                 let rendered_blocks =
-                    processor.render_document_bibliography_blocks::<F>(&groups, None, None);
+                    processor.render_document_bibliography_blocks::<F>(&groups, None, None, run);
                 let mut output = String::new();
                 for block in rendered_blocks {
                     if block.entries.is_empty() {
@@ -180,6 +189,7 @@ impl Processor {
         blocks: Vec<BibliographyBlock>,
         parser: &P,
         format: DocumentFormat,
+        mut run: RunState,
     ) -> String
     where
         P: CitationParser,
@@ -187,8 +197,9 @@ impl Processor {
     {
         let staged = stage_document_bibliography_blocks(body, &blocks);
         let parsed_staged = parser.parse_document(&staged, &self.locale);
-        let mut rendered = self.render_document_body::<F>(&staged, parsed_staged, format);
-        self.replace_document_bibliography_blocks::<F>(&mut rendered, &blocks, format);
+        let mut rendered = self.render_document_body::<F>(&staged, parsed_staged, format, &mut run);
+        let run = run.finalize();
+        self.replace_document_bibliography_blocks::<F>(&mut rendered, &blocks, format, &run);
         self.finalize_document_output::<P, F>(parser, format, rendered)
     }
 
@@ -212,11 +223,14 @@ impl Processor {
         P: CitationParser,
         F: crate::render::format::OutputFormat<Output = String>,
     {
+        let mut run = self.begin_run();
         let parsed = parser.parse_document(content, &self.locale);
         let body = content.get(parsed.body_start..).unwrap_or(content);
-        let mut rendered = self.render_document_body::<F>(body, parsed, format);
+        let mut rendered = self.render_document_body::<F>(body, parsed, format, &mut run);
+        let run = run.finalize();
         // Render ordered sectional blocks via the unified primitive.
-        let rendered_groups = self.render_document_bibliography_blocks::<F>(blocks, None, None);
+        let rendered_groups =
+            self.render_document_bibliography_blocks::<F>(blocks, None, None, &run);
         for rendered_group in rendered_groups {
             let section = render_document_bibliography_block_replacement(
                 rendered.placeholders.as_mut(),
@@ -237,6 +251,7 @@ impl Processor {
         parsed: ParsedDocument,
         parser: &P,
         format: DocumentFormat,
+        run: RunState,
     ) -> String
     where
         P: CitationParser,
@@ -247,29 +262,38 @@ impl Processor {
             parsed,
             parser,
             format,
-            |p: &super::super::Processor| {
-                p.render_document_bibliography::<F>(true, None, None)
+            run,
+            |p: &super::super::Processor, run| {
+                p.render_document_bibliography::<F>(true, None, None, run)
                     .content
             },
         )
     }
 
     /// Generic helper for rendering document body + trailing bibliography.
+    ///
+    /// Owns `run` for the whole body-then-bibliography sequence: the body is
+    /// rendered while `run` accumulates cite-order state (`&mut RunState`),
+    /// then `run` is finalized once, and `render_bibliography` receives the
+    /// resulting `&FinalizedRun` — so bibliography rendering always sees the
+    /// complete state left by every citation in the body.
     fn render_document_with_trailing_bibliography<P, F, B>(
         &self,
         body: &str,
         parsed: ParsedDocument,
         parser: &P,
         format: DocumentFormat,
+        mut run: RunState,
         render_bibliography: B,
     ) -> String
     where
         P: CitationParser,
         F: crate::render::format::OutputFormat<Output = String>,
-        B: FnOnce(&Self) -> String,
+        B: FnOnce(&Self, &FinalizedRun) -> String,
     {
-        let mut rendered = self.render_document_body::<F>(body, parsed, format);
-        let bibliography = render_bibliography(self);
+        let mut rendered = self.render_document_body::<F>(body, parsed, format, &mut run);
+        let run = run.finalize();
+        let bibliography = render_bibliography(self, &run);
         append_document_bibliography(&mut rendered, format, bibliography);
         self.finalize_document_output::<P, F>(parser, format, rendered)
     }
@@ -285,6 +309,7 @@ impl Processor {
         content: &str,
         parsed: ParsedDocument,
         format: DocumentFormat,
+        run: &mut RunState,
     ) -> RenderedDocumentBody
     where
         F: crate::render::format::OutputFormat<Output = String>,
@@ -292,9 +317,9 @@ impl Processor {
         if matches!(format, DocumentFormat::Html) {
             let mut placeholders = HtmlPlaceholderRegistry::default();
             let content = if self.is_note_style() {
-                self.process_note_document_html(content, parsed, &mut placeholders)
+                self.process_note_document_html(content, parsed, &mut placeholders, run)
             } else {
-                self.process_inline_document_html(content, parsed, &mut placeholders)
+                self.process_inline_document_html(content, parsed, &mut placeholders, run)
             };
             return RenderedDocumentBody {
                 content,
@@ -313,12 +338,13 @@ impl Processor {
             // body renderer does not yet model, so keep that narrow legacy
             // exception isolated from author-date terminal conversion.
             let content = if self.is_note_style() {
-                self.process_note_document::<F>(content, parsed)
+                self.process_note_document::<F>(content, parsed, run)
             } else {
                 self.process_inline_document_with_placeholders::<F>(
                     content,
                     parsed,
                     &mut placeholders,
+                    run,
                 )
             };
             return RenderedDocumentBody {
@@ -333,9 +359,9 @@ impl Processor {
         }
 
         let content = if self.is_note_style() {
-            self.process_note_document::<F>(content, parsed)
+            self.process_note_document::<F>(content, parsed, run)
         } else {
-            self.process_inline_document::<F>(content, parsed)
+            self.process_inline_document::<F>(content, parsed, run)
         };
 
         RenderedDocumentBody {
@@ -360,13 +386,14 @@ impl Processor {
         content: &str,
         parsed: ParsedDocument,
         placeholders: &mut HtmlPlaceholderRegistry,
+        run: &mut RunState,
     ) -> String
     where
         F: crate::render::format::OutputFormat<Output = String>,
     {
         let mut result = String::new();
         let mut last_idx = 0;
-        let normalized = self.normalize_integral_name_citations(&parsed);
+        let normalized = self.normalize_integral_name_citations(&parsed, run);
 
         for (parsed, citation) in parsed.citations.iter().zip(normalized) {
             debug_assert!(
@@ -377,7 +404,7 @@ impl Processor {
                 content.len()
             );
             result.push_str(&content[last_idx..parsed.start]);
-            match self.process_citation_with_format::<F>(&citation) {
+            match self.process_citation_with_format::<F>(&citation, run) {
                 Ok(rendered) => result.push_str(&placeholders.push_inline(rendered)),
                 Err(_) => result.push_str(&content[parsed.start..parsed.end]),
             }
@@ -393,13 +420,18 @@ impl Processor {
         clippy::string_slice,
         reason = "parser-guaranteed boundaries and indices"
     )]
-    fn process_inline_document<F>(&self, content: &str, parsed: ParsedDocument) -> String
+    fn process_inline_document<F>(
+        &self,
+        content: &str,
+        parsed: ParsedDocument,
+        run: &mut RunState,
+    ) -> String
     where
         F: crate::render::format::OutputFormat<Output = String>,
     {
         let mut result = String::new();
         let mut last_idx = 0;
-        let normalized = self.normalize_integral_name_citations(&parsed);
+        let normalized = self.normalize_integral_name_citations(&parsed, run);
 
         for (parsed, citation) in parsed.citations.iter().zip(normalized) {
             debug_assert!(
@@ -410,7 +442,7 @@ impl Processor {
                 content.len()
             );
             result.push_str(&content[last_idx..parsed.start]);
-            match self.process_citation_with_format::<F>(&citation) {
+            match self.process_citation_with_format::<F>(&citation, run) {
                 Ok(rendered) => result.push_str(&rendered),
                 Err(_) => result.push_str(&content[parsed.start..parsed.end]),
             }
@@ -431,10 +463,11 @@ impl Processor {
         content: &str,
         parsed: ParsedDocument,
         placeholders: &mut HtmlPlaceholderRegistry,
+        run: &mut RunState,
     ) -> String {
         let mut result = String::new();
         let mut last_idx = 0;
-        let normalized = self.normalize_integral_name_citations(&parsed);
+        let normalized = self.normalize_integral_name_citations(&parsed, run);
 
         for (parsed, citation) in parsed.citations.iter().zip(normalized) {
             debug_assert!(
@@ -445,7 +478,7 @@ impl Processor {
                 content.len()
             );
             result.push_str(&content[last_idx..parsed.start]);
-            match self.process_citation_with_format::<crate::render::html::Html>(&citation) {
+            match self.process_citation_with_format::<crate::render::html::Html>(&citation, run) {
                 Ok(rendered) => result.push_str(&placeholders.push_inline(rendered)),
                 Err(_) => result.push_str(&content[parsed.start..parsed.end]),
             }
@@ -462,11 +495,13 @@ impl Processor {
         rendered: &mut RenderedDocumentBody,
         blocks: &[BibliographyBlock],
         format: DocumentFormat,
+        run: &FinalizedRun,
     ) where
         F: crate::render::format::OutputFormat<Output = String>,
     {
         let groups: Vec<_> = blocks.iter().map(|b| b.group.clone()).collect();
-        let rendered_groups = self.render_document_bibliography_blocks::<F>(&groups, None, None);
+        let rendered_groups =
+            self.render_document_bibliography_blocks::<F>(&groups, None, None, run);
         for (index, rendered_group) in rendered_groups.into_iter().enumerate() {
             let placeholder = bibliography_block_placeholder(index);
             let replacement = render_document_bibliography_block_replacement(

--- a/crates/citum-engine/src/processor/mod.rs
+++ b/crates/citum-engine/src/processor/mod.rs
@@ -32,6 +32,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 mod bibliography;
 mod citation;
 mod note_context;
+mod run_state;
 mod setup;
 
 /// Author/date disambiguation and year-suffix assignment.
@@ -64,8 +65,8 @@ use citum_schema::Style;
 use citum_schema::locale::Locale;
 use citum_schema::options::Config;
 use indexmap::IndexMap;
-use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use run_state::RunState;
+use std::collections::HashMap;
 
 /// The Citum processor facade.
 ///
@@ -83,33 +84,12 @@ pub struct Processor {
     pub default_config: Config,
     /// Pre-calculated processing hints.
     pub hints: HashMap<String, ProcHints>,
-    /// Citation numbers assigned to references (for numeric styles).
-    pub citation_numbers: RefCell<HashMap<String, usize>>,
-    /// IDs of items that were cited in a visible way.
-    pub cited_ids: RefCell<HashSet<String>>,
     /// Compound sets keyed by set ID.
     pub compound_sets: IndexMap<String, Vec<String>>,
     /// Reverse lookup for set membership by reference ID.
     pub compound_set_by_ref: HashMap<String, String>,
     /// Position within a set (0-based) for each reference ID.
     pub compound_member_index: HashMap<String, usize>,
-    /// Compound numeric groups: citation number → ordered ref IDs in the group.
-    pub compound_groups: RefCell<IndexMap<usize, Vec<String>>>,
-    /// Dynamic equivalent of `compound_set_by_ref` for cite-time groups.
-    ///
-    /// Maps each dynamic group member (head and tails) to the head's ref ID,
-    /// which acts as the set identifier. Merged with static data at render time.
-    pub dynamic_compound_set_by_ref: RefCell<HashMap<String, String>>,
-    /// Dynamic equivalent of `compound_member_index` for cite-time groups.
-    ///
-    /// Maps each dynamic group member to its 0-based position within the group.
-    /// Merged with static data at render time.
-    pub dynamic_compound_member_index: RefCell<HashMap<String, usize>>,
-    /// Dynamic equivalent of `compound_sets` for cite-time groups.
-    ///
-    /// Maps each dynamic group's head ref ID to the ordered list of all members.
-    /// Merged with static `compound_sets` at render time so sub-label lookup works.
-    pub dynamic_compound_sets: RefCell<IndexMap<String, Vec<String>>>,
     /// Whether to output semantic markup (HTML spans, Djot attributes).
     /// Defaults to true; set to false to suppress class attributes (e.g. `--no-semantics`).
     pub show_semantics: bool,
@@ -117,9 +97,14 @@ pub struct Processor {
     pub inject_ast_indices: bool,
     /// Document-level abbreviation map for post-render substitution.
     pub abbreviation_map: Option<crate::api::AbbreviationMap>,
-    /// First note number in which each reference was cited (note styles only).
-    /// Populated during `normalize_note_context`; keyed by reference ID.
-    pub first_note_by_id: RefCell<HashMap<String, u32>>,
+    /// Mutable per-render-run state (citation numbers, cite-order tracking,
+    /// dynamic compound groups, first-note tracking).
+    ///
+    /// See `docs/specs/EXPLICIT_RENDER_RUN_STATE.md`. This is a transitional
+    /// single-run-per-processor shape; a later migration step will thread
+    /// `RunState` explicitly through registration/render calls instead of
+    /// storing it on `Processor`.
+    pub(crate) run_state: RunState,
 }
 
 /// Processed output containing citations and bibliography.

--- a/crates/citum-engine/src/processor/mod.rs
+++ b/crates/citum-engine/src/processor/mod.rs
@@ -65,7 +65,7 @@ use citum_schema::Style;
 use citum_schema::locale::Locale;
 use citum_schema::options::Config;
 use indexmap::IndexMap;
-use run_state::RunState;
+pub use run_state::{FinalizedRun, RunState};
 use std::collections::HashMap;
 
 /// The Citum processor facade.
@@ -97,14 +97,6 @@ pub struct Processor {
     pub inject_ast_indices: bool,
     /// Document-level abbreviation map for post-render substitution.
     pub abbreviation_map: Option<crate::api::AbbreviationMap>,
-    /// Mutable per-render-run state (citation numbers, cite-order tracking,
-    /// dynamic compound groups, first-note tracking).
-    ///
-    /// See `docs/specs/EXPLICIT_RENDER_RUN_STATE.md`. This is a transitional
-    /// single-run-per-processor shape; a later migration step will thread
-    /// `RunState` explicitly through registration/render calls instead of
-    /// storing it on `Processor`.
-    pub(crate) run_state: RunState,
 }
 
 /// Processed output containing citations and bibliography.

--- a/crates/citum-engine/src/processor/note_context.rs
+++ b/crates/citum-engine/src/processor/note_context.rs
@@ -10,6 +10,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! and `Ibid` before citation rendering begins.
 
 use super::Processor;
+use super::run_state::RunState;
 use crate::reference::{Citation, CitationItem};
 use citum_schema::citation::Position;
 
@@ -112,8 +113,14 @@ impl Processor {
     /// Normalize citation note context for note styles.
     ///
     /// Document/plugin layers should provide explicit `note_number` values.
-    /// When missing, this method assigns sequential note numbers in citation order.
-    pub fn normalize_note_context(&self, citations: &[Citation]) -> Vec<Citation> {
+    /// When missing, this method assigns sequential note numbers in citation
+    /// order and records each reference's first-occurrence note number into
+    /// `run`.
+    pub fn normalize_note_context(
+        &self,
+        citations: &[Citation],
+        run: &mut RunState,
+    ) -> Vec<Citation> {
         if !self.is_note_style() {
             return citations.to_vec();
         }
@@ -138,7 +145,7 @@ impl Processor {
         // Build first-occurrence note number map: id → note_number of first cite.
         // Clear first so repeated calls (e.g. reprocessing after insertion/reordering)
         // don't accumulate stale entries from prior runs.
-        let mut first_note = self.run_state.first_note_by_id.borrow_mut();
+        let mut first_note = run.first_note_by_id.borrow_mut();
         first_note.clear();
         for citation in &normalized {
             if let Some(note_number) = citation.note_number {
@@ -147,6 +154,7 @@ impl Processor {
                 }
             }
         }
+        drop(first_note);
 
         normalized
     }

--- a/crates/citum-engine/src/processor/note_context.rs
+++ b/crates/citum-engine/src/processor/note_context.rs
@@ -138,7 +138,7 @@ impl Processor {
         // Build first-occurrence note number map: id → note_number of first cite.
         // Clear first so repeated calls (e.g. reprocessing after insertion/reordering)
         // don't accumulate stale entries from prior runs.
-        let mut first_note = self.first_note_by_id.borrow_mut();
+        let mut first_note = self.run_state.first_note_by_id.borrow_mut();
         first_note.clear();
         for citation in &normalized {
             if let Some(note_number) = citation.note_number {

--- a/crates/citum-engine/src/processor/rendering/tests.rs
+++ b/crates/citum-engine/src/processor/rendering/tests.rs
@@ -1091,7 +1091,7 @@ fn render_single_bibliography_entry(style: Style, reference: Reference) -> Strin
     bibliography.insert(id, reference);
 
     Processor::new(style, bibliography)
-        .render_bibliography_with_format::<crate::render::plain::PlainText>()
+        .render_bibliography_with_format_standalone::<crate::render::plain::PlainText>()
 }
 
 fn bibliography_style_with_template(template: Vec<TemplateComponent>) -> Style {

--- a/crates/citum-engine/src/processor/run_state.rs
+++ b/crates/citum-engine/src/processor/run_state.rs
@@ -1,0 +1,71 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Per-render-run mutable state for [`Processor`](super::Processor).
+//!
+//! This module is the first step of the migration described in
+//! `docs/specs/EXPLICIT_RENDER_RUN_STATE.md`: it relocates the seven
+//! `RefCell` fields that were previously declared directly on `Processor`
+//! into their own type, `RunState`, with all existing call sites updated to
+//! go through `self.run_state` (or `processor.run_state` in tests). No
+//! method signatures change in this step — `Processor` still owns exactly
+//! one `RunState` for its lifetime, so behavior is identical to before.
+//!
+//! Subsequent migration steps (see the spec) will thread `&mut RunState`
+//! explicitly through registration methods and introduce a `FinalizedRun`
+//! typestate so the ordering contract between citation registration and
+//! bibliography/citation-number-dependent rendering is enforced by the type
+//! system rather than by doc comments.
+
+use indexmap::IndexMap;
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+
+/// Mutable per-render-run state: citation numbering, cite-order tracking,
+/// and dynamic (cite-time) compound-group membership.
+///
+/// See `docs/specs/EXPLICIT_RENDER_RUN_STATE.md` for the full design and
+/// migration plan.
+#[derive(Debug)]
+pub struct RunState {
+    /// Citation numbers assigned to references (for numeric styles).
+    pub(super) citation_numbers: RefCell<HashMap<String, usize>>,
+    /// IDs of items that were cited in a visible way.
+    pub(super) cited_ids: RefCell<HashSet<String>>,
+    /// Compound numeric groups: citation number → ordered ref IDs in the group.
+    pub(super) compound_groups: RefCell<IndexMap<usize, Vec<String>>>,
+    /// Dynamic equivalent of `Processor::compound_set_by_ref` for cite-time groups.
+    ///
+    /// Maps each dynamic group member (head and tails) to the head's ref ID,
+    /// which acts as the set identifier. Merged with static data at render time.
+    pub(super) dynamic_compound_set_by_ref: RefCell<HashMap<String, String>>,
+    /// Dynamic equivalent of `Processor::compound_member_index` for cite-time groups.
+    ///
+    /// Maps each dynamic group member to its 0-based position within the group.
+    /// Merged with static data at render time.
+    pub(super) dynamic_compound_member_index: RefCell<HashMap<String, usize>>,
+    /// Dynamic equivalent of `Processor::compound_sets` for cite-time groups.
+    ///
+    /// Maps each dynamic group's head ref ID to the ordered list of all members.
+    /// Merged with static `compound_sets` at render time so sub-label lookup works.
+    pub(super) dynamic_compound_sets: RefCell<IndexMap<String, Vec<String>>>,
+    /// First note number in which each reference was cited (note styles only).
+    /// Populated during `normalize_note_context`; keyed by reference ID.
+    pub(super) first_note_by_id: RefCell<HashMap<String, u32>>,
+}
+
+impl Default for RunState {
+    fn default() -> Self {
+        Self {
+            citation_numbers: RefCell::new(HashMap::new()),
+            cited_ids: RefCell::new(HashSet::new()),
+            compound_groups: RefCell::new(IndexMap::new()),
+            dynamic_compound_set_by_ref: RefCell::new(HashMap::new()),
+            dynamic_compound_member_index: RefCell::new(HashMap::new()),
+            dynamic_compound_sets: RefCell::new(IndexMap::new()),
+            first_note_by_id: RefCell::new(HashMap::new()),
+        }
+    }
+}

--- a/crates/citum-engine/src/processor/run_state.rs
+++ b/crates/citum-engine/src/processor/run_state.rs
@@ -5,19 +5,31 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 //! Per-render-run mutable state for [`Processor`](super::Processor).
 //!
-//! This module is the first step of the migration described in
-//! `docs/specs/EXPLICIT_RENDER_RUN_STATE.md`: it relocates the seven
-//! `RefCell` fields that were previously declared directly on `Processor`
-//! into their own type, `RunState`, with all existing call sites updated to
-//! go through `self.run_state` (or `processor.run_state` in tests). No
-//! method signatures change in this step — `Processor` still owns exactly
-//! one `RunState` for its lifetime, so behavior is identical to before.
+//! See `docs/specs/EXPLICIT_RENDER_RUN_STATE.md` for the full design.
 //!
-//! Subsequent migration steps (see the spec) will thread `&mut RunState`
-//! explicitly through registration methods and introduce a `FinalizedRun`
-//! typestate so the ordering contract between citation registration and
-//! bibliography/citation-number-dependent rendering is enforced by the type
-//! system rather than by doc comments.
+//! `RunState` owns the citation-order-dependent state that used to live as
+//! `RefCell` fields directly on `Processor`: citation numbers, the cited-ID
+//! set, dynamic (cite-time) compound-group membership, and first-note
+//! tracking. It is created fresh via [`Processor::begin_run`](super::Processor::begin_run),
+//! populated in citation-processing order by registration methods that take
+//! `&mut RunState`, and then finalized into a [`FinalizedRun`] so that
+//! bibliography rendering — which takes `&FinalizedRun` — cannot be called
+//! before registration is complete. That ordering contract is enforced by
+//! the type system: there is no way to construct a `FinalizedRun` other than
+//! through [`RunState::finalize`]. Citation rendering itself stays
+//! `&mut RunState`-threaded rather than moving to `&FinalizedRun`:
+//! registration and rendering are interleaved per citation (see
+//! `citation.rs`'s module docs), so a citation can only be rendered as part
+//! of the same in-progress run that is registering it.
+//!
+//! Two fields, `citation_numbers` and `first_note_by_id`, stay behind a
+//! `RefCell` even inside `RunState`/`FinalizedRun`: the render layer
+//! (`Renderer::get_or_assign_citation_number`) lazily assigns a citation
+//! number the first time a reference is rendered, which is a monotonic,
+//! assign-once operation, not a read. This does not weaken the ordering
+//! contract this type adds — it only means "render before registration is
+//! complete" is a compile error, not that rendering can never touch interior
+//! state.
 
 use indexmap::IndexMap;
 use std::cell::RefCell;
@@ -26,46 +38,88 @@ use std::collections::{HashMap, HashSet};
 /// Mutable per-render-run state: citation numbering, cite-order tracking,
 /// and dynamic (cite-time) compound-group membership.
 ///
-/// See `docs/specs/EXPLICIT_RENDER_RUN_STATE.md` for the full design and
-/// migration plan.
-#[derive(Debug)]
+/// Create with [`Processor::begin_run`](super::Processor::begin_run);
+/// populate via registration methods (`&self, &mut RunState`); consume via
+/// [`finalize`](RunState::finalize) before rendering.
+///
+/// `Clone` is provided for long-lived callers (e.g. the FFI session handle)
+/// that need to render a bibliography from a snapshot of the current state
+/// without pausing ongoing citation registration on the original `RunState`.
+#[derive(Debug, Clone)]
 pub struct RunState {
     /// Citation numbers assigned to references (for numeric styles).
+    ///
+    /// Stays `RefCell`: the render layer lazily assigns numbers the first
+    /// time a reference is rendered (see module docs).
     pub(super) citation_numbers: RefCell<HashMap<String, usize>>,
+    /// First note number in which each reference was cited (note styles only).
+    ///
+    /// Stays `RefCell` for the same reason as `citation_numbers`.
+    pub(super) first_note_by_id: RefCell<HashMap<String, u32>>,
     /// IDs of items that were cited in a visible way.
-    pub(super) cited_ids: RefCell<HashSet<String>>,
+    pub(super) cited_ids: HashSet<String>,
     /// Compound numeric groups: citation number → ordered ref IDs in the group.
-    pub(super) compound_groups: RefCell<IndexMap<usize, Vec<String>>>,
+    pub(super) compound_groups: IndexMap<usize, Vec<String>>,
     /// Dynamic equivalent of `Processor::compound_set_by_ref` for cite-time groups.
     ///
     /// Maps each dynamic group member (head and tails) to the head's ref ID,
     /// which acts as the set identifier. Merged with static data at render time.
-    pub(super) dynamic_compound_set_by_ref: RefCell<HashMap<String, String>>,
+    pub(super) dynamic_compound_set_by_ref: HashMap<String, String>,
     /// Dynamic equivalent of `Processor::compound_member_index` for cite-time groups.
     ///
     /// Maps each dynamic group member to its 0-based position within the group.
     /// Merged with static data at render time.
-    pub(super) dynamic_compound_member_index: RefCell<HashMap<String, usize>>,
+    pub(super) dynamic_compound_member_index: HashMap<String, usize>,
     /// Dynamic equivalent of `Processor::compound_sets` for cite-time groups.
     ///
     /// Maps each dynamic group's head ref ID to the ordered list of all members.
     /// Merged with static `compound_sets` at render time so sub-label lookup works.
-    pub(super) dynamic_compound_sets: RefCell<IndexMap<String, Vec<String>>>,
-    /// First note number in which each reference was cited (note styles only).
-    /// Populated during `normalize_note_context`; keyed by reference ID.
-    pub(super) first_note_by_id: RefCell<HashMap<String, u32>>,
+    pub(super) dynamic_compound_sets: IndexMap<String, Vec<String>>,
 }
 
 impl Default for RunState {
     fn default() -> Self {
         Self {
             citation_numbers: RefCell::new(HashMap::new()),
-            cited_ids: RefCell::new(HashSet::new()),
-            compound_groups: RefCell::new(IndexMap::new()),
-            dynamic_compound_set_by_ref: RefCell::new(HashMap::new()),
-            dynamic_compound_member_index: RefCell::new(HashMap::new()),
-            dynamic_compound_sets: RefCell::new(IndexMap::new()),
             first_note_by_id: RefCell::new(HashMap::new()),
+            cited_ids: HashSet::new(),
+            compound_groups: IndexMap::new(),
+            dynamic_compound_set_by_ref: HashMap::new(),
+            dynamic_compound_member_index: HashMap::new(),
+            dynamic_compound_sets: IndexMap::new(),
         }
+    }
+}
+
+impl RunState {
+    /// Complete the registration phase, producing a [`FinalizedRun`].
+    ///
+    /// This is a plain newtype wrap with no additional computation; it
+    /// exists purely as a compile-time marker that registration for this
+    /// run is considered complete, so rendering methods that require
+    /// citation order/numbering can require `&FinalizedRun` instead of
+    /// `&RunState`.
+    #[must_use]
+    pub fn finalize(self) -> FinalizedRun {
+        FinalizedRun(self)
+    }
+}
+
+/// A [`RunState`] that has completed the registration phase.
+///
+/// Rendering methods that depend on cite order or citation numbers (e.g.
+/// bibliography rendering, citation-collapse across a document) take
+/// `&FinalizedRun` rather than `&RunState`, so calling them before
+/// registration is complete is a compile error.
+#[derive(Debug)]
+pub struct FinalizedRun(pub(super) RunState);
+
+impl FinalizedRun {
+    /// Borrow the underlying run state.
+    ///
+    /// Available to processor submodules that need read access to run
+    /// fields during rendering (e.g. `cited_ids`, `compound_groups`).
+    pub(super) fn state(&self) -> &RunState {
+        &self.0
     }
 }

--- a/crates/citum-engine/src/processor/setup.rs
+++ b/crates/citum-engine/src/processor/setup.rs
@@ -22,8 +22,7 @@ use citum_schema::options::{
     SortingMultilingualMode, bibliography::BibliographyConfig,
 };
 use indexmap::IndexMap;
-use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 impl Default for Processor {
     fn default() -> Self {
@@ -36,19 +35,13 @@ impl Default for Processor {
             locale: Locale::en_us(),
             default_config: Config::default(),
             hints: HashMap::new(),
-            citation_numbers: RefCell::new(HashMap::new()),
-            cited_ids: RefCell::new(HashSet::new()),
             compound_sets,
             compound_set_by_ref,
             compound_member_index,
-            compound_groups: RefCell::new(IndexMap::new()),
-            dynamic_compound_set_by_ref: RefCell::new(HashMap::new()),
-            dynamic_compound_member_index: RefCell::new(HashMap::new()),
-            dynamic_compound_sets: RefCell::new(IndexMap::new()),
             show_semantics: true,
             inject_ast_indices: false,
             abbreviation_map: None,
-            first_note_by_id: RefCell::new(HashMap::new()),
+            run_state: super::run_state::RunState::default(),
         }
     }
 }
@@ -86,19 +79,13 @@ impl Processor {
             locale,
             default_config: Config::default(),
             hints: HashMap::new(),
-            citation_numbers: RefCell::new(HashMap::new()),
-            cited_ids: RefCell::new(HashSet::new()),
             compound_sets,
             compound_set_by_ref,
             compound_member_index,
-            compound_groups: RefCell::new(IndexMap::new()),
-            dynamic_compound_set_by_ref: RefCell::new(HashMap::new()),
-            dynamic_compound_member_index: RefCell::new(HashMap::new()),
-            dynamic_compound_sets: RefCell::new(IndexMap::new()),
             show_semantics: true,
             inject_ast_indices: false,
             abbreviation_map: None,
-            first_note_by_id: RefCell::new(HashMap::new()),
+            run_state: super::run_state::RunState::default(),
         };
 
         // Pre-calculate hints for disambiguation.
@@ -238,7 +225,7 @@ impl Processor {
 
     /// Initialize citation numbers if the map is currently empty.
     fn initialize_numeric_numbers(&self, ordered_ids: Vec<String>) {
-        if !self.citation_numbers.borrow().is_empty() {
+        if !self.run_state.citation_numbers.borrow().is_empty() {
             return;
         }
 
@@ -268,7 +255,7 @@ impl Processor {
     /// Also populates compound groups for numeric styles that enable compound
     /// numbering.
     fn initialize_numeric_citation_numbers_from_ordered_ids(&self, ordered_ids: Vec<String>) {
-        let mut numbers = self.citation_numbers.borrow_mut();
+        let mut numbers = self.run_state.citation_numbers.borrow_mut();
         if !numbers.is_empty() {
             return;
         }
@@ -278,7 +265,7 @@ impl Processor {
         if compound_config.is_some() {
             let mut set_first_seen: IndexMap<String, usize> = IndexMap::new();
             let mut current_number = 1usize;
-            let mut compound_groups = self.compound_groups.borrow_mut();
+            let mut compound_groups = self.run_state.compound_groups.borrow_mut();
             compound_groups.clear();
 
             for ref_id in &ordered_ids {

--- a/crates/citum-engine/src/processor/setup.rs
+++ b/crates/citum-engine/src/processor/setup.rs
@@ -12,6 +12,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 use super::Processor;
 use super::disambiguation::Disambiguator;
+use super::run_state::RunState;
 use crate::error::ProcessorError;
 use crate::reference::{Bibliography, CitationItem, Reference};
 use crate::values::ProcHints;
@@ -41,7 +42,6 @@ impl Default for Processor {
             show_semantics: true,
             inject_ast_indices: false,
             abbreviation_map: None,
-            run_state: super::run_state::RunState::default(),
         }
     }
 }
@@ -85,7 +85,6 @@ impl Processor {
             show_semantics: true,
             inject_ast_indices: false,
             abbreviation_map: None,
-            run_state: super::run_state::RunState::default(),
         };
 
         // Pre-calculate hints for disambiguation.
@@ -206,30 +205,30 @@ impl Processor {
     /// When the style declares an explicit bibliography sort, or the
     /// processing family provides a bibliography default, citation numbers
     /// must follow that resolved bibliography order.
-    pub(crate) fn initialize_numeric_citation_numbers(&self) {
+    pub(crate) fn initialize_numeric_citation_numbers(&self, run: &mut RunState) {
         if !self.is_numeric_style() {
             return;
         }
 
-        self.initialize_numeric_numbers(self.sort_citation_number_order());
+        self.initialize_numeric_numbers(run, self.sort_citation_number_order());
     }
 
     /// Initialize numeric bibliography numbers from resolved bibliography order.
-    pub(crate) fn initialize_numeric_bibliography_numbers(&self) {
+    pub(crate) fn initialize_numeric_bibliography_numbers(&self, run: &mut RunState) {
         if !self.is_numeric_bibliography_style() {
             return;
         }
 
-        self.initialize_numeric_numbers(self.sort_bibliography_number_order());
+        self.initialize_numeric_numbers(run, self.sort_bibliography_number_order());
     }
 
     /// Initialize citation numbers if the map is currently empty.
-    fn initialize_numeric_numbers(&self, ordered_ids: Vec<String>) {
-        if !self.run_state.citation_numbers.borrow().is_empty() {
+    fn initialize_numeric_numbers(&self, run: &mut RunState, ordered_ids: Vec<String>) {
+        if !run.citation_numbers.borrow().is_empty() {
             return;
         }
 
-        self.initialize_numeric_citation_numbers_from_ordered_ids(ordered_ids);
+        self.initialize_numeric_citation_numbers_from_ordered_ids(run, ordered_ids);
     }
 
     /// Calculate the document-wide reference order for citation numbering.
@@ -254,8 +253,12 @@ impl Processor {
     ///
     /// Also populates compound groups for numeric styles that enable compound
     /// numbering.
-    fn initialize_numeric_citation_numbers_from_ordered_ids(&self, ordered_ids: Vec<String>) {
-        let mut numbers = self.run_state.citation_numbers.borrow_mut();
+    fn initialize_numeric_citation_numbers_from_ordered_ids(
+        &self,
+        run: &mut RunState,
+        ordered_ids: Vec<String>,
+    ) {
+        let mut numbers = run.citation_numbers.borrow_mut();
         if !numbers.is_empty() {
             return;
         }
@@ -265,8 +268,7 @@ impl Processor {
         if compound_config.is_some() {
             let mut set_first_seen: IndexMap<String, usize> = IndexMap::new();
             let mut current_number = 1usize;
-            let mut compound_groups = self.run_state.compound_groups.borrow_mut();
-            compound_groups.clear();
+            run.compound_groups.clear();
 
             for ref_id in &ordered_ids {
                 if let Some(set_id) = self.compound_set_by_ref.get(ref_id) {
@@ -284,7 +286,7 @@ impl Processor {
                                 numbers.insert(member.clone(), current_number);
                             }
                             if present_members.len() > 1 {
-                                compound_groups.insert(current_number, present_members);
+                                run.compound_groups.insert(current_number, present_members);
                             }
                         } else {
                             numbers.insert(ref_id.clone(), current_number);
@@ -301,6 +303,23 @@ impl Processor {
                 numbers.insert(ref_id, index + 1);
             }
         }
+    }
+
+    /// Begin a new render run.
+    ///
+    /// Allocates fresh per-run state (citation numbers, cite-order tracking,
+    /// dynamic compound groups, first-note tracking) and performs numeric
+    /// citation-number pre-initialization from the processor's immutable
+    /// bibliography/style data. Registration methods (`&self, &mut RunState`)
+    /// populate the returned `RunState` in citation-processing order; call
+    /// [`RunState::finalize`] before rendering. See
+    /// `docs/specs/EXPLICIT_RENDER_RUN_STATE.md`.
+    #[must_use]
+    pub fn begin_run(&self) -> RunState {
+        let mut run = RunState::default();
+        self.initialize_numeric_citation_numbers(&mut run);
+        self.initialize_numeric_bibliography_numbers(&mut run);
+        run
     }
 
     /// Create a new processor with default English locale (en-US).

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -527,7 +527,8 @@ fn test_normalize_note_context_assigns_missing_numbers() {
         },
     ];
 
-    let normalized = processor.normalize_note_context(&citations);
+    let mut run = processor.begin_run();
+    let normalized = processor.normalize_note_context(&citations, &mut run);
     assert_eq!(normalized[0].note_number, Some(1));
     assert_eq!(normalized[1].note_number, Some(7));
     assert_eq!(normalized[2].note_number, Some(8));
@@ -1713,6 +1714,80 @@ fn test_numeric_citation_numbers_with_repeated_refs() {
     assert_eq!(cit3, "[1]", "Second citation of ref1 should still be [1]");
 }
 
+/// Verifies the headline property `docs/specs/EXPLICIT_RENDER_RUN_STATE.md`
+/// exists to make possible: rendering the same citation list twice through
+/// one reused `Processor`, each with its own fresh `RunState` from
+/// `begin_run`, produces identical output. Before this refactor `Processor`
+/// accumulated state across its whole lifetime, so this property was not
+/// just untested — it was not expressible.
+#[test]
+fn test_processor_is_reusable_across_independent_runs() {
+    let style = make_style();
+    let mut bib = make_bibliography();
+    bib.insert(
+        "smith2020".to_string(),
+        Reference::from(LegacyReference {
+            id: "smith2020".to_string(),
+            ref_type: "book".to_string(),
+            author: Some(vec![Name::new("Smith", "Jane")]),
+            title: Some("A Later Study".to_string()),
+            issued: Some(DateVariable::year(2020)),
+            ..Default::default()
+        }),
+    );
+    let processor = Processor::new(style, bib);
+
+    let citations = vec![
+        Citation {
+            id: Some("c1".into()),
+            items: vec![crate::reference::CitationItem {
+                id: "kuhn1962".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+        Citation {
+            id: Some("c2".into()),
+            items: vec![crate::reference::CitationItem {
+                id: "smith2020".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        },
+    ];
+
+    let mut first_run = processor.begin_run();
+    let first_pass = processor
+        .process_citations_with_format::<crate::render::plain::PlainText>(
+            &citations,
+            &mut first_run,
+        )
+        .unwrap();
+    let first_run = first_run.finalize();
+    let first_bibliography =
+        processor.render_bibliography_with_format::<crate::render::plain::PlainText>(&first_run);
+
+    let mut second_run = processor.begin_run();
+    let second_pass = processor
+        .process_citations_with_format::<crate::render::plain::PlainText>(
+            &citations,
+            &mut second_run,
+        )
+        .unwrap();
+    let second_run = second_run.finalize();
+    let second_bibliography =
+        processor.render_bibliography_with_format::<crate::render::plain::PlainText>(&second_run);
+
+    assert_eq!(
+        first_pass, second_pass,
+        "rendering the same citations through two independent runs must produce identical citation text"
+    );
+    assert_eq!(
+        first_bibliography, second_bibliography,
+        "rendering the same citations through two independent runs must produce an identical bibliography"
+    );
+}
+
 /// Tests the behavior of `test_numeric_citation_numbers_follow_registry_order`.
 #[test]
 fn test_numeric_citation_numbers_follow_registry_order() {
@@ -2030,7 +2105,7 @@ fn test_whole_entry_linking_html() {
     );
 
     let processor = Processor::new(style, bib);
-    let result = processor.render_bibliography_with_format::<Html>();
+    let result = processor.render_bibliography_with_format_standalone::<Html>();
 
     assert_eq!(
         result,
@@ -2065,7 +2140,7 @@ fn test_global_title_linking_html() {
     );
 
     let processor = Processor::new(style, bib);
-    let result = processor.render_bibliography_with_format::<Html>();
+    let result = processor.render_bibliography_with_format_standalone::<Html>();
 
     // The title should be automatically hyperlinked because of global config.
     // Note: In this test, title substitutes for author, so it gets citum-author class.
@@ -2114,7 +2189,7 @@ fn test_inline_title_link_takes_precedence_over_global_title_link_html() {
     );
 
     let processor = Processor::new(style, bib);
-    let result = processor.render_bibliography_with_format::<Html>();
+    let result = processor.render_bibliography_with_format_standalone::<Html>();
 
     assert_eq!(
         result,
@@ -2156,7 +2231,7 @@ fn test_chicago_title_preset_preserves_djot_markup_html() {
     );
 
     let processor = Processor::new(style, bib);
-    let result = processor.render_bibliography_with_format::<Html>();
+    let result = processor.render_bibliography_with_format_standalone::<Html>();
 
     assert!(
         result.contains(
@@ -2193,7 +2268,7 @@ fn test_whole_entry_linking_typst() {
     );
 
     let processor = Processor::new(style, bib);
-    let result = processor.render_bibliography_with_format::<Typst>();
+    let result = processor.render_bibliography_with_format_standalone::<Typst>();
 
     assert_eq!(
         result,
@@ -2217,8 +2292,9 @@ fn test_typst_single_item_citation_links_to_bibliography_entry() {
         ..Default::default()
     };
 
+    let mut run = processor.begin_run();
     let result = processor
-        .process_citation_with_format::<Typst>(&citation)
+        .process_citation_with_format::<Typst>(&citation, &mut run)
         .unwrap();
 
     assert_eq!(result, "(#link(<ref-kuhn1962>)[Kuhn, 1962])");
@@ -3113,8 +3189,8 @@ fn test_bibliography_per_group_disambiguation() {
     ));
 
     let processor = Processor::new(style, bib);
-    let result =
-        processor.render_grouped_bibliography_with_format::<crate::render::plain::PlainText>();
+    let result = processor
+        .render_grouped_bibliography_with_format_standalone::<crate::render::plain::PlainText>();
 
     // Year-suffix letters follow the article-stripped bibliography sort (§3): the
     // leading "A" of "A title" is a sort article, so it normalizes to "title" and
@@ -3225,8 +3301,8 @@ fn test_grouped_numeric_bibliography_rerender_preserves_numbers_and_substitution
     );
 
     let processor = Processor::new(style, bib);
-    let result =
-        processor.render_grouped_bibliography_with_format::<crate::render::plain::PlainText>();
+    let result = processor
+        .render_grouped_bibliography_with_format_standalone::<crate::render::plain::PlainText>();
 
     assert!(
         result.contains("[2] Smith, John"),
@@ -3311,8 +3387,8 @@ fn test_group_heading_localized_uses_processor_locale() {
     locale.locale = "vi-VN".to_string();
 
     let processor = Processor::with_locale(style, bib, locale);
-    let output =
-        processor.render_grouped_bibliography_with_format::<crate::render::plain::PlainText>();
+    let output = processor
+        .render_grouped_bibliography_with_format_standalone::<crate::render::plain::PlainText>();
 
     // The localized heading from the first group should be resolved and displayed.
     // The processor locale is "vi-VN" so it should use the "vi" entry.
@@ -3395,8 +3471,8 @@ fn test_group_heading_term_resolves_from_locale() {
     );
 
     let processor = Processor::new(style, bib);
-    let output =
-        processor.render_grouped_bibliography_with_format::<crate::render::plain::PlainText>();
+    let output = processor
+        .render_grouped_bibliography_with_format_standalone::<crate::render::plain::PlainText>();
 
     // The term heading from the first group should be resolved from the locale.
     // For English, GeneralTerm::And should resolve to "and".
@@ -3432,7 +3508,7 @@ fn test_grouped_bibliography_html_suppresses_heading_for_single_group() {
     }]);
 
     let processor = Processor::new(style, make_bibliography());
-    let output = processor.render_grouped_bibliography_with_format::<Html>();
+    let output = processor.render_grouped_bibliography_with_format_standalone::<Html>();
 
     // When all references fall into a single group with no unassigned entries,
     // the group heading is suppressed, so no heading markup should appear.
@@ -3509,7 +3585,7 @@ fn test_grouped_bibliography_html_uses_html_headings() {
     );
 
     let processor = Processor::new(style, bib);
-    let output = processor.render_grouped_bibliography_with_format::<Html>();
+    let output = processor.render_grouped_bibliography_with_format_standalone::<Html>();
 
     // When there are multiple groups, headings should be rendered.
     // The first group heading should contain at least 30 chars to satisfy the test assertion rule.
@@ -4105,10 +4181,10 @@ fn test_compound_numeric_number_assignment() {
     );
 
     let processor = Processor::with_compound_sets(style, bib, sets);
-    // Trigger number initialization via process_references
-    let _ = processor.process_references();
+    // begin_run triggers number initialization from bibliography order.
+    let run = processor.begin_run();
 
-    let numbers = processor.run_state.citation_numbers.borrow();
+    let numbers = run.citation_numbers.borrow();
     // ref-a and ref-b share the same set membership -> same citation number.
     assert_eq!(
         numbers.get("ref-a"),
@@ -4125,7 +4201,7 @@ fn test_compound_numeric_number_assignment() {
     assert_eq!(numbers.get("ref-c"), Some(&2), "ungrouped ref should be 2");
 
     // Verify compound_groups tracking
-    let groups = processor.run_state.compound_groups.borrow();
+    let groups = &run.compound_groups;
     assert!(
         groups.contains_key(&1),
         "compound_groups should track group 1"
@@ -4241,8 +4317,8 @@ bibliography:
 #[test]
 fn test_grouped_compound_bibliography_leader_only_match_stays_singleton() {
     let processor = make_grouped_compound_selection_processor("selected", "other");
-    let output =
-        processor.render_grouped_bibliography_with_format::<crate::render::plain::PlainText>();
+    let output = processor
+        .render_grouped_bibliography_with_format_standalone::<crate::render::plain::PlainText>();
     let selected_body = extract_selected_group_body(&output);
 
     assert!(
@@ -4266,8 +4342,8 @@ fn test_grouped_compound_bibliography_leader_only_match_stays_singleton() {
 #[test]
 fn test_grouped_compound_bibliography_non_leader_match_renders_selected_member() {
     let processor = make_grouped_compound_selection_processor("other", "selected");
-    let output =
-        processor.render_grouped_bibliography_with_format::<crate::render::plain::PlainText>();
+    let output = processor
+        .render_grouped_bibliography_with_format_standalone::<crate::render::plain::PlainText>();
     let selected_body = extract_selected_group_body(&output);
 
     assert!(
@@ -4291,8 +4367,8 @@ fn test_grouped_compound_bibliography_non_leader_match_renders_selected_member()
 #[test]
 fn test_grouped_compound_bibliography_matching_members_merge_within_group() {
     let processor = make_grouped_compound_selection_processor("selected", "selected");
-    let output =
-        processor.render_grouped_bibliography_with_format::<crate::render::plain::PlainText>();
+    let output = processor
+        .render_grouped_bibliography_with_format_standalone::<crate::render::plain::PlainText>();
     let selected_body = extract_selected_group_body(&output);
 
     assert!(
@@ -4313,11 +4389,13 @@ fn test_grouped_compound_bibliography_matching_members_merge_within_group() {
 #[test]
 fn test_document_bibliography_block_selects_members_before_compound_merge() {
     let processor = make_grouped_compound_selection_processor("other", "selected");
+    let run = processor.begin_run().finalize();
     let rendered = processor.render_document_bibliography_block::<crate::render::plain::PlainText>(
         &make_selected_bibliography_group(),
         &mut std::collections::HashSet::new(),
         None,
         None,
+        &run,
     );
 
     assert_eq!(rendered.heading.as_deref(), Some("Selected"));
@@ -4352,18 +4430,21 @@ fn test_multi_bibliography_block_excludes_first_block_entries() {
         disambiguate: None,
     };
 
+    let run = processor.begin_run().finalize();
     let mut assigned = std::collections::HashSet::new();
     let block1 = processor.render_document_bibliography_block::<crate::render::plain::PlainText>(
         &make_selected_bibliography_group(),
         &mut assigned,
         None,
         None,
+        &run,
     );
     let block2 = processor.render_document_bibliography_block::<crate::render::plain::PlainText>(
         &catchall,
         &mut assigned,
         None,
         None,
+        &run,
     );
 
     assert!(
@@ -4699,7 +4780,7 @@ bibliography:
     );
 
     let processor = Processor::with_compound_sets(style, bib, sets);
-    let result = processor.render_bibliography_with_format::<Html>();
+    let result = processor.render_bibliography_with_format_standalone::<Html>();
 
     assert_eq!(
         result.matches("<div class=\"citum-bibliography\">").count(),
@@ -4775,9 +4856,9 @@ bibliography:
 
     let processor = Processor::with_compound_sets(style, bib, sets);
     let result = processor
-        .render_selected_bibliography_with_format::<crate::render::plain::PlainText, _>(vec![
-            "ref-b".to_string(),
-        ]);
+        .render_selected_bibliography_with_format_standalone::<crate::render::plain::PlainText, _>(
+            vec!["ref-b".to_string()],
+        );
 
     assert!(
         result.contains("Jones"),
@@ -5460,8 +5541,17 @@ fn test_dynamic_group_first_occurrence_wins() {
         ..Default::default()
     };
 
-    let rendered_first = processor.process_citation(&first).unwrap();
-    let rendered_second = processor.process_citation(&second).unwrap();
+    // Both citations must share one run: dynamic grouping's "first occurrence
+    // wins" rule depends on cited_ids/dynamic-group state accumulated across
+    // calls, which the one-shot `process_citation` convenience does not
+    // provide (each call begins its own throwaway run).
+    let mut run = processor.begin_run();
+    let rendered_first = processor
+        .process_citation_with_format::<crate::render::plain::PlainText>(&first, &mut run)
+        .unwrap();
+    let rendered_second = processor
+        .process_citation_with_format::<crate::render::plain::PlainText>(&second, &mut run)
+        .unwrap();
 
     // First citation: ref-a and ref-b form a group — renders as [1a,1b].
     assert_eq!(
@@ -5521,8 +5611,15 @@ fn test_dynamic_group_ungrouped_first_occurrence_wins() {
         ..Default::default()
     };
 
-    let rendered_first = processor.process_citation(&first).unwrap();
-    let rendered_second = processor.process_citation(&second).unwrap();
+    // Both citations must share one run — see the comment in
+    // test_dynamic_group_first_occurrence_wins.
+    let mut run = processor.begin_run();
+    let rendered_first = processor
+        .process_citation_with_format::<crate::render::plain::PlainText>(&first, &mut run)
+        .unwrap();
+    let rendered_second = processor
+        .process_citation_with_format::<crate::render::plain::PlainText>(&second, &mut run)
+        .unwrap();
 
     // First citation: ref-a is standalone, no sub-label.
     assert_eq!(

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -4108,7 +4108,7 @@ fn test_compound_numeric_number_assignment() {
     // Trigger number initialization via process_references
     let _ = processor.process_references();
 
-    let numbers = processor.citation_numbers.borrow();
+    let numbers = processor.run_state.citation_numbers.borrow();
     // ref-a and ref-b share the same set membership -> same citation number.
     assert_eq!(
         numbers.get("ref-a"),
@@ -4125,7 +4125,7 @@ fn test_compound_numeric_number_assignment() {
     assert_eq!(numbers.get("ref-c"), Some(&2), "ungrouped ref should be 2");
 
     // Verify compound_groups tracking
-    let groups = processor.compound_groups.borrow();
+    let groups = processor.run_state.compound_groups.borrow();
     assert!(
         groups.contains_key(&1),
         "compound_groups should track group 1"

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -557,7 +557,7 @@ options:
     let processor = Processor::new(style, script_partition_bibliography());
 
     assert_eq!(
-        processor.render_grouped_bibliography_with_format::<PlainText>(),
+        processor.render_grouped_bibliography_with_format_standalone::<PlainText>(),
         "## Cyrillic\n\nБета\n\n## Latin\n\nAlpha\n\n## Han\n\n東京"
     );
 }
@@ -590,7 +590,7 @@ groups:
     );
     let processor = Processor::new(style, script_partition_bibliography());
 
-    let output = processor.render_grouped_bibliography_with_format::<PlainText>();
+    let output = processor.render_grouped_bibliography_with_format_standalone::<PlainText>();
 
     // Manual groups gate wins; auto-partition section headings must not appear
     assert_eq!(output, "Бета\n\nAlpha\n\n東京");
@@ -631,7 +631,7 @@ fn language_partition_sections_reset_subsequent_author_substitution_per_section(
     let processor = Processor::new(style, bibliography);
 
     assert_eq!(
-        processor.render_grouped_bibliography_with_format::<PlainText>(),
+        processor.render_grouped_bibliography_with_format_standalone::<PlainText>(),
         "## Russian\n\nSmith, John. Alpha.\n\n———. Beta.\n\n## English\n\nSmith, John. Gamma."
     );
 }
@@ -1280,7 +1280,7 @@ bibliography:
     bib.insert("ITEM-1".to_string(), legacy.into());
 
     let processor = Processor::new(style, bib).with_inject_ast_indices(true);
-    let rendered = processor.render_bibliography_with_format::<Html>();
+    let rendered = processor.render_bibliography_with_format_standalone::<Html>();
 
     assert!(
         rendered.contains(r#"class="citum-author" data-index="0""#),
@@ -1381,7 +1381,7 @@ fn assert_list_preview_inherits_parent_index(use_type_template: bool) {
 
     let processor = Processor::new(build_list_index_preview_style(use_type_template), bib)
         .with_inject_ast_indices(true);
-    let rendered = processor.render_bibliography_with_format::<Html>();
+    let rendered = processor.render_bibliography_with_format_standalone::<Html>();
 
     assert!(
         rendered.contains(r#"class="citum-author" data-index="0""#),
@@ -1830,10 +1830,12 @@ enum TestOutputFormat {
 
 fn render_bibliography_in_format(processor: &Processor, fmt: TestOutputFormat) -> String {
     match fmt {
-        TestOutputFormat::Plain => processor.render_bibliography_with_format::<PlainText>(),
-        TestOutputFormat::Html => processor.render_bibliography_with_format::<Html>(),
-        TestOutputFormat::Latex => processor.render_bibliography_with_format::<Latex>(),
-        TestOutputFormat::Typst => processor.render_bibliography_with_format::<Typst>(),
+        TestOutputFormat::Plain => {
+            processor.render_bibliography_with_format_standalone::<PlainText>()
+        }
+        TestOutputFormat::Html => processor.render_bibliography_with_format_standalone::<Html>(),
+        TestOutputFormat::Latex => processor.render_bibliography_with_format_standalone::<Latex>(),
+        TestOutputFormat::Typst => processor.render_bibliography_with_format_standalone::<Typst>(),
     }
 }
 
@@ -2751,7 +2753,7 @@ bibliography:
     bibliography.insert("with-pages".to_string(), with_pages.into());
 
     let processor = Processor::new(style, bibliography);
-    let rendered = processor.render_selected_bibliography_with_format::<PlainText, _>([
+    let rendered = processor.render_selected_bibliography_with_format_standalone::<PlainText, _>([
         "without-pages".to_string(),
         "with-pages".to_string(),
     ]);
@@ -2826,7 +2828,7 @@ fn anonymous_entry_type_variants_reorder_online_entries_and_drop_print_fallback_
     bibliography.insert("authorful-encyclopedia".to_string(), authorful_encyclopedia);
 
     let processor = Processor::new(style, bibliography);
-    let rendered = processor.render_selected_bibliography_with_format::<PlainText, _>([
+    let rendered = processor.render_selected_bibliography_with_format_standalone::<PlainText, _>([
         "print-dictionary".to_string(),
         "print-encyclopedia".to_string(),
         "online-encyclopedia".to_string(),
@@ -2849,8 +2851,9 @@ fn elsevier_harvard_entry_encyclopedia_uses_entry_template_instead_of_chapter_de
     .expect("expanded bibliography should load");
 
     let processor = Processor::new(style, bibliography);
-    let rendered =
-        processor.render_selected_bibliography_with_format::<PlainText, _>(["ITEM-18".to_string()]);
+    let rendered = processor.render_selected_bibliography_with_format_standalone::<PlainText, _>([
+        "ITEM-18".to_string(),
+    ]);
 
     assert_eq!(
         rendered.trim(),
@@ -2877,7 +2880,7 @@ fn apa_dataset_without_title_falls_back_to_bracketed_label_version_and_doi() {
     bibliography.insert("apa-titleless-dataset".to_string(), legacy.into());
 
     let processor = Processor::new(style, bibliography);
-    let rendered = processor.render_selected_bibliography_with_format::<PlainText, _>([
+    let rendered = processor.render_selected_bibliography_with_format_standalone::<PlainText, _>([
         "apa-titleless-dataset".to_string(),
     ]);
 
@@ -2941,7 +2944,7 @@ fn apa_web_native_entries_render_without_retrieved_fallbacks() {
         .collect();
 
     let processor = Processor::new(style, bibliography);
-    let rendered = processor.render_selected_bibliography_with_format::<PlainText, _>([
+    let rendered = processor.render_selected_bibliography_with_format_standalone::<PlainText, _>([
         "6188419/IC98IKSD".to_string(),
         "6188419/XA2MLUAS".to_string(),
         "6188419/HCFRWJZR".to_string(),
@@ -3000,7 +3003,7 @@ fn apa_magazine_and_newspaper_entries_keep_special_format_translators_and_direct
         .collect();
 
     let processor = Processor::new(style, bibliography);
-    let rendered = processor.render_selected_bibliography_with_format::<PlainText, _>([
+    let rendered = processor.render_selected_bibliography_with_format_standalone::<PlainText, _>([
         "6188419/BXMWCMVJ".to_string(),
         "6188419/389M98AT".to_string(),
     ]);
@@ -3080,7 +3083,7 @@ fn apa_structural_entries_use_component_packaging_instead_of_generic_fallbacks()
         .collect();
 
     let processor = Processor::new(style, bibliography);
-    let rendered = processor.render_selected_bibliography_with_format::<PlainText, _>([
+    let rendered = processor.render_selected_bibliography_with_format_standalone::<PlainText, _>([
         "6188419/RYT8J733".to_string(),
         "6188419/Q2MWRA2D".to_string(),
         "6188419/2G36L2LR".to_string(),
@@ -3138,7 +3141,7 @@ fn render_structural_bibliography_case(value: serde_json::Value) -> String {
     let processor = Processor::new(style, bibliography);
 
     processor
-        .render_selected_bibliography_with_format::<PlainText, _>([id])
+        .render_selected_bibliography_with_format_standalone::<PlainText, _>([id])
         .lines()
         .find(|line| !line.trim().is_empty())
         .expect("expected one bibliography line")
@@ -3281,7 +3284,7 @@ fn apa_personal_communication_entries_do_not_render_in_bibliography() {
     ]);
 
     let processor = Processor::new(style, bibliography);
-    let rendered = processor.render_selected_bibliography_with_format::<PlainText, _>([
+    let rendered = processor.render_selected_bibliography_with_format_standalone::<PlainText, _>([
         "ITEM-28".to_string(),
         "sr-recipient".to_string(),
     ]);
@@ -3324,7 +3327,7 @@ fn bibliography_local_entry_links_apply_on_the_default_render_path() {
     let bib = citum_schema::bib_map!["linked-book" => reference];
 
     let processor = Processor::new(style, bib);
-    let rendered = processor.render_bibliography_with_format::<Html>();
+    let rendered = processor.render_bibliography_with_format_standalone::<Html>();
 
     assert!(
         rendered.contains(r#"href="https://example.com/linked-book""#),
@@ -3445,7 +3448,7 @@ fn royal_society_of_chemistry_restores_legacy_page_less_doi_behavior() {
     .expect("expanded bibliography should load");
     let processor = Processor::new(style, bib);
     let result = processor
-        .render_selected_bibliography_with_format::<citum_engine::render::plain::PlainText, _>(
+        .render_selected_bibliography_with_format_standalone::<citum_engine::render::plain::PlainText, _>(
             vec!["ITEM-1".to_string()],
         );
 
@@ -3468,7 +3471,7 @@ fn editor_author_substitute_omits_verb_role_label_in_bibliography() {
     let bib = make_editor_substitute_bibliography();
     let processor = Processor::new(style, bib);
     let result = processor
-        .render_selected_bibliography_with_format::<citum_engine::render::plain::PlainText, _>(
+        .render_selected_bibliography_with_format_standalone::<citum_engine::render::plain::PlainText, _>(
             vec!["ancient-tale".to_string(), "ipcc2023".to_string()],
         );
 
@@ -3504,7 +3507,7 @@ fn editor_author_substitute_renders_comma_short_capitalized_label() {
     let bib = make_editor_substitute_bibliography();
     let processor = Processor::new(style, bib);
     let result = processor
-        .render_selected_bibliography_with_format::<citum_engine::render::plain::PlainText, _>(
+        .render_selected_bibliography_with_format_standalone::<citum_engine::render::plain::PlainText, _>(
             vec!["ancient-tale".to_string(), "ipcc2023".to_string()],
         );
 
@@ -4019,7 +4022,7 @@ fn original_published_date_variable_renders_when_reference_has_original_date() {
     let bibliography = IndexMap::from([("gatsby".to_string(), reference)]);
     let processor = Processor::new(style, bibliography);
     let rendered = processor
-        .render_selected_bibliography_with_format::<PlainText, _>(["gatsby".to_string()])
+        .render_selected_bibliography_with_format_standalone::<PlainText, _>(["gatsby".to_string()])
         .trim()
         .to_string();
 
@@ -4081,7 +4084,7 @@ fn original_published_date_variable_renders_for_patent_references() {
     let bibliography = IndexMap::from([("patent".to_string(), reference)]);
     let processor = Processor::new(style, bibliography);
     let rendered = processor
-        .render_selected_bibliography_with_format::<PlainText, _>(["patent".to_string()])
+        .render_selected_bibliography_with_format_standalone::<PlainText, _>(["patent".to_string()])
         .trim()
         .to_string();
 
@@ -4180,7 +4183,9 @@ fn given_original_publication_fields_when_a_bibliography_group_checks_field_pres
     let bibliography = IndexMap::from([("primary".to_string(), reference)]);
     let processor = Processor::new(style, bibliography);
     let rendered = processor
-        .render_selected_bibliography_with_format::<PlainText, _>(["primary".to_string()])
+        .render_selected_bibliography_with_format_standalone::<PlainText, _>(
+            ["primary".to_string()],
+        )
         .trim()
         .to_string();
 
@@ -4237,7 +4242,9 @@ fn original_title_variable_renders_the_original_language_title() {
     let bibliography = IndexMap::from([("memory-police".to_string(), reference)]);
     let processor = Processor::new(style, bibliography);
     let rendered = processor
-        .render_selected_bibliography_with_format::<PlainText, _>(["memory-police".to_string()])
+        .render_selected_bibliography_with_format_standalone::<PlainText, _>([
+            "memory-police".to_string()
+        ])
         .trim()
         .to_string();
 
@@ -4288,7 +4295,9 @@ fn given_a_number_component_with_free_text_when_a_text_case_override_is_set_then
     let bibliography = IndexMap::from([("reprint".to_string(), reference)]);
     let processor = Processor::new(style, bibliography);
     let rendered = processor
-        .render_selected_bibliography_with_format::<PlainText, _>(["reprint".to_string()])
+        .render_selected_bibliography_with_format_standalone::<PlainText, _>(
+            ["reprint".to_string()],
+        )
         .trim()
         .to_string();
 
@@ -4473,10 +4482,11 @@ fn processor_renders_bibliography_annotations() {
 
     let annotation_style = AnnotationStyle::default();
 
-    let rendered = processor.render_bibliography_with_format_and_annotations::<PlainText>(
-        Some(&annotations),
-        Some(&annotation_style),
-    );
+    let rendered = processor
+        .render_bibliography_with_format_and_annotations_standalone::<PlainText>(
+            Some(&annotations),
+            Some(&annotation_style),
+        );
 
     assert_eq!(rendered, "Test Book\n\nThis is an annotation.");
 }
@@ -4518,7 +4528,7 @@ groups:
     );
 
     let processor = Processor::new(style, bib);
-    let rendered = processor.render_grouped_bibliography_with_format::<PlainText>();
+    let rendered = processor.render_grouped_bibliography_with_format_standalone::<PlainText>();
 
     assert_eq!(rendered, "First Book\n\nSecond Book");
 }
@@ -4564,7 +4574,7 @@ groups:
     );
 
     let processor = Processor::new(style, bib);
-    let rendered = processor.render_grouped_bibliography_with_format::<PlainText>();
+    let rendered = processor.render_grouped_bibliography_with_format_standalone::<PlainText>();
 
     assert_eq!(
         rendered,
@@ -4619,7 +4629,7 @@ fn given_grouped_html_bibliography_when_journal_article_rendered_then_container_
     );
 
     let processor = Processor::new(style, bib);
-    let rendered = processor.render_grouped_bibliography_with_format::<Html>();
+    let rendered = processor.render_grouped_bibliography_with_format_standalone::<Html>();
 
     assert!(
         rendered.contains("<em>Journal of Testing</em>"),
@@ -4678,7 +4688,7 @@ fn given_grouped_html_bibliography_when_title_has_inline_djot_markup_then_markup
     );
 
     let processor = Processor::new(style, bib);
-    let rendered = processor.render_grouped_bibliography_with_format::<Html>();
+    let rendered = processor.render_grouped_bibliography_with_format_standalone::<Html>();
 
     assert!(
         rendered.contains("<em>in vitro</em>"),
@@ -4754,7 +4764,7 @@ fn given_quoted_title_with_inner_quotes_when_html_bibliography_rendered_then_inn
         quoted_title_style(false),
         title_with_inner_quotes_bibliography(),
     );
-    let rendered = processor.render_bibliography_with_format::<Html>();
+    let rendered = processor.render_bibliography_with_format_standalone::<Html>();
 
     assert!(
         rendered.contains("“The ‘Parmenides’ dialogue”"),
@@ -4777,7 +4787,7 @@ fn given_quoted_title_with_inner_quotes_when_grouped_html_bibliography_rendered_
         quoted_title_style(true),
         title_with_inner_quotes_bibliography(),
     );
-    let rendered = processor.render_grouped_bibliography_with_format::<Html>();
+    let rendered = processor.render_grouped_bibliography_with_format_standalone::<Html>();
 
     assert!(
         rendered.contains("“The ‘Parmenides’ dialogue”"),
@@ -4877,7 +4887,7 @@ fn given_multilingual_ref_when_rendering_html_then_data_attrs_match_displayed_fo
     );
 
     let processor = Processor::new(style, bib);
-    let rendered = processor.render_grouped_bibliography_with_format::<Html>();
+    let rendered = processor.render_grouped_bibliography_with_format_standalone::<Html>();
 
     // data-title must be set to the combined (transliterated [translated]) form on the attribute
     assert!(

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -2201,8 +2201,9 @@ citation:
         ..Default::default()
     };
 
+    let mut run = processor.begin_run();
     let rendered = processor
-        .process_citation_with_format::<Html>(&citation)
+        .process_citation_with_format::<Html>(&citation, &mut run)
         .expect("citation should render");
 
     assert!(

--- a/crates/citum-engine/tests/common/mod.rs
+++ b/crates/citum-engine/tests/common/mod.rs
@@ -213,6 +213,7 @@ pub fn run_test_case_native_with_options(options: TestCaseOptions) {
     }
 
     let processor = Processor::new(style, bibliography);
+    let mut run = processor.begin_run();
 
     if options.mode == "citation" {
         let mut results = Vec::new();
@@ -233,7 +234,9 @@ pub fn run_test_case_native_with_options(options: TestCaseOptions) {
             };
 
             let res = processor
-                .process_citation(&citation)
+                .process_citation_with_format::<citum_engine::render::plain::PlainText>(
+                    &citation, &mut run,
+                )
                 .expect("Failed to process citation");
             results.push(res);
         }
@@ -258,11 +261,17 @@ pub fn run_test_case_native_with_options(options: TestCaseOptions) {
                     items,
                     ..Default::default()
                 };
-                processor.process_citation(&citation).ok();
+                processor
+                    .process_citation_with_format::<citum_engine::render::plain::PlainText>(
+                        &citation, &mut run,
+                    )
+                    .ok();
             }
         }
 
-        let actual = processor.render_bibliography();
+        let run = run.finalize();
+        let actual = processor
+            .render_bibliography_with_format::<citum_engine::render::plain::PlainText>(&run);
         assert_eq!(
             actual.trim(),
             options.expected.trim(),

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -1555,7 +1555,7 @@ fn djot_note_preserves_italic_markup_in_html_bibliography() {
         )),
     );
 
-    let output = Processor::new(style, bib).render_bibliography_with_format::<Html>();
+    let output = Processor::new(style, bib).render_bibliography_with_format_standalone::<Html>();
     assert_eq!(
         output,
         "<div class=\"citum-bibliography\">\n<div class=\"citum-entry\" id=\"ref-ref1\" data-year=\"2024\" data-title=\"Test Book\"><span class=\"citum-note\"><em>italic</em></span></div>\n</div>",
@@ -1606,7 +1606,7 @@ fn djot_note_sentence_case_does_not_restart_across_markup_boundaries() {
         )),
     );
 
-    let output = Processor::new(style, bib).render_bibliography_with_format::<Html>();
+    let output = Processor::new(style, bib).render_bibliography_with_format_standalone::<Html>();
     assert_eq!(
         output,
         "<div class=\"citum-bibliography\">\n<div class=\"citum-entry\" id=\"ref-ref1\" data-year=\"2024\" data-title=\"Test Book\"><span class=\"citum-note\">Foo <em>bar</em> baz</span></div>\n</div>",

--- a/crates/citum-engine/tests/multilingual.rs
+++ b/crates/citum-engine/tests/multilingual.rs
@@ -121,7 +121,7 @@ fn test_romanized_translated_preset_uses_parallel_metadata() {
         .process_citation(&single_item_citation("CJK-JAPANESE-BOOK"))
         .expect("Japanese book citation should render");
     let entry = processor
-        .render_selected_bibliography_with_format::<citum_engine::render::plain::PlainText, _>(
+        .render_selected_bibliography_with_format_standalone::<citum_engine::render::plain::PlainText, _>(
             vec!["CJK-JAPANESE-BOOK".to_string()],
         );
 
@@ -151,11 +151,11 @@ fn test_bibliography_locales_switch_full_entry_layouts() {
     let processor = Processor::new(style, bibliography);
 
     let japanese_entry = processor
-        .render_selected_bibliography_with_format::<citum_engine::render::plain::PlainText, _>(
+        .render_selected_bibliography_with_format_standalone::<citum_engine::render::plain::PlainText, _>(
             vec!["CJK-JAPANESE-LANGUAGE-TAGGED".to_string()],
         );
     let default_entry = processor
-        .render_selected_bibliography_with_format::<citum_engine::render::plain::PlainText, _>(
+        .render_selected_bibliography_with_format_standalone::<citum_engine::render::plain::PlainText, _>(
             vec!["CSL-ET-AL-LATIN".to_string()],
         );
 

--- a/crates/citum-migrate/src/measured_citation.rs
+++ b/crates/citum-migrate/src/measured_citation.rs
@@ -734,7 +734,7 @@ pub(crate) fn score_bibliography_candidate(
 ) -> CandidateScore {
     let Ok(processed) = catch_candidate_unwind(|| {
         let processor = Processor::new(style.clone(), bibliography.clone());
-        processor.process_references_with_format::<PlainText>()
+        processor.process_references_with_format_standalone::<PlainText>()
     }) else {
         return invalid_candidate_score(references);
     };

--- a/crates/citum-migrate/src/template_compiler/node_compiler.rs
+++ b/crates/citum-migrate/src/template_compiler/node_compiler.rs
@@ -28,7 +28,8 @@ impl TemplateCompiler {
 
         // Check if we should use a substitute instead of the primary
         // Rare contributor roles (composer, illustrator) often have author as first substitute
-        let role = if let Some(role) = primary_role {
+        let role = {
+            let role = primary_role?;
             // If primary is a rare role and we have substitutes, prefer the first common one
             let rare_roles = [
                 ContributorRole::Composer,
@@ -53,8 +54,6 @@ impl TemplateCompiler {
             } else {
                 role
             }
-        } else {
-            return None;
         };
 
         let form = match names.options.mode {

--- a/crates/citum-migrate/src/template_diff.rs
+++ b/crates/citum-migrate/src/template_diff.rs
@@ -372,14 +372,13 @@ fn derive_template_variant_diff(
                 after: None,
                 component: component.clone(),
             }
-        } else if let Some(after) = last_anchor.clone() {
+        } else {
+            let after = last_anchor.clone()?;
             TemplateAddOperation {
                 before: None,
                 after: Some(after),
                 component: component.clone(),
             }
-        } else {
-            return None;
         };
         diff.add.push(add);
         last_anchor = Some(component_selector);

--- a/crates/citum-schema-style/src/style_base.rs
+++ b/crates/citum-schema-style/src/style_base.rs
@@ -381,7 +381,7 @@ mod tests {
         assert_eq!(base, StyleBase::ChicagoNotes18th);
 
         let back = serde_yaml::to_string(&base).expect("serialization failed");
-        assert!(back.trim() == "chicago-notes-18th");
+        assert_eq!(back.trim(), "chicago-notes-18th");
     }
 
     #[test]

--- a/crates/citum-server/src/rpc.rs
+++ b/crates/citum-server/src/rpc.rs
@@ -776,7 +776,8 @@ fn render_citation(params: &Value, id: Value) -> Result<Value, ServerError> {
     processor.set_inject_ast_indices(inject_ast_indices);
 
     let output_format = params.output_format.unwrap_or_default();
-    let result = render_citation_with_format(&processor, &citation, output_format)
+    let mut run = processor.begin_run();
+    let result = render_citation_with_format(&processor, &citation, output_format, &mut run)
         .map_err(|e| ServerError::CitationError(e.to_string()))?;
 
     Ok(json!({
@@ -830,13 +831,16 @@ fn render_citation_with_format(
     processor: &Processor,
     citation: &Citation,
     format: OutputFormat,
+    run: &mut citum_engine::processor::RunState,
 ) -> Result<String, ServerError> {
     match format {
-        OutputFormat::Plain => Ok(processor.process_citation_with_format::<PlainText>(citation)?),
-        OutputFormat::Html => Ok(processor.process_citation_with_format::<Html>(citation)?),
-        OutputFormat::Djot => Ok(processor.process_citation_with_format::<Djot>(citation)?),
-        OutputFormat::Latex => Ok(processor.process_citation_with_format::<Latex>(citation)?),
-        OutputFormat::Typst => Ok(processor.process_citation_with_format::<Typst>(citation)?),
+        OutputFormat::Plain => {
+            Ok(processor.process_citation_with_format::<PlainText>(citation, run)?)
+        }
+        OutputFormat::Html => Ok(processor.process_citation_with_format::<Html>(citation, run)?),
+        OutputFormat::Djot => Ok(processor.process_citation_with_format::<Djot>(citation, run)?),
+        OutputFormat::Latex => Ok(processor.process_citation_with_format::<Latex>(citation, run)?),
+        OutputFormat::Typst => Ok(processor.process_citation_with_format::<Typst>(citation, run)?),
     }
 }
 
@@ -845,11 +849,13 @@ fn render_bibliography_with_format(
     format: OutputFormat,
 ) -> Result<String, ServerError> {
     match format {
-        OutputFormat::Plain => Ok(processor.render_bibliography_with_format::<PlainText>()),
-        OutputFormat::Html => Ok(processor.render_bibliography_with_format::<Html>()),
-        OutputFormat::Djot => Ok(processor.render_bibliography_with_format::<Djot>()),
-        OutputFormat::Latex => Ok(processor.render_bibliography_with_format::<Latex>()),
-        OutputFormat::Typst => Ok(processor.render_bibliography_with_format::<Typst>()),
+        OutputFormat::Plain => {
+            Ok(processor.render_bibliography_with_format_standalone::<PlainText>())
+        }
+        OutputFormat::Html => Ok(processor.render_bibliography_with_format_standalone::<Html>()),
+        OutputFormat::Djot => Ok(processor.render_bibliography_with_format_standalone::<Djot>()),
+        OutputFormat::Latex => Ok(processor.render_bibliography_with_format_standalone::<Latex>()),
+        OutputFormat::Typst => Ok(processor.render_bibliography_with_format_standalone::<Typst>()),
     }
 }
 

--- a/docs/specs/EXPLICIT_RENDER_RUN_STATE.md
+++ b/docs/specs/EXPLICIT_RENDER_RUN_STATE.md
@@ -1,0 +1,223 @@
+# Explicit Render-Run State for `Processor` Specification
+
+**Status:** Draft
+**Date:** 2026-07-09
+**Supersedes:** (none)
+**Related:** bean `csl26-dog9`; `docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md` finding 6; follow-up note in bean `csl26-qi7l`
+
+## Purpose
+
+`Processor` (`crates/citum-engine/src/processor/mod.rs`) currently holds seven
+interior-mutable (`RefCell`) fields — `citation_numbers`, `cited_ids`,
+`compound_groups`, `dynamic_compound_set_by_ref`,
+`dynamic_compound_member_index`, `dynamic_compound_sets`, and
+`first_note_by_id` — that are mutated from `&self` render methods. Rendering
+therefore becomes an implicit state machine: bibliography output depends on
+which citations were processed first, and processing the same citation list
+twice through one `Processor` can produce different output (dynamic compound
+groups are first-occurrence-wins). This is intentional citeproc semantics, but
+today the ordering contract lives only in comments (e.g.
+`processor/citation.rs:178-180`, "must be called before
+`track_cited_ids_and_init_numbers`"). It also makes `Processor` effectively
+single-threaded, since `RefCell` is not `Sync`.
+
+This spec defines an explicit per-run state object, `RunState`, plus a
+`FinalizedRun` typestate, so that:
+
+- `Processor` becomes an immutable, reusable, shareable description of a style
+  + bibliography + locale.
+- The register-before-render ordering contract is enforced by the type system
+  rather than by doc comments.
+- A `Processor` can be rendered against fresh state repeatedly without cloning
+  the whole style/bibliography per render (the workaround
+  `DocumentSession::render_citations` currently uses,
+  `api/session.rs:367`, specifically to reset state).
+
+## Scope
+
+**In scope:**
+
+- Introducing `RunState` to own the seven currently-`RefCell` fields.
+- A `FinalizedRun` typestate gating bibliography/citation-number-dependent
+  rendering.
+- Updating all internal call sites (`processor/citation.rs`,
+  `processor/note_context.rs`, `processor/setup.rs`,
+  `processor/bibliography/{mod,grouping,compound}.rs`,
+  `processor/rendering/{mod,collapse,grouped/core}.rs`) to the new shape.
+- Updating `api/session.rs` and `api/document.rs` to the
+  begin-run/register/finalize flow.
+- Updating the FFI (`ffi/mod.rs`) and WASM (`citum-bindings`) surfaces to an
+  opaque session handle with no C ABI signature changes.
+
+**Explicitly out of scope:**
+
+- Changing `Rc<Config>` / `Rc<BibliographyConfig>` to `Arc` (tracked as a
+  follow-up in bean `csl26-qi7l`; only worth doing once a real workload shows
+  single-threaded rendering as a bottleneck).
+- Parallelizing bibliography entry rendering with `rayon` (same follow-up;
+  `FinalizedRun` is a prerequisite, not a trigger, for that work).
+- Changing the citeproc semantics themselves (first-occurrence-wins dynamic
+  grouping, lazy numeric assignment) — this spec makes the *existing*
+  semantics typed, not different.
+
+## Design
+
+### `RunState` and `FinalizedRun`
+
+```rust
+/// Mutable per-render-run state: citation numbering, cite-order tracking,
+/// and dynamic (cite-time) compound-group membership.
+///
+/// Constructed via `Processor::begin_run`. Registration methods
+/// (`&self, &mut RunState`) populate it in citation-processing order;
+/// `finalize` then produces a `FinalizedRun` for rendering.
+pub struct RunState {
+    cited_ids: HashSet<String>,
+    compound_groups: IndexMap<usize, Vec<String>>,
+    dynamic_compound_set_by_ref: HashMap<String, String>,
+    dynamic_compound_member_index: HashMap<String, usize>,
+    dynamic_compound_sets: IndexMap<String, Vec<String>>,
+    // Kept RefCell internally: the render layer (`Renderer`) lazily assigns
+    // citation numbers and first-note numbers *during* rendering (see
+    // "Idempotency" below). The typestate boundary still enforces that
+    // registration is complete before a `FinalizedRun` can exist.
+    citation_numbers: RefCell<HashMap<String, usize>>,
+    first_note_by_id: RefCell<HashMap<String, u32>>,
+}
+
+/// A `RunState` that has completed the registration phase. Rendering
+/// methods take `&FinalizedRun` instead of `&RunState` so "render before
+/// registration is complete" is a compile error.
+pub struct FinalizedRun(RunState);
+```
+
+`Processor` keeps only immutable, construction-time data: `style`,
+`bibliography`, `locale`, `default_config`, `hints`, and the three *static*
+compound maps (`compound_sets`, `compound_set_by_ref`,
+`compound_member_index` — derived once from style-declared compound sets, not
+cite-time state).
+
+`Processor::begin_run(&self) -> RunState` constructs a fresh, empty run and
+performs numeric pre-initialization (`initialize_numeric_citation_numbers`,
+`initialize_numeric_bibliography_numbers`) using the processor's immutable
+data.
+
+### Registration phase
+
+Methods that populate per-run state take `(&self, run: &mut RunState)`:
+`track_cited_ids_and_init_numbers`, `resolve_dynamic_group`,
+`register_nocite_ids`, `normalize_note_context`. `annotate_positions` is
+unaffected — it only mutates its `&mut [Citation]` argument, not processor or
+run fields.
+
+One-shot convenience methods (`process_citation`, `process_citations`) remain
+available on `&self` for simple callers: internally they call `begin_run`,
+register, finalize, and render against a throwaway run, preserving today's
+API surface for callers that don't need cross-call state.
+
+### Finalization and rendering
+
+`RunState::finalize(self) -> FinalizedRun` is a plain newtype wrap — no
+additional computation; it exists purely as a compile-time marker that
+registration for this run is considered complete.
+
+Render methods (`render_citation_content`, and everything under
+`processor/bibliography/`) take `(&self, run: &FinalizedRun)`. `Renderer::new`
+sources `citation_numbers: &run.0.citation_numbers` and
+`first_note_by_id: Some(&run.0.first_note_by_id)` — `Renderer`'s existing
+`&'a RefCell<...>` field types are unchanged, only their origin moves from
+`Processor` to `RunState`.
+
+### Idempotency, precisely stated
+
+The render phase is **idempotent under repeated calls with the same
+`FinalizedRun`**, and **pure with respect to the six non-`RefCell` run
+fields**. It is *not* strictly read-only for `citation_numbers`:
+`Renderer::get_or_assign_citation_number` (`rendering/grouped/core.rs:799`)
+lazily assigns a citation number the first time a reference is rendered, if
+one is not already present. This assignment is monotonic and
+assign-once-per-id — rendering the same `FinalizedRun` twice, or rendering
+citations and then the bibliography from the same run, produces stable,
+consistent numbers. It is *not* safe to construct two `FinalizedRun`s
+concurrently over shared mutable numbering state; that is why
+`citation_numbers` stays behind a `RefCell` inside `RunState` rather than
+becoming a plain field read via `&FinalizedRun` — the compile-time contract
+this spec adds is "registration precedes rendering," not "rendering never
+touches interior state."
+
+### FFI / WASM
+
+The C ABI's opaque `*mut Processor`-shaped handle is preserved; only its
+pointee changes:
+
+```rust
+struct FfiSession {
+    processor: Processor,
+    run: RunState,
+}
+```
+
+`citum_processor_new*` allocates an `FfiSession` (processor +
+`processor.begin_run()`) and returns it cast through the existing opaque
+pointer type. `citum_render_citation_*` registers into `session.run` before
+rendering (via a throwaway `FinalizedRun` snapshot, or a `&FinalizedRun`
+view — implementation detail, not an ABI change).
+`citum_render_bibliography_*` finalizes and renders. No C header signature
+changes. `citum-bindings` (WASM) mirrors the same handle shape.
+
+### `api/session.rs` and `api/document.rs`
+
+`DocumentSession::render_citations` currently builds a *fresh*
+`Processor::new(style.clone(), bibliography_cache.clone())` per render call
+specifically to get clean run state (`api/session.rs:367`, comment: "each
+render still clones the style and bibliography into a fresh processor").
+After this change, the session can hold one `Processor` across renders and
+call `begin_run()` per render instead — removing the per-render style/
+bibliography clone. `api/document.rs`'s single-pass pipeline
+(`Processor::new` → `register_nocite_ids` → `process_citations_with_format`
+→ `render_document_bibliography`) converts to
+`begin_run` → register → `finalize` → render in the same order it already
+runs in.
+
+## Implementation Notes
+
+Migration proceeds in four phases, each independently green
+(`just pre-commit`):
+
+- **(a)** Introduce `RunState` (new `processor/run_state.rs`) wrapping the
+  existing seven fields; `Processor` holds a transitional `RunState` (or
+  `RefCell<RunState>`) so no `&self` signatures change yet. Pure relocation.
+- **(b)** Thread `&mut RunState` through registration methods; delete the
+  transitional field from `Processor`; add `begin_run`.
+- **(c)** Add the `FinalizedRun` typestate; convert bibliography and citation
+  render entry points to `&FinalizedRun`. This is where the ordering contract
+  becomes a compile error.
+- **(d)** FFI/WASM session plumbing (`FfiSession`, ABI-preserving).
+
+Steps (a)-(b) are mechanical (mostly signature threading). Steps (c)-(d)
+touch cross-crate boundaries (FFI/WASM) and want a human review pass.
+
+## Acceptance Criteria
+
+- [ ] `Processor` no longer declares any of the seven `RefCell` fields;
+      they live on `RunState`.
+- [ ] `RunState::finalize(self) -> FinalizedRun` exists; render methods that
+      depend on cite order or citation numbers take `&FinalizedRun`, not
+      `&self`-only.
+- [ ] It is a compile error to call a bibliography/citation-number-dependent
+      render method before `finalize()` — i.e. there is no path to construct
+      a `FinalizedRun` other than through `RunState::finalize`.
+- [ ] A test demonstrates running the same citation list twice through one
+      reused `Processor` with two independent `begin_run()` calls and
+      asserts identical output (the property that was previously
+      impossible to state, let alone test).
+- [ ] `cargo nextest run` and `just pre-commit` pass at every phase.
+- [ ] No oracle/fidelity regression (`just workflow-test`, `report-core.js`
+      before/after).
+- [ ] FFI/WASM C ABI signatures are unchanged; a call sequence of
+      `citum_render_citation_*` ×N followed by `citum_render_bibliography_*`
+      on one handle produces the same output as before the refactor.
+
+## Changelog
+
+- 2026-07-09: Initial draft.

--- a/docs/specs/EXPLICIT_RENDER_RUN_STATE.md
+++ b/docs/specs/EXPLICIT_RENDER_RUN_STATE.md
@@ -1,6 +1,6 @@
 # Explicit Render-Run State for `Processor` Specification
 
-**Status:** Draft
+**Status:** Active
 **Date:** 2026-07-09
 **Supersedes:** (none)
 **Related:** bean `csl26-dog9`; `docs/architecture/audits/2026-07-03_CITUM_ENGINE_REVIEW.md` finding 6; follow-up note in bean `csl26-qi7l`
@@ -131,8 +131,9 @@ sources `citation_numbers: &run.0.citation_numbers` and
 ### Idempotency, precisely stated
 
 The render phase is **idempotent under repeated calls with the same
-`FinalizedRun`**, and **pure with respect to the six non-`RefCell` run
-fields**. It is *not* strictly read-only for `citation_numbers`:
+`FinalizedRun`**, and **pure with respect to the five non-`RefCell` run
+fields** (`cited_ids`, `compound_groups`, and the three dynamic compound
+maps). It is *not* strictly read-only for `citation_numbers`:
 `Renderer::get_or_assign_citation_number` (`rendering/grouped/core.rs:799`)
 lazily assigns a citation number the first time a reference is rendered, if
 one is not already present. This assignment is monotonic and
@@ -197,27 +198,56 @@ Migration proceeds in four phases, each independently green
 Steps (a)-(b) are mechanical (mostly signature threading). Steps (c)-(d)
 touch cross-crate boundaries (FFI/WASM) and want a human review pass.
 
+**Deviation from the phase split above (discovered during implementation):**
+Rust's borrow checker rejects `self.method(&mut self.run_state)` — a method
+receiver (`&self`) and a mutable borrow of one of its own fields cannot be
+passed as two arguments to the same call, even though they are logically
+disjoint. This means `Processor` cannot hold `RunState` as a field *and* have
+its methods take `&mut RunState` as an explicit parameter; the two are
+mutually exclusive. Phases (b) and (c) were therefore implemented together as
+one change: `RunState` was removed from `Processor` entirely (not left as a
+"transitional field") in the same step that threaded `&mut RunState` through
+registration methods and introduced `FinalizedRun`. Every caller (FFI,
+`api/session.rs`, `api/document.rs`, CLI, server, `citum-migrate`, and both
+the in-crate and integration test suites) had to be updated in that same
+change to keep compiling, so the four-phase commit split became one
+comprehensive pass instead. Convenience wrappers (`process_citation`,
+`process_citations`, and a `*_standalone` family added for the bibliography
+methods) preserve the pre-refactor zero-argument call shape for the ~150
+call sites that don't need cross-call continuity.
+
 ## Acceptance Criteria
 
-- [ ] `Processor` no longer declares any of the seven `RefCell` fields;
+- [x] `Processor` no longer declares any of the seven `RefCell` fields;
       they live on `RunState`.
-- [ ] `RunState::finalize(self) -> FinalizedRun` exists; render methods that
+- [x] `RunState::finalize(self) -> FinalizedRun` exists; render methods that
       depend on cite order or citation numbers take `&FinalizedRun`, not
       `&self`-only.
-- [ ] It is a compile error to call a bibliography/citation-number-dependent
+- [x] It is a compile error to call a bibliography/citation-number-dependent
       render method before `finalize()` — i.e. there is no path to construct
       a `FinalizedRun` other than through `RunState::finalize`.
-- [ ] A test demonstrates running the same citation list twice through one
+- [x] A test demonstrates running the same citation list twice through one
       reused `Processor` with two independent `begin_run()` calls and
       asserts identical output (the property that was previously
-      impossible to state, let alone test).
-- [ ] `cargo nextest run` and `just pre-commit` pass at every phase.
-- [ ] No oracle/fidelity regression (`just workflow-test`, `report-core.js`
-      before/after).
-- [ ] FFI/WASM C ABI signatures are unchanged; a call sequence of
-      `citum_render_citation_*` ×N followed by `citum_render_bibliography_*`
-      on one handle produces the same output as before the refactor.
+      impossible to state, let alone test) —
+      `test_processor_is_reusable_across_independent_runs` in
+      `crates/citum-engine/src/processor/tests.rs`.
+- [x] `cargo nextest run` and `just pre-commit` pass (fmt + clippy
+      `-D warnings` + 1854 tests, `--workspace --all-features`).
+- [x] No oracle/fidelity regression: `just workflow-test styles-legacy/apa.csl`
+      (author-date, 20/20 citations, 45/46 bibliography) and
+      `styles-legacy/apa-numeric-superscript.csl` (numeric/compound, 20/20
+      citations, 17/51 bibliography) both match byte-for-byte against a
+      `git stash`-isolated pre-refactor baseline — the shortfalls are
+      pre-existing migration-fidelity gaps, unchanged by this refactor.
+- [x] FFI/WASM C ABI signatures are unchanged: `ffi/mod.rs` now boxes an
+      opaque `FfiSession { processor, run }` behind the same pointer shape;
+      `citum_render_citation_*` mutates the session's `run`,
+      `citum_render_bibliography_*` renders from a cloned, finalized
+      snapshot so accumulation across calls on one handle is preserved.
 
 ## Changelog
 
 - 2026-07-09: Initial draft.
+- 2026-07-09: Implemented (phases a-d, see Implementation Notes for the
+  phase-split deviation); Status → Active.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -200,3 +200,4 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | [`CLI_UX_REDESIGN.md`](./CLI_UX_REDESIGN.md) — clean command model for style discovery, registry management, and CLI validation UX | Active | — |
 | [`AUTHORING_AGENT_SKILL.md`](./AUTHORING_AGENT_SKILL.md) — Citum Authoring Agent Skill specification for AI-assisted style authoring | Active | — |
 | [`REPO_LOCAL_HARNESS.md`](./REPO_LOCAL_HARNESS.md) — repo-owned control surfaces for Claude/Codex workflow and skill boundaries | Active | — |
+| [`EXPLICIT_RENDER_RUN_STATE.md`](./EXPLICIT_RENDER_RUN_STATE.md) — typed per-run state (`RunState`/`FinalizedRun`) replacing `Processor`'s `RefCell` fields | Draft | `processor/tests.rs` |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -200,4 +200,4 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | [`CLI_UX_REDESIGN.md`](./CLI_UX_REDESIGN.md) — clean command model for style discovery, registry management, and CLI validation UX | Active | — |
 | [`AUTHORING_AGENT_SKILL.md`](./AUTHORING_AGENT_SKILL.md) — Citum Authoring Agent Skill specification for AI-assisted style authoring | Active | — |
 | [`REPO_LOCAL_HARNESS.md`](./REPO_LOCAL_HARNESS.md) — repo-owned control surfaces for Claude/Codex workflow and skill boundaries | Active | — |
-| [`EXPLICIT_RENDER_RUN_STATE.md`](./EXPLICIT_RENDER_RUN_STATE.md) — typed per-run state (`RunState`/`FinalizedRun`) replacing `Processor`'s `RefCell` fields | Draft | `processor/tests.rs` |
+| [`EXPLICIT_RENDER_RUN_STATE.md`](./EXPLICIT_RENDER_RUN_STATE.md) — typed per-run state (`RunState`/`FinalizedRun`) replacing `Processor`'s `RefCell` fields | Active | `processor/tests.rs` |

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -31,12 +31,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
+name = "biblatex"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "53d0c374feba1b9a59042a7c1cf00ce7c34b977b9134fe7c42b08e5183729f66"
 dependencies = [
- "generic-array",
+ "paste",
+ "roman-numerals-rs",
+ "strum",
+ "unicode-normalization",
+ "unscanny",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -103,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "citum-edtf"
-version = "0.40.1"
+version = "0.73.0"
 dependencies = [
  "serde",
  "winnow",
@@ -111,22 +130,24 @@ dependencies = [
 
 [[package]]
 name = "citum-engine"
-version = "0.40.1"
+version = "0.73.0"
 dependencies = [
  "citum-edtf",
+ "citum-refs",
  "citum-schema",
+ "citum-schema-data",
  "csl-legacy",
  "icu_collator",
  "icu_locale",
  "indexmap 2.14.0",
  "jotdown",
  "orgize",
+ "pulldown-cmark",
  "serde",
  "serde_json",
  "serde_yaml_ng",
  "thiserror",
  "unicode-script",
- "url",
  "winnow",
 ]
 
@@ -141,8 +162,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "citum-refs"
+version = "0.73.0"
+dependencies = [
+ "biblatex",
+ "ciborium",
+ "citum-schema",
+ "csl-legacy",
+ "indexmap 2.14.0",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "thiserror",
+ "url",
+]
+
+[[package]]
 name = "citum-resolver-api"
-version = "0.40.1"
+version = "0.73.0"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -150,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema"
-version = "0.40.1"
+version = "0.73.0"
 dependencies = [
  "citum-schema-data",
  "citum-schema-style",
@@ -158,7 +195,7 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-data"
-version = "0.40.1"
+version = "0.73.0"
 dependencies = [
  "citum-edtf",
  "csl-legacy",
@@ -170,11 +207,10 @@ dependencies = [
 
 [[package]]
 name = "citum-schema-style"
-version = "0.40.1"
+version = "0.73.0"
 dependencies = [
  "ciborium",
  "cid",
- "citum-edtf",
  "citum-resolver-api",
  "citum-schema-data",
  "csl-legacy",
@@ -185,8 +221,13 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "sha2",
- "url",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-str"
@@ -196,9 +237,9 @@ checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -211,17 +252,16 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
 ]
 
 [[package]]
 name = "csl-legacy"
-version = "0.40.1"
+version = "0.73.0"
 dependencies = [
  "indexmap 2.14.0",
  "roxmltree",
@@ -257,11 +297,12 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -304,13 +345,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
+name = "getopts"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "typenum",
- "version_check",
+ "unicode-width",
 ]
 
 [[package]]
@@ -353,6 +393,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "icu_collator"
@@ -693,6 +742,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +774,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +806,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "roman-numerals-rs"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85cd47a33a4510b1424fe796498e174c6a9cf94e606460ef022a19f3e4ff85e"
 
 [[package]]
 name = "roxmltree"
@@ -822,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -924,10 +1004,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -936,16 +1037,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-script"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unscanny"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
 
 [[package]]
 name = "unsigned-varint"
@@ -977,12 +1099,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasip2"

--- a/fuzz/fuzz_targets/ffi_render_batch_and_bibliography.rs
+++ b/fuzz/fuzz_targets/ffi_render_batch_and_bibliography.rs
@@ -7,7 +7,7 @@ use citum_engine::ffi::{
 use libfuzzer_sys::fuzz_target;
 use std::ffi::CString;
 
-fn processor() -> *mut citum_engine::Processor {
+fn processor() -> *mut citum_engine::ffi::FfiSession {
     let style = serde_json::to_string(&citum_schema::Style::default()).unwrap_or_default();
     let style = CString::new(style).unwrap_or_default();
     let bibliography = CString::new("{}").unwrap_or_default();

--- a/fuzz/fuzz_targets/ffi_render_citation.rs
+++ b/fuzz/fuzz_targets/ffi_render_citation.rs
@@ -6,7 +6,7 @@ use citum_engine::ffi::{
 use libfuzzer_sys::fuzz_target;
 use std::ffi::CString;
 
-fn processor() -> *mut citum_engine::Processor {
+fn processor() -> *mut citum_engine::ffi::FfiSession {
     let style = serde_json::to_string(&citum_schema::Style::default()).unwrap_or_default();
     let style = CString::new(style).unwrap_or_default();
     let bibliography = CString::new("{}").unwrap_or_default();


### PR DESCRIPTION
## Summary

Implemented bean csl26-dog9 (explicit render-run state for Processor) in full — all four migration phases from the design, on branch feat/engine-explicit-render-run-state, three commits:

1. docs(specs): wrote docs/specs/EXPLICIT_RENDER_RUN_STATE.md
2. refactor(engine): move render fields into RunState — phase (a), mechanical relocation
3. refactor(engine): make render-run state explicit — the full implementation

## What changed

Processor's seven RefCell fields moved to a new RunState/FinalizedRun typestate (begin_run → register → finalize → render), making the "register before render" ordering contract a compile error instead of a comment. Rust's borrow checker forced phases (b) and (c) to land together (a method can't take &self and &mut self.field simultaneously), which cascaded into every downstream consumer — FFI (new opaque FfiSession handle, ABI unchanged), citum-cli, citum-server, citum-bindings, citum-migrate, and the engine's own test/bench/example suites, all updated to compile against the new signatures. One-shot convenience wrappers preserve the old zero-arg call shape for ~150 call sites that don't need cross-call continuity.

Bugs found and fixed along the way: two tests relied on the old implicit accumulation across process_citation calls for dynamic compound-grouping's "first occurrence wins" rule; both now thread one explicit RunState.

## Verification

- Full workspace just pre-commit (fmt + clippy -D warnings + nextest) green — 1854 tests, --all-features
- Added test_processor_is_reusable_across_independent_runs, the idempotency property this refactor makes both expressible and true
- Confirmed no fidelity regression via just workflow-test on an author-date style and a numeric/compound style, each matching byte-for-byte against a git stash-isolated pre-refactor baseline

Filed csl26-nitz (deferred) for the Rc→Arc/rayon follow-up noted in csl26-qi7l. The bean and spec are both closed out/marked Active. Branch is ready for you to review and open a PR when you'd like — I didn't push or open one, per your workflow rules.