### PR TITLE
fix(engine): preserve unresolved sorted citations

### DIFF
--- a/crates/citum-engine/README.md
+++ b/crates/citum-engine/README.md
@@ -3,7 +3,7 @@
 `citum-engine` is the Rust citation and bibliography processor for Citum. Use
 it when your application already has, or can load, Citum styles, reference data,
 and citation occurrences, and needs formatted citations or bibliographies as
-plain text, HTML, Djot, LaTeX, or Typst.
+plain text, HTML, Djot, LaTeX, Typst, or CommonMark/Markdown.
 
 The engine is intentionally narrower than the full Citum application stack. It
 does not manage registries, fetch remote styles, or persist user data. Those
@@ -14,10 +14,10 @@ or application-specific resolver.
 
 ```toml
 [dependencies]
-citum-engine = "0.53"
+citum-engine = "0.73"
 
 # Optional, but recommended when loading bibliography files.
-citum-io = "0.53"
+citum-io = "0.73"
 ```
 
 Default features include `icu`, which enables ICU-backed collation and locale
@@ -27,6 +27,7 @@ support used by sorting and rendering. Optional features:
 |---|---|
 | `ffi` | Enables the C ABI module. |
 | `schema` | Enables JSON Schema generation support for API-facing types. |
+| `parallel` | Opts into Rayon bibliography rendering above the internal size threshold; profile before enabling. |
 
 ## Which API to Use
 
@@ -122,7 +123,7 @@ The document-level API expects:
 | Style | `StyleInput`; optionally a separate resolved `Style` | `format_document` resolves local path or inline YAML values from `request.style`. `format_document_with_style` uses its explicit `Style` argument, but the request still includes a `style` field. |
 | References | `RefsInput` | Local bibliography path, inline YAML, inline JSON, or legacy bare JSON map. |
 | Citations | `Vec<CitationOccurrence>` | Ordered as they appear in the document so note positions and repeated citations can be processed. |
-| Output format | `OutputFormatKind` | `plain`, `html`, `djot`, `latex`, or `typst`. |
+| Output format | `OutputFormatKind` | `plain`, `html`, `djot`, `latex`, `typst`, or `markdown`. |
 
 The result contains formatted citations, a formatted bibliography, per-entry
 bibliography metadata, and structured warnings. Missing references and

--- a/crates/citum-engine/src/processor/setup.rs
+++ b/crates/citum-engine/src/processor/setup.rs
@@ -541,25 +541,29 @@ impl Processor {
         spec: &citum_schema::CitationSpec,
     ) -> Vec<CitationItem> {
         if let Some(sort_spec) = &spec.sort {
-            let mut items_with_refs: Vec<(CitationItem, &Reference)> = items
+            let mut items_with_refs: Vec<(CitationItem, Option<&Reference>)> = items
                 .into_iter()
-                .filter_map(|item| {
-                    self.bibliography
-                        .get(&item.id)
-                        .map(|reference| (item, reference))
+                .map(|item| {
+                    let reference = self.bibliography.get(&item.id);
+                    (item, reference)
                 })
                 .collect();
 
             let resolved_sort = sort_spec.resolve();
             let sorter = crate::sorting::ReferenceSorter::new(&self.locale);
-            items_with_refs.sort_by(|left, right| {
-                for sort_key in &resolved_sort.template {
-                    let cmp = sorter.compare_by_key(left.1, right.1, sort_key);
-                    if cmp != std::cmp::Ordering::Equal {
-                        return cmp;
+            items_with_refs.sort_by(|left, right| match (left.1, right.1) {
+                (Some(left_reference), Some(right_reference)) => {
+                    for sort_key in &resolved_sort.template {
+                        let cmp = sorter.compare_by_key(left_reference, right_reference, sort_key);
+                        if cmp != std::cmp::Ordering::Equal {
+                            return cmp;
+                        }
                     }
+                    std::cmp::Ordering::Equal
                 }
-                std::cmp::Ordering::Equal
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => std::cmp::Ordering::Equal,
             });
 
             return items_with_refs

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -489,6 +489,41 @@ fn test_process_citation() {
     assert_eq!(result, "(Kuhn, 1962)");
 }
 
+/// Citation sorting must retain unresolved items so rendering reports them.
+#[test]
+fn citation_sort_preserves_missing_reference_error() {
+    let mut style = make_style();
+    style.citation.as_mut().expect("citation spec").sort = Some(
+        citum_schema::grouping::GroupSortEntry::Explicit(citum_schema::grouping::GroupSort {
+            template: vec![citum_schema::grouping::GroupSortKey {
+                key: citum_schema::grouping::SortKey::Author,
+                ascending: true,
+                order: None,
+                sort_order: None,
+            }],
+        }),
+    );
+    let processor = Processor::new(style, make_bibliography());
+    let citation = Citation {
+        items: vec![
+            CitationItem {
+                id: "missing-reference".to_string(),
+                ..Default::default()
+            },
+            CitationItem {
+                id: "kuhn1962".to_string(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    assert!(matches!(
+        processor.process_citation(&citation),
+        Err(ProcessorError::ReferenceNotFound(id)) if id == "missing-reference"
+    ));
+}
+
 /// Tests that note citations receive proper sequential numbering.
 ///
 /// Verifies that citations with missing note numbers are auto-assigned,


### PR DESCRIPTION
## Summary

- publish the July 10 follow-up architecture and code audit for `citum-engine`
- preserve unresolved citation items during sorting so missing references return the documented error
- reconcile findings with the July 3–4 audit beans and record two non-duplicate follow-ups
- refresh the crate README's versions and supported format/feature list

## Scope

- `docs/architecture/audits/2026-07-10_CITUM_ENGINE_FOLLOW_UP_REVIEW.md`
- citation sorting and its regression test
- engine README corrections
- completed audit/fix beans plus open performance and multilingual-sorting follow-ups

## Validation

- `cargo test -p citum-engine citation_sort_preserves_missing_reference_error`
- `python3 scripts/audit-rust-review-smells.py --changed` — no findings
- `just pre-commit` — fmt and strict Clippy passed; 1,856 tests passed, 0 skipped
- pre-push gate repeated fmt, Clippy, and all 1,856 tests successfully
- bean hygiene — no issues

## Risk

Low. The Rust change only retains citation items that were previously discarded when their reference lookup failed; normal rendering then follows the existing `ReferenceNotFound` path. Resolved-item ordering is unchanged.

## Follow-ups

- `csl26-plaz`: avoid duplicate document bibliography rendering
- `csl26-2tbe`: apply multilingual sort policy to year-suffix ordering
- existing cleanup family remains under `csl26-8m2p`
