### PR TITLE
feat(schema): localize punctuation collisions

### DIFF
--- a/.beans/archive/csl26-0vo3--design-locale-configurable-punctuation-collision-s.md
+++ b/.beans/archive/csl26-0vo3--design-locale-configurable-punctuation-collision-s.md
@@ -1,7 +1,7 @@
 ---
 # csl26-0vo3
 title: Design locale-configurable punctuation-collision system
-status: todo
+status: completed
 type: task
 priority: normal
 tags:
@@ -10,7 +10,7 @@ tags:
     - locale
     - schema
 created_at: 2026-07-12T18:51:44Z
-updated_at: 2026-07-12T19:04:43Z
+updated_at: 2026-07-12T20:42:36Z
 blocking:
     - csl26-zfqr
 ---
@@ -40,22 +40,34 @@ than a general pattern-rewrite table (the CSL-M `<punct-handling>`
 proposal, deliberately rejected — see spec for reasoning). This bean is the
 concrete design decision + implementation that section leaves open.
 
-- [ ] Finalize exact grammar-options field names and the full set of
+- [x] Finalize exact grammar-options field names and the full set of
       class-pair collision policies (spec sketches StrongTerminal/WeakTerminal/
       CommaLike classes and a strong-plus-comma-policy field; needs a
       final decision, not just a sketch)
-- [ ] Confirm the terminal-mark suppression-set field csl26-zfqr needs
+- [x] Confirm the terminal-mark suppression-set field csl26-zfqr needs
       (default "?!…") is the same field this design produces, not a
       second competing one
-- [ ] Add new field(s) to citum-schema-style with #[serde(default)],
+- [x] Add new field(s) to citum-schema-style with #[serde(default)],
       regenerate JSON schema in the same commit (per
       crates/citum-schema/CLAUDE.md)
-- [ ] Update docs/guides/AUTHORING_LOCALES.md's grammar-options example
-- [ ] Populate en-US.yaml (and any other embedded locales) with defaults
-- [ ] Wire the new field(s) into resolve_punctuation_collision and/or
+- [x] Update docs/guides/AUTHORING_LOCALES.md's grammar-options example
+- [x] Populate en-US.yaml (and any other embedded locales) with defaults
+- [x] Wire the new field(s) into resolve_punctuation_collision and/or
       DANGLING_PUNCTUATION_PATTERNS as appropriate
-- [ ] Flip docs/specs/PUNCTUATION_NORMALIZATION.md Status to Active in the
+- [x] Flip docs/specs/PUNCTUATION_NORMALIZATION.md Status to Active in the
       implementation commit
-- [ ] French spacing (NBSP/narrow-NBSP before : ; ! ? and guillemets) is
+- [x] French spacing (NBSP/narrow-NBSP before : ; ! ? and guillemets) is
       scoped OUT of this pass per the spec — file as a separate follow-up
       if still wanted after this lands
+
+## Summary of Changes
+
+- Added locale defaults and direct style overrides for strong-terminal comma
+  collisions, with compatibility-first English behavior.
+- Shared the resolved policy across citation and bibliography joins, including
+  markup-aware dangling-punctuation cleanup.
+- Defined `delimiter-suppressing-terminal-marks` for `csl26-zfqr`; structured
+  title consumption remains part of that separate bean.
+- Activated the punctuation-normalization spec, updated locale documentation,
+  and regenerated the public locale and style schemas.
+- Kept French spacing outside this implementation as specified.

--- a/crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs
@@ -11,6 +11,7 @@ use super::super::Renderer;
 use crate::render::ProcTemplateComponent;
 use crate::render::bibliography::{append_rendered_component, component_starts_new_sentence};
 use crate::render::component::render_component_with_format;
+use crate::render::punctuation::strong_terminal_comma_policy;
 use crate::values::RenderContext;
 use citum_schema::NoteStartTextCase;
 use citum_schema::locale::GeneralTerm;
@@ -46,6 +47,11 @@ impl Renderer<'_> {
             .first()
             .and_then(|component| component.config.as_ref())
             .is_some_and(|config| config.punctuation_in_quote);
+        let strong_terminal_comma_policy = strong_terminal_comma_policy(
+            components
+                .first()
+                .and_then(|component| component.config.as_deref()),
+        );
         let default_separator = components
             .first()
             .and_then(|component| component.bibliography_config.as_ref())
@@ -76,6 +82,7 @@ impl Renderer<'_> {
                 &rendered,
                 &default_separator,
                 punctuation_in_quote,
+                strong_terminal_comma_policy,
             );
         }
     }

--- a/crates/citum-engine/src/processor/setup.rs
+++ b/crates/citum-engine/src/processor/setup.rs
@@ -65,6 +65,41 @@ impl Processor {
             });
     }
 
+    /// Return whether applying locale punctuation defaults would change `config`.
+    fn punctuation_defaults_require_resolution(&self, config: &Config) -> bool {
+        let punctuation = config.punctuation.as_ref();
+        let policy_is_unset = punctuation
+            .and_then(|options| options.strong_terminal_comma_policy)
+            .is_none();
+        let marks_are_unset = punctuation
+            .and_then(|options| options.delimiter_suppressing_terminal_marks.as_ref())
+            .is_none();
+
+        (policy_is_unset
+            && self.locale.grammar_options.strong_terminal_comma_policy
+                != citum_schema::options::StrongTerminalCommaPolicy::default())
+            || (marks_are_unset
+                && self
+                    .locale
+                    .grammar_options
+                    .delimiter_suppressing_terminal_marks
+                    != "?!…")
+    }
+
+    /// Apply locale punctuation defaults only when they change the effective config.
+    fn with_punctuation_defaults<'a>(
+        &self,
+        config: std::borrow::Cow<'a, Config>,
+    ) -> std::borrow::Cow<'a, Config> {
+        if !self.punctuation_defaults_require_resolution(&config) {
+            return config;
+        }
+
+        let mut config = config.into_owned();
+        self.resolve_punctuation_defaults(&mut config);
+        std::borrow::Cow::Owned(config)
+    }
+
     /// Core internal constructor path.
     ///
     /// Resolves the style presets before initializing the processor.
@@ -467,38 +502,40 @@ impl Processor {
 
     /// Return merged config for citation rendering.
     ///
-    /// Combines global style options with citation-specific overrides.
+    /// Combines global style options with citation-specific overrides, borrowing
+    /// the global configuration when no merge or locale resolution is required.
     pub fn get_citation_config(&self) -> std::borrow::Cow<'_, Config> {
         let base = self.get_config();
-        let mut config = match self
+        let config = match self
             .style
             .citation
             .as_ref()
             .and_then(|citation| citation.options.as_ref())
         {
-            Some(citation_options) => citation_options.merged_with(base),
-            None => base.clone(),
+            Some(citation_options) => std::borrow::Cow::Owned(citation_options.merged_with(base)),
+            None => std::borrow::Cow::Borrowed(base),
         };
-        self.resolve_punctuation_defaults(&mut config);
-        std::borrow::Cow::Owned(config)
+        self.with_punctuation_defaults(config)
     }
 
     /// Return merged shared config for bibliography rendering.
     ///
-    /// Combines global shared style options with bibliography-local shared overrides.
+    /// Combines global shared style options with bibliography-local shared overrides,
+    /// borrowing the global configuration when no merge or locale resolution is required.
     pub fn get_bibliography_config(&self) -> std::borrow::Cow<'_, Config> {
         let base = self.get_config();
-        let mut config = match self
+        let config = match self
             .style
             .bibliography
             .as_ref()
             .and_then(|bibliography| bibliography.options.as_ref())
         {
-            Some(bibliography_options) => bibliography_options.merged_with(base),
-            None => base.clone(),
+            Some(bibliography_options) => {
+                std::borrow::Cow::Owned(bibliography_options.merged_with(base))
+            }
+            None => std::borrow::Cow::Borrowed(base),
         };
-        self.resolve_punctuation_defaults(&mut config);
-        std::borrow::Cow::Owned(config)
+        self.with_punctuation_defaults(config)
     }
 
     /// Return effective bibliography-only configuration.

--- a/crates/citum-engine/src/processor/setup.rs
+++ b/crates/citum-engine/src/processor/setup.rs
@@ -20,7 +20,7 @@ use citum_schema::Style;
 use citum_schema::locale::Locale;
 use citum_schema::options::{
     BibliographyPartitionKind, BibliographyPartitionMode, BibliographySortPartitioning, Config,
-    SortingMultilingualMode, bibliography::BibliographyConfig,
+    PunctuationConfig, SortingMultilingualMode, bibliography::BibliographyConfig,
 };
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -47,6 +47,24 @@ impl Default for Processor {
 }
 
 impl Processor {
+    /// Fill unset style punctuation options from the active locale.
+    fn resolve_punctuation_defaults(&self, config: &mut Config) {
+        let punctuation = config
+            .punctuation
+            .get_or_insert_with(PunctuationConfig::default);
+        punctuation
+            .strong_terminal_comma_policy
+            .get_or_insert(self.locale.grammar_options.strong_terminal_comma_policy);
+        punctuation
+            .delimiter_suppressing_terminal_marks
+            .get_or_insert_with(|| {
+                self.locale
+                    .grammar_options
+                    .delimiter_suppressing_terminal_marks
+                    .clone()
+            });
+    }
+
     /// Core internal constructor path.
     ///
     /// Resolves the style presets before initializing the processor.
@@ -452,15 +470,17 @@ impl Processor {
     /// Combines global style options with citation-specific overrides.
     pub fn get_citation_config(&self) -> std::borrow::Cow<'_, Config> {
         let base = self.get_config();
-        match self
+        let mut config = match self
             .style
             .citation
             .as_ref()
             .and_then(|citation| citation.options.as_ref())
         {
-            Some(citation_options) => std::borrow::Cow::Owned(citation_options.merged_with(base)),
-            None => std::borrow::Cow::Borrowed(base),
-        }
+            Some(citation_options) => citation_options.merged_with(base),
+            None => base.clone(),
+        };
+        self.resolve_punctuation_defaults(&mut config);
+        std::borrow::Cow::Owned(config)
     }
 
     /// Return merged shared config for bibliography rendering.
@@ -468,17 +488,17 @@ impl Processor {
     /// Combines global shared style options with bibliography-local shared overrides.
     pub fn get_bibliography_config(&self) -> std::borrow::Cow<'_, Config> {
         let base = self.get_config();
-        match self
+        let mut config = match self
             .style
             .bibliography
             .as_ref()
             .and_then(|bibliography| bibliography.options.as_ref())
         {
-            Some(bibliography_options) => {
-                std::borrow::Cow::Owned(bibliography_options.merged_with(base))
-            }
-            None => std::borrow::Cow::Borrowed(base),
-        }
+            Some(bibliography_options) => bibliography_options.merged_with(base),
+            None => base.clone(),
+        };
+        self.resolve_punctuation_defaults(&mut config);
+        std::borrow::Cow::Owned(config)
     }
 
     /// Return effective bibliography-only configuration.

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -145,6 +145,20 @@ fn locale_punctuation_defaults_and_style_overrides_reach_render_configs() {
     );
 }
 
+#[test]
+fn schema_default_punctuation_keeps_render_configs_borrowed() {
+    let processor = Processor::with_locale(make_style(), Bibliography::default(), Locale::en_us());
+
+    assert!(matches!(
+        processor.get_citation_config(),
+        std::borrow::Cow::Borrowed(_)
+    ));
+    assert!(matches!(
+        processor.get_bibliography_config(),
+        std::borrow::Cow::Borrowed(_)
+    ));
+}
+
 fn make_note_style() -> Style {
     let mut style = make_style();
     style.options = Some(Config {

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -102,6 +102,49 @@ fn make_style() -> Style {
     }
 }
 
+#[test]
+fn locale_punctuation_defaults_and_style_overrides_reach_render_configs() {
+    let mut locale = Locale::en_us();
+    locale.grammar_options.strong_terminal_comma_policy =
+        citum_schema::options::StrongTerminalCommaPolicy::KeepTerminal;
+    locale.grammar_options.delimiter_suppressing_terminal_marks = "?!…".to_string();
+
+    let processor = Processor::with_locale(make_style(), Bibliography::default(), locale.clone());
+    for config in [
+        processor.get_citation_config(),
+        processor.get_bibliography_config(),
+    ] {
+        let punctuation = config.punctuation.as_ref().unwrap();
+        assert_eq!(
+            punctuation.strong_terminal_comma_policy,
+            Some(citum_schema::options::StrongTerminalCommaPolicy::KeepTerminal)
+        );
+        assert_eq!(
+            punctuation.delimiter_suppressing_terminal_marks.as_deref(),
+            Some("?!…")
+        );
+    }
+
+    let mut style = make_style();
+    style.options.as_mut().unwrap().punctuation = Some(citum_schema::options::PunctuationConfig {
+        strong_terminal_comma_policy: Some(
+            citum_schema::options::StrongTerminalCommaPolicy::KeepBoth,
+        ),
+        delimiter_suppressing_terminal_marks: Some("!?".to_string()),
+    });
+    let processor = Processor::with_locale(style, Bibliography::default(), locale);
+    let config = processor.get_citation_config();
+    let punctuation = config.punctuation.as_ref().unwrap();
+    assert_eq!(
+        punctuation.strong_terminal_comma_policy,
+        Some(citum_schema::options::StrongTerminalCommaPolicy::KeepBoth)
+    );
+    assert_eq!(
+        punctuation.delimiter_suppressing_terminal_marks.as_deref(),
+        Some("!?")
+    );
+}
+
 fn make_note_style() -> Style {
     let mut style = make_style();
     style.options = Some(Config {

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -10,16 +10,17 @@ use crate::api::{AnnotationFormat, AnnotationStyle};
 use crate::render::component::{ProcEntry, ProcTemplateComponent, render_component_with_format};
 use crate::render::format::OutputFormat;
 use crate::render::plain::PlainText;
+use crate::render::punctuation::{is_strong_terminal, strong_terminal_comma_policy};
 use crate::render::rich_text::{render_djot_inline, render_org_inline};
 
 /// Returns true if the character is a sentence-ending or clause-ending punctuation mark.
 fn is_final_punctuation(c: char) -> bool {
-    matches!(c, '.' | ',' | ':' | ';' | '!' | '?')
+    matches!(c, '.' | ',' | ':' | ';' | '!' | '?' | '…')
 }
 
 /// Returns true if the character ends a sentence (period, question mark, exclamation).
 fn is_sentence_ending_punctuation(c: char) -> bool {
-    matches!(c, '.' | '!' | '?')
+    matches!(c, '.' | '!' | '?' | '…')
 }
 
 /// Returns the first character of the visible (markup-stripped) text for
@@ -123,6 +124,11 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
         .first()
         .and_then(|c| c.config.as_ref())
         .is_some_and(|cfg| cfg.punctuation_in_quote);
+    let strong_terminal_comma_policy = strong_terminal_comma_policy(
+        proc_template
+            .first()
+            .and_then(|component| component.config.as_deref()),
+    );
 
     // Get the bibliography separator from the config, defaulting to ". "
     let default_separator = proc_template
@@ -143,6 +149,7 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
                 &previous,
                 default_separator,
                 punctuation_in_quote,
+                strong_terminal_comma_policy,
             );
         }
     }
@@ -165,6 +172,7 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
             &final_rendered,
             default_separator,
             punctuation_in_quote,
+            strong_terminal_comma_policy,
         );
     }
 
@@ -197,7 +205,7 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
         _ => {}
     }
 
-    cleanup_dangling_punctuation::<F>(&mut entry_output);
+    cleanup_dangling_punctuation::<F>(&mut entry_output, strong_terminal_comma_policy);
     entry_output
 }
 
@@ -212,6 +220,7 @@ pub(crate) fn append_rendered_component<F: OutputFormat<Output = String>>(
     rendered: &str,
     default_separator: &str,
     punctuation_in_quote: bool,
+    strong_terminal_comma_policy: citum_schema::options::StrongTerminalCommaPolicy,
 ) {
     if !entry_output.is_empty() {
         let last_char = entry_output.chars().last().unwrap_or(' ');
@@ -229,8 +238,15 @@ pub(crate) fn append_rendered_component<F: OutputFormat<Output = String>>(
                 entry_output.push(' ');
             }
         } else if ends_with_punctuation {
-            // Output already ends in terminal punctuation — just ensure a separating space.
-            if !last_char.is_whitespace() {
+            // English-compatible locales retain a comma after a strong terminal mark;
+            // locales configured for collapsing retain only the terminal mark.
+            if sep_first_char == ','
+                && is_strong_terminal(trimmed_last)
+                && strong_terminal_comma_policy
+                    == citum_schema::options::StrongTerminalCommaPolicy::KeepBoth
+            {
+                entry_output.push_str(default_separator);
+            } else if !last_char.is_whitespace() {
                 entry_output.push(' ');
             }
         } else if punctuation_in_quote
@@ -390,6 +406,9 @@ const DANGLING_PUNCTUATION_PATTERNS: [(&str, &str); 13] = [
     ("  ", " "), // Double space to single
 ];
 
+/// Strong-terminal/comma pairs suppressed by locale policy.
+const STRONG_TERMINAL_COMMA_PATTERNS: [(&str, &str); 3] = [("!,", "!"), ("?,", "?"), ("…,", "…")];
+
 /// Collapse dangling/duplicated punctuation (`". ."` → `"."`, doubled spaces,
 /// etc.) without corrupting interleaved markup, URLs, or attribute values.
 ///
@@ -405,7 +424,10 @@ const DANGLING_PUNCTUATION_PATTERNS: [(&str, &str); 13] = [
     clippy::string_slice,
     reason = "byte ranges come from OutputFormat::visible_runs, which always yields char boundaries"
 )]
-fn cleanup_dangling_punctuation<F: OutputFormat<Output = String>>(output: &mut String) {
+fn cleanup_dangling_punctuation<F: OutputFormat<Output = String>>(
+    output: &mut String,
+    strong_terminal_comma_policy: citum_schema::options::StrongTerminalCommaPolicy,
+) {
     let fmt = F::default();
     loop {
         let runs = fmt.visible_runs(output);
@@ -418,10 +440,20 @@ fn cleanup_dangling_punctuation<F: OutputFormat<Output = String>>(output: &mut S
             }
         }
 
-        let Some((pat, replacement, visible_at)) = DANGLING_PUNCTUATION_PATTERNS
-            .iter()
-            .find_map(|&(pat, repl)| visible.find(pat).map(|idx| (pat, repl, idx)))
-        else {
+        let locale_pattern = if strong_terminal_comma_policy
+            == citum_schema::options::StrongTerminalCommaPolicy::KeepTerminal
+        {
+            STRONG_TERMINAL_COMMA_PATTERNS
+                .iter()
+                .find_map(|&(pat, repl)| visible.find(pat).map(|idx| (pat, repl, idx)))
+        } else {
+            None
+        };
+        let Some((pat, replacement, visible_at)) = locale_pattern.or_else(|| {
+            DANGLING_PUNCTUATION_PATTERNS
+                .iter()
+                .find_map(|&(pat, repl)| visible.find(pat).map(|idx| (pat, repl, idx)))
+        }) else {
             break;
         };
 
@@ -674,7 +706,13 @@ mod tests {
         // (IEEE house style: separator ", ", punctuation-in-quote enabled)
         let mut entry_output = String::from("\u{201C}Deep Learning\u{201D}");
         // when the next component (the journal title) is appended
-        append_rendered_component::<PlainText>(&mut entry_output, "Nature", ", ", true);
+        append_rendered_component::<PlainText>(
+            &mut entry_output,
+            "Nature",
+            ", ",
+            true,
+            Default::default(),
+        );
         // then the comma is pulled inside the closing quotation mark
         assert_eq!(entry_output, "\u{201C}Deep Learning,\u{201D} Nature");
     }
@@ -684,7 +722,13 @@ mod tests {
         // given a quoted title followed by a period-delimited separator
         let mut entry_output = String::from("\u{201C}Deep Learning\u{201D}");
         // when the next component is appended
-        append_rendered_component::<PlainText>(&mut entry_output, "Nature", ". ", true);
+        append_rendered_component::<PlainText>(
+            &mut entry_output,
+            "Nature",
+            ". ",
+            true,
+            Default::default(),
+        );
         // then the period is pulled inside the closing quotation mark (unchanged behaviour)
         assert_eq!(entry_output, "\u{201C}Deep Learning.\u{201D} Nature");
     }
@@ -694,9 +738,40 @@ mod tests {
         // given punctuation-in-quote disabled
         let mut entry_output = String::from("\u{201C}Deep Learning\u{201D}");
         // when the next component is appended with a comma separator
-        append_rendered_component::<PlainText>(&mut entry_output, "Nature", ", ", false);
+        append_rendered_component::<PlainText>(
+            &mut entry_output,
+            "Nature",
+            ", ",
+            false,
+            Default::default(),
+        );
         // then the comma stays outside the closing quotation mark
         assert_eq!(entry_output, "\u{201C}Deep Learning\u{201D}, Nature");
+    }
+
+    #[test]
+    fn strong_terminal_comma_policy_controls_bibliography_separator() {
+        for terminal in ['!', '?', '…'] {
+            let mut keep_both = format!("Title{terminal}");
+            append_rendered_component::<PlainText>(
+                &mut keep_both,
+                "Next",
+                ", ",
+                false,
+                citum_schema::options::StrongTerminalCommaPolicy::KeepBoth,
+            );
+            assert_eq!(keep_both, format!("Title{terminal}, Next"));
+
+            let mut keep_terminal = format!("Title{terminal}");
+            append_rendered_component::<PlainText>(
+                &mut keep_terminal,
+                "Next",
+                ", ",
+                false,
+                citum_schema::options::StrongTerminalCommaPolicy::KeepTerminal,
+            );
+            assert_eq!(keep_terminal, format!("Title{terminal} Next"));
+        }
     }
 
     #[test]
@@ -1119,7 +1194,13 @@ mod tests {
         // additionally insert the ". " separator's period, which used to
         // produce "\emph{Title.}. Next" (rendering as "Title.. Next").
         let mut entry_output = Latex.emph("Title.".to_string());
-        append_rendered_component::<Latex>(&mut entry_output, "Next", ". ", false);
+        append_rendered_component::<Latex>(
+            &mut entry_output,
+            "Next",
+            ". ",
+            false,
+            Default::default(),
+        );
 
         assert_eq!(Latex.visible_text(&entry_output), "Title. Next");
         assert!(
@@ -1134,7 +1215,7 @@ mod tests {
         // from an explicitly authored suffix) must still collapse to one
         // period, and the emph markup must survive intact.
         let mut output = r"\emph{Title.}. Next".to_string();
-        cleanup_dangling_punctuation::<Latex>(&mut output);
+        cleanup_dangling_punctuation::<Latex>(&mut output, Default::default());
 
         assert_eq!(Latex.visible_text(&output), "Title. Next");
         assert!(
@@ -1149,7 +1230,7 @@ mod tests {
         // pattern inside it must survive even though the identical pattern
         // outside the link gets collapsed.
         let mut output = r"\href{https://example.com/a, .b}{Link}, .".to_string();
-        cleanup_dangling_punctuation::<Latex>(&mut output);
+        cleanup_dangling_punctuation::<Latex>(&mut output, Default::default());
 
         assert!(
             output.contains("https://example.com/a, .b"),
@@ -1161,12 +1242,31 @@ mod tests {
     #[test]
     fn cleanup_dangling_punctuation_collapses_across_a_typst_markup_boundary() {
         let mut output = "#emph[Title.]. Next".to_string();
-        cleanup_dangling_punctuation::<Typst>(&mut output);
+        cleanup_dangling_punctuation::<Typst>(&mut output, Default::default());
 
         assert_eq!(Typst.visible_text(&output), "Title. Next");
         assert!(
             output.contains("#emph[Title"),
             "emph markup must survive: {output}"
         );
+    }
+
+    #[test]
+    fn cleanup_dangling_punctuation_applies_locale_policy_across_markup() {
+        let mut latex = r"\emph{Title!}, Next".to_string();
+        cleanup_dangling_punctuation::<Latex>(
+            &mut latex,
+            citum_schema::options::StrongTerminalCommaPolicy::KeepTerminal,
+        );
+        assert_eq!(Latex.visible_text(&latex), "Title! Next");
+        assert!(latex.contains(r"\emph{Title!}"));
+
+        let mut typst = "#emph[Title…], Next".to_string();
+        cleanup_dangling_punctuation::<Typst>(
+            &mut typst,
+            citum_schema::options::StrongTerminalCommaPolicy::KeepTerminal,
+        );
+        assert_eq!(Typst.visible_text(&typst), "Title… Next");
+        assert!(typst.contains("#emph[Title…]"));
     }
 }

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -240,12 +240,14 @@ pub(crate) fn append_rendered_component<F: OutputFormat<Output = String>>(
         } else if ends_with_punctuation {
             // English-compatible locales retain a comma after a strong terminal mark;
             // locales configured for collapsing retain only the terminal mark.
-            if sep_first_char == ','
-                && is_strong_terminal(trimmed_last)
-                && strong_terminal_comma_policy
+            if sep_first_char == ',' && is_strong_terminal(trimmed_last) {
+                if strong_terminal_comma_policy
                     == citum_schema::options::StrongTerminalCommaPolicy::KeepBoth
-            {
-                entry_output.push_str(default_separator);
+                {
+                    entry_output.push_str(default_separator);
+                } else if let Some(separator_tail) = default_separator.strip_prefix(',') {
+                    entry_output.push_str(separator_tail);
+                }
             } else if !last_char.is_whitespace() {
                 entry_output.push(' ');
             }
@@ -772,6 +774,20 @@ mod tests {
             );
             assert_eq!(keep_terminal, format!("Title{terminal} Next"));
         }
+    }
+
+    #[test]
+    fn keep_terminal_policy_preserves_bibliography_separator_tail() {
+        let mut entry_output = "Title?".to_string();
+        append_rendered_component::<PlainText>(
+            &mut entry_output,
+            "Next",
+            ",\u{00A0}",
+            false,
+            citum_schema::options::StrongTerminalCommaPolicy::KeepTerminal,
+        );
+
+        assert_eq!(entry_output, "Title?\u{00A0}Next");
     }
 
     #[test]

--- a/crates/citum-engine/src/render/citation.rs
+++ b/crates/citum-engine/src/render/citation.rs
@@ -6,53 +6,10 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use crate::render::component::{ProcTemplate, render_component_with_format};
 use crate::render::format::OutputFormat;
 use crate::render::plain::PlainText;
+use crate::render::punctuation::{
+    is_terminal_punctuation, resolve_punctuation_collision, strong_terminal_comma_policy,
+};
 use citum_schema::template::WrapPunctuation;
-
-fn is_terminal_punctuation(ch: char) -> bool {
-    matches!(ch, ':' | '.' | ';' | '!' | '?' | ',')
-}
-
-fn resolve_punctuation_collision(first: char, second: char) -> String {
-    match (first, second) {
-        (':', ':') => ":".to_string(),
-        ('.', ':') => ".:".to_string(),
-        (';', ':') => ";".to_string(),
-        ('!', ':') => "!".to_string(),
-        ('?', ':') => "?".to_string(),
-        (',', ':') => ",:".to_string(),
-        (':', '.') => ":".to_string(),
-        ('.', '.') => ".".to_string(),
-        (';', '.') => ";".to_string(),
-        ('!', '.') => "!".to_string(),
-        ('?', '.') => "?".to_string(),
-        (',', '.') => ",.".to_string(),
-        (':', ';') => ":;".to_string(),
-        ('.', ';') => ".;".to_string(),
-        (';', ';') => ";".to_string(),
-        ('!', ';') => "!;".to_string(),
-        ('?', ';') => "?;".to_string(),
-        (',', ';') => ",;".to_string(),
-        (':', '!') => "!".to_string(),
-        ('.', '!') => ".!".to_string(),
-        (';', '!') => "!".to_string(),
-        ('!', '!') => "!".to_string(),
-        ('?', '!') => "?!".to_string(),
-        (',', '!') => ",!".to_string(),
-        (':', '?') => "?".to_string(),
-        ('.', '?') => ".?".to_string(),
-        (';', '?') => "?".to_string(),
-        ('!', '?') => "!?".to_string(),
-        ('?', '?') => "?".to_string(),
-        (',', '?') => ",?".to_string(),
-        (':', ',') => ":,".to_string(),
-        ('.', ',') => ".,".to_string(),
-        (';', ',') => ";,".to_string(),
-        ('!', ',') => "!,".to_string(),
-        ('?', ',') => "?,".to_string(),
-        (',', ',') => ",".to_string(),
-        _ => format!("{first}{second}"),
-    }
-}
 
 /// Append `delim` to `content`, applying house-style punctuation rules at the join point.
 ///
@@ -78,6 +35,7 @@ fn push_delimiter<F: OutputFormat<Output = String>>(
     content: &mut String,
     delim: &str,
     punctuation_in_quote: bool,
+    strong_terminal_comma_policy: citum_schema::options::StrongTerminalCommaPolicy,
 ) {
     let delim_first = delim.chars().next();
 
@@ -109,13 +67,25 @@ fn push_delimiter<F: OutputFormat<Output = String>>(
     } else if content.ends_with(visible_last) {
         // Case 2a: raw content genuinely ends with the visible terminal char — merge as before.
         content.pop();
-        content.push_str(&resolve_punctuation_collision(visible_last, first));
+        content.push_str(&resolve_punctuation_collision(
+            visible_last,
+            first,
+            strong_terminal_comma_policy,
+        ));
         content.push_str(&delim[first.len_utf8()..]);
     } else {
         // Case 2b: the visible terminal punctuation is behind trailing markup (e.g. LaTeX
-        // `}`) — leave the raw markup alone and just drop the delimiter's redundant leading
-        // punctuation instead of popping from `content`.
-        content.push_str(&delim[first.len_utf8()..]);
+        // `}`). A retained comma can safely follow the markup wrapper; all collapsing cases
+        // leave the raw markup alone and drop the incoming punctuation as before.
+        if first == ','
+            && crate::render::punctuation::is_strong_terminal(visible_last)
+            && strong_terminal_comma_policy
+                == citum_schema::options::StrongTerminalCommaPolicy::KeepBoth
+        {
+            content.push_str(delim);
+        } else {
+            content.push_str(&delim[first.len_utf8()..]);
+        }
     }
 }
 
@@ -154,11 +124,21 @@ pub fn citation_to_string_with_format<F: OutputFormat<Output = String>>(
         .first()
         .and_then(|c| c.config.as_ref())
         .is_some_and(|cfg| cfg.punctuation_in_quote);
+    let strong_terminal_comma_policy = strong_terminal_comma_policy(
+        proc_template
+            .first()
+            .and_then(|component| component.config.as_deref()),
+    );
 
     let mut content = String::new();
     for (i, part) in parts.iter().enumerate() {
         if i > 0 {
-            push_delimiter::<F>(&mut content, delim, punctuation_in_quote);
+            push_delimiter::<F>(
+                &mut content,
+                delim,
+                punctuation_in_quote,
+                strong_terminal_comma_policy,
+            );
         }
         content.push_str(part);
     }
@@ -411,6 +391,101 @@ ENDING IN COMMA
 
         assert_eq!(plain, expected);
         assert_eq!(typst, expected);
+    }
+
+    #[test]
+    fn test_keep_terminal_policy_suppresses_comma_after_strong_terminal_marks() {
+        let config = Config {
+            punctuation: Some(citum_schema::options::PunctuationConfig {
+                strong_terminal_comma_policy: Some(
+                    citum_schema::options::StrongTerminalCommaPolicy::KeepTerminal,
+                ),
+                delimiter_suppressing_terminal_marks: None,
+            }),
+            ..Default::default()
+        };
+        let cases = [
+            ("question", "?", "“question”? comma"),
+            ("exclamation", "!", "“exclamation”! comma"),
+            ("ellipsis", "…", "“ellipsis”… comma"),
+        ];
+
+        for (value, suffix, expected) in cases {
+            let template = full_monty_template(&config, "ENDING IN COMMA", value, suffix);
+            assert_eq!(
+                citation_to_string(&template, None, None, None, Some(", ")),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn test_keep_both_policy_preserves_comma_after_ellipsis() {
+        let config = Config::default();
+        let template = full_monty_template(&config, "ENDING IN COMMA", "ellipsis", "…");
+
+        assert_eq!(
+            citation_to_string(&template, None, None, None, Some(", ")),
+            "“ellipsis”…, comma"
+        );
+    }
+
+    #[test]
+    fn test_strong_terminal_comma_policy_applies_across_typst_markup() {
+        let template = |policy| {
+            let config = Config {
+                punctuation: Some(citum_schema::options::PunctuationConfig {
+                    strong_terminal_comma_policy: Some(policy),
+                    delimiter_suppressing_terminal_marks: None,
+                }),
+                ..Default::default()
+            };
+            vec![
+                ProcTemplateComponent {
+                    template_component: TemplateComponent::Title(TemplateTitle {
+                        rendering: Rendering {
+                            emph: Some(true),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                    value: "Title!".to_string(),
+                    config: Some(config.clone().into()),
+                    ..Default::default()
+                },
+                ProcTemplateComponent {
+                    template_component: TemplateComponent::Date(TemplateDate {
+                        date: DateVariable::Issued,
+                        form: DateForm::Year,
+                        ..Default::default()
+                    }),
+                    value: "next".to_string(),
+                    config: Some(config.into()),
+                    ..Default::default()
+                },
+            ]
+        };
+
+        assert_eq!(
+            citation_to_string_with_format::<Typst>(
+                &template(citum_schema::options::StrongTerminalCommaPolicy::KeepBoth),
+                None,
+                None,
+                None,
+                Some(", "),
+            ),
+            "#emph[Title!], next"
+        );
+        assert_eq!(
+            citation_to_string_with_format::<Typst>(
+                &template(citum_schema::options::StrongTerminalCommaPolicy::KeepTerminal),
+                None,
+                None,
+                None,
+                Some(", "),
+            ),
+            "#emph[Title!] next"
+        );
     }
 
     fn full_monty_template(

--- a/crates/citum-engine/src/render/mod.rs
+++ b/crates/citum-engine/src/render/mod.rs
@@ -30,6 +30,7 @@ pub mod markdown;
 pub(crate) mod markup;
 pub mod org;
 pub mod plain;
+pub(crate) mod punctuation;
 pub mod rich_text;
 pub mod typst;
 mod visible_scan;

--- a/crates/citum-engine/src/render/punctuation.rs
+++ b/crates/citum-engine/src/render/punctuation.rs
@@ -1,0 +1,80 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Shared punctuation classification and collision resolution.
+
+use citum_schema::options::{Config, StrongTerminalCommaPolicy};
+
+/// Return the resolved strong-terminal/comma policy from a processed config.
+pub(crate) fn strong_terminal_comma_policy(config: Option<&Config>) -> StrongTerminalCommaPolicy {
+    config
+        .and_then(|config| config.punctuation.as_ref())
+        .and_then(|punctuation| punctuation.strong_terminal_comma_policy)
+        .unwrap_or_default()
+}
+
+/// Return whether `ch` participates in punctuation-collision resolution.
+pub(crate) fn is_terminal_punctuation(ch: char) -> bool {
+    matches!(ch, ':' | '.' | ';' | '!' | '?' | ',' | '…')
+}
+
+/// Return whether `ch` is a strong terminal punctuation mark.
+pub(crate) fn is_strong_terminal(ch: char) -> bool {
+    matches!(ch, '!' | '?' | '…')
+}
+
+/// Resolve one punctuation pair while preserving the established compatibility matrix.
+pub(crate) fn resolve_punctuation_collision(
+    first: char,
+    second: char,
+    strong_terminal_comma_policy: StrongTerminalCommaPolicy,
+) -> String {
+    if second == ','
+        && is_strong_terminal(first)
+        && strong_terminal_comma_policy == StrongTerminalCommaPolicy::KeepTerminal
+    {
+        return first.to_string();
+    }
+
+    match (first, second) {
+        (':', ':') => ":".to_string(),
+        ('.', ':') => ".:".to_string(),
+        (';', ':') => ";".to_string(),
+        ('!', ':') => "!".to_string(),
+        ('?', ':') => "?".to_string(),
+        (',', ':') => ",:".to_string(),
+        (':', '.') => ":".to_string(),
+        ('.', '.') => ".".to_string(),
+        (';', '.') => ";".to_string(),
+        ('!', '.') => "!".to_string(),
+        ('?', '.') => "?".to_string(),
+        (',', '.') => ",.".to_string(),
+        (':', ';') => ":;".to_string(),
+        ('.', ';') => ".;".to_string(),
+        (';', ';') => ";".to_string(),
+        ('!', ';') => "!;".to_string(),
+        ('?', ';') => "?;".to_string(),
+        (',', ';') => ",;".to_string(),
+        (':', '!') => "!".to_string(),
+        ('.', '!') => ".!".to_string(),
+        (';', '!') => "!".to_string(),
+        ('!', '!') => "!".to_string(),
+        ('?', '!') => "?!".to_string(),
+        (',', '!') => ",!".to_string(),
+        (':', '?') => "?".to_string(),
+        ('.', '?') => ".?".to_string(),
+        (';', '?') => "?".to_string(),
+        ('!', '?') => "!?".to_string(),
+        ('?', '?') => "?".to_string(),
+        (',', '?') => ",?".to_string(),
+        (':', ',') => ":,".to_string(),
+        ('.', ',') => ".,".to_string(),
+        (';', ',') => ";,".to_string(),
+        ('!', ',') => "!,".to_string(),
+        ('?', ',') => "?,".to_string(),
+        (',', ',') => ",".to_string(),
+        _ => format!("{first}{second}"),
+    }
+}

--- a/crates/citum-schema-style/embedded/locales/de-DE.yaml
+++ b/crates/citum-schema-style/embedded/locales/de-DE.yaml
@@ -808,6 +808,8 @@ grammar-options:
   page-range-delimiter: "–"
   title-subtitle-delimiter: ": "
   subtitle-delimiter: ", "
+  strong-terminal-comma-policy: keep-terminal
+  delimiter-suppressing-terminal-marks: "?!…"
 
 legacy-term-aliases:
   page: term.page-label

--- a/crates/citum-schema-style/embedded/locales/en-US.yaml
+++ b/crates/citum-schema-style/embedded/locales/en-US.yaml
@@ -967,6 +967,8 @@ grammar-options:
   page-range-delimiter: "–"
   title-subtitle-delimiter: ": "
   subtitle-delimiter: "; "
+  strong-terminal-comma-policy: keep-both
+  delimiter-suppressing-terminal-marks: "?!…"
   note-punctuation: inside
   note-number: outside
   note-marker-order: after

--- a/crates/citum-schema-style/embedded/locales/es-ES.yaml
+++ b/crates/citum-schema-style/embedded/locales/es-ES.yaml
@@ -338,6 +338,8 @@ grammar-options:
   page-range-delimiter: "–"
   title-subtitle-delimiter: ": "
   subtitle-delimiter: "; "
+  strong-terminal-comma-policy: keep-both
+  delimiter-suppressing-terminal-marks: "?!…"
 
 legacy-term-aliases:
   page: term.page-label

--- a/crates/citum-schema-style/embedded/locales/eu-ES.yaml
+++ b/crates/citum-schema-style/embedded/locales/eu-ES.yaml
@@ -137,6 +137,8 @@ grammar-options:
   page-range-delimiter: "–"
   title-subtitle-delimiter: ": "
   subtitle-delimiter: "; "
+  strong-terminal-comma-policy: keep-both
+  delimiter-suppressing-terminal-marks: "?!…"
 
 legacy-term-aliases:
   page: term.page-label

--- a/crates/citum-schema-style/embedded/locales/fr-FR.yaml
+++ b/crates/citum-schema-style/embedded/locales/fr-FR.yaml
@@ -918,6 +918,8 @@ grammar-options:
   page-range-delimiter: "‑"
   title-subtitle-delimiter: " : "
   subtitle-delimiter: " ; "
+  strong-terminal-comma-policy: keep-terminal
+  delimiter-suppressing-terminal-marks: "?!…"
   note-punctuation: adaptive
   note-number: same
   note-marker-order: before

--- a/crates/citum-schema-style/embedded/locales/overrides/de-DE-chicago.yaml
+++ b/crates/citum-schema-style/embedded/locales/overrides/de-DE-chicago.yaml
@@ -27,6 +27,8 @@ grammar-options:
   serial-comma: false
   title-subtitle-delimiter: ": "
   subtitle-delimiter: "; "
+  strong-terminal-comma-policy: keep-terminal
+  delimiter-suppressing-terminal-marks: "?!…"
 
 messages:
   # Chicago-German chapter entries introduce the container by adjacency; the

--- a/crates/citum-schema-style/embedded/locales/overrides/en-US-chicago.yaml
+++ b/crates/citum-schema-style/embedded/locales/overrides/en-US-chicago.yaml
@@ -19,4 +19,6 @@ grammar-options:
   page-range-delimiter: "\u2013"
   title-subtitle-delimiter: ": "
   subtitle-delimiter: "; "
+  strong-terminal-comma-policy: keep-both
+  delimiter-suppressing-terminal-marks: "?!…"
 legacy-term-aliases: {}

--- a/crates/citum-schema-style/embedded/locales/tr-TR.yaml
+++ b/crates/citum-schema-style/embedded/locales/tr-TR.yaml
@@ -805,6 +805,8 @@ grammar-options:
   page-range-delimiter: "-"
   title-subtitle-delimiter: ": "
   subtitle-delimiter: "; "
+  strong-terminal-comma-policy: keep-both
+  delimiter-suppressing-terminal-marks: "?!…"
 
 legacy-term-aliases:
   page: term.page-label

--- a/crates/citum-schema-style/src/locale/types.rs
+++ b/crates/citum-schema-style/src/locale/types.rs
@@ -476,6 +476,12 @@ pub struct GrammarOptions {
     /// Delimiter between subtitle parts inside a structured title.
     #[serde(default = "default_subtitle_delimiter")]
     pub subtitle_delimiter: String,
+    /// Policy for a strong terminal mark followed by a style-supplied comma.
+    #[serde(default)]
+    pub strong_terminal_comma_policy: crate::options::StrongTerminalCommaPolicy,
+    /// Terminal marks that suppress a following delimiter's punctuation core.
+    #[serde(default = "default_delimiter_suppressing_terminal_marks")]
+    pub delimiter_suppressing_terminal_marks: String,
     /// Default placement of movable punctuation relative to closing
     /// quotation marks when a footnote marker is introduced. Overridable
     /// per-style via `options.notes.punctuation`.
@@ -504,6 +510,8 @@ impl Default for GrammarOptions {
             page_range_delimiter: default_page_range_delimiter(),
             title_subtitle_delimiter: default_title_subtitle_delimiter(),
             subtitle_delimiter: default_subtitle_delimiter(),
+            strong_terminal_comma_policy: crate::options::StrongTerminalCommaPolicy::default(),
+            delimiter_suppressing_terminal_marks: default_delimiter_suppressing_terminal_marks(),
             note_punctuation: crate::options::NoteQuotePlacement::default(),
             note_number: crate::options::NoteNumberPlacement::default(),
             note_marker_order: crate::options::NoteMarkerOrder::default(),
@@ -537,6 +545,10 @@ fn default_title_subtitle_delimiter() -> String {
 
 fn default_subtitle_delimiter() -> String {
     "; ".into()
+}
+
+fn default_delimiter_suppressing_terminal_marks() -> String {
+    "?!…".into()
 }
 
 /// Message syntax variant active in a locale file.

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -146,6 +146,9 @@ pub struct Config {
     /// Defaults to false; en-US locale typically sets this to true.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub punctuation_in_quote: bool,
+    /// Locale-sensitive punctuation-collision overrides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub punctuation: Option<PunctuationConfig>,
     /// Delimiter between volume/issue and pages for serial sources.
     /// Processor adds trailing space when rendering.
     /// Examples: Comma (APA ", "), Colon (Chicago ": ").
@@ -439,6 +442,43 @@ pub struct NoteConfig {
     pub unknown_fields: std::collections::BTreeMap<String, serde_yaml::Value>,
 }
 
+/// Style-level overrides for locale punctuation-collision defaults.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub struct PunctuationConfig {
+    /// Policy for a strong terminal mark followed by a style-supplied comma.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strong_terminal_comma_policy: Option<StrongTerminalCommaPolicy>,
+    /// Terminal marks that suppress a following delimiter's punctuation core.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delimiter_suppressing_terminal_marks: Option<String>,
+}
+
+impl PunctuationConfig {
+    /// Merge `other` over this configuration field by field.
+    fn merge(&mut self, other: &Self) {
+        if let Some(policy) = other.strong_terminal_comma_policy {
+            self.strong_terminal_comma_policy = Some(policy);
+        }
+        if let Some(marks) = &other.delimiter_suppressing_terminal_marks {
+            self.delimiter_suppressing_terminal_marks = Some(marks.clone());
+        }
+    }
+}
+
+/// Controls how a strong terminal mark collides with a following comma.
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum StrongTerminalCommaPolicy {
+    /// Preserve both the terminal mark and the following comma.
+    #[default]
+    KeepBoth,
+    /// Preserve the terminal mark and suppress the following comma.
+    KeepTerminal,
+}
+
 /// Controls where movable punctuation is placed relative to closing quotation marks.
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -558,6 +598,17 @@ pub enum LinkAnchor {
 }
 
 impl Config {
+    fn merge_punctuation(&mut self, other: &Config) {
+        let Some(other_punctuation) = &other.punctuation else {
+            return;
+        };
+        if let Some(punctuation) = &mut self.punctuation {
+            punctuation.merge(other_punctuation);
+        } else {
+            self.punctuation = Some(other_punctuation.clone());
+        }
+    }
+
     /// Effective processing mode, falling back to the default when unset.
     ///
     /// Centralizes the `processing: None` fallback so every consumer resolves
@@ -592,6 +643,8 @@ impl Config {
             org_abbreviation_memory,
             custom,
         );
+
+        self.merge_punctuation(other);
 
         if let Some(other_sorting) = &other.sorting {
             if let Some(this_sorting) = &mut self.sorting {
@@ -651,6 +704,7 @@ impl CitationOptions {
             page_range_delimiter: None,
             links: self.links.clone(),
             punctuation_in_quote: self.punctuation_in_quote,
+            punctuation: None,
             volume_pages_delimiter: self.volume_pages_delimiter.clone(),
             strip_periods: self.strip_periods,
             notes: self.notes.clone(),
@@ -752,6 +806,7 @@ impl BibliographyOptions {
             page_range_delimiter: None,
             links: self.links.clone(),
             punctuation_in_quote: self.punctuation_in_quote,
+            punctuation: None,
             volume_pages_delimiter: self.volume_pages_delimiter.clone(),
             strip_periods: self.strip_periods,
             notes: None,
@@ -955,6 +1010,8 @@ impl<'de> Deserialize<'de> for Config {
             #[serde(default, skip_serializing_if = "std::ops::Not::not")]
             punctuation_in_quote: bool,
             #[serde(skip_serializing_if = "Option::is_none")]
+            punctuation: Option<PunctuationConfig>,
+            #[serde(skip_serializing_if = "Option::is_none")]
             volume_pages_delimiter: Option<DelimiterPunctuation>,
             #[serde(skip_serializing_if = "Option::is_none", rename = "strip-periods")]
             strip_periods: Option<bool>,
@@ -994,6 +1051,7 @@ impl<'de> Deserialize<'de> for Config {
             page_range_delimiter: wire.page_range_delimiter,
             links: wire.links,
             punctuation_in_quote: wire.punctuation_in_quote,
+            punctuation: wire.punctuation,
             volume_pages_delimiter: wire.volume_pages_delimiter,
             strip_periods: wire.strip_periods,
             notes: wire.notes,
@@ -1356,6 +1414,43 @@ locale-override: en-US-chicago
         assert_eq!(merged.processing, Some(Processing::AuthorDate));
         assert!(merged.strip_periods.unwrap_or(false));
         assert!(merged.locators.is_some());
+    }
+
+    #[test]
+    fn test_punctuation_config_deserializes_and_merges_field_by_field() {
+        let yaml = r#"
+punctuation:
+  strong-terminal-comma-policy: keep-terminal
+  delimiter-suppressing-terminal-marks: "?!…"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let punctuation = config.punctuation.as_ref().unwrap();
+        assert_eq!(
+            punctuation.strong_terminal_comma_policy,
+            Some(StrongTerminalCommaPolicy::KeepTerminal)
+        );
+        assert_eq!(
+            punctuation.delimiter_suppressing_terminal_marks.as_deref(),
+            Some("?!…")
+        );
+
+        let override_config = Config {
+            punctuation: Some(PunctuationConfig {
+                strong_terminal_comma_policy: Some(StrongTerminalCommaPolicy::KeepBoth),
+                delimiter_suppressing_terminal_marks: None,
+            }),
+            ..Default::default()
+        };
+        let merged = Config::merged(&config, &override_config);
+        let punctuation = merged.punctuation.as_ref().unwrap();
+        assert_eq!(
+            punctuation.strong_terminal_comma_policy,
+            Some(StrongTerminalCommaPolicy::KeepBoth)
+        );
+        assert_eq!(
+            punctuation.delimiter_suppressing_terminal_marks.as_deref(),
+            Some("?!…")
+        );
     }
 
     #[test]

--- a/crates/citum-schema-style/src/reference_multilingual_tests.rs
+++ b/crates/citum-schema-style/src/reference_multilingual_tests.rs
@@ -167,6 +167,25 @@ grammar-options:
     }
 
     #[test]
+    fn test_locale_punctuation_collision_defaults_deserialization() {
+        let yaml = r#"
+locale: x-test
+grammar-options:
+  strong-terminal-comma-policy: keep-terminal
+  delimiter-suppressing-terminal-marks: "?!…"
+"#;
+        let locale = Locale::from_yaml_str(yaml).unwrap();
+        assert_eq!(
+            locale.grammar_options.strong_terminal_comma_policy,
+            crate::options::StrongTerminalCommaPolicy::KeepTerminal
+        );
+        assert_eq!(
+            locale.grammar_options.delimiter_suppressing_terminal_marks,
+            "?!…"
+        );
+    }
+
+    #[test]
     fn test_field_languages_deserialization() {
         let yaml = r#"
 id: chapter-1

--- a/docs/guides/AUTHORING_LOCALES.md
+++ b/docs/guides/AUTHORING_LOCALES.md
@@ -1,14 +1,19 @@
 # Authoring Locales
 
 This guide tells you when and how to add MessageFormat 2 (MF2) entries to a
-Citum locale file in `locales/`. It is the practical companion to
+Citum locale file in the
+[embedded locale directory](../../crates/citum-schema-style/embedded/locales/).
+It is the practical companion to
 [`docs/specs/LOCALE_MESSAGES.md`](../specs/LOCALE_MESSAGES.md).
 
 ## Status
 
-- MF2 evaluator: live in `crates/citum-schema-style/src/locale/message.rs`.
+- MF2 evaluator: live in
+  [`message.rs`](../../crates/citum-schema-style/src/locale/message.rs).
 - Engine call sites: live. `resolved_locator_term` and `resolved_role_term`
-  are wired in `crates/citum-engine/src/values/` (locator, number, contributor/labels)
+  are wired in the
+  [engine value modules](../../crates/citum-engine/src/values/)
+  (locator, number, contributor/labels)
   and consult the `messages:` map first, falling back to the legacy `terms:` /
   `roles:` / `locators:` maps.
 - Gendered term values: live through `MaybeGendered<T>` in the legacy locale
@@ -61,11 +66,22 @@ grammar-options:
   close-quote: "..."
   serial-comma: false
   page-range-delimiter: "..."
+  strong-terminal-comma-policy: keep-both
+  delimiter-suppressing-terminal-marks: "?!…"
 legacy-term-aliases:
   # bridge old engine keys to new message IDs
 ```
 
-Use `locales/en-US.yaml`, `fr-FR.yaml`, or `de-DE.yaml` as references for
+Use `strong-terminal-comma-policy: keep-terminal` for locales that suppress a
+style-supplied comma after `?`, `!`, or `…` (currently German and French).
+Styles can override either punctuation field under `options.punctuation`.
+`delimiter-suppressing-terminal-marks` is also the shared locale vocabulary
+for structured-title delimiter suppression; title rendering consumes it in
+the separately tracked `csl26-zfqr` work.
+
+Use [`en-US.yaml`](../../crates/citum-schema-style/embedded/locales/en-US.yaml),
+[`fr-FR.yaml`](../../crates/citum-schema-style/embedded/locales/fr-FR.yaml), or
+[`de-DE.yaml`](../../crates/citum-schema-style/embedded/locales/de-DE.yaml) as references for
 gender-invariant messages. `es-ES.yaml` is the current concrete example of a
 locale that carries MF2 messages while keeping gendered role labels in `roles:`
 until MF2 can dispatch on both `$gender` and `$count` in one message. The same
@@ -161,7 +177,8 @@ found: it is a free/open-source rule-based machine translation platform that
 maintains explicit morphological grammars for languages it supports, and its
 wiki (`wiki.apertium.org`) contains relatively rigorous community-curated
 notes on case marking, agreement, and date formation. The Basque locale
-(`locales/eu-ES.yaml`) was bootstrapped from
+([`eu-ES.yaml`](../../crates/citum-schema-style/embedded/locales/eu-ES.yaml))
+was bootstrapped from
 [`wiki.apertium.org/wiki/Basque_to_English`](https://wiki.apertium.org/wiki/Basque_to_English)
 for exactly this reason.
 
@@ -278,7 +295,7 @@ cargo run --bin citum -- render refs \
 Step 4 installs the locale into the user data directory
 (`~/.local/share/citum/locales/` on Linux, `~/Library/Application Support/citum/locales/`
 on macOS) so the renderer can find it under any style — builtin or file-based.
-The resolution order is: sibling `locales/` (file-based styles only) → user
+The resolution order is: sibling locale directory (file-based styles only) → user
 store → embedded.
 
 `citum locale lint <file>` validates MF2 message structure before the render

--- a/docs/schemas/locale.json
+++ b/docs/schemas/locale.json
@@ -597,6 +597,16 @@
           "type": "string",
           "default": "; "
         },
+        "strong-terminal-comma-policy": {
+          "description": "Policy for a strong terminal mark followed by a style-supplied comma.",
+          "$ref": "#/$defs/StrongTerminalCommaPolicy",
+          "default": "keep-both"
+        },
+        "delimiter-suppressing-terminal-marks": {
+          "description": "Terminal marks that suppress a following delimiter's punctuation core.",
+          "type": "string",
+          "default": "?!…"
+        },
         "note-punctuation": {
           "description": "Default placement of movable punctuation relative to closing\nquotation marks when a footnote marker is introduced. Overridable\nper-style via `options.notes.punctuation`.",
           "$ref": "#/$defs/NoteQuotePlacement",
@@ -613,6 +623,21 @@
           "default": "after"
         }
       }
+    },
+    "StrongTerminalCommaPolicy": {
+      "description": "Controls how a strong terminal mark collides with a following comma.",
+      "oneOf": [
+        {
+          "description": "Preserve both the terminal mark and the following comma.",
+          "type": "string",
+          "const": "keep-both"
+        },
+        {
+          "description": "Preserve the terminal mark and suppress the following comma.",
+          "type": "string",
+          "const": "keep-terminal"
+        }
+      ]
     },
     "NoteQuotePlacement": {
       "description": "Controls where movable punctuation is placed relative to closing quotation marks.",

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -2975,6 +2975,17 @@
           "description": "Whether to place periods/commas inside quotation marks.\ntrue = American style (\"text.\"), false = British style (\"text\".)\nDefaults to false; en-US locale typically sets this to true.",
           "type": "boolean"
         },
+        "punctuation": {
+          "description": "Locale-sensitive punctuation-collision overrides.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PunctuationConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "volume-pages-delimiter": {
           "description": "Delimiter between volume/issue and pages for serial sources.\nProcessor adds trailing space when rendering.\nExamples: Comma (APA \", \"), Colon (Chicago \": \").",
           "anyOf": [
@@ -5003,6 +5014,45 @@
           "description": "No labels",
           "type": "string",
           "const": "none"
+        }
+      ]
+    },
+    "PunctuationConfig": {
+      "description": "Style-level overrides for locale punctuation-collision defaults.",
+      "type": "object",
+      "properties": {
+        "strong-terminal-comma-policy": {
+          "description": "Policy for a strong terminal mark followed by a style-supplied comma.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StrongTerminalCommaPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "delimiter-suppressing-terminal-marks": {
+          "description": "Terminal marks that suppress a following delimiter's punctuation core.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "StrongTerminalCommaPolicy": {
+      "description": "Controls how a strong terminal mark collides with a following comma.",
+      "oneOf": [
+        {
+          "description": "Preserve both the terminal mark and the following comma.",
+          "type": "string",
+          "const": "keep-both"
+        },
+        {
+          "description": "Preserve the terminal mark and suppress the following comma.",
+          "type": "string",
+          "const": "keep-terminal"
         }
       ]
     },

--- a/docs/specs/LOCALE_MESSAGES.md
+++ b/docs/specs/LOCALE_MESSAGES.md
@@ -573,6 +573,8 @@ grammar-options:
   page-range-delimiter: "\u2013"
   title-subtitle-delimiter: ": "
   subtitle-delimiter:   "; "
+  strong-terminal-comma-policy: keep-both
+  delimiter-suppressing-terminal-marks: "?!…"
 
 legacy-term-aliases:
   page:          term.page-label
@@ -652,6 +654,8 @@ grammar-options:
   page-range-delimiter: "\u2013"
   title-subtitle-delimiter: ": "
   subtitle-delimiter:   "; "
+  strong-terminal-comma-policy: keep-both
+  delimiter-suppressing-terminal-marks: "?!…"
 ```
 
 The same message IDs (`term.page-label`, `role.editor.verb`) carry
@@ -669,6 +673,8 @@ language-specific realizations without any change to the style YAML.
 | `page-range-delimiter` | `string` | Default separator between page range endpoints. |
 | `title-subtitle-delimiter` | `string` | Default separator between a structured title's main title and subtitle group. |
 | `subtitle-delimiter` | `string` | Default separator between subtitle parts inside a structured title. |
+| `strong-terminal-comma-policy` | `keep-both \| keep-terminal` | Whether a comma is retained after `?`, `!`, or `…`. |
+| `delimiter-suppressing-terminal-marks` | `string` | Terminal marks that suppress a following delimiter's punctuation core. |
 
 ---
 
@@ -871,6 +877,8 @@ pub struct RawGrammarOptions {
     pub page_range_delimiter: Option<String>,
     pub title_subtitle_delimiter: Option<String>,
     pub subtitle_delimiter: Option<String>,
+    pub strong_terminal_comma_policy: Option<StrongTerminalCommaPolicy>,
+    pub delimiter_suppressing_terminal_marks: Option<String>,
 }
 ```
 

--- a/docs/specs/PUNCTUATION_NORMALIZATION.md
+++ b/docs/specs/PUNCTUATION_NORMALIZATION.md
@@ -1,9 +1,9 @@
 # Punctuation Normalization Design
 
-**Status:** Draft
+**Status:** Active
 **Date:** 2026-02-15
-**Updated:** 2026-07-12 (cross-locale research addendum + recommended design
-for the collision-resolution half of this problem; see Changelog)
+**Updated:** 2026-07-12 (locale-configurable collision policy activated; see
+Changelog)
 **Related:** CSL schema#379 (upstream, "Make punctuation collapsing
 localisable" — tracked as bucket-1-partial in
 [2026-07-12_CSL_SCHEMA_ISSUE_TRIAGE.md](../architecture/audits/2026-07-12_CSL_SCHEMA_ISSUE_TRIAGE.md));
@@ -196,38 +196,53 @@ above suggests the realistic cross-locale need is small and enumerable
 (a handful of class-pair policies plus one mark-set field), which is a much
 better fit for Citum's existing style.
 
-**Sketch — punctuation classes** (informed by UAX #14/#29 categories):
+**Punctuation classes** (informed by UAX #14/#29 categories):
 - `StrongTerminal`: `?`, `!`, `…`
 - `WeakTerminal`: `.`, `:`
 - `CommaLike`: `,`, `;`
 
-**Sketch — collision-policy fields** (new `grammar-options` entries,
-locale-default + style-overridable, alongside the existing quote-movement
-three-parameter model — these are complementary axes, not a replacement):
-- A weak-plus-weak collapse rule (`..` → `.`, `:.` → `:`) — likely fixed
-  behavior, not worth a field, since no researched locale disagrees.
-- A weak-plus-strong rule (keep the strong mark) — same, likely fixed.
-- `strong-plus-comma-policy: keep-both | keep-strong` — the schema#379 case.
-  English default `keep-both`; German/French default `keep-strong`.
-- A suppressing-mark set for delimiter suppression (not collision
-  resolution but the same underlying mechanism) — this is exactly
-  `csl26-zfqr`'s proposed field: when a structured-title main part's last
-  character is in this set, a following configured delimiter's punctuation
-  core is suppressed and only its whitespace tail is kept. Default `"?!…"`,
-  locale-overridable, per `csl26-zfqr`'s existing root-cause analysis
-  (`render_structured_title`, `crates/citum-engine/src/values/title.rs:255`;
-  `structured_title_delimiters`, `title.rs:330`).
+**Collision-policy fields** are locale defaults under `grammar-options` and
+may be overridden per style under `options.punctuation`:
+
+- `strong-terminal-comma-policy: keep-both | keep-terminal` controls only a
+  `StrongTerminal` followed by a style-supplied comma. English, Spanish,
+  Basque, and Turkish default to `keep-both`; German and French default to
+  `keep-terminal`.
+- `delimiter-suppressing-terminal-marks` is a string-set field with default
+  `"?!…"`. It is the single field reserved for `csl26-zfqr`: when a
+  structured-title part ends in one of these marks, that follow-up will drop
+  the punctuation core of the configured delimiter while preserving its
+  whitespace tail.
+
+All other punctuation pairs retain Citum's existing resolver matrix. This is
+an explicit compatibility decision: the first localized policy does not
+reinterpret weak/strong/comma-like combinations that existing styles and
+fidelity tests already expose. Broader class-matrix normalization requires
+separate evidence and a separate compatibility review.
+
+The style override has this shape:
+
+```yaml
+options:
+  punctuation:
+    strong-terminal-comma-policy: keep-terminal
+    delimiter-suppressing-terminal-marks: "?!…"
+```
+
+Locale defaults are resolved first and any non-null style field replaces the
+corresponding locale value.
+
+- A suppressing-mark set for delimiter suppression (not collision resolution
+  itself) is therefore shared with `csl26-zfqr`, rather than introducing a
+  second title-specific field.
 - French spacing (NBSP/narrow-NBSP before `: ; ! ?` and around guillemets,
   with a France/Québec variant) is a real, researched need but is scoped as
   a **follow-up**, not required for the schema#379/zfqr fix — track
   separately once the collision-policy fields above are settled, to avoid
   scope creep in the first implementation pass.
 
-This design intentionally leaves the exact field names and the full set of
-class-pair policies as an open implementation decision (tracked in the new
-bean below), not fixed here — the point of this section is the *shape*
-(narrow named fields, not a general table) and the reconciliation with
-`csl26-zfqr`'s already-designed need, not a final schema.
+The compatibility matrix and the two field names above are normative for this
+first implementation.
 
 ## Implementation Notes
 
@@ -270,15 +285,28 @@ However, refactoring current ad-hoc code into a clean function would prevent bug
 - `csln#66` - Multilingual/multiscript support (pre-rename issue tracker; historical reference only)
 - PR #51 (pre-rename) - Curly quote rendering (exposed fragility of current approach)
 
+## Acceptance Criteria
+
+- [x] Locale grammar options expose a strong-terminal/comma policy and one
+  shared delimiter-suppressing mark set.
+- [x] Styles can override either locale value independently.
+- [x] Citation and bibliography joins honor `keep-both` and `keep-terminal`
+  without changing established results for other punctuation pairs.
+- [x] German/French and English-compatible embedded locales declare their
+  intended defaults.
+- [x] French punctuation spacing remains explicitly out of scope.
+
 ## Changelog
 
+- **2026-07-12**: Activated the compatibility-first collision policy. Finalized
+  `strong-terminal-comma-policy`,
+  `delimiter-suppressing-terminal-marks`, direct style overrides, locale
+  defaults, and the fixed compatibility boundary for all other pairs.
 - **2026-07-12**: Added "Cross-Locale Prior Art" and "Recommended Design"
   sections covering the punctuation-*collision* half of this problem
   (distinct from the quote-*movement* model above), motivated by CSL
   schema#379 and reconciled with `csl26-zfqr`'s independently-designed need.
   Decision: narrow named `grammar-options` fields, not a general rewrite
-  table. Updated stale `csln#66`/PR #51 references. Status remains Draft —
-  no implementation in this change; see the new tracking bean for the next
-  step.
+  table. Updated stale `csln#66`/PR #51 references.
 - **2026-02-15**: Initial draft (quote-movement three-parameter model,
   migration path).


### PR DESCRIPTION
## Summary

- add locale-configurable strong-terminal/comma collision policy with
  compatibility-first schema defaults
- resolve direct style overrides before locale grammar options and schema
  defaults, then share the result across citation and bibliography joins
- preserve the existing punctuation collision matrix while making `!`, `?`,
  and `…` followed by comma configurable, including markup-aware cleanup
- activate the punctuation normalization spec, update locale authoring
  references, regenerate public schemas, and archive `csl26-0vo3`

## Validation

- `just pre-commit` — 1,912 tests passed; fmt and Clippy clean
- pre-push gate — alint, bean hygiene, fmt, Clippy, and 1,912 tests passed
- `just schema-gen`
- `python3 scripts/audit-rust-review-smells.py --changed` — clean
- targeted schema, processor, citation, bibliography, markup, and collision
  matrix tests — passed
- APA workflow comparison — matched the recorded baseline (20/20 citation,
  45/46 bibliography; the existing oracle mismatch is unchanged)

## Benchmark

Rendering stayed within noise or improved relative to the captured baseline:
APA citation -1.15% (no statistically significant change), bibliography 10
items -4.55%, 200 items +2.44% (not significant), and 400 items -3.72%.
Format serialization measurements were noisy across warm reruns and do not
exercise the changed render path.

## Risk and follow-ups

- English-compatible defaults retain both marks; German and French defaults
  retain the strong terminal mark. Other existing collision pairs are unchanged.
- `delimiter-suppressing-terminal-marks` is defined here as the shared field for
  `csl26-zfqr`; structured-title consumption remains in that bean.
- French NBSP/narrow-NBSP spacing remains explicitly out of scope.

implements https://github.com/citation-style-language/schema/issues/379
