### PR TITLE
fix(engine): unify bibliography group routing

### DIFF
--- a/.beans/archive/csl26-mnoo--render-grouped-bibliography-inner-ignores-groups-e.md
+++ b/.beans/archive/csl26-mnoo--render-grouped-bibliography-inner-ignores-groups-e.md
@@ -1,11 +1,11 @@
 ---
 # csl26-mnoo
 title: render_grouped_bibliography_inner ignores groups_enabled
-status: todo
+status: completed
 type: bug
 priority: normal
 created_at: 2026-07-11T12:10:07Z
-updated_at: 2026-07-11T12:20:24Z
+updated_at: 2026-07-11T14:22:59Z
 parent: csl26-8m2p
 ---
 
@@ -53,12 +53,12 @@ out of scope.
 
 ## Checklist
 
-- [ ] Add the same `.filter(|bibliography| bibliography.groups_enabled)` gate
+- [x] Add the same `.filter(|bibliography| bibliography.groups_enabled)` gate
       to `render_grouped_bibliography_inner`'s custom-groups check
-- [ ] Add regression test(s) covering `groups_enabled: false` + `groups:`
+- [x] Add regression test(s) covering `groups_enabled: false` + `groups:`
       still present via the standalone bibliography API
       (`render_bibliography` / `render_grouped_bibliography_with_format_standalone`)
-- [ ] Consider a shared helper (e.g. `Processor::effective_custom_groups(&self) -> Option<&[BibliographyGroup]>`)
+- [x] Consider a shared helper (e.g. `Processor::effective_custom_groups(&self) -> Option<&[BibliographyGroup]>`)
       so this condition can't drift between call sites again — three call
       sites currently duplicate the same check inline
 
@@ -103,3 +103,32 @@ separate either way — group-local disambiguation and per-group templates
 need a different data shape than a flat entries pass, which is exactly why
 PR #1037 left custom groups on the historical two-pass render in the first
 place.
+
+## Implementation
+
+The bounded refactor and its selection/layout contract are specified in `docs/specs/BIBLIOGRAPHY_RENDERING_PIPELINE.md` v1.1. Compound-numeric rendering remains an explicit compatibility path.
+
+## Validation
+
+- `just pre-commit`: 1,865 tests passed; formatting and all-target/all-feature Clippy clean.
+- New disabled-group, live-run all-references, partition-precedence, and compound characterization tests pass.
+- Rendering benchmarks were checked against an unchanged 400-entry control. Sustained-load slowdown affected the control by about 91%; both target paths degraded less, so no path-specific regression was observed.
+- Frontmatter validation and the changed-Rust review-smell audit pass.
+
+## Summary of Changes
+
+Centralized the groups_enabled gate in Processor::effective_custom_groups and
+routed all three former inline checks through it. Fixed standalone/live-run
+all-references rendering (restrict_to_cited is now honored end-to-end),
+replaced render_with_legacy_grouping with render_flat_compound_entries, and
+unified flat routing through render_flat_bibliography while keeping the
+partition and compound compatibility paths. Added disabled-group,
+partition-precedence, live-run, and compound regression tests plus a grouped
+partition benchmark; updated the two active bibliography specs.
+
+Post-review cleanups (same branch): removed the unconditional rendered.clone()
+on the flat no-partitioning path, extracted sorted_eligible_refs to dedupe the
+cited-eligibility filter, and converted short contains() test assertions to a
+full-string assert_eq per CODING_STANDARDS. Review also surfaced a pre-existing
+compound edge case, filed as [[csl26-uidd]] (merged row dropped when only a
+non-leader member is cited).

--- a/.beans/csl26-uidd--compound-bibliography-drops-merged-row-when-only-a.md
+++ b/.beans/csl26-uidd--compound-bibliography-drops-merged-row-when-only-a.md
@@ -1,0 +1,16 @@
+---
+# csl26-uidd
+title: Compound bibliography drops merged row when only a non-leader member is cited
+status: todo
+type: bug
+created_at: 2026-07-11T14:22:11Z
+updated_at: 2026-07-11T14:22:11Z
+---
+
+Found during code review of csl26-mnoo (branch codex/fix-grouped-bibliography-routing).
+
+render_flat_compound_entries (processor/bibliography/grouping.rs) filters already-merged compound rows by the retained leader ID against cited_ids. merge_compound_entries keys each merged row under the first configured member present in the full processed set, so for a compound set [A, B] where only B is cited, the merged row carries id=A; A is not in cited_ids, and the entire row — including the cited member B — is silently dropped from cited-only content. Meanwhile DocumentBibliography.entries (computed unmerged from the cited subset) still includes B, so content and entries disagree.
+
+This is pre-existing behavior (the removed render_with_legacy_grouping applied the same post-merge filter) and csl26-mnoo deliberately preserved it as the historical compound-selection contract. A fix would select cited membership before/during merging (a row is retained if ANY member is cited, or members are filtered pre-merge like custom groups do in render_with_custom_groups_filtered), which is a behavior change needing its own tests and a look at how citation-number assignment should behave for the uncited leader.
+
+Related: with sort-partitioning active, the compound path filters refs by cited_ids BEFORE merging (render_with_partition_sections branch), so partitioned and unpartitioned compound styles already have divergent selection semantics for this edge case.

--- a/crates/citum-engine/benches/rendering.rs
+++ b/crates/citum-engine/benches/rendering.rs
@@ -26,8 +26,9 @@ use citum_engine::{
 };
 use citum_schema::grouping::{GroupSort, GroupSortKey, NameSortOrder, SortKey as GroupSortKeyKind};
 use citum_schema::options::{
-    BibliographyOptions, Config, Disambiguation, GivennameRule, Group, LabelConfig, LabelPreset,
-    Processing, ProcessingCustom, Sort, SortEntry, SortKey, SortSpec,
+    BibliographyOptions, BibliographyPartitionKind, BibliographyPartitionMode,
+    BibliographySortPartitioning, Config, Disambiguation, GivennameRule, Group, LabelConfig,
+    LabelPreset, Processing, ProcessingCustom, Sort, SortEntry, SortKey, SortSpec,
     bibliography::CompoundNumericConfig,
 };
 use citum_schema::{
@@ -119,6 +120,7 @@ fn bench_rendering(c: &mut Criterion) {
     bench_bibliography_type_variants(c);
     bench_compound_bibliography(c);
     bench_document_bibliography(c, &style);
+    bench_grouped_partition_bibliography(c, &style);
 }
 
 /// Benchmark the document bibliography facade (`csl26-plaz`) on the shape it
@@ -146,6 +148,38 @@ fn bench_document_bibliography(c: &mut Criterion, style: &Style) {
                     processor
                         .process_document::<_, PlainText>(&document, &parser, DocumentFormat::Plain)
                         .unwrap(),
+                );
+            });
+        },
+    );
+}
+
+/// Benchmark the all-references grouped path while automatic partition sections are active.
+///
+/// Unlike a disabled-groups benchmark, this has identical output before and after
+/// `csl26-mnoo`, so its timing remains a valid behavioral no-op comparison.
+fn bench_grouped_partition_bibliography(c: &mut Criterion, style: &Style) {
+    let mut partitioned_style = style.clone();
+    let bibliography = partitioned_style
+        .bibliography
+        .as_mut()
+        .expect("APA benchmark style should define a bibliography");
+    let options = bibliography.options.get_or_insert_default();
+    options.sort_partitioning = Some(BibliographySortPartitioning {
+        by: BibliographyPartitionKind::Language,
+        mode: BibliographyPartitionMode::Sections,
+        order: Vec::new(),
+        headings: Default::default(),
+        unknown_fields: Default::default(),
+    });
+
+    let processor = Processor::new(partitioned_style, make_large_bibliography(400));
+    c.bench_function(
+        "Render Grouped Partition Bibliography (APA, 400 all refs)",
+        |b| {
+            b.iter(|| {
+                black_box(
+                    processor.render_grouped_bibliography_with_format_standalone::<PlainText>(),
                 );
             });
         },

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -27,6 +27,15 @@ use std::sync::Arc;
 
 use super::EntryRenderContext;
 
+/// Products requested from the shared flat bibliography render pass.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FlatBibliographyOutput {
+    /// Produce only the formatted bibliography string.
+    ContentOnly,
+    /// Produce the formatted string and flat per-reference entry data.
+    ContentAndEntries,
+}
+
 impl Processor {
     /// Resolve a localized or literal group heading.
     pub(super) fn resolve_group_heading(&self, heading: &GroupHeading) -> Option<String> {
@@ -484,10 +493,16 @@ impl Processor {
         ));
     }
 
-    /// Render bibliography using legacy (cited/uncited) grouping.
-    fn render_with_legacy_grouping<F>(
+    /// Render already-merged compound entries as a flat bibliography.
+    ///
+    /// The compound path renders every configured member before merging. A
+    /// cited-only document then filters the merged rows by their retained
+    /// leader ID, preserving the historical compound-selection contract.
+    /// All-references callers render every merged row.
+    fn render_flat_compound_entries<F>(
         &self,
         bibliography: &[ProcEntry],
+        restrict_to_cited: bool,
         annotations: Option<&HashMap<String, String>>,
         annotation_style: Option<&AnnotationStyle>,
         run: &FinalizedRun,
@@ -496,32 +511,37 @@ impl Processor {
         F: OutputFormat<Output = String>,
     {
         let fmt = F::default();
-        let cited_ids = &run.state().cited_ids;
-        let cited_entries: Vec<ProcEntry> = bibliography
-            .iter()
-            .filter(|entry| cited_ids.contains(&entry.id))
-            .cloned()
-            .collect();
+        let selected = if restrict_to_cited {
+            Cow::Owned(
+                bibliography
+                    .iter()
+                    .filter(|entry| run.state().cited_ids.contains(&entry.id))
+                    .cloned()
+                    .collect(),
+            )
+        } else {
+            Cow::Borrowed(bibliography)
+        };
 
-        let mut result = String::new();
-        if !cited_entries.is_empty() {
-            result.push_str(&crate::render::refs_to_string_with_format::<F>(
-                cited_entries,
+        let result = if selected.is_empty() {
+            String::new()
+        } else {
+            crate::render::refs_to_string_slice_with_format::<F>(
+                selected.as_ref(),
                 annotations,
                 annotation_style,
-            ));
-        }
+            )
+        };
 
         fmt.finish(result)
     }
 
-    /// Render the bibliography with grouping for uncited (nocite) items.
+    /// Render all loaded references with the style's effective grouping policy.
     ///
-    /// If `style.bibliography.groups` is defined, uses configurable grouping
-    /// with per-group sorting. Group selectors apply to individual references
-    /// before compound numeric rows are merged, so each rendered group only
-    /// includes the members that matched its selector. Otherwise, falls back to
-    /// hardcoded cited/uncited grouping for backward compatibility.
+    /// Enabled manual groups take precedence over automatic partition sections,
+    /// which in turn take precedence over flat rendering. Group selectors apply
+    /// to individual references before compound numeric rows are merged, so each
+    /// rendered group only includes the members that matched its selector.
     pub fn render_grouped_bibliography_with_format<F>(&self, run: &FinalizedRun) -> String
     where
         F: OutputFormat<Output = String>,
@@ -582,20 +602,19 @@ impl Processor {
     /// When `false`, all loaded references are eligible; this hook is reserved for the
     /// `allrefs` escape hatch (csl26-f9ri) and is not yet exposed publicly.
     ///
-    /// Both `content` and `entries` are computed from the same cited subset so
+    /// Both `content` and `entries` are computed from the same eligible subset so
     /// subsequent-author substitution stays consistent across both outputs.
     ///
-    /// The flat and sort-partitioned-sections cases (the common document shape)
-    /// render each cited reference's template exactly once — see
-    /// [`render_flat_document_bibliography`](Self::render_flat_document_bibliography)
-    /// — instead of once for `content` and again for `entries`. Custom
+    /// The flat and sort-partitioned-sections cases render each eligible
+    /// reference's template exactly once — see
+    /// [`render_flat_bibliography`](Self::render_flat_bibliography) — instead
+    /// of once for `content` and again for `entries`. Custom
     /// bibliography groups (`style.bibliography.groups`) need group-local
     /// disambiguation and per-group templates that a flat entry list can't
-    /// carry, compound-numeric merging needs to see every configured group
+    /// carry. Compound-numeric merging needs to see every configured group
     /// member whether cited or not (see
-    /// [`merge_compound_entries`](Self::merge_compound_entries)), and the
-    /// unrestricted `allrefs` case always needs the full library — those three
-    /// keep the historical two-pass render.
+    /// [`merge_compound_entries`](Self::merge_compound_entries)), so it keeps
+    /// its historical full-member content pass.
     pub(crate) fn render_document_bibliography<F>(
         &self,
         restrict_to_cited: bool,
@@ -606,15 +625,9 @@ impl Processor {
     where
         F: OutputFormat<Output = String>,
     {
-        let has_custom_groups = self
-            .style
-            .bibliography
-            .as_ref()
-            .filter(|bibliography| bibliography.groups_enabled)
-            .and_then(|bibliography| bibliography.groups.as_ref())
-            .is_some();
+        let has_custom_groups = self.effective_custom_groups().is_some();
 
-        if !restrict_to_cited || has_custom_groups || !run.state().compound_groups.is_empty() {
+        if has_custom_groups || !run.state().compound_groups.is_empty() {
             let content = self.render_grouped_bibliography_inner::<F>(
                 restrict_to_cited,
                 annotations,
@@ -637,25 +650,44 @@ impl Processor {
             .as_ref()
             .filter(|partitioning| crate::sort_partitioning::should_render_sections(partitioning));
 
-        self.render_flat_document_bibliography::<F>(
+        self.render_flat_bibliography::<F>(
+            restrict_to_cited,
             partitioning,
+            FlatBibliographyOutput::ContentAndEntries,
             annotations,
             annotation_style,
             run,
         )
     }
 
-    /// Render the flat, cited-only document bibliography in one pass.
+    /// Collect the eligible references — all loaded, or only the cited/`nocite`
+    /// subset when `restrict_to_cited` is `true` — in bibliography sort order.
+    fn sorted_eligible_refs(&self, restrict_to_cited: bool, run: &FinalizedRun) -> Vec<&Reference> {
+        let mut refs: Vec<&Reference> = self.bibliography.values().collect();
+        if restrict_to_cited {
+            let cited = &run.state().cited_ids;
+            refs.retain(|reference| {
+                reference
+                    .id()
+                    .as_deref()
+                    .is_some_and(|id| cited.contains(id))
+            });
+        }
+        self.sort_references(refs)
+    }
+
+    /// Render a flat or automatically partitioned bibliography in one pass.
     ///
-    /// Fast path for [`render_document_bibliography`](Self::render_document_bibliography)
-    /// once the caller has established there are no custom bibliography groups
-    /// and no compound-numeric groups active for this run. Renders each cited
-    /// reference's template exactly once (`render_numbered_refs` — the
+    /// Shared by document and grouped bibliography surfaces once the caller
+    /// has established there are no custom or compound-numeric groups active.
+    /// When `restrict_to_cited` is `true`, only cited and `nocite` references
+    /// are eligible; otherwise every loaded reference is eligible. Renders each
+    /// eligible reference's template exactly once (`render_numbered_refs` — the
     /// expensive step, resolving names/dates/titles through the full template)
     /// and reuses that render for both outputs:
     ///
     /// - `entries`: one continuous subsequent-author-substitution pass over the
-    ///   flat, globally sorted cited set — matches the historical
+    ///   flat, globally sorted eligible set — matches the historical
     ///   `process_selected_references_with_format` contract, including its
     ///   ordering.
     /// - `content`: without partitioning, the same flat pass rendered to a
@@ -675,9 +707,11 @@ impl Processor {
     /// non-numeric styles could differ from a per-section index — but
     /// non-numeric styles do not render a citation-number variable, so that
     /// fallback value is never observable in output.
-    fn render_flat_document_bibliography<F>(
+    fn render_flat_bibliography<F>(
         &self,
+        restrict_to_cited: bool,
         partitioning: Option<&BibliographySortPartitioning>,
+        output: FlatBibliographyOutput,
         annotations: Option<&HashMap<String, String>>,
         annotation_style: Option<&AnnotationStyle>,
         run: &FinalizedRun,
@@ -685,15 +719,23 @@ impl Processor {
     where
         F: OutputFormat<Output = String>,
     {
-        let cited = &run.state().cited_ids;
-        let mut refs: Vec<&Reference> = self.bibliography.values().collect();
-        refs.retain(|reference| {
-            reference
-                .id()
-                .as_deref()
-                .is_some_and(|id| cited.contains(id))
-        });
-        let sorted_refs = self.sort_references(refs);
+        let sorted_refs = self.sorted_eligible_refs(restrict_to_cited, run);
+
+        if output == FlatBibliographyOutput::ContentOnly
+            && let Some(partitioning) = partitioning
+        {
+            let content = self.render_with_partition_sections::<F>(
+                sorted_refs,
+                partitioning,
+                annotations,
+                annotation_style,
+                run,
+            );
+            return super::DocumentBibliography {
+                content,
+                entries: Vec::new(),
+            };
+        }
 
         let ctx = self.flat_render_context(run);
         let numbered_refs = super::number_sorted_refs(sorted_refs.iter().copied(), run);
@@ -704,9 +746,12 @@ impl Processor {
             .subsequent_author_substitute
             .as_ref();
 
-        let entries = self.apply_substitution_post_pass::<F>(rendered.clone(), substitute, &ctx);
-
-        let content = if let Some(partitioning) = partitioning {
+        if let Some(partitioning) = partitioning {
+            // Only ContentAndEntries reaches this branch: ContentOnly with
+            // partitioning returned through `render_with_partition_sections`
+            // above, so `entries` is always wanted here.
+            let entries =
+                self.apply_substitution_post_pass::<F>(rendered.clone(), substitute, &ctx);
             let mut result = String::new();
             for (partition_key, refs_in_section) in crate::sort_partitioning::partition_references(
                 sorted_refs,
@@ -720,7 +765,7 @@ impl Processor {
                     .iter()
                     .filter_map(|reference| reference.id().map(|id| id.to_string()))
                     .collect();
-                let section_rendered: Vec<_> = rendered
+                let section_rendered = rendered
                     .iter()
                     .filter(|(reference, _)| {
                         reference
@@ -740,15 +785,25 @@ impl Processor {
                     annotation_style,
                 );
             }
-            F::default().finish(result)
-        } else if entries.is_empty() {
+            return super::DocumentBibliography {
+                content: F::default().finish(result),
+                entries,
+            };
+        }
+
+        let rendered_entries = self.apply_substitution_post_pass::<F>(rendered, substitute, &ctx);
+        let content = if rendered_entries.is_empty() {
             String::new()
         } else {
             crate::render::refs_to_string_slice_with_format::<F>(
-                &entries,
+                &rendered_entries,
                 annotations,
                 annotation_style,
             )
+        };
+        let entries = match output {
+            FlatBibliographyOutput::ContentAndEntries => rendered_entries,
+            FlatBibliographyOutput::ContentOnly => Vec::new(),
         };
 
         super::DocumentBibliography { content, entries }
@@ -758,8 +813,8 @@ impl Processor {
     ///
     /// When `restrict_to_cited` is `true`, each branch limits its candidate
     /// set to references present in `run`'s `cited_ids`. When `false`, all
-    /// loaded references are eligible (the original all-refs behaviour used
-    /// by standalone `render refs`, FFI, and tests).
+    /// loaded references are eligible (the all-references behaviour used by
+    /// the standalone grouped API, FFI, and tests).
     fn render_grouped_bibliography_inner<F>(
         &self,
         restrict_to_cited: bool,
@@ -770,12 +825,7 @@ impl Processor {
     where
         F: OutputFormat<Output = String>,
     {
-        if let Some(groups) = self
-            .style
-            .bibliography
-            .as_ref()
-            .and_then(|bibliography| bibliography.groups.as_ref())
-        {
+        if let Some(groups) = self.effective_custom_groups() {
             let id_stubs = self.sorted_id_stubs();
             let selected = if restrict_to_cited {
                 let cited = &run.state().cited_ids;
@@ -801,31 +851,43 @@ impl Processor {
         }
 
         let bibliography_options = self.get_bibliography_options();
-        if let Some(partitioning) = bibliography_options.sort_partitioning.as_ref()
-            && crate::sort_partitioning::should_render_sections(partitioning)
-        {
-            let mut refs: Vec<&Reference> = self.bibliography.values().collect();
-            if restrict_to_cited {
-                let cited = &run.state().cited_ids;
-                refs.retain(|r| r.id().as_deref().is_some_and(|id| cited.contains(id)));
+        let partitioning = bibliography_options
+            .sort_partitioning
+            .as_ref()
+            .filter(|partitioning| crate::sort_partitioning::should_render_sections(partitioning));
+
+        if !run.state().compound_groups.is_empty() {
+            if let Some(partitioning) = partitioning {
+                let sorted_refs = self.sorted_eligible_refs(restrict_to_cited, run);
+                return self.render_with_partition_sections::<F>(
+                    sorted_refs,
+                    partitioning,
+                    annotations,
+                    annotation_style,
+                    run,
+                );
             }
-            let sorted_refs = self.sort_references(refs);
-            return self.render_with_partition_sections::<F>(
-                sorted_refs,
-                partitioning,
+
+            let all_entries = self.process_references_with_format::<F>(run).bibliography;
+            let merged = self.merge_compound_entries::<F>(all_entries, run);
+            return self.render_flat_compound_entries::<F>(
+                &merged,
+                restrict_to_cited,
                 annotations,
                 annotation_style,
                 run,
             );
         }
 
-        let all_entries = self.process_references_with_format::<F>(run).bibliography;
-        self.render_with_legacy_grouping::<F>(
-            &self.merge_compound_entries::<F>(all_entries, run),
+        self.render_flat_bibliography::<F>(
+            restrict_to_cited,
+            partitioning,
+            FlatBibliographyOutput::ContentOnly,
             annotations,
             annotation_style,
             run,
         )
+        .content
     }
 
     /// Extract and render entries for a bibliography group.

--- a/crates/citum-engine/src/processor/bibliography/mod.rs
+++ b/crates/citum-engine/src/processor/bibliography/mod.rs
@@ -35,6 +35,7 @@ use crate::reference::Reference;
 use crate::render::format::OutputFormat;
 use crate::render::{ProcEntry, ProcTemplate};
 use crate::values::ProcHints;
+use citum_schema::grouping::BibliographyGroup;
 use citum_schema::options::{Config, bibliography::BibliographyConfig};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -54,13 +55,13 @@ pub(crate) struct RenderedBibliographyGroup {
 ///
 /// Returned by [`Processor::render_document_bibliography`] — the unified facade
 /// used by the batch, session, and document-string rendering paths. Both fields
-/// are computed from the same cited subset so subsequent-author substitution
+/// are computed from the same eligible subset so subsequent-author substitution
 /// stays consistent between the rendered string and the per-entry data.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct DocumentBibliography {
     /// The full rendered bibliography string for the document.
     pub(crate) content: String,
-    /// Flat per-entry data, one entry per cited reference.
+    /// Flat per-entry data, one entry per eligible reference.
     pub(crate) entries: Vec<crate::render::ProcEntry>,
 }
 
@@ -131,6 +132,19 @@ struct EntryRenderContext<'a> {
 }
 
 impl Processor {
+    /// Return the manual bibliography groups that are currently enabled.
+    ///
+    /// Keeping the `groups_enabled` gate here ensures every bibliography
+    /// rendering surface interprets a retained but disabled `groups:` block
+    /// identically.
+    fn effective_custom_groups(&self) -> Option<&[BibliographyGroup]> {
+        self.style
+            .bibliography
+            .as_ref()
+            .filter(|bibliography| bibliography.groups_enabled)
+            .and_then(|bibliography| bibliography.groups.as_deref())
+    }
+
     /// Build the [`EntryRenderContext`] for a flat (ungrouped) bibliography
     /// pass: processor-level style, hints, and merged configs.
     fn flat_render_context<'a>(&'a self, run: &'a FinalizedRun) -> EntryRenderContext<'a> {
@@ -513,13 +527,7 @@ impl Processor {
         let selected: HashSet<String> = item_ids.into_iter().collect();
 
         // 1. Check for custom bibliography groups
-        if let Some(groups) = self
-            .style
-            .bibliography
-            .as_ref()
-            .filter(|bibliography| bibliography.groups_enabled)
-            .and_then(|bibliography| bibliography.groups.as_ref())
-        {
+        if let Some(groups) = self.effective_custom_groups() {
             let all_entries = self.sorted_id_stubs();
             return self.render_with_custom_groups_filtered::<F>(
                 &all_entries,

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -4352,14 +4352,7 @@ bibliography:
     );
 }
 
-/// Verifies the document bibliography facade keeps its historical two-pass
-/// render for compound-numeric groups: `render_document_bibliography`'s
-/// single-pass fast path (`csl26-plaz`) must not activate when a run has
-/// active compound groups, because merging a compound entry needs to see
-/// every configured group member — cited or not — while `entries` must stay
-/// cited-only and unmerged.
-#[test]
-fn test_render_document_bibliography_compound_groups_use_full_render() {
+fn make_compound_document_processor(partitioned: bool) -> Processor {
     use indexmap::IndexMap;
 
     let yaml = r#"
@@ -4384,7 +4377,22 @@ bibliography:
       form: long
     - title: primary
 "#;
-    let style: Style = serde_yaml::from_str(yaml).unwrap();
+    let mut style: Style = serde_yaml::from_str(yaml).unwrap();
+    if partitioned {
+        style
+            .bibliography
+            .as_mut()
+            .unwrap()
+            .options
+            .get_or_insert_default()
+            .sort_partitioning = Some(citum_schema::options::BibliographySortPartitioning {
+            by: citum_schema::options::BibliographyPartitionKind::Language,
+            mode: citum_schema::options::BibliographyPartitionMode::Sections,
+            order: Vec::new(),
+            headings: HashMap::new(),
+            unknown_fields: Default::default(),
+        });
+    }
 
     let refs_json = r#"[
         {
@@ -4426,7 +4434,31 @@ bibliography:
         vec!["ref-a".to_string(), "ref-b".to_string()],
     );
 
-    let processor = Processor::with_compound_sets(style, bib, sets);
+    Processor::with_compound_sets(style, bib, sets)
+}
+
+#[test]
+fn test_partitioned_compound_bibliography_preserves_all_references_merge() {
+    let processor = make_compound_document_processor(true);
+    let partitioned = processor
+        .render_grouped_bibliography_with_format_standalone::<crate::render::plain::PlainText>();
+    assert_eq!(
+        partitioned,
+        "[1] a) A. Smith. Article A., b) B. Jones. Article B.\n\n[2] C. Brown. Standalone Article.",
+        "partitioned all-references content should merge both compound members under one \
+         label and retain standalone entries"
+    );
+}
+
+/// Verifies the document bibliography facade keeps its historical two-pass
+/// render for compound-numeric groups: `render_document_bibliography`'s
+/// single-pass fast path (`csl26-plaz`) must not activate when a run has
+/// active compound groups, because merging a compound entry needs to see
+/// every configured group member — cited or not — while `entries` must stay
+/// cited-only and unmerged.
+#[test]
+fn test_render_document_bibliography_compound_groups_use_full_render() {
+    let processor = make_compound_document_processor(false);
 
     // Cite only "ref-a" — the other compound-group member ("ref-b") and the
     // standalone reference ("ref-c") are never cited.

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -21,8 +21,8 @@ use citum_schema::reference::ClassExtension;
 use common::*;
 
 use citum_engine::{
-    Processor, render::html::Html, render::latex::Latex, render::plain::PlainText,
-    render::typst::Typst,
+    Citation, CitationItem, Processor, render::html::Html, render::latex::Latex,
+    render::plain::PlainText, render::typst::Typst,
 };
 use citum_schema::{
     BibliographySpec, CitationSpec, Style, StyleInfo,
@@ -211,9 +211,18 @@ bibliography:
 }
 
 fn partition_reference(id: &str, title: &str, language: Option<&str>) -> InputReference {
+    typed_partition_reference(id, "book", title, language)
+}
+
+fn typed_partition_reference(
+    id: &str,
+    ref_type: &str,
+    title: &str,
+    language: Option<&str>,
+) -> InputReference {
     let mut fixture = serde_json::json!({
         "id": id,
-        "type": "book",
+        "type": ref_type,
         "title": title
     });
     if let Some(language) = language {
@@ -605,6 +614,108 @@ groups:
     assert!(
         !output.contains("Han"),
         "auto-partition heading 'Han' must not appear when manual groups are configured: {output}"
+    );
+}
+
+#[test]
+fn disabled_manual_groups_render_every_reference_flat() {
+    announce_behavior(
+        "Disabling a retained manual groups block renders the complete standalone bibliography without group headings.",
+    );
+    let style = build_partition_style(
+        "",
+        r#"
+groups-enabled: false
+groups:
+  - id: disabled-books
+    heading: { literal: "Disabled Books" }
+    selector:
+      type: book
+"#,
+    );
+    let bibliography = IndexMap::from([
+        (
+            "book".to_string(),
+            typed_partition_reference("book", "book", "Alpha Book", Some("en")),
+        ),
+        (
+            "article".to_string(),
+            typed_partition_reference("article", "article-journal", "Beta Article", Some("en")),
+        ),
+    ]);
+    let processor = Processor::new(style, bibliography);
+
+    assert_eq!(
+        processor.render_grouped_bibliography_with_format_standalone::<PlainText>(),
+        "Alpha Book\n\nBeta Article"
+    );
+}
+
+#[test]
+fn grouped_live_run_remains_all_references() {
+    announce_behavior(
+        "Grouped rendering against a live run includes the whole library even when only one reference has been cited.",
+    );
+    let style = build_partition_style("", "");
+    let bibliography = IndexMap::from([
+        (
+            "cited".to_string(),
+            typed_partition_reference("cited", "book", "Alpha Cited", Some("en")),
+        ),
+        (
+            "uncited".to_string(),
+            typed_partition_reference("uncited", "article-journal", "Beta Uncited", Some("en")),
+        ),
+    ]);
+    let processor = Processor::new(style, bibliography);
+    let citation = Citation {
+        items: vec![CitationItem {
+            id: "cited".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let mut run = processor.begin_run();
+    processor
+        .process_citation_with_format::<PlainText>(&citation, &mut run)
+        .expect("citation should render");
+    let run = run.finalize();
+
+    assert_eq!(
+        processor.render_grouped_bibliography_with_format::<PlainText>(&run),
+        "Alpha Cited\n\nBeta Uncited"
+    );
+}
+
+#[test]
+fn disabled_manual_groups_fall_through_to_partition_sections() {
+    announce_behavior(
+        "Disabling manual groups leaves automatic bibliography partition sections active.",
+    );
+    let style = build_partition_style(
+        r#"
+options:
+  sort-partitioning:
+    by: language
+    mode: sections
+    order: [ru, en]
+    headings:
+      ru: { literal: "Russian" }
+      en: { literal: "English" }
+"#,
+        r#"
+groups-enabled: false
+groups:
+  - id: disabled
+    heading: { literal: "Disabled Manual Group" }
+    selector: {}
+"#,
+    );
+    let processor = Processor::new(style, language_partition_bibliography());
+
+    assert_eq!(
+        processor.render_grouped_bibliography_with_format_standalone::<PlainText>(),
+        "## Russian\n\nBeta\n\n## English\n\nAlpha\n\nGamma"
     );
 }
 

--- a/docs/specs/BIBLIOGRAPHY_GROUPING.md
+++ b/docs/specs/BIBLIOGRAPHY_GROUPING.md
@@ -187,6 +187,9 @@ bibliography:
 
 Style-level groups apply to every document rendered with that style unless
 the document provides its own frontmatter `bibliography:` list or caller blocks.
+`bibliography.groups-enabled: false` disables only these manual style groups;
+the retained `groups:` configuration is ignored and any automatic
+`sort-partitioning` sections remain active.
 
 ## Per-Document Frontmatter Groups
 

--- a/docs/specs/BIBLIOGRAPHY_RENDERING_PIPELINE.md
+++ b/docs/specs/BIBLIOGRAPHY_RENDERING_PIPELINE.md
@@ -1,92 +1,105 @@
 # Bibliography Rendering Pipeline
 
-Status: Active
+**Status:** Active
+**Version:** 1.1
+**Date:** 2026-07-11
+**Related:** beans `csl26-plaz`, `csl26-mnoo`, `csl26-f9ri`; `BIBLIOGRAPHY_GROUPING.md`
 
-## Overview
+## Purpose
 
-This document describes the consolidated bibliography rendering pipeline introduced in the
-`refactor(engine): unify document bibliography rendering` refactor. It is the authoritative
-reference for how the three document-context API surfaces route to a single rendering facade,
-how the document-free (standalone) path stays separate, and where the reserved `allrefs`
-escape hatch fits.
+This specification defines how bibliography APIs select eligible references, choose a layout,
+and derive rendered content and per-entry data. Selection and layout are independent decisions:
+whether an API renders cited or all loaded references must not change because manual groups or
+automatic partition sections are configured.
 
-## Pipeline Diagram
+## Scope
+
+This covers document-context bibliography rendering, the standalone grouped API, its FFI
+wrappers, and explicitly selected bibliography rendering. The public document-level `allrefs`
+option and `nocite: @*` syntax remain reserved for `csl26-f9ri`.
+
+## Design
+
+### Pipeline
 
 ```mermaid
 flowchart LR
-    fd["format_document"]
-    se["DocumentSession"]
-    pd["process_document"]
-    gate["cited_ids\ncited + nocite IDs"]
-    facade["render_document_bibliography\nrestrict_to_cited: bool"]
-    inner["render_grouped_bibliography_inner"]
-    psr["process_selected_references\ncited subset"]
-    pra["process_references\nall refs"]
-    allrefs["allrefs flag\ncsl26-f9ri"]
-    out["DocumentBibliography\ncontent + entries"]
-    cli["CLI / FFI render refs"]
-    sel["render_selected_bibliography\nexplicit item_ids"]
-    str["String"]
+    document["Document APIs"] --> cited["Select cited + nocite IDs"]
+    grouped["Standalone grouped API / FFI"] --> all["Select all loaded IDs"]
+    selected["Selected bibliography API"] --> explicit["Select explicit IDs"]
 
-    fd --> gate
-    se --> gate
-    pd --> gate
-    gate --> facade
-    allrefs -.->|"restrict=false"| facade
+    cited --> layout["Choose layout"]
+    all --> layout
+    explicit --> layout
 
-    facade --> inner
-    facade -->|"restrict=true"| psr
-    facade -->|"restrict=false"| pra
+    layout -->|"groups-enabled + groups"| custom["Custom-group renderer"]
+    layout -->|"visible sort partitions"| partitions["Partition sections"]
+    layout -->|"otherwise"| flat["Flat renderer"]
 
-    inner --> out
-    psr --> out
-    pra --> out
-
-    cli --> sel
-    sel --> str
+    partitions --> shared["Shared flat render pass"]
+    flat --> shared
+    shared --> output["content + entries"]
+    custom --> output
 ```
 
-## Routing Rules
+### Selection rules
 
-| Call site | restrict_to_cited | Returns |
+| API surface | Eligible references | Result |
 |---|---|---|
-| `format_bibliography` (batch, session) | `true` | `DocumentBibliography` (content + entries) |
-| `pipeline.rs` `process_document_with_default_bibliography` | `true` | `.content` only |
-| `render_refs` / FFI / standalone CLI | — (explicit `item_ids`) | `String` |
-| `allrefs` flag (csl26-f9ri, reserved) | `false` | `DocumentBibliography` |
+| `format_bibliography`, `process_document`, `DocumentSession` | IDs cited in-text or registered through `nocite` | `DocumentBibliography` |
+| `render_grouped_bibliography_with_format*` and `citum_render_bibliography_grouped_*` | All loaded references, regardless of the run's cited IDs | `String` |
+| `render_selected_bibliography_with_format*` | Caller-supplied IDs | `String` |
+| Reserved document `allrefs` hook | All loaded references | `DocumentBibliography` |
 
-## Content engine sub-paths (`render_grouped_bibliography_inner`)
+The internal `restrict_to_cited` flag therefore controls selection only. `true` selects the
+document's cited and `nocite` IDs; `false` selects the full loaded library.
 
-1. **Custom groups** (`style.bibliography.groups` defined) → `render_with_custom_groups_filtered`
-2. **Sort partitioning** (`bibliography.sort_partitioning` with `render_sections: true`) → `render_with_partition_sections`
-3. **Flat fallback** (no groups, no partitioning) → `render_with_legacy_grouping`
+### Layout precedence
 
-All three sub-paths honour `restrict_to_cited` — cited IDs come from `self.cited_ids`
-(populated by the citation pipeline and `register_nocite_ids`).
+After selection, rendering chooses exactly one layout:
 
-## Per-entry data consistency
+1. Manual `bibliography.groups` when `groups_enabled` is `true`.
+2. Automatic `sort_partitioning` sections when configured for visible sections.
+3. Flat rendering.
 
-`entries` are computed by `process_selected_references_with_format` over the same cited
-subset that `render_grouped_bibliography_inner` uses for `content`. This guarantees that
-subsequent-author substitution (e.g. `———`) sees only the cited subset in both outputs.
+Setting `groups_enabled: false` disables only manual groups. A retained `groups:` block is
+ignored, and automatic partition sections remain eligible.
 
-## Document-free path
+### Shared flat and partition rendering
 
-`render_bibliography_with_format`, `render_selected_bibliography_with_format_and_annotations`,
-and the standalone CLI (`human.rs`) bypass `render_document_bibliography` entirely. They
-call `render_selected_bibliography_with_format_and_annotations` with an explicit `item_ids`
-set and do not read `cited_ids`. These paths are unchanged by this refactor.
+Flat and automatic-partition layouts render each eligible reference template once. The pass
+produces globally sorted, unmerged `entries`; `content` is then derived from those rendered
+templates. Partition content applies subsequent-author substitution independently in each
+section so substitution state resets at section boundaries.
 
-## Reserved: `allrefs` flag (csl26-f9ri)
+Custom groups remain separate because group-local templates, sorting, and disambiguation cannot
+be represented by one flat entry list.
 
-Passing `restrict_to_cited = false` to `render_document_bibliography` makes every loaded
-reference eligible — the `allrefs` escape hatch for printing a bibliography without a
-document context. The engine hook is in place; the public API surface (`allrefs: bool` on
-`FormatDocumentRequest` / session, and the `@*` Pandoc wildcard in `nocite`) is deferred
-to csl26-f9ri.
+### Compound-numeric exception
 
-## Related specs
+Active compound-numeric groups keep a dedicated content path. Merging may require configured
+group members beyond the document's cited subset, while document `entries` remain cited-only and
+unmerged. Automatic partition sections merge compound members within each rendered partition.
 
-- [NOCITE_BIBLIOGRAPHY_ONLY_ENTRIES.md](NOCITE_BIBLIOGRAPHY_ONLY_ENTRIES.md) — nocite
-  semantics and API surface; `register_nocite_ids` feeds `cited_ids` that gate the
-  document bibliography.
+## Implementation Notes
+
+- `Processor::effective_custom_groups` is the single gate for enabled manual groups.
+- `Processor::render_flat_bibliography` is shared by document and grouped rendering when no
+  custom or compound-numeric groups are active.
+- FFI grouped rendering finalizes a clone of the live run, but still requests all loaded
+  references; existing cited IDs affect selectors, not eligibility.
+
+## Acceptance Criteria
+
+- [x] Disabled manual groups render a flat full-library standalone bibliography.
+- [x] Grouped rendering against a live run includes cited and uncited references.
+- [x] Disabled manual groups fall through to automatic partition sections.
+- [x] Document bibliography output remains restricted to cited and `nocite` references.
+- [x] Flat and partition content preserve substitution, annotation, numbering, and compound
+      behavior.
+
+## Changelog
+
+- v1.1 (2026-07-11): Separate selection from layout and define disabled-group, standalone,
+  FFI, shared-renderer, and compound behavior (`csl26-mnoo`).
+- v1.0 (2026-07-11): Consolidate document bibliography rendering (`csl26-plaz`).


### PR DESCRIPTION
## Summary

Fixes the grouped-bibliography routing gaps tracked in bean `csl26-mnoo` (follow-up from the PR #1037 review):

- **Centralized `groups_enabled` gate** — new `Processor::effective_custom_groups()` helper; all three former inline checks route through it, so a retained-but-disabled `groups:` block now renders flat everywhere (previously `render_grouped_bibliography_inner` ignored `groups-enabled: false`).
- **Fixed standalone/live-run all-references rendering** — the legacy cited/uncited helper filtered to cited IDs unconditionally, so the standalone grouped API and FFI (`restrict_to_cited: false`) could render an empty or truncated bibliography. Replaced with `render_flat_compound_entries`, which honors the flag.
- **Unified flat routing** — flat and partition-section rendering share `render_flat_bibliography` (single template render for both `content` and `entries`), while the efficient partition and compound-numeric compatibility paths are preserved unchanged.

## Post-review cleanups (self-review with `/code-review`, high effort)

- Removed an unconditional `rendered.clone()` on the flat no-partitioning document path (hot path).
- Extracted `sorted_eligible_refs` to deduplicate the collect → retain-cited → sort sequence.
- Replaced short `contains()` test assertions with a full-string `assert_eq!` per CODING_STANDARDS.
- A pre-existing compound edge case surfaced during review (merged row dropped when only a non-leader member is cited) is deliberately **not** changed here — documented as the historical contract and tracked in bean `csl26-uidd`.

## Tests

- New coverage: disabled-group flat rendering, disabled-groups → partition-sections precedence, live-run all-references, partitioned compound all-references characterization, plus a grouped-partition benchmark.
- `just pre-commit`: formatting, Clippy (all targets/features, `-D warnings`), and all 1,865 tests pass.

## Docs

- `docs/specs/BIBLIOGRAPHY_RENDERING_PIPELINE.md` (v1.1) and `docs/specs/BIBLIOGRAPHY_GROUPING.md` updated to match the routing contract.

Closes bean `csl26-mnoo`.
