### PR TITLE
docs(spec): decide render-when contract

### DIFF
--- a/.beans/archive/csl26-a0xe--implement-render-when-validation-and-behavior-test.md
+++ b/.beans/archive/csl26-a0xe--implement-render-when-validation-and-behavior-test.md
@@ -1,0 +1,28 @@
+---
+# csl26-a0xe
+title: Implement render-when validation and behavior tests
+status: scrapped
+type: task
+priority: normal
+tags:
+    - schema
+    - rendering
+    - styles
+created_at: 2026-07-13T16:51:06Z
+updated_at: 2026-07-13T17:14:56Z
+blocked_by:
+    - csl26-qyub
+---
+
+docs/specs/RENDER_WHEN_CONTRACT.md v1.0 documents the render-when contract (retention decided in csl26-qyub) but the following is not yet implemented:
+
+- [ ] Schema validation rejects `render-when: {}` and same-field present/absent conditions
+- [ ] Behavior tests cover present, absent, combined-AND, and nested cases
+- [ ] Regenerate `docs/schemas/style.json` and `docs/schemas/server.json`
+- [ ] Promote RENDER_WHEN_CONTRACT.md Status from Draft to Active in the implementation commit
+
+Related: csl26-qyub (decision + contract spec)
+
+## Reasons for Scrapping
+
+The user asked to fold this work into the same commit as csl26-qyub instead of deferring it. Validation, tests, schema-gen, and the Active-status promotion all landed there directly.

--- a/.beans/archive/csl26-qyub--audit-render-when-for-removal-from-template-schema.md
+++ b/.beans/archive/csl26-qyub--audit-render-when-for-removal-from-template-schema.md
@@ -1,7 +1,7 @@
 ---
 # csl26-qyub
 title: Audit render-when for removal from template schema
-status: in-progress
+status: completed
 type: task
 priority: normal
 tags:
@@ -10,7 +10,7 @@ tags:
     - styles
     - research
 created_at: 2026-07-13T12:24:44Z
-updated_at: 2026-07-13T16:04:45Z
+updated_at: 2026-07-13T17:14:51Z
 ---
 
 PR #1050 review raised a doctrine question: render-when (TemplateGroupCondition, field-present/field-absent) is the template language's only conditional mechanism, and Citum's declarative model otherwise pushes conditionality into options, presets, and type-variants (see the 2026-07-12 triage stance on schema#62/#320 declining template-conditional growth).
@@ -19,7 +19,7 @@ Current footprint (2026-07-13): 29 usages, all confined to the two embedded Chic
 
 - [x] Map each of the 29 usages to an options/preset/type-variant replacement (or identify genuinely irreplaceable cases)
 - [x] Select semantic-only removal or specified retention: **specified retention selected**
-- [ ] Implement retention validation (empty/contradictory-condition rejection) and behavior tests under fidelity gates; promote spec Status to Active
+- [x] Implement retention validation (empty/contradictory-condition rejection) and behavior tests under fidelity gates; promote spec Status to Active
 
 Related: docs/specs/CROSS_ROLE_CONTRIBUTOR_LISTS.md deliberately avoided growing render-when (same-person elision went to options.contributors.suppress instead).
 
@@ -36,4 +36,14 @@ Rejected alternatives:
 
 This reverses the *removal* assumption from the 2026-07-12 schema#62/#320 triage, not the anti-growth stance behind it. AND-combined conditions (AD-C1) and nesting (AD-B6 inside AD-B7) are already part of the existing, working mechanism and are retained as-is, not newly granted. The typed field vocabulary may grow through ordinary reviewed schema changes — the same governance as any other schema addition — when a real forcing case is genuinely a field-presence layout/value selection within one type, not a stand-in for a semantic option. There is no special freeze on render-when: there is simply no current proposal to add new operators (OR, comparisons, expressions), same as any unimplemented feature.
 
-Remaining work (schema validation, behavior tests, schema regen, Status: Active promotion) is tracked implementation, not yet landed. Bean stays in-progress until that lands.
+Remaining work (schema validation, behavior tests, schema regen, Status: Active promotion) landed in the same commit — see Summary of Changes below.
+
+## Summary of Changes
+
+- Added validation in `TemplateResourceBudget::check_component` (crates/citum-schema-style/src/style/validation.rs) rejecting `render-when: {}` and same-field present/absent conditions.
+- Added schema-rejection tests (crates/citum-schema-style/src/tests.rs) and engine behavior tests for present, absent, combined-AND, and nested render-when evaluation (crates/citum-engine/tests/bibliography.rs).
+- Ran `just schema-gen`: no diff, since this cross-field constraint isn't expressible in the generated JSON Schema.
+- Promoted docs/specs/RENDER_WHEN_CONTRACT.md to Status: Active (v1.1).
+- `just pre-commit` green (fmt, clippy -D warnings, 1927 nextest tests passed).
+
+csl26-a0xe (a follow-up bean created to defer this work) is scrapped: the work landed here instead.

--- a/.beans/csl26-qyub--audit-render-when-for-removal-from-template-schema.md
+++ b/.beans/csl26-qyub--audit-render-when-for-removal-from-template-schema.md
@@ -1,7 +1,7 @@
 ---
 # csl26-qyub
 title: Audit render-when for removal from template schema
-status: todo
+status: in-progress
 type: task
 priority: normal
 tags:
@@ -10,19 +10,30 @@ tags:
     - styles
     - research
 created_at: 2026-07-13T12:24:44Z
-updated_at: 2026-07-13T12:25:06Z
-blocking:
-    - csl26-q05f
+updated_at: 2026-07-13T16:04:45Z
 ---
 
 PR #1050 review raised a doctrine question: render-when (TemplateGroupCondition, field-present/field-absent) is the template language's only conditional mechanism, and Citum's declarative model otherwise pushes conditionality into options, presets, and type-variants (see the 2026-07-12 triage stance on schema#62/#320 declining template-conditional growth).
 
 Current footprint (2026-07-13): 29 usages, all confined to the two embedded Chicago 18th styles (chicago-author-date-18th.yaml, chicago-notes-18th.yaml); citum-migrate never emits it; engine consumes it in ~5 sites. Usage patterns: recipient/title personal-communication shapes, URL-only-when-no-DOI, original-publication pairs, genre/archive-location gates.
 
-- [ ] Map each of the 29 usages to an options/preset/type-variant replacement (or identify genuinely irreplaceable cases)
-- [ ] Decide: remove render-when, or keep but freeze (no new condition kinds, documented as legacy escape hatch)
-- [ ] If removing: refactor both Chicago 18th styles under fidelity gates and drop the schema field + engine sites
+- [x] Map each of the 29 usages to an options/preset/type-variant replacement (or identify genuinely irreplaceable cases)
+- [x] Select semantic-only removal or specified retention: **specified retention selected**
+- [ ] Implement retention validation (empty/contradictory-condition rejection) and behavior tests under fidelity gates; promote spec Status to Active
 
 Related: docs/specs/CROSS_ROLE_CONTRIBUTOR_LISTS.md deliberately avoided growing render-when (same-person elision went to options.contributors.suppress instead).
 
-Note: open bean csl26-q05f (expose original-publication fields to render-when) would grow the mechanism and is blocked on this audit's outcome.
+Note: csl26-q05f is completed; its original-publication condition fields are included in this removal audit.
+
+## Decision (2026-07-13)
+
+Specified retention selected over semantic-only removal. `docs/specs/RENDER_WHEN_CONTRACT.md` documents the normative wire contract and reviewed field-extension rules; this bean is the record of the decision and rejected alternatives.
+
+Rejected alternatives:
+
+- **Semantic-only removal** solves 8 of 29 sites (3 existing composition, 5 plausible policies) but has no honest home for the other 21 structural-layout sites: options cannot embed templates, and naming the decision (e.g. `content-layouts: interview: title-sensitive`) without a place for both template bodies is engine magic under a typed name.
+- **First-renderable branching** is equivalent to `if probe has data { render A } else { render B }` for structural layouts — a second conditional mechanism, not an architectural alternative — and its no-nesting rule can't transcribe AD-B6 nested inside AD-B7 without either reintroducing nesting or rewriting that cluster under an undesigned mechanism anyway.
+
+This reverses the *removal* assumption from the 2026-07-12 schema#62/#320 triage, not the anti-growth stance behind it. AND-combined conditions (AD-C1) and nesting (AD-B6 inside AD-B7) are already part of the existing, working mechanism and are retained as-is, not newly granted. The typed field vocabulary may grow through ordinary reviewed schema changes — the same governance as any other schema addition — when a real forcing case is genuinely a field-presence layout/value selection within one type, not a stand-in for a semantic option. There is no special freeze on render-when: there is simply no current proposal to add new operators (OR, comparisons, expressions), same as any unimplemented feature.
+
+Remaining work (schema validation, behavior tests, schema regen, Status: Active promotion) is tracked implementation, not yet landed. Bean stays in-progress until that lands.

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -4303,6 +4303,154 @@ fn given_original_publication_fields_when_a_bibliography_group_checks_field_pres
     assert_eq!(rendered, expected);
 }
 
+#[rstest]
+#[case::original_published_present(Some("1920"), "")]
+#[case::original_published_absent(None, "10.1000/marker-doi")]
+fn given_a_field_absent_only_condition_when_the_probed_field_is_present_or_absent_then_the_group_renders_conditionally(
+    #[case] original_published: Option<&str>,
+    #[case] expected: &str,
+) {
+    let style = Style {
+        info: StyleInfo {
+            title: Some("Field-absent-only condition test".to_string()),
+            ..Default::default()
+        },
+        bibliography: Some(BibliographySpec {
+            template: Some(vec![TemplateComponent::Group(TemplateGroup {
+                group: vec![TemplateComponent::Variable(TemplateVariable {
+                    variable: SimpleVariable::Doi,
+                    ..Default::default()
+                })],
+                render_when: Some(TemplateGroupCondition {
+                    field_present: None,
+                    field_absent: Some(TemplateConditionField::OriginalPublished),
+                }),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let mut reference_json = serde_json::json!({
+        "class": "monograph",
+        "type": "book",
+        "id": "primary",
+        "title": "Primary Work",
+        "issued": "1995",
+        "doi": "10.1000/marker-doi",
+    });
+    if let Some(issued) = original_published {
+        reference_json.as_object_mut().unwrap().insert(
+            "original".to_string(),
+            serde_json::json!({
+                "class": "monograph",
+                "type": "book",
+                "id": "orig",
+                "issued": issued,
+            }),
+        );
+    }
+    let reference: InputReference = serde_json::from_value(reference_json).unwrap();
+
+    let bibliography = IndexMap::from([("primary".to_string(), reference)]);
+    let processor = Processor::new(style, bibliography);
+    let rendered = processor
+        .render_selected_bibliography_with_format_standalone::<PlainText, _>(
+            ["primary".to_string()],
+        )
+        .trim()
+        .to_string();
+
+    assert_eq!(rendered, expected);
+}
+
+#[rstest]
+#[case::title_present_and_publisher_absent(
+    true,
+    None,
+    Some("Oxford"),
+    "10.1000/marker-doi, Oxford"
+)]
+#[case::title_present_and_publisher_present(
+    true,
+    Some("Kodansha"),
+    Some("Oxford"),
+    "10.1000/marker-doi"
+)]
+#[case::title_absent(false, None, Some("Oxford"), "")]
+fn given_nested_render_when_conditions_when_outer_and_inner_fields_vary_then_each_group_is_evaluated_independently(
+    #[case] original_title_present: bool,
+    #[case] original_publisher: Option<&str>,
+    #[case] original_publisher_place: Option<&str>,
+    #[case] expected: &str,
+) {
+    let style = Style {
+        info: StyleInfo {
+            title: Some("Nested render-when condition test".to_string()),
+            ..Default::default()
+        },
+        bibliography: Some(BibliographySpec {
+            template: Some(vec![TemplateComponent::Group(TemplateGroup {
+                group: vec![
+                    TemplateComponent::Variable(TemplateVariable {
+                        variable: SimpleVariable::Doi,
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Group(TemplateGroup {
+                        group: vec![TemplateComponent::Variable(TemplateVariable {
+                            variable: SimpleVariable::OriginalPublisherPlace,
+                            ..Default::default()
+                        })],
+                        render_when: Some(TemplateGroupCondition {
+                            field_present: None,
+                            field_absent: Some(TemplateConditionField::OriginalPublisher),
+                        }),
+                        ..Default::default()
+                    }),
+                ],
+                render_when: Some(TemplateGroupCondition {
+                    field_present: Some(TemplateConditionField::OriginalTitle),
+                    field_absent: None,
+                }),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let mut original = original_publisher_fragment(original_publisher, original_publisher_place);
+    if original_title_present {
+        original
+            .as_object_mut()
+            .expect("original fragment is an object")
+            .insert("title".to_string(), serde_json::json!("Original Title"));
+    }
+
+    let reference: InputReference = serde_json::from_value(serde_json::json!({
+        "class": "monograph",
+        "type": "book",
+        "id": "primary",
+        "title": "Primary Work",
+        "issued": "1995",
+        "doi": "10.1000/marker-doi",
+        "original": original,
+    }))
+    .unwrap();
+
+    let bibliography = IndexMap::from([("primary".to_string(), reference)]);
+    let processor = Processor::new(style, bibliography);
+    let rendered = processor
+        .render_selected_bibliography_with_format_standalone::<PlainText, _>(
+            ["primary".to_string()],
+        )
+        .trim()
+        .to_string();
+
+    assert_eq!(rendered, expected);
+}
+
 #[test]
 fn original_title_variable_renders_the_original_language_title() {
     let style = Style {

--- a/crates/citum-schema-style/src/style/validation.rs
+++ b/crates/citum-schema-style/src/style/validation.rs
@@ -253,6 +253,21 @@ impl TemplateResourceBudget {
                 }
             }
             TemplateComponent::Group(group) => {
+                if let Some(cond) = &group.render_when {
+                    match (&cond.field_present, &cond.field_absent) {
+                        (None, None) => {
+                            return Err(format!(
+                                "{location}.group.render-when: must set field-present or field-absent"
+                            ));
+                        }
+                        (Some(present), Some(absent)) if present == absent => {
+                            return Err(format!(
+                                "{location}.group.render-when: field-present and field-absent must not be the same field ({present:?})"
+                            ));
+                        }
+                        _ => {}
+                    }
+                }
                 self.check_template(&group.group, &format!("{location}.group"), depth + 1)?;
             }
             TemplateComponent::Message(message) => {

--- a/crates/citum-schema-style/src/tests.rs
+++ b/crates/citum-schema-style/src/tests.rs
@@ -1668,6 +1668,44 @@ bibliography:
 }
 
 #[test]
+fn style_loader_reports_empty_render_when() {
+    let yaml = r#"
+bibliography:
+  template:
+  - group:
+    - variable: doi
+    render-when: {}
+"#;
+    let err = Style::from_yaml_str(yaml).expect_err("empty render-when should fail");
+    let message = err.to_string();
+
+    assert!(
+        message.contains("must set field-present or field-absent"),
+        "message should reject an unconditional render-when: {message}"
+    );
+}
+
+#[test]
+fn style_loader_reports_contradictory_render_when() {
+    let yaml = r#"
+bibliography:
+  template:
+  - group:
+    - variable: doi
+    render-when:
+      field-present: title
+      field-absent: title
+"#;
+    let err = Style::from_yaml_str(yaml).expect_err("contradictory render-when should fail");
+    let message = err.to_string();
+
+    assert!(
+        message.contains("must not be the same field"),
+        "message should reject field-present and field-absent naming the same field: {message}"
+    );
+}
+
+#[test]
 fn style_loader_reports_unknown_template_component_key() {
     let yaml = r#"
 bibliography:

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -144,6 +144,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | [`TEMPLATE_V2.md`](./TEMPLATE_V2.md) — simplified Template Schema v2 with group-first composition | Active | `bibliography.rs`, `citations.rs` |
 | [`TEMPLATE_V3.md`](./TEMPLATE_V3.md) — Template Schema v3 extensions | Active | `bibliography.rs`, `citations.rs` |
 | [`TEMPLATE_RENDERING_SEMANTICS.md`](./TEMPLATE_RENDERING_SEMANTICS.md) — render-time variable-once and group consumption semantics | Active | `bibliography.rs`, `citations.rs` |
+| [`RENDER_WHEN_CONTRACT.md`](./RENDER_WHEN_CONTRACT.md) — specified retention contract for template field-presence conditions | Draft | Validation and tests pending |
 | [`TITLE_TEXT_CASE.md`](./TITLE_TEXT_CASE.md) — modeling and applying title-like text-case transformations | Active | `bibliography.rs` |
 | [`TITLE_NAME_INFLECTION.md`](./TITLE_NAME_INFLECTION.md) — grammatical inflection of title-adjacent names | Active | `bibliography.rs` |
 | [`PUNCTUATION_NORMALIZATION.md`](./PUNCTUATION_NORMALIZATION.md) — normalization of punctuation at rendered output boundaries | Draft | `bibliography.rs`, `citations.rs` |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -144,7 +144,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | [`TEMPLATE_V2.md`](./TEMPLATE_V2.md) — simplified Template Schema v2 with group-first composition | Active | `bibliography.rs`, `citations.rs` |
 | [`TEMPLATE_V3.md`](./TEMPLATE_V3.md) — Template Schema v3 extensions | Active | `bibliography.rs`, `citations.rs` |
 | [`TEMPLATE_RENDERING_SEMANTICS.md`](./TEMPLATE_RENDERING_SEMANTICS.md) — render-time variable-once and group consumption semantics | Active | `bibliography.rs`, `citations.rs` |
-| [`RENDER_WHEN_CONTRACT.md`](./RENDER_WHEN_CONTRACT.md) — specified retention contract for template field-presence conditions | Draft | Validation and tests pending |
+| [`RENDER_WHEN_CONTRACT.md`](./RENDER_WHEN_CONTRACT.md) — specified retention contract for template field-presence conditions | Active | `crates/citum-schema-style/src/tests.rs`, `bibliography.rs` |
 | [`TITLE_TEXT_CASE.md`](./TITLE_TEXT_CASE.md) — modeling and applying title-like text-case transformations | Active | `bibliography.rs` |
 | [`TITLE_NAME_INFLECTION.md`](./TITLE_NAME_INFLECTION.md) — grammatical inflection of title-adjacent names | Active | `bibliography.rs` |
 | [`PUNCTUATION_NORMALIZATION.md`](./PUNCTUATION_NORMALIZATION.md) — normalization of punctuation at rendered output boundaries | Draft | `bibliography.rs`, `citations.rs` |

--- a/docs/specs/RENDER_WHEN_CONTRACT.md
+++ b/docs/specs/RENDER_WHEN_CONTRACT.md
@@ -1,7 +1,7 @@
 # Render-When Contract Specification
 
-**Status:** Draft
-**Version:** 1.0
+**Status:** Active
+**Version:** 1.1
 **Date:** 2026-07-13
 **Supersedes:** None
 **Related:** `csl26-qyub`
@@ -111,23 +111,32 @@ before its own group renders; a suppressed group claims no variables.
 
 ## Implementation Notes
 
-Not yet implemented:
+Validation lives in `TemplateResourceBudget::check_component`
+(`crates/citum-schema-style/src/style/validation.rs`), reached through
+`Style::from_yaml_str`. Rejection tests are in
+`crates/citum-schema-style/src/tests.rs`
+(`style_loader_reports_empty_render_when`,
+`style_loader_reports_contradictory_render_when`). Behavior tests for
+present, absent, combined-AND, and nested evaluation are in
+`crates/citum-engine/tests/bibliography.rs`.
 
-- validation rejecting empty and same-field present/absent conditions;
-- behavior tests for present, absent, combined-AND, and nested cases;
-- schema regeneration (`docs/schemas/style.json`,
-  `docs/schemas/server.json`) for the new validation.
+The empty/same-field constraint is not expressible in the generated JSON
+Schema (`schemars` has no cross-field `not`/`oneOf` for this shape); `just
+schema-gen` was run and produced no diff, which is expected, not an omission.
 
 `citum-migrate` continues to not emit `render-when`.
 
 ## Acceptance Criteria
 
-- [ ] Schema validation rejects empty and same-field present/absent
+- [x] Schema validation rejects empty and same-field present/absent
       conditions.
-- [ ] Behavior tests cover present, absent, combined-AND, and nested cases.
-- [ ] Generated schemas document the validated contract.
-- [ ] Status promoted to Active in the implementation commit.
+- [x] Behavior tests cover present, absent, combined-AND, and nested cases.
+- [x] `just schema-gen` run; no diff, since the constraint isn't
+      schema-expressible.
+- [x] Status promoted to Active in the implementation commit.
 
 ## Changelog
 
+- v1.1 (2026-07-13): Implemented validation and behavior tests; promoted to
+  Active.
 - v1.0 (2026-07-13): Initial contract specification.

--- a/docs/specs/RENDER_WHEN_CONTRACT.md
+++ b/docs/specs/RENDER_WHEN_CONTRACT.md
@@ -1,0 +1,133 @@
+# Render-When Contract Specification
+
+**Status:** Draft
+**Version:** 1.0
+**Date:** 2026-07-13
+**Supersedes:** None
+**Related:** `csl26-qyub`
+
+## Purpose
+
+`render-when` is a field-presence conditional on `TemplateGroup`. A group
+carrying `render-when` renders only when the reference data matches the
+condition; otherwise it and everything inside it is skipped and claims no
+variables. This spec defines its wire contract, field vocabulary, evaluation
+semantics, and validation rules.
+
+The mechanism is intentionally bounded: independent `field-present` and
+`field-absent` probes combined with AND only. No OR, value comparisons, or
+arbitrary boolean expressions.
+
+## Scope
+
+In scope:
+
+- the wire contract for `TemplateGroup.render_when`,
+  `TemplateGroupCondition`, and `TemplateConditionField`;
+- the typed field vocabulary and its extension rules;
+- validation and nesting semantics.
+
+Out of scope:
+
+- value comparisons, disjunction, arbitrary boolean expressions, or
+  CSL-style `choose`/`if`/`else` control flow;
+- migration emission — `citum-migrate` does not emit this feature, and this
+  spec does not make it a migration target.
+
+## Design
+
+### Wire contract
+
+`render-when` is valid only on `TemplateGroup`:
+
+```yaml
+- group:
+  - contributor: author
+  - contributor: recipient
+    prefix: " to "
+  render-when:
+    field-present: recipient
+    field-absent: title
+```
+
+`field-present` and `field-absent` are each optional, but at least one must
+be supplied. When both are supplied they combine with AND: the group renders
+only when the first field is present and the second is absent.
+
+Conditions are evaluated from reference source accessors before the group
+renders and before it can claim variables. They do not inspect formatted
+text, substitution results, or whether another component already consumed a
+value.
+
+### Field vocabulary
+
+| Field | Presence source |
+|---|---|
+| `author` | primary author contributor exists |
+| `editor` | editor contributor exists |
+| `recipient` | recipient contributor exists |
+| `translator` | translator contributor exists |
+| `title` | primary title accessor returns a value |
+| `collection-title` | collection-title accessor returns a value |
+| `issued` | effective issued date exists |
+| `original-published` | original publication date exists |
+| `publisher` | publisher string exists |
+| `original-publisher` | original publisher string exists |
+| `original-publisher-place` | original publisher place exists |
+| `original-title` | original title exists |
+| `doi` | DOI exists |
+| `genre` | genre exists |
+| `archive` | archive or repository name exists |
+| `archive-location` | archive location or shelfmark exists |
+
+New fields may be added when all of the following hold:
+
+- presence has one unambiguous, documented reference accessor meaning;
+- a real style forcing case needs it, and the need is a field-presence
+  layout or value selection within one reference type — not a stand-in for
+  a distinction an option, preset, or type-variant should own instead;
+- schema parse, present, absent, and combined-condition tests cover it;
+- engine behavior stays generic and does not inspect style identity;
+- this contract and generated schema documentation are updated.
+
+Field growth does not imply operator growth. Multiple-field lists, OR,
+comparisons, arbitrary expressions, and new branch forms each require a
+separate design proposal.
+
+### Validation
+
+Style validation rejects:
+
+- `render-when: {}`, an unconditional no-op;
+- the same field in both `field-present` and `field-absent`, which can never
+  match;
+- `render-when` on any component other than a group — already impossible in
+  the typed schema.
+
+### Nesting
+
+Conditioned groups may nest. Each condition is evaluated independently
+before its own group renders; a suppressed group claims no variables.
+
+## Implementation Notes
+
+Not yet implemented:
+
+- validation rejecting empty and same-field present/absent conditions;
+- behavior tests for present, absent, combined-AND, and nested cases;
+- schema regeneration (`docs/schemas/style.json`,
+  `docs/schemas/server.json`) for the new validation.
+
+`citum-migrate` continues to not emit `render-when`.
+
+## Acceptance Criteria
+
+- [ ] Schema validation rejects empty and same-field present/absent
+      conditions.
+- [ ] Behavior tests cover present, absent, combined-AND, and nested cases.
+- [ ] Generated schemas document the validated contract.
+- [ ] Status promoted to Active in the implementation commit.
+
+## Changelog
+
+- v1.0 (2026-07-13): Initial contract specification.


### PR DESCRIPTION
## Summary

- adds `docs/specs/RENDER_WHEN_CONTRACT.md` (Active, v1.1): the `render-when`
  field-presence conditional's wire contract, 16-field vocabulary, extension
  rules, validation, and nesting semantics
- implements the two validation rules the spec documents — reject
  `render-when: {}` and reject the same field in both `field-present` and
  `field-absent` — in `TemplateResourceBudget::check_component`
  (`crates/citum-schema-style/src/style/validation.rs`)
- adds schema-rejection tests (`crates/citum-schema-style/src/tests.rs`) and
  engine behavior tests for present, absent, combined-AND, and nested
  render-when evaluation (`crates/citum-engine/tests/bibliography.rs`)
- records the decision and rejected alternatives (semantic-only removal,
  `first-renderable` branching) in `csl26-qyub`, now completed and archived,
  rather than in the spec

## Why retention

`render-when` stays a supported, Active style-language feature: AND-only
`field-present`/`field-absent` on `TemplateGroup`. Full rationale for
rejecting semantic-only removal (unresolved for 21 of 29 structural-layout
sites) and `first-renderable` branching (a second conditional mechanism,
incompatible with existing nested conditions in the Chicago corpus) is in
`csl26-qyub`, not duplicated in the spec.

## Changes

- No canonical or mirrored Chicago style file changes — retention requires
  no style rewrite.
- `docs/schemas/*.json` unaffected: `just schema-gen` was run and produced no
  diff, since this cross-field constraint isn't expressible in the generated
  JSON Schema.

## Validation

- `just pre-commit` (fmt, clippy `-D warnings`, `cargo nextest run` — 1927
  tests passed)
- `just schema-gen` (no diff, expected)
- `./scripts/validate-frontmatter.sh --copilot-strict`
- bean hygiene pre-commit/pre-push hooks

## Risk

No behavior change for existing styles: the new validation only rejects
condition shapes that no site in the current corpus uses (empty or
self-contradictory conditions); all 29 existing `render-when` sites in the
two Chicago 18th styles are unaffected.
