### PR TITLE
fix(engine): format-aware punctuation boundaries

### DIFF
--- a/.beans/archive/csl26-ztxq--format-aware-punctuation-boundary-detection.md
+++ b/.beans/archive/csl26-ztxq--format-aware-punctuation-boundary-detection.md
@@ -1,14 +1,14 @@
 ---
 # csl26-ztxq
 title: Format-aware punctuation boundary detection
-status: in-progress
+status: completed
 type: task
 priority: normal
 tags:
     - punctuation
     - rendering
 created_at: 2026-07-04T17:11:33Z
-updated_at: 2026-07-11T19:09:00Z
+updated_at: 2026-07-11T19:46:20Z
 parent: csl26-8m2p
 ---
 
@@ -26,3 +26,41 @@ Confirmed at source: `render/bibliography.rs::visible_text` (line 26) strips onl
 4. **Tests:** per-backend rstest matrix (same entry rendered via each format asserts identical `visible_text` output — the backends-differ-only-in-markup rule from DESIGN_PRINCIPLES), plus regression cases from engine review part2 finding 13 ('Title.. Next' in LaTeX, marker-terminated Typst emphasis, URL containing ', .').
 
 Note: csl26-zfqr no longer depends on this work — its check moved to source text (see that bean). Sizing: item 1-2 Sonnet-executable; item 3 span-mapping needs a review pass.
+
+## Summary of Changes
+
+Implemented all 4 items from the fix design across 3 commits on
+`fix/engine-format-aware-punctuation-boundaries`:
+
+1. `feat(engine): add format-aware visible-text hook` — added
+   `OutputFormat::visible_runs`/`visible_text` with a per-backend lexer
+   (shared scanning primitives in new `render/visible_scan.rs`), and
+   threaded it generically (`::<F>`) through
+   `first_visible_char`/`last_visible_non_space_char`/
+   `ends_with_sentence_ending_visible_punctuation`/`terminal_link`/
+   `component_starts_new_sentence`/`append_rendered_component`. Org
+   keeps the default whole-fragment-visible passthrough (documented):
+   its unescaped single-char delimiters make a lexer no more reliable
+   than the renderer itself already is.
+2. `fix(engine): span-aware punctuation cleanup` — rewrote
+   `cleanup_dangling_punctuation` to match the pattern table against
+   the visible projection only and apply minimal raw edits, so
+   `\href{...}` URLs, attributes, and interleaved markup are never
+   touched (went with the full span-mapping design, not the
+   documented-gap intermediate).
+3. `fix(engine): markup-aware citation delimiter` — `push_delimiter`'s
+   collision table now decides off the visible last char; when it's
+   hidden behind trailing markup, drops the delimiter's leading
+   punctuation instead of mutating the markup tail (included in this
+   PR per review, not deferred).
+4. Tests: per-backend `visible_runs`/`visible_text` unit tests in each
+   format module, a cross-backend parity test, and finding-13
+   regressions (LaTeX `\emph{Title.}` no longer doubles punctuation,
+   href targets survive cleanup, Typst boundary case).
+
+Verified: full workspace `just pre-commit` green (1897 tests);
+`just workflow-test styles-legacy/apa.csl` shows the same 45/46
+baseline as `main` (the 1 pre-existing failure is unrelated
+year/title/publisher/doi content, confirmed via stash comparison);
+spot-checked LaTeX/Typst CLI rendering of `examples/references.json`
+with apa — no doubled punctuation, markup intact.

--- a/.beans/csl26-ztxq--format-aware-punctuation-boundary-detection.md
+++ b/.beans/csl26-ztxq--format-aware-punctuation-boundary-detection.md
@@ -1,14 +1,14 @@
 ---
 # csl26-ztxq
 title: Format-aware punctuation boundary detection
-status: todo
+status: in-progress
 type: task
 priority: normal
 tags:
     - punctuation
     - rendering
 created_at: 2026-07-04T17:11:33Z
-updated_at: 2026-07-06T18:45:57Z
+updated_at: 2026-07-11T19:09:00Z
 parent: csl26-8m2p
 ---
 

--- a/crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs
@@ -60,7 +60,7 @@ impl Renderer<'_> {
                 continue;
             }
 
-            if component_starts_new_sentence(
+            if component_starts_new_sentence::<F>(
                 &entry_output,
                 &rendered,
                 &default_separator,
@@ -71,7 +71,7 @@ impl Renderer<'_> {
             }
 
             let rendered = render_component_with_format::<F>(component);
-            append_rendered_component(
+            append_rendered_component::<F>(
                 &mut entry_output,
                 &rendered,
                 &default_separator,

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -22,39 +22,26 @@ fn is_sentence_ending_punctuation(c: char) -> bool {
     matches!(c, '.' | '!' | '?')
 }
 
-/// Extracts the visible (non-markup) text content from a rendered fragment.
-fn visible_text(input: &str) -> String {
-    let mut output = String::with_capacity(input.len());
-    let mut in_tag = false;
-
-    for ch in input.chars() {
-        match ch {
-            '<' => in_tag = true,
-            '>' if in_tag => in_tag = false,
-            _ if !in_tag => output.push(ch),
-            _ => {}
-        }
-    }
-
-    output
-}
-
-/// Returns the first character of the visible (tag-stripped) text, which may be whitespace.
-fn first_visible_char(input: &str) -> Option<char> {
-    visible_text(input).chars().next()
+/// Returns the first character of the visible (markup-stripped) text for
+/// format `F`, which may be whitespace.
+fn first_visible_char<F: OutputFormat<Output = String>>(input: &str) -> Option<char> {
+    F::default().visible_text(input).chars().next()
 }
 
 /// Returns the last non-whitespace visible character, used for punctuation deduplication.
-fn last_visible_non_space_char(input: &str) -> Option<char> {
-    visible_text(input)
+fn last_visible_non_space_char<F: OutputFormat<Output = String>>(input: &str) -> Option<char> {
+    F::default()
+        .visible_text(input)
         .chars()
         .rev()
         .find(|ch| !ch.is_whitespace())
 }
 
 /// Returns true if the rendered output ends with sentence-ending punctuation, used to suppress trailing period addition.
-fn ends_with_sentence_ending_visible_punctuation(input: &str) -> bool {
-    let visible = visible_text(input);
+fn ends_with_sentence_ending_visible_punctuation<F: OutputFormat<Output = String>>(
+    input: &str,
+) -> bool {
+    let visible = F::default().visible_text(input);
     let mut chars = visible.chars().rev().filter(|ch| !ch.is_whitespace());
     match chars.next() {
         Some(ch) if is_sentence_ending_punctuation(ch) => true,
@@ -66,7 +53,7 @@ fn ends_with_sentence_ending_visible_punctuation(input: &str) -> bool {
 /// Returns true when the next rendered component should be treated as sentence-initial
 /// under the same join semantics used by bibliography rendering.
 #[must_use]
-pub(crate) fn component_starts_new_sentence(
+pub(crate) fn component_starts_new_sentence<F: OutputFormat<Output = String>>(
     entry_output: &str,
     rendered: &str,
     default_separator: &str,
@@ -76,19 +63,19 @@ pub(crate) fn component_starts_new_sentence(
         return true;
     }
 
-    let first_char = first_visible_char(rendered).unwrap_or(' ');
+    let first_char = first_visible_char::<F>(rendered).unwrap_or(' ');
     let starts_with_separator = matches!(first_char, ',' | ';' | ':' | ' ' | '.' | '(');
 
     if starts_with_separator {
         return false;
     }
 
-    if ends_with_sentence_ending_visible_punctuation(entry_output) {
+    if ends_with_sentence_ending_visible_punctuation::<F>(entry_output) {
         return true;
     }
 
     let last_char = entry_output.chars().last().unwrap_or(' ');
-    let trimmed_last = last_visible_non_space_char(entry_output).unwrap_or(' ');
+    let trimmed_last = last_visible_non_space_char::<F>(entry_output).unwrap_or(' ');
     if !last_char.is_whitespace()
         && !first_char.is_whitespace()
         && !is_final_punctuation(trimmed_last)
@@ -151,7 +138,7 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
         }
 
         if let Some((_, _, previous)) = pending_component.replace((index, component, rendered)) {
-            append_rendered_component(
+            append_rendered_component::<F>(
                 &mut entry_output,
                 &previous,
                 default_separator,
@@ -173,7 +160,7 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
         } else {
             rendered
         };
-        append_rendered_component(
+        append_rendered_component::<F>(
             &mut entry_output,
             &final_rendered,
             default_separator,
@@ -189,7 +176,7 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
         Some(suffix) if !suffix.is_empty() => {
             // The suffix is suppressed after a terminal URL/DOI by default; a
             // style may force it back on per link kind (IEEE: DOI, MLA: URL).
-            let suppress = match terminal_link(&entry_output) {
+            let suppress = match terminal_link::<F>(&entry_output) {
                 TerminalLink::Doi => !bib_cfg.is_some_and(|b| b.entry_suffix_after_doi),
                 TerminalLink::Url => !bib_cfg.is_some_and(|b| b.entry_suffix_after_url),
                 TerminalLink::None => false,
@@ -220,7 +207,7 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
 /// The separator logic inspects the boundary between the accumulated output
 /// and the incoming `rendered` string; `punctuation_in_quote` controls whether
 /// a period should be pulled inside a preceding closing quotation mark.
-pub(crate) fn append_rendered_component(
+pub(crate) fn append_rendered_component<F: OutputFormat<Output = String>>(
     entry_output: &mut String,
     rendered: &str,
     default_separator: &str,
@@ -228,9 +215,9 @@ pub(crate) fn append_rendered_component(
 ) {
     if !entry_output.is_empty() {
         let last_char = entry_output.chars().last().unwrap_or(' ');
-        let first_char = first_visible_char(rendered).unwrap_or(' ');
+        let first_char = first_visible_char::<F>(rendered).unwrap_or(' ');
         let sep_first_char = default_separator.chars().next().unwrap_or('.');
-        let trimmed_last = last_visible_non_space_char(entry_output).unwrap_or(' ');
+        let trimmed_last = last_visible_non_space_char::<F>(entry_output).unwrap_or(' ');
         let ends_with_punctuation = is_final_punctuation(trimmed_last);
         // The incoming component already carries its own leading separator (e.g. ", " or "; ").
         let starts_with_separator = matches!(first_char, ',' | ';' | ':' | ' ' | '.' | '(');
@@ -329,7 +316,7 @@ pub fn refs_to_string_slice_with_format<F: OutputFormat<Output = String>>(
             }
         }
 
-        if visible_text(&entry_output).trim().is_empty() {
+        if fmt.visible_text(&entry_output).trim().is_empty() {
             continue;
         }
 
@@ -367,8 +354,8 @@ enum TerminalLink {
 }
 
 /// Classify whether an entry ends in a DOI, a plain URL, or neither.
-fn terminal_link(output: &str) -> TerminalLink {
-    let visible = visible_text(output);
+fn terminal_link<F: OutputFormat<Output = String>>(output: &str) -> TerminalLink {
+    let visible = F::default().visible_text(output);
     let trimmed = visible.trim_end_matches('.').trim_end();
     let last = trimmed.rsplit_once(' ').map_or(trimmed, |(_, last)| last);
     let is_doi = last.contains("doi.org/")
@@ -430,25 +417,38 @@ fn cleanup_dangling_punctuation(output: &mut String) {
 mod tests {
     use super::*;
     use crate::render::component::ProcTemplateComponent;
+    use crate::render::djot::Djot;
+    use crate::render::html::Html;
+    use crate::render::latex::Latex;
+    use crate::render::markdown::Markdown;
+    use crate::render::typst::Typst;
     use citum_schema::template::{Rendering, TemplateComponent, WrapConfig, WrapPunctuation};
 
     #[test]
     fn terminal_link_classifies_url_doi_and_plain_text() {
         // given a DOI in url form, doi: form, or bare 10.x form → Doi
-        assert!(terminal_link("Author. Title. https://doi.org/10.1/x") == TerminalLink::Doi);
-        assert!(terminal_link("Author. Title. doi:10.1038/abc") == TerminalLink::Doi);
-        assert!(terminal_link("Author. Title. doi: 10.1038/abc") == TerminalLink::Doi);
+        assert!(
+            terminal_link::<PlainText>("Author. Title. https://doi.org/10.1/x")
+                == TerminalLink::Doi
+        );
+        assert!(terminal_link::<PlainText>("Author. Title. doi:10.1038/abc") == TerminalLink::Doi);
+        assert!(terminal_link::<PlainText>("Author. Title. doi: 10.1038/abc") == TerminalLink::Doi);
         // given a plain URL → Url
-        assert!(terminal_link("Author. Title. https://example.com/page") == TerminalLink::Url);
+        assert!(
+            terminal_link::<PlainText>("Author. Title. https://example.com/page")
+                == TerminalLink::Url
+        );
         // given prose with no terminal link → None
-        assert!(terminal_link("Author. Title. Publisher, 2020") == TerminalLink::None);
+        assert!(terminal_link::<PlainText>("Author. Title. Publisher, 2020") == TerminalLink::None);
         // a trailing period is ignored when classifying
-        assert!(terminal_link("Author. https://example.com/page.") == TerminalLink::Url);
+        assert!(
+            terminal_link::<PlainText>("Author. https://example.com/page.") == TerminalLink::Url
+        );
     }
 
     #[test]
     fn test_component_starts_new_sentence_at_entry_start() {
-        assert!(component_starts_new_sentence(
+        assert!(component_starts_new_sentence::<PlainText>(
             "",
             "Edited by Grimm, Jacob",
             ". ",
@@ -458,7 +458,7 @@ mod tests {
 
     #[test]
     fn test_component_starts_new_sentence_after_period() {
-        assert!(component_starts_new_sentence(
+        assert!(component_starts_new_sentence::<PlainText>(
             "Collected Essays.",
             "edited by Grimm, Jacob",
             ". ",
@@ -468,7 +468,7 @@ mod tests {
 
     #[test]
     fn test_component_does_not_start_new_sentence_after_colon() {
-        assert!(!component_starts_new_sentence(
+        assert!(!component_starts_new_sentence::<PlainText>(
             "Collected Essays:",
             "edited by Grimm, Jacob",
             ". ",
@@ -618,7 +618,7 @@ mod tests {
         // (IEEE house style: separator ", ", punctuation-in-quote enabled)
         let mut entry_output = String::from("\u{201C}Deep Learning\u{201D}");
         // when the next component (the journal title) is appended
-        append_rendered_component(&mut entry_output, "Nature", ", ", true);
+        append_rendered_component::<PlainText>(&mut entry_output, "Nature", ", ", true);
         // then the comma is pulled inside the closing quotation mark
         assert_eq!(entry_output, "\u{201C}Deep Learning,\u{201D} Nature");
     }
@@ -628,7 +628,7 @@ mod tests {
         // given a quoted title followed by a period-delimited separator
         let mut entry_output = String::from("\u{201C}Deep Learning\u{201D}");
         // when the next component is appended
-        append_rendered_component(&mut entry_output, "Nature", ". ", true);
+        append_rendered_component::<PlainText>(&mut entry_output, "Nature", ". ", true);
         // then the period is pulled inside the closing quotation mark (unchanged behaviour)
         assert_eq!(entry_output, "\u{201C}Deep Learning.\u{201D} Nature");
     }
@@ -638,7 +638,7 @@ mod tests {
         // given punctuation-in-quote disabled
         let mut entry_output = String::from("\u{201C}Deep Learning\u{201D}");
         // when the next component is appended with a comma separator
-        append_rendered_component(&mut entry_output, "Nature", ", ", false);
+        append_rendered_component::<PlainText>(&mut entry_output, "Nature", ", ", false);
         // then the comma stays outside the closing quotation mark
         assert_eq!(entry_output, "\u{201C}Deep Learning\u{201D}, Nature");
     }
@@ -1018,6 +1018,57 @@ mod tests {
         assert!(
             blank_line_count <= 1,
             "should not have spurious blank lines: {result}"
+        );
+    }
+
+    // ── Cross-backend punctuation-boundary regressions (bean csl26-ztxq) ────
+    // DESIGN_PRINCIPLES §7: backends may differ only in markup, not in
+    // citation logic. See docs/architecture/audits/2026-07-04_CITUM_ENGINE_REVIEW_PART2.md
+    // finding 13.
+
+    #[test]
+    fn visible_text_is_identical_across_backends_for_the_same_logical_content() {
+        // Each markup backend's emph() wraps "Title." in its own markup; the
+        // visible text must be identical across all of them. `PlainText` is
+        // excluded: it has no markup lexer to strip — its `emph()` output
+        // (`_Title._`) *is* the literal plain-text rendering, not markup
+        // hiding "Title.", so the parity claim doesn't apply to it.
+        assert_eq!(
+            Html.visible_text(&Html.emph("Title.".to_string())),
+            "Title."
+        );
+        assert_eq!(
+            Latex.visible_text(&Latex.emph("Title.".to_string())),
+            "Title."
+        );
+        assert_eq!(
+            Typst.visible_text(&Typst.emph("Title.".to_string())),
+            "Title."
+        );
+        assert_eq!(
+            Markdown.visible_text(&Markdown.emph("Title.".to_string())),
+            "Title."
+        );
+        assert_eq!(
+            Djot.visible_text(&Djot.emph("Title.".to_string())),
+            "Title."
+        );
+    }
+
+    #[test]
+    fn append_rendered_component_does_not_double_punctuate_an_emphasized_latex_title() {
+        // Regression for finding 13: `\emph{Title.}` ends in a raw `}`, but its
+        // *visible* last char is the period. append_rendered_component must see
+        // that (via first_visible_char/last_visible_non_space_char) and not
+        // additionally insert the ". " separator's period, which used to
+        // produce "\emph{Title.}. Next" (rendering as "Title.. Next").
+        let mut entry_output = Latex.emph("Title.".to_string());
+        append_rendered_component::<Latex>(&mut entry_output, "Next", ". ", false);
+
+        assert_eq!(Latex.visible_text(&entry_output), "Title. Next");
+        assert!(
+            !Latex.visible_text(&entry_output).contains(".."),
+            "no doubled period, got: {entry_output}"
         );
     }
 }

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -197,7 +197,7 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
         _ => {}
     }
 
-    cleanup_dangling_punctuation(&mut entry_output);
+    cleanup_dangling_punctuation::<F>(&mut entry_output);
     entry_output
 }
 
@@ -370,36 +370,92 @@ fn terminal_link<F: OutputFormat<Output = String>>(output: &str) -> TerminalLink
     }
 }
 
-fn cleanup_dangling_punctuation(output: &mut String) {
-    let patterns = [
-        (", .", "."),
-        (", ,", ","),
-        (": .", "."),
-        ("; .", "."),
-        // NOTE: Removed (".,", ".") pattern - it was too aggressive and removed legitimate
-        // component suffixes like "S.," from author initials. In Citum, component suffixes are
-        // explicit and well-defined, so we don't have the CSL 1.0 dual-punctuation issue.
-        (" ,", ","),
-        (" ;", ";"),
-        (" :", ":"),
-        (" .", "."),
-        (",  ", ", "),
-        (". .", "."),
-        (".. ", ". "),
-        ("..", "."),
-        ("  ", " "), // Double space to single
-    ];
+/// Dangling-punctuation patterns to collapse, tried in order at each fixed-point step.
+const DANGLING_PUNCTUATION_PATTERNS: [(&str, &str); 13] = [
+    (", .", "."),
+    (", ,", ","),
+    (": .", "."),
+    ("; .", "."),
+    // NOTE: Removed (".,", ".") pattern - it was too aggressive and removed legitimate
+    // component suffixes like "S.," from author initials. In Citum, component suffixes are
+    // explicit and well-defined, so we don't have the CSL 1.0 dual-punctuation issue.
+    (" ,", ","),
+    (" ;", ";"),
+    (" :", ":"),
+    (" .", "."),
+    (",  ", ", "),
+    (". .", "."),
+    (".. ", ". "),
+    ("..", "."),
+    ("  ", " "), // Double space to single
+];
 
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for (pattern, replacement) in &patterns {
-            if output.contains(pattern) {
-                *output = output.replace(pattern, replacement);
-                changed = true;
+/// Collapse dangling/duplicated punctuation (`". ."` → `"."`, doubled spaces,
+/// etc.) without corrupting interleaved markup, URLs, or attribute values.
+///
+/// The pattern table above is matched against the format `F`'s *visible*
+/// projection of `output` only. A match's replacement is written at the
+/// raw position of the match's first visible byte, and the match's other
+/// visible bytes are deleted from the raw string — any markup interleaved
+/// between them (e.g. a LaTeX `\emph{Title.}` boundary sitting between the
+/// separator's leading space and its period) is left untouched. Re-derives
+/// the visible projection after every edit (entries are short, so this is
+/// cheap) since an edit can expose a new match.
+#[allow(
+    clippy::string_slice,
+    reason = "byte ranges come from OutputFormat::visible_runs, which always yields char boundaries"
+)]
+fn cleanup_dangling_punctuation<F: OutputFormat<Output = String>>(output: &mut String) {
+    let fmt = F::default();
+    loop {
+        let runs = fmt.visible_runs(output);
+        let mut visible = String::with_capacity(output.len());
+        let mut raw_pos = Vec::with_capacity(output.len());
+        for run in &runs {
+            if let Some(slice) = output.get(run.clone()) {
+                visible.push_str(slice);
+                raw_pos.extend(run.clone());
             }
         }
+
+        let Some((pat, replacement, visible_at)) = DANGLING_PUNCTUATION_PATTERNS
+            .iter()
+            .find_map(|&(pat, repl)| visible.find(pat).map(|idx| (pat, repl, idx)))
+        else {
+            break;
+        };
+
+        let matched_raw_positions: Vec<usize> = (visible_at..visible_at + pat.len())
+            .filter_map(|k| raw_pos.get(k).copied())
+            .collect();
+        if matched_raw_positions.len() != pat.len() {
+            // Projection/pattern mismatch (shouldn't happen for ASCII patterns
+            // against char-boundary-safe runs) — bail rather than risk a bad edit.
+            break;
+        }
+
+        apply_minimal_raw_edit(output, &matched_raw_positions, replacement);
     }
+}
+
+/// Rewrite `output` so the raw byte at `positions[0]` is replaced by
+/// `replacement` and the raw bytes at `positions[1..]` are deleted, leaving
+/// every other byte (including any interleaved markup) untouched.
+fn apply_minimal_raw_edit(output: &mut String, positions: &[usize], replacement: &str) {
+    let Some((&front, rest)) = positions.split_first() else {
+        return;
+    };
+    let drop: std::collections::HashSet<usize> = rest.iter().copied().collect();
+
+    let mut new_output = String::with_capacity(output.len() + replacement.len());
+    for (pos, ch) in output.char_indices() {
+        if pos == front {
+            new_output.push_str(replacement);
+        } else if !drop.contains(&pos) {
+            new_output.push(ch);
+        }
+    }
+    *output = new_output;
 }
 
 #[cfg(test)]
@@ -1069,6 +1125,48 @@ mod tests {
         assert!(
             !Latex.visible_text(&entry_output).contains(".."),
             "no doubled period, got: {entry_output}"
+        );
+    }
+
+    #[test]
+    fn cleanup_dangling_punctuation_collapses_across_a_latex_markup_boundary() {
+        // A literal doubled period straddling an `\emph{...}` boundary (e.g.
+        // from an explicitly authored suffix) must still collapse to one
+        // period, and the emph markup must survive intact.
+        let mut output = r"\emph{Title.}. Next".to_string();
+        cleanup_dangling_punctuation::<Latex>(&mut output);
+
+        assert_eq!(Latex.visible_text(&output), "Title. Next");
+        assert!(
+            output.contains(r"\emph{Title"),
+            "emph markup must survive: {output}"
+        );
+    }
+
+    #[test]
+    fn cleanup_dangling_punctuation_never_touches_the_href_target() {
+        // The URL inside \href{...} is not visible text; a dangling-punctuation
+        // pattern inside it must survive even though the identical pattern
+        // outside the link gets collapsed.
+        let mut output = r"\href{https://example.com/a, .b}{Link}, .".to_string();
+        cleanup_dangling_punctuation::<Latex>(&mut output);
+
+        assert!(
+            output.contains("https://example.com/a, .b"),
+            "href target must be untouched: {output}"
+        );
+        assert_eq!(Latex.visible_text(&output), "Link.");
+    }
+
+    #[test]
+    fn cleanup_dangling_punctuation_collapses_across_a_typst_markup_boundary() {
+        let mut output = "#emph[Title.]. Next".to_string();
+        cleanup_dangling_punctuation::<Typst>(&mut output);
+
+        assert_eq!(Typst.visible_text(&output), "Title. Next");
+        assert!(
+            output.contains("#emph[Title"),
+            "emph markup must survive: {output}"
         );
     }
 }

--- a/crates/citum-engine/src/render/citation.rs
+++ b/crates/citum-engine/src/render/citation.rs
@@ -59,19 +59,27 @@ fn resolve_punctuation_collision(first: char, second: char) -> String {
 /// Three cases are handled in priority order:
 /// 1. **Punctuation-in-quote** – when `punctuation_in_quote` is set and `delim` starts with
 ///    a comma, the comma is pulled *inside* a preceding closing quotation mark (`"` or `\u{201D}`)
-///    before appending the rest of the delimiter.
-/// 2. **Punctuation collision** – when the last char of `content` and the first char of `delim`
-///    are both terminal punctuation, the pair is resolved via [`resolve_punctuation_collision`]
-///    (e.g. `".` + `". "` → `". "` rather than `".. "`).
+///    before appending the rest of the delimiter. Quote marks are literal Unicode characters
+///    in every backend, not markup, so this case looks at the raw last char directly.
+/// 2. **Punctuation collision** – when format `F`'s *visible* last char of `content` and the
+///    first char of `delim` are both terminal punctuation, the pair is resolved via
+///    [`resolve_punctuation_collision`] (e.g. `".` + `". "` → `". "` rather than `".. "`). If
+///    the raw content genuinely ends with that char, it's popped and merged as before; if the
+///    visible terminal punctuation is hidden behind trailing markup (e.g. a LaTeX `\emph{...}`
+///    close brace), the raw markup is left alone and the delimiter's redundant leading
+///    punctuation is dropped instead.
 /// 3. **Default** – append `delim` verbatim.
 #[inline]
 #[allow(
     clippy::string_slice,
     reason = "UTF-8 safe slicing based on char boundary checks"
 )]
-fn push_delimiter(content: &mut String, delim: &str, punctuation_in_quote: bool) {
+fn push_delimiter<F: OutputFormat<Output = String>>(
+    content: &mut String,
+    delim: &str,
+    punctuation_in_quote: bool,
+) {
     let delim_first = delim.chars().next();
-    let content_last = content.chars().last();
 
     if punctuation_in_quote
         && delim_first == Some(',')
@@ -83,17 +91,31 @@ fn push_delimiter(content: &mut String, delim: &str, punctuation_in_quote: bool)
         content.push(',');
         content.push(if is_curly { '\u{201D}' } else { '"' });
         content.push_str(&delim[1..]);
-    } else if let (Some(last), Some(first)) = (content_last, delim_first)
-        && is_terminal_punctuation(last)
-        && is_terminal_punctuation(first)
-    {
-        // Case 2: two adjacent terminal punctuation marks — merge them and skip the duplicate.
-        content.pop();
-        content.push_str(&resolve_punctuation_collision(last, first));
-        content.push_str(&delim[first.len_utf8()..]);
-    } else {
+        return;
+    }
+
+    let Some(first) = delim_first else {
+        content.push_str(delim);
+        return;
+    };
+    let Some(visible_last) = F::default().visible_text(content).chars().last() else {
+        content.push_str(delim);
+        return;
+    };
+
+    if !is_terminal_punctuation(visible_last) || !is_terminal_punctuation(first) {
         // Case 3: no special rule — append the delimiter verbatim.
         content.push_str(delim);
+    } else if content.ends_with(visible_last) {
+        // Case 2a: raw content genuinely ends with the visible terminal char — merge as before.
+        content.pop();
+        content.push_str(&resolve_punctuation_collision(visible_last, first));
+        content.push_str(&delim[first.len_utf8()..]);
+    } else {
+        // Case 2b: the visible terminal punctuation is behind trailing markup (e.g. LaTeX
+        // `}`) — leave the raw markup alone and just drop the delimiter's redundant leading
+        // punctuation instead of popping from `content`.
+        content.push_str(&delim[first.len_utf8()..]);
     }
 }
 
@@ -136,7 +158,7 @@ pub fn citation_to_string_with_format<F: OutputFormat<Output = String>>(
     let mut content = String::new();
     for (i, part) in parts.iter().enumerate() {
         if i > 0 {
-            push_delimiter(&mut content, delim, punctuation_in_quote);
+            push_delimiter::<F>(&mut content, delim, punctuation_in_quote);
         }
         content.push_str(part);
     }

--- a/crates/citum-engine/src/render/djot.rs
+++ b/crates/citum-engine/src/render/djot.rs
@@ -5,7 +5,10 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 //! Djot output format.
 
+use std::ops::Range;
+
 use super::format::{OutputFormat, QuoteMarks};
+use super::visible_scan::{RunBuilder, find_matching, skip_balanced};
 use citum_schema::template::WrapPunctuation;
 
 #[derive(Default, Clone)]
@@ -124,6 +127,59 @@ impl OutputFormat for Djot {
             content
         }
     }
+
+    /// Strip `_`/`*` emphasis delimiters and a `[content]{.class}` span's or
+    /// `[content](url)` link's bracket-plus-attribute markup, keeping the
+    /// bracketed content visible. A bracket pair followed by neither `{` nor
+    /// `(` (i.e. from [`Self::wrap_punctuation`]'s `WrapPunctuation::Brackets`)
+    /// keeps its brackets visible, since those are house-style punctuation.
+    ///
+    /// Djot's [`Self::text`] does not escape its input ("no escaping for
+    /// Djot as requested"), so a data field containing a literal `_`, `*`,
+    /// `[`, or `]` is inherently ambiguous with markup here — the same
+    /// ambiguity the Djot renderer itself already has.
+    fn visible_runs(&self, fragment: &str) -> Vec<Range<usize>> {
+        let mut runs = RunBuilder::default();
+        let chars: Vec<(usize, char)> = fragment.char_indices().collect();
+        let mut i = 0;
+        let mut pending_close: Option<usize> = None;
+        while let Some(&(pos, ch)) = chars.get(i) {
+            match ch {
+                '_' | '*' => i += 1,
+                '[' => {
+                    let close_i = find_matching(&chars, i, '[', ']', false);
+                    let after = close_i.and_then(|c| chars.get(c + 1).map(|&(_, next)| next));
+                    if matches!(after, Some('{' | '(')) {
+                        pending_close = close_i;
+                        i += 1;
+                    } else {
+                        runs.push_visible(pos, pos + 1);
+                        i += 1;
+                    }
+                }
+                ']' => {
+                    if pending_close == Some(i) {
+                        pending_close = None;
+                        let mut j = i + 1;
+                        match chars.get(j).map(|&(_, c)| c) {
+                            Some('{') => j = skip_balanced(&chars, j, '{', '}', false),
+                            Some('(') => j = skip_balanced(&chars, j, '(', ')', false),
+                            _ => {}
+                        }
+                        i = j;
+                    } else {
+                        runs.push_visible(pos, pos + 1);
+                        i += 1;
+                    }
+                }
+                _ => {
+                    runs.push_visible(pos, pos + ch.len_utf8());
+                    i += 1;
+                }
+            }
+        }
+        runs.finish()
+    }
 }
 
 #[cfg(test)]
@@ -228,5 +284,34 @@ mod tests {
                 expected
             );
         }
+    }
+
+    #[test]
+    fn visible_text_strips_emph_and_strong_delimiters() {
+        let fmt = Djot;
+        assert_eq!(fmt.visible_text("_Title._"), "Title.");
+        assert_eq!(fmt.visible_text("*Title.*"), "Title.");
+    }
+
+    #[test]
+    fn visible_text_strips_semantic_span_attributes() {
+        let fmt = Djot;
+        assert_eq!(fmt.visible_text("[Smith]{.author}"), "Smith");
+    }
+
+    #[test]
+    fn visible_text_hides_link_url_keeps_text() {
+        let fmt = Djot;
+        assert_eq!(
+            fmt.visible_text("[Example](https://example.com/a.b)"),
+            "Example"
+        );
+    }
+
+    #[test]
+    fn visible_text_keeps_literal_wrap_brackets_visible() {
+        let fmt = Djot;
+        // WrapPunctuation::Brackets: bare `[content]`, no `{...}`/`(...)` follows.
+        assert_eq!(fmt.visible_text("[Dataset]"), "[Dataset]");
     }
 }

--- a/crates/citum-engine/src/render/format.rs
+++ b/crates/citum-engine/src/render/format.rs
@@ -5,6 +5,9 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 //! Output format trait for pluggable renderers.
 
+use std::borrow::Cow;
+use std::ops::Range;
+
 use citum_schema::locale::GrammarOptions;
 use citum_schema::template::WrapPunctuation;
 
@@ -260,6 +263,45 @@ pub trait OutputFormat: Default + Clone {
     /// Render a full citation container with one or more reference IDs.
     fn citation(&self, _ids: Vec<String>, content: Self::Output) -> Self::Output {
         content
+    }
+
+    // ── Visible-text methods ────────────────────────────────────────────────
+    // Used by bibliography/citation punctuation-boundary logic so separator
+    // and dedup decisions look at logical text, not backend markup (the
+    // "backends differ only in markup" rule — see DESIGN_PRINCIPLES §7).
+
+    /// Byte ranges of `fragment` that are visible (non-markup) text, in order.
+    ///
+    /// The default treats the whole fragment as visible, which is correct
+    /// for [`PlainText`](crate::render::plain::PlainText) and safe for any
+    /// third-party format that hasn't implemented a lexer: boundary logic
+    /// simply falls back to looking at raw characters, as it always has.
+    /// Backends whose inline methods (`emph`, `link`, `wrap_punctuation`,
+    /// ...) emit markup should override this to exclude it.
+    fn visible_runs(&self, fragment: &str) -> Vec<Range<usize>> {
+        let mut runs = Vec::new();
+        if !fragment.is_empty() {
+            runs.push(0..fragment.len());
+        }
+        runs
+    }
+
+    /// The visible (markup-stripped) text of a rendered fragment.
+    ///
+    /// Borrows `fragment` unchanged when it is entirely visible (the common
+    /// case); otherwise stitches the visible runs into an owned `String`.
+    fn visible_text<'a>(&self, fragment: &'a str) -> Cow<'a, str> {
+        let runs = self.visible_runs(fragment);
+        if runs.len() == 1 && runs.first() == Some(&(0..fragment.len())) {
+            return Cow::Borrowed(fragment);
+        }
+        let mut owned = String::with_capacity(fragment.len());
+        for run in runs {
+            if let Some(slice) = fragment.get(run) {
+                owned.push_str(slice);
+            }
+        }
+        Cow::Owned(owned)
     }
 
     /// Hyperlink the content to a URL.

--- a/crates/citum-engine/src/render/html.rs
+++ b/crates/citum-engine/src/render/html.rs
@@ -230,4 +230,18 @@ impl OutputFormat for Html {
 
         format!(r#"<div class="citum-entry" {attrs}>{content}</div>"#)
     }
+
+    fn visible_runs(&self, fragment: &str) -> Vec<std::ops::Range<usize>> {
+        let mut runs = super::visible_scan::RunBuilder::default();
+        let mut in_tag = false;
+        for (i, ch) in fragment.char_indices() {
+            match ch {
+                '<' => in_tag = true,
+                '>' if in_tag => in_tag = false,
+                _ if !in_tag => runs.push_visible(i, i + ch.len_utf8()),
+                _ => {}
+            }
+        }
+        runs.finish()
+    }
 }

--- a/crates/citum-engine/src/render/latex.rs
+++ b/crates/citum-engine/src/render/latex.rs
@@ -5,7 +5,11 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 //! LaTeX output format.
 
+use std::borrow::Cow;
+use std::ops::Range;
+
 use super::format::{OutputFormat, QuoteMarks};
+use super::visible_scan::{RunBuilder, skip_balanced};
 use citum_schema::template::WrapPunctuation;
 
 /// LaTeX renderer.
@@ -227,5 +231,209 @@ impl OutputFormat for Latex {
         _metadata: &super::format::ProcEntryMetadata,
     ) -> Self::Output {
         format!("\\noindent\\hangindent=2em\\hangafter=1 {content}")
+    }
+
+    /// Strip LaTeX commands (`\emph`, `\textbf`, ...) and their brace
+    /// delimiters, keeping brace *contents* visible. A backslash-escaped
+    /// punctuation mark (`\&`, `\_`, `\%`, `\#`, `\$`, `\{`, `\}`) is visible
+    /// as the escaped character itself. `\href{target}{content}` is
+    /// special-cased so the URL target stays invisible — it must not
+    /// participate in separator/dedup decisions — while `content` does.
+    ///
+    /// Named commands that stand in for a single visible character
+    /// (`\textbackslash{}`, `\textasciitilde{}`, `\textasciicircum{}`) have
+    /// no backing byte range here — see [`Self::visible_text`], which
+    /// synthesizes them for boundary decisions.
+    fn visible_runs(&self, fragment: &str) -> Vec<Range<usize>> {
+        let mut runs = RunBuilder::default();
+        let chars: Vec<(usize, char)> = fragment.char_indices().collect();
+        let mut i = 0;
+        while let Some(&(pos, ch)) = chars.get(i) {
+            if ch == '\\' {
+                let (escape, next_i) = scan_backslash_escape(&chars, i);
+                if let LatexEscape::Punct(_) = escape
+                    && let Some(&(epos, echar)) = chars.get(i + 1)
+                {
+                    runs.push_visible(epos, epos + echar.len_utf8());
+                }
+                i = next_i;
+                continue;
+            }
+            if ch == '{' || ch == '}' {
+                i += 1;
+                continue;
+            }
+            runs.push_visible(pos, pos + ch.len_utf8());
+            i += 1;
+        }
+        runs.finish()
+    }
+
+    /// As [`Self::visible_runs`], but additionally synthesizes the single
+    /// visible character that `\textbackslash{}`/`\textasciitilde{}`/
+    /// `\textasciicircum{}` stand in for (`\`, `~`, `^`), since those have no
+    /// backing byte range in the raw fragment. Used for read-only boundary
+    /// decisions (first/last visible char); `visible_runs` stays raw-byte
+    /// accurate for `cleanup_dangling_punctuation`'s in-place raw edits.
+    fn visible_text<'a>(&self, fragment: &'a str) -> Cow<'a, str> {
+        let chars: Vec<(usize, char)> = fragment.char_indices().collect();
+        let mut i = 0;
+        let mut owned = String::with_capacity(fragment.len());
+        let mut any_markup = false;
+        while let Some(&(_, ch)) = chars.get(i) {
+            if ch == '\\' {
+                any_markup = true;
+                let (escape, next_i) = scan_backslash_escape(&chars, i);
+                match escape {
+                    LatexEscape::Punct(c) => owned.push(c),
+                    LatexEscape::Command { synth: Some(c) } => owned.push(c),
+                    LatexEscape::Command { synth: None } | LatexEscape::Bare => {}
+                }
+                i = next_i;
+                continue;
+            }
+            if ch == '{' || ch == '}' {
+                any_markup = true;
+                i += 1;
+                continue;
+            }
+            owned.push(ch);
+            i += 1;
+        }
+        if any_markup {
+            Cow::Owned(owned)
+        } else {
+            Cow::Borrowed(fragment)
+        }
+    }
+}
+
+/// Outcome of classifying the backslash escape at `chars[i]`.
+enum LatexEscape {
+    /// An escaped punctuation mark (`\&`, `\_`, ...); visible as the escaped char.
+    Punct(char),
+    /// A named ascii-alpha command. `synth` holds the single character it
+    /// stands in for (`\textbackslash{}` → `\`, etc.), when applicable.
+    Command { synth: Option<char> },
+    /// A lone backslash with no recognized continuation.
+    Bare,
+}
+
+/// Classify the `\` at `chars[i]`, returning the outcome and the index just
+/// past it — past the command name (and past `\href`'s target brace group),
+/// or past the escaped char for punctuation escapes.
+fn scan_backslash_escape(chars: &[(usize, char)], i: usize) -> (LatexEscape, usize) {
+    match chars.get(i + 1).map(|&(_, c)| c) {
+        Some(c @ ('{' | '}' | '$' | '&' | '#' | '_' | '%')) => (LatexEscape::Punct(c), i + 2),
+        Some(c) if c.is_ascii_alphabetic() => {
+            let mut j = i + 1;
+            let mut command = String::new();
+            while let Some(&(_, cc)) = chars.get(j) {
+                if !cc.is_ascii_alphabetic() {
+                    break;
+                }
+                command.push(cc);
+                j += 1;
+            }
+            let synth = match command.as_str() {
+                "textbackslash" => Some('\\'),
+                "textasciitilde" => Some('~'),
+                "textasciicircum" => Some('^'),
+                _ => None,
+            };
+            let end = if command == "href" {
+                skip_balanced(chars, j, '{', '}', false)
+            } else {
+                j
+            };
+            (LatexEscape::Command { synth }, end)
+        }
+        _ => (LatexEscape::Bare, i + 1),
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    reason = "Panicking is acceptable and often desired in tests."
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn visible_text_strips_emph_command_and_braces() {
+        let fmt = Latex;
+        assert_eq!(fmt.visible_text(r"\emph{Title.}"), "Title.");
+    }
+
+    #[test]
+    fn visible_text_keeps_escaped_punctuation() {
+        let fmt = Latex;
+        assert_eq!(fmt.visible_text(r"Smith \& Jones"), "Smith & Jones");
+    }
+
+    #[test]
+    fn visible_text_hides_href_target_keeps_content() {
+        let fmt = Latex;
+        assert_eq!(
+            fmt.visible_text(r"\href{https://example.com/a.b}{Example}"),
+            "Example"
+        );
+    }
+
+    #[test]
+    fn visible_text_handles_nested_commands() {
+        let fmt = Latex;
+        assert_eq!(fmt.visible_text(r"\textbf{\emph{Title.}}"), "Title.");
+    }
+
+    #[test]
+    fn visible_text_is_borrowed_when_no_markup() {
+        let fmt = Latex;
+        assert_eq!(fmt.visible_text("Plain text."), "Plain text.");
+    }
+
+    #[test]
+    fn visible_text_synthesizes_escaped_backslash() {
+        let fmt = Latex;
+        assert_eq!(fmt.visible_text(r"C:\textbackslash{}Users"), r"C:\Users");
+    }
+
+    #[test]
+    fn visible_text_synthesizes_escaped_tilde() {
+        let fmt = Latex;
+        assert_eq!(
+            fmt.visible_text(r"Title\textasciitilde{}Subtitle"),
+            "Title~Subtitle"
+        );
+    }
+
+    #[test]
+    fn visible_text_synthesizes_escaped_caret() {
+        let fmt = Latex;
+        assert_eq!(fmt.visible_text(r"x\textasciicircum{}2"), "x^2");
+    }
+
+    #[test]
+    fn visible_text_synthesized_char_is_seen_as_the_trailing_char() {
+        // A field ending in an escaped tilde must expose that tilde as the
+        // last visible char, not disappear (the gap this fixes: the raw
+        // fragment's last char is `}`, not `~`).
+        let fmt = Latex;
+        let rendered = fmt.emph(r"Title\textasciitilde{}".to_string());
+        assert_eq!(fmt.visible_text(&rendered).chars().last(), Some('~'));
+    }
+
+    #[test]
+    fn visible_runs_does_not_claim_a_byte_range_for_synthesized_chars() {
+        // visible_runs stays raw-byte accurate (used for in-place raw edits
+        // in cleanup_dangling_punctuation) — the synthesized char has no
+        // backing byte, so it must not appear as a run.
+        let fmt = Latex;
+        let runs = fmt.visible_runs(r"\textasciitilde{}");
+        assert!(runs.is_empty(), "expected no visible runs, got {runs:?}");
     }
 }

--- a/crates/citum-engine/src/render/markdown.rs
+++ b/crates/citum-engine/src/render/markdown.rs
@@ -20,7 +20,10 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! consumers must enable the extension:
 //! `pandoc --from commonmark+footnotes` (or `--from gfm`).
 
+use std::ops::Range;
+
 use super::format::{OutputFormat, QuoteMarks};
+use super::visible_scan::{RunBuilder, find_matching, skip_balanced};
 use citum_schema::template::WrapPunctuation;
 
 /// Escape CommonMark-active characters in raw bibliography data text.
@@ -172,6 +175,77 @@ impl OutputFormat for Markdown {
             content
         }
     }
+
+    /// Strip `*`/`**` emphasis delimiters, `<span>`/`<sup>` raw-HTML wrappers,
+    /// and a `[content](url)` link's `[`/`](url)` markup — keeping link text
+    /// visible but the URL hidden. A bracket pair *not* followed by `(url)`
+    /// (i.e. from [`Self::wrap_punctuation`]'s `WrapPunctuation::Brackets`)
+    /// keeps its brackets visible, since those are house-style punctuation.
+    /// Backslash-escaped characters are visible as themselves.
+    fn visible_runs(&self, fragment: &str) -> Vec<Range<usize>> {
+        let mut runs = RunBuilder::default();
+        let chars: Vec<(usize, char)> = fragment.char_indices().collect();
+        let mut i = 0;
+        let mut in_tag = false;
+        let mut pending_link_close: Option<usize> = None;
+        while let Some(&(pos, ch)) = chars.get(i) {
+            if in_tag {
+                if ch == '>' {
+                    in_tag = false;
+                }
+                i += 1;
+                continue;
+            }
+            match ch {
+                '\\' => {
+                    if let Some(&(epos, echar)) = chars.get(i + 1) {
+                        runs.push_visible(epos, epos + echar.len_utf8());
+                    }
+                    i += 2;
+                }
+                '<' => {
+                    in_tag = true;
+                    i += 1;
+                }
+                '*' => {
+                    i += 1;
+                    if chars.get(i).map(|&(_, c)| c) == Some('*') {
+                        i += 1;
+                    }
+                }
+                '[' => {
+                    let close_i = find_matching(&chars, i, '[', ']', true);
+                    let is_link = close_i
+                        .is_some_and(|c| chars.get(c + 1).map(|&(_, next)| next) == Some('('));
+                    if is_link {
+                        pending_link_close = close_i;
+                        i += 1;
+                    } else {
+                        runs.push_visible(pos, pos + 1);
+                        i += 1;
+                    }
+                }
+                ']' => {
+                    if pending_link_close == Some(i) {
+                        pending_link_close = None;
+                        let mut j = i + 1;
+                        if chars.get(j).map(|&(_, c)| c) == Some('(') {
+                            j = skip_balanced(&chars, j, '(', ')', true);
+                        }
+                        i = j;
+                    } else {
+                        runs.push_visible(pos, pos + 1);
+                        i += 1;
+                    }
+                }
+                _ => {
+                    runs.push_visible(pos, pos + ch.len_utf8());
+                    i += 1;
+                }
+            }
+        }
+        runs.finish()
+    }
 }
 
 #[cfg(test)]
@@ -287,5 +361,44 @@ mod tests {
         assert_eq!(fmt.text("<doi:10.1/x>"), "\\<doi:10.1/x\\>");
         assert_eq!(fmt.text("Smith & Jones"), "Smith \\& Jones");
         assert_eq!(fmt.text("<em>bold</em>"), "\\<em\\>bold\\</em\\>");
+    }
+
+    #[test]
+    fn visible_text_strips_emph_and_strong_delimiters() {
+        let fmt = Markdown;
+        assert_eq!(fmt.visible_text("*Title.*"), "Title.");
+        assert_eq!(fmt.visible_text("**Title.**"), "Title.");
+    }
+
+    #[test]
+    fn visible_text_hides_link_url_keeps_text() {
+        let fmt = Markdown;
+        assert_eq!(
+            fmt.visible_text("[Example](https://example.com/a.b)"),
+            "Example"
+        );
+    }
+
+    #[test]
+    fn visible_text_keeps_literal_wrap_brackets_visible() {
+        let fmt = Markdown;
+        // WrapPunctuation::Brackets: bare `[content]`, not a link.
+        assert_eq!(fmt.visible_text("[Dataset]"), "[Dataset]");
+    }
+
+    #[test]
+    fn visible_text_strips_raw_html_spans() {
+        let fmt = Markdown;
+        assert_eq!(
+            fmt.visible_text("<span style=\"font-variant:small-caps\">Smith</span>"),
+            "Smith"
+        );
+        assert_eq!(fmt.visible_text("<sup>2</sup>"), "2");
+    }
+
+    #[test]
+    fn visible_text_keeps_escaped_punctuation() {
+        let fmt = Markdown;
+        assert_eq!(fmt.visible_text(r"A \* B"), "A * B");
     }
 }

--- a/crates/citum-engine/src/render/mod.rs
+++ b/crates/citum-engine/src/render/mod.rs
@@ -32,6 +32,7 @@ pub mod org;
 pub mod plain;
 pub mod rich_text;
 pub mod typst;
+mod visible_scan;
 
 #[cfg(test)]
 #[allow(

--- a/crates/citum-engine/src/render/org.rs
+++ b/crates/citum-engine/src/render/org.rs
@@ -9,6 +9,14 @@ use super::format::{OutputFormat, QuoteMarks};
 use citum_schema::template::WrapPunctuation;
 
 /// Renders processed citations and bibliography entries as org-mode markup.
+///
+/// Does not override [`OutputFormat::visible_runs`]: org-mode's `/.../`,
+/// `*...*`, `~...~`, `^...^` markers are unescaped single characters (see
+/// [`OutputFormat::text`] below), so a data field containing a literal
+/// instance of one is already indistinguishable from markup in the rendered
+/// output itself — a lexer here could not resolve that ambiguity any better
+/// than the renderer did. Boundary/dedup logic for this backend falls back
+/// to the raw text default, a known, documented gap (see bean `csl26-ztxq`).
 #[derive(Default, Clone)]
 pub struct OrgOutputFormat;
 

--- a/crates/citum-engine/src/render/typst.rs
+++ b/crates/citum-engine/src/render/typst.rs
@@ -5,7 +5,10 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 //! Typst output format.
 
+use std::ops::Range;
+
 use super::format::{OutputFormat, QuoteMarks};
+use super::visible_scan::{RunBuilder, skip_balanced};
 use citum_schema::template::WrapPunctuation;
 
 /// Typst renderer.
@@ -262,5 +265,118 @@ impl OutputFormat for Typst {
         };
 
         format!("{} <{}>", content, self.format_id(id))
+    }
+
+    /// Strip `#func(...)[...]` wrappers (function name, parenthesized
+    /// arguments — e.g. a `#link("url")` target — and the content group's
+    /// `[`/`]` delimiters), keeping the bracketed content visible. A literal
+    /// `[content]` not preceded by `#func` (i.e. from
+    /// [`Self::wrap_punctuation`]'s `WrapPunctuation::Brackets`) keeps its
+    /// brackets visible, since those are house-style punctuation, not
+    /// markup. Backslash-escaped characters are visible as themselves.
+    fn visible_runs(&self, fragment: &str) -> Vec<Range<usize>> {
+        let mut runs = RunBuilder::default();
+        let chars: Vec<(usize, char)> = fragment.char_indices().collect();
+        let mut i = 0;
+        let mut bracket_stack: Vec<bool> = Vec::new();
+        while let Some(&(pos, ch)) = chars.get(i) {
+            match ch {
+                '\\' => {
+                    if let Some(&(epos, echar)) = chars.get(i + 1) {
+                        runs.push_visible(epos, epos + echar.len_utf8());
+                    }
+                    i += 2;
+                }
+                '#' => i = consume_function_head(&chars, i, &mut bracket_stack),
+                '[' => {
+                    bracket_stack.push(false);
+                    runs.push_visible(pos, pos + 1);
+                    i += 1;
+                }
+                ']' => {
+                    if !bracket_stack.pop().unwrap_or(false) {
+                        runs.push_visible(pos, pos + 1);
+                    }
+                    i += 1;
+                }
+                _ => {
+                    runs.push_visible(pos, pos + ch.len_utf8());
+                    i += 1;
+                }
+            }
+        }
+        runs.finish()
+    }
+}
+
+/// Consume a `#ident(...)?[`-style function head starting at the `#` at
+/// `chars[i]`: the identifier and any parenthesized arguments are markup
+/// (invisible); if a content group `[` follows, push `true` onto
+/// `bracket_stack` so its matching `]` is later recognized as markup too.
+fn consume_function_head(
+    chars: &[(usize, char)],
+    i: usize,
+    bracket_stack: &mut Vec<bool>,
+) -> usize {
+    let mut j = i + 1;
+    while chars
+        .get(j)
+        .is_some_and(|&(_, c)| c.is_ascii_alphanumeric() || c == '_')
+    {
+        j += 1;
+    }
+    if chars.get(j).map(|&(_, c)| c) == Some('(') {
+        j = skip_balanced(chars, j, '(', ')', true);
+    }
+    if chars.get(j).map(|&(_, c)| c) == Some('[') {
+        bracket_stack.push(true);
+        j += 1;
+    }
+    j
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    reason = "Panicking is acceptable and often desired in tests."
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn visible_text_strips_emph_function_and_brackets() {
+        let fmt = Typst;
+        assert_eq!(fmt.visible_text("#emph[Title.]"), "Title.");
+    }
+
+    #[test]
+    fn visible_text_hides_link_target_keeps_content() {
+        let fmt = Typst;
+        assert_eq!(
+            fmt.visible_text(r#"#link("https://example.com/a.b")[Example]"#),
+            "Example"
+        );
+    }
+
+    #[test]
+    fn visible_text_handles_nested_functions() {
+        let fmt = Typst;
+        assert_eq!(fmt.visible_text("#strong[#emph[Title.]]"), "Title.");
+    }
+
+    #[test]
+    fn visible_text_keeps_literal_wrap_brackets_visible() {
+        let fmt = Typst;
+        // WrapPunctuation::Brackets: bare `[content]`, not a function call.
+        assert_eq!(fmt.visible_text("[Dataset]"), "[Dataset]");
+    }
+
+    #[test]
+    fn visible_text_keeps_escaped_punctuation() {
+        let fmt = Typst;
+        assert_eq!(fmt.visible_text(r"A \# B"), "A # B");
     }
 }

--- a/crates/citum-engine/src/render/visible_scan.rs
+++ b/crates/citum-engine/src/render/visible_scan.rs
@@ -1,0 +1,160 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Shared scanning primitives for per-backend `OutputFormat::visible_runs` lexers.
+//!
+//! Each backend's markup (LaTeX commands, Typst functions, Markdown/Djot
+//! delimiters) has its own syntax, but they share two recurring shapes: a
+//! delimiter pair that nests (`{`/`}`, `(`/`)`, `[`/`]`) and needs to be
+//! skipped or matched, and a run of visible byte ranges that needs to be
+//! accumulated as markup is stripped away. This module factors both out so
+//! the individual lexers in `html.rs`, `latex.rs`, `typst.rs`, `markdown.rs`,
+//! and `djot.rs` stay focused on their own syntax.
+
+use std::ops::Range;
+
+/// Accumulates visible byte ranges over a fragment, merging adjacent pushes
+/// into a single run so callers don't need to track run boundaries themselves.
+#[derive(Default)]
+pub(crate) struct RunBuilder {
+    runs: Vec<Range<usize>>,
+}
+
+impl RunBuilder {
+    /// Mark the byte range `start..end` as visible, extending the previous
+    /// run when it directly abuts `start`. No-op when `start >= end`.
+    pub(crate) fn push_visible(&mut self, start: usize, end: usize) {
+        if start >= end {
+            return;
+        }
+        if let Some(last) = self.runs.last_mut()
+            && last.end == start
+        {
+            last.end = end;
+            return;
+        }
+        self.runs.push(start..end);
+    }
+
+    /// Consume the builder, returning the accumulated visible runs in order.
+    pub(crate) fn finish(self) -> Vec<Range<usize>> {
+        self.runs
+    }
+}
+
+/// Find the index (into `chars`) of the delimiter matching `open_ch` at
+/// `chars[open_i]`, tracking nested `open_ch`/`close_ch` pairs. Returns
+/// `None` if `chars[open_i]` isn't `open_ch` or the delimiter is unmatched.
+///
+/// When `respect_escapes` is set, a backslash escapes the following
+/// character: neither is inspected for delimiter matching.
+pub(crate) fn find_matching(
+    chars: &[(usize, char)],
+    open_i: usize,
+    open_ch: char,
+    close_ch: char,
+    respect_escapes: bool,
+) -> Option<usize> {
+    if chars.get(open_i).map(|&(_, c)| c) != Some(open_ch) {
+        return None;
+    }
+    let mut depth = 0i32;
+    let mut i = open_i;
+    while let Some(&(_, ch)) = chars.get(i) {
+        if respect_escapes && ch == '\\' {
+            i += 2;
+            continue;
+        }
+        if ch == open_ch {
+            depth += 1;
+        } else if ch == close_ch {
+            depth -= 1;
+            if depth == 0 {
+                return Some(i);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Skip a balanced `open_ch`/`close_ch` group starting at `chars[i]`,
+/// returning the index just past the matching close delimiter. Returns `i`
+/// unchanged when `chars[i]` isn't `open_ch`, or when the group is
+/// unterminated the length of `chars` (i.e. skip to the end).
+pub(crate) fn skip_balanced(
+    chars: &[(usize, char)],
+    i: usize,
+    open_ch: char,
+    close_ch: char,
+    respect_escapes: bool,
+) -> usize {
+    if chars.get(i).map(|&(_, c)| c) != Some(open_ch) {
+        return i;
+    }
+    find_matching(chars, i, open_ch, close_ch, respect_escapes).map_or(chars.len(), |end| end + 1)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    reason = "Panicking is acceptable and often desired in tests."
+)]
+mod tests {
+    use super::*;
+
+    fn chars_of(s: &str) -> Vec<(usize, char)> {
+        s.char_indices().collect()
+    }
+
+    #[test]
+    fn run_builder_merges_adjacent_pushes() {
+        let mut builder = RunBuilder::default();
+        builder.push_visible(0, 3);
+        builder.push_visible(3, 5);
+        builder.push_visible(7, 9);
+        assert_eq!(builder.finish(), vec![0..5, 7..9]);
+    }
+
+    #[test]
+    fn run_builder_ignores_empty_pushes() {
+        let mut builder = RunBuilder::default();
+        builder.push_visible(2, 2);
+        assert_eq!(builder.finish(), Vec::<Range<usize>>::new());
+    }
+
+    #[test]
+    fn find_matching_tracks_nesting_depth() {
+        let chars = chars_of("[a[b]c]d");
+        assert_eq!(find_matching(&chars, 0, '[', ']', false), Some(6));
+    }
+
+    #[test]
+    fn find_matching_respects_escapes() {
+        let chars = chars_of(r"[a\]b]c");
+        assert_eq!(find_matching(&chars, 0, '[', ']', true), Some(5));
+    }
+
+    #[test]
+    fn find_matching_returns_none_when_unterminated() {
+        let chars = chars_of("[abc");
+        assert_eq!(find_matching(&chars, 0, '[', ']', false), None);
+    }
+
+    #[test]
+    fn skip_balanced_returns_index_past_close() {
+        let chars = chars_of("{abc}def");
+        assert_eq!(skip_balanced(&chars, 0, '{', '}', false), 5);
+    }
+
+    #[test]
+    fn skip_balanced_is_noop_when_not_at_open() {
+        let chars = chars_of("abc");
+        assert_eq!(skip_balanced(&chars, 0, '{', '}', false), 0);
+    }
+}


### PR DESCRIPTION
## Summary
- `visible_text` stripped only HTML `<...>` tags, so bibliography/citation punctuation-boundary logic treated LaTeX/Typst/Markdown/Djot markup (`}`, `]`, `_`, `*`) as the "last visible char", violating the backends-differ-only-in-markup rule (DESIGN_PRINCIPLES §7) — e.g. `\emph{Title.}` rendered as `Title.. Next` in LaTeX.
- Adds `OutputFormat::visible_runs`/`visible_text` with a per-backend lexer (shared scanning primitives in new `render/visible_scan.rs`), threaded generically through all bibliography boundary helpers and `citation.rs::push_delimiter`.
- Rewrites `cleanup_dangling_punctuation` to match its pattern table against the visible projection only, applying minimal raw edits so `\href{...}` URLs, attributes, and interleaved markup are never touched.
- Closes bean `csl26-ztxq` / audit finding 13 (`docs/architecture/audits/2026-07-04_CITUM_ENGINE_REVIEW_PART2.md`).

## Commits
1. `feat(engine): add format-aware visible-text hook` — the trait hook + per-backend lexers + generic threading through the bibliography helpers.
2. `fix(engine): span-aware punctuation cleanup` — span-mapped rewrite of `cleanup_dangling_punctuation`.
3. `fix(engine): markup-aware citation delimiter` — `push_delimiter` collision logic made markup-aware.
4. `docs: complete csl26-ztxq punctuation bean` — bean summary + archive.

## Scope
- `crates/citum-engine/src/render/{format,visible_scan,html,latex,typst,markdown,djot,org,bibliography,citation}.rs`
- `crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs` (call-site update only)
- `.beans/archive/csl26-ztxq--*.md`

Org intentionally keeps the default whole-fragment-visible passthrough — its `/.../`, `*...*` delimiters are unescaped in `Self::text`, so a lexer there couldn't resolve an ambiguity the renderer itself doesn't resolve either. Documented on `OrgOutputFormat`.

## Validation
- `just pre-commit` (fmt --check + clippy --all-targets --all-features -D warnings + nextest): **1897/1897 passed**, workspace-wide.
- `just workflow-test styles-legacy/apa.csl`: bibliography 45/46, identical to `main` baseline (verified via `git stash`) — the 1 failure is a pre-existing, unrelated year/title/publisher/doi content mismatch.
- Spot-checked `citum render refs -f latex|typst` on `examples/references.json` with `apa` — no doubled punctuation, markup intact.
- New tests: per-backend `visible_runs`/`visible_text` unit tests in each format module, a cross-backend visible-text parity test, and finding-13 regressions (LaTeX `\emph{Title.}` no longer doubles punctuation, href targets survive cleanup, Typst boundary case).

## Risk
- `push_delimiter`'s markup-aware branch is new logic for citations (not just bibliography) — covered by existing `citation.rs` collision-matrix tests plus new markup-boundary behavior, but is the least-exercised path since citation-side punctuation collisions needing this are rarer than bibliography ones.
- PlainText's `visible_text` now legitimately returns underscore-wrapped emphasis unchanged (it has no markup to strip) — a behavior clarification, not a regression, but worth reviewer awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
