### PR TITLE
Cross-Role Contributor Lists

### DIFF
--- a/.beans/archive/csl26-78ds--engine-cache-effective-primary-resolution-on-sortd.md
+++ b/.beans/archive/csl26-78ds--engine-cache-effective-primary-resolution-on-sortd.md
@@ -1,0 +1,18 @@
+---
+# csl26-78ds
+title: 'engine: cache effective-primary resolution on sort/disambiguation paths'
+status: completed
+type: task
+priority: normal
+tags:
+    - engine
+    - performance
+created_at: 2026-07-15T10:10:08Z
+updated_at: 2026-07-15T15:19:42Z
+---
+
+From PR #1052 review. extract_author_sort_key_opt re-runs effective_primary/semantic_names (+ fresh Config::default()) per pairwise comparison inside sort_by comparators (disambiguation.rs:777, setup.rs:625); effective_primary_names computes semantic_names twice (emptiness probe discards result); per-entry clones: TemplateContributor clone per run in resolve_entry_label, ContributorMerge HashMap clone per effective_merge call, roles.to_vec() per name in append_contributor. CachedReference/cache_sort_value machinery exists for exactly this. Benchmarks currently fine — latent cost on large bibliographies with list primaries.
+
+## Summary of Changes
+
+Single-pass effective-primary resolution (EffectivePrimaryResolution carries names; effective_primary/effective_primary_names are thin wrappers — no double semantic_names). Generic ReferenceSorter::sort_by_keys precomputes per-item sort keys (Schwartzian transform, shared compare_cached_values) replacing per-comparison compare_by_key at disambiguation year-suffix sort and setup citation-item sort. ContributorConfig::effective_merge and merged.rs effective_merge return Cow, cloning only for the default. Skipped by design: Rc role slices, per-entry component clone shaving. Criterion vs pre-change baseline: citation processing −14%, bibliography benches −27% to −47%. Folded into PR #1052 feat commit.

--- a/.beans/archive/csl26-7ip9--cross-role-names-collapse-mechanism.md
+++ b/.beans/archive/csl26-7ip9--cross-role-names-collapse-mechanism.md
@@ -1,7 +1,7 @@
 ---
 # csl26-7ip9
 title: Cross-role names-collapse mechanism
-status: in-progress
+status: completed
 type: task
 priority: low
 tags:
@@ -9,7 +9,7 @@ tags:
     - rendering
     - contributors
 created_at: 2026-07-12T18:16:09Z
-updated_at: 2026-07-13T11:44:58Z
+updated_at: 2026-07-13T19:50:41Z
 parent: csl26-kcda
 ---
 
@@ -20,5 +20,11 @@ items with distinct writer/director credits).
 
 - [x] Design a cross-role names-collapse option, distinct from the
       existing citation-number CitationCollapse variant —
-      docs/specs/CROSS_ROLE_CONTRIBUTOR_LISTS.md (Draft)
-- [ ] Implement the merged contributor list mechanism per the spec
+      docs/specs/CROSS_ROLE_CONTRIBUTOR_LISTS.md (Active v1.0)
+- [x] Implement the merged contributor list mechanism per the spec
+
+Completed cross-role contributor lists across native reference/schema models,
+locale terms, rendering, suppression, sorting/disambiguation, CSL migration,
+fixtures, generated schemas, and APA behavior. Native Citum data explicitly
+records multi-role identity; strict NFC name comparison is confined to legacy
+CSL-JSON conversion. Validation evidence is recorded in PR #1052.

--- a/.beans/archive/csl26-nnkf--review-pr-1052-cross-role-contributor-lists.md
+++ b/.beans/archive/csl26-nnkf--review-pr-1052-cross-role-contributor-lists.md
@@ -1,0 +1,31 @@
+---
+# csl26-nnkf
+title: 'Review PR #1052: cross-role contributor lists'
+status: completed
+type: task
+priority: high
+tags:
+    - review
+    - contributors
+created_at: 2026-07-14T21:13:37Z
+updated_at: 2026-07-15T11:22:27Z
+---
+
+Careful multi-pass review of PR #1052 (specs, schema, engine, migration/tests, mechanical+hygiene) per plan this-pr-got-away-snug-kay.md. Findings report in chat for triage.
+
+- [x] Pass 1: specs vs APA sources
+- [x] Pass 2: schema surface
+- [x] Pass 3: engine semantics
+- [x] Pass 4: migration/tests/fixtures
+- [x] Pass 5: /code-review supplement + verification + hygiene
+- [x] Findings report delivered
+
+Interim: pre-commit gate green (1971/1971), schema-gen no drift, oracle 20/20 + 45/46 (single pre-existing standard-ref failure; PR counts stale). Key manual findings: matching.rs not on effective_primary resolver; migrate drops translator label for split editor/translator; invented locale abbreviations (wrtr.) need content sign-off.
+
+## Summary of Changes
+
+Review-only (no code changes). Delivered 19-finding report in chat: 7 confirmed correctness findings (merged-list role-substitute suppression missing vs spec; Matcher fork off effective_primary; role_omitted bypass in structural label paths x2; empty-names substitute kills fallback chain + disambiguation key; sort/render divergence on empty merged component; migrate drops translator label for split editor/translator; 3 scalar-assumption stragglers), 1 locale-content decision (invented writer abbreviations), spec/doc gaps, efficiency bean candidates (uncached primary resolution in sort comparators), cleanup bundle. Gate green 1971/1971; schema-gen clean; oracle 20/20+45/46 (pre-existing standard-ref failure; PR counts stale). Awaiting Bruce's triage.
+
+## Fix wave (2026-07-15)
+
+Bruce triaged: polish PR maximally. All 7 correctness findings + spec gaps + locale content fixed in-PR via two Sonnet batches plus manual Matcher config fix (effective config, field rename). Deferred: csl26-78ds (efficiency), csl26-tsmg (cleanup). Gate 1986/1986 green, schema-gen no drift, oracle 20/20 + 45/46 unchanged. Fixes squashed into feat commit via jj; PR body refreshed; pushed with lease (CONFIRM given).

--- a/.beans/csl26-h6b9--distinguish-classical-and-modern-recording-authors.md
+++ b/.beans/csl26-h6b9--distinguish-classical-and-modern-recording-authors.md
@@ -1,0 +1,23 @@
+---
+# csl26-h6b9
+title: Distinguish classical and modern recording authorship
+status: todo
+type: feature
+priority: low
+tags:
+    - schema
+    - contributors
+created_at: 2026-07-14T16:01:17Z
+updated_at: 2026-07-14T16:01:17Z
+parent: csl26-kcda
+---
+
+Follow-up from PR #1052 and the APA audio-work evidence reviewed there.
+Related: csl26-013w.
+
+- [ ] Represent the classical-versus-modern recording distinction in native
+      reference data without relying on title or genre heuristics.
+- [ ] Select composer or recording artist for the primary slot according to
+      that distinction.
+- [ ] Specify and implement recorded-by rendering and identical-credit elision.
+- [ ] Add exact conversion, citation, bibliography, and suppression tests.

--- a/.beans/csl26-hyc4--model-audiovisual-contributor-subroles-and-apa-pri.md
+++ b/.beans/csl26-hyc4--model-audiovisual-contributor-subroles-and-apa-pri.md
@@ -1,0 +1,24 @@
+---
+# csl26-hyc4
+title: Model audiovisual contributor subroles and APA primary mappings
+status: todo
+type: feature
+priority: low
+tags:
+    - schema
+    - contributors
+created_at: 2026-07-14T16:01:16Z
+updated_at: 2026-07-14T16:01:16Z
+parent: csl26-kcda
+---
+
+Follow-up from PR #1052 and the APA audiovisual evidence reviewed there.
+Related: csl26-013w.
+
+- [ ] Add distinct native roles needed for executive producer, host, instructor,
+      uploader, artist, and photographer credits without collapsing them into
+      broader roles.
+- [ ] Define locale terms and style-schema mappings for the new roles.
+- [ ] Define APA primary-slot substitutions for each representable audiovisual
+      reference type.
+- [ ] Add exact schema, conversion, rendering, citation, and bibliography tests.

--- a/.beans/csl26-ijvf--design-style-level-secondary-contributor-membershi.md
+++ b/.beans/csl26-ijvf--design-style-level-secondary-contributor-membershi.md
@@ -1,0 +1,24 @@
+---
+# csl26-ijvf
+title: Design style-level secondary contributor membership
+status: todo
+type: feature
+priority: low
+tags:
+    - schema
+    - contributors
+created_at: 2026-07-14T16:01:18Z
+updated_at: 2026-07-14T16:01:18Z
+parent: csl26-kcda
+---
+
+Follow-up from PR #1052 for contributor placement outside templates.
+Related: csl26-013w.
+
+- [ ] Specify a style-level secondary contributor block with explicit include
+      or omit semantics.
+- [ ] Define ordering, duplicate-role handling, and interaction with primary
+      substitution and role suppression.
+- [ ] Define migration behavior for CSL names components that occupy the
+      secondary block.
+- [ ] Add compatibility, schema-validation, and rendering acceptance tests.

--- a/.beans/csl26-tsmg--schemaengine-consolidate-duplicated-role-list-vali.md
+++ b/.beans/csl26-tsmg--schemaengine-consolidate-duplicated-role-list-vali.md
@@ -1,0 +1,14 @@
+---
+# csl26-tsmg
+title: 'schema/engine: consolidate duplicated role-list validation and label-presentation types'
+status: todo
+type: task
+priority: low
+tags:
+    - cleanup
+    - contributors
+created_at: 2026-07-15T10:10:08Z
+updated_at: 2026-07-15T10:10:08Z
+---
+
+From PR #1052 review. (a) distinct-role validation implemented 3x with divergent error text (style/validation.rs template arm + validate_candidate_list, schema-data ContributorRoles::try_from); (b) RoleLabelPresentation duplicates RoleLabel minus term, with three near-identical structural_label_presentation unpack blocks in merged.rs::label_presentation; (c) active_roles filter duplicated between assemble_names branches; (d) sorting.rs inline EffectivePrimary::Merged branch duplicates effective_primary_names; (e) single-use SubstituteRoleLabelContext struct; (f) bib.json advertises only 'roles' — decide whether legacy 'role:' alias needs schema-level documentation.

--- a/crates/citum-analyze/src/semantic.rs
+++ b/crates/citum-analyze/src/semantic.rs
@@ -105,7 +105,13 @@ pub fn to_semantic_items(component: &TemplateComponent, items: &mut Vec<Semantic
         TemplateComponent::Number(n) => items.push(SemanticItem::Number(n.number.clone())),
         TemplateComponent::Date(d) => items.push(SemanticItem::Date(d.date.clone())),
         TemplateComponent::Contributor(c) => {
-            items.push(SemanticItem::Contributor(c.contributor.clone()));
+            items.extend(
+                c.contributor
+                    .as_slice()
+                    .iter()
+                    .cloned()
+                    .map(SemanticItem::Contributor),
+            );
         }
         TemplateComponent::Title(t) => items.push(SemanticItem::Title(t.title.clone())),
         TemplateComponent::Term(t) => items.push(SemanticItem::Term(t.term.clone())),

--- a/crates/citum-engine/benches/rendering.rs
+++ b/crates/citum-engine/benches/rendering.rs
@@ -725,7 +725,7 @@ fn build_type_variant_bench_style() -> Style {
                     .expect("type selector should parse"),
                 vec![
                     TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author,
+                        contributor: ContributorRole::Author.into(),
                         form: citum_schema::template::ContributorForm::Long,
                         ..Default::default()
                     }),
@@ -824,7 +824,7 @@ fn build_compound_bench_style() -> Style {
                     ..Default::default()
                 }),
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: citum_schema::template::ContributorForm::Long,
                     ..Default::default()
                 }),

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -622,7 +622,7 @@ mod tests {
             citation: Some(CitationSpec {
                 template: Some(vec![
                     TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author,
+                        contributor: ContributorRole::Author.into(),
                         form: ContributorForm::Short,
                         rendering: Rendering::default(),
                         ..Default::default()
@@ -1007,7 +1007,7 @@ mod tests {
             citation: Some(CitationSpec {
                 template: Some(vec![
                     TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author,
+                        contributor: ContributorRole::Author.into(),
                         form: ContributorForm::Short,
                         rendering: Rendering::default(),
                         ..Default::default()
@@ -1203,7 +1203,7 @@ mod tests {
             citation: Some(CitationSpec {
                 integral: Some(Box::new(CitationSpec {
                     template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author,
+                        contributor: ContributorRole::Author.into(),
                         form: ContributorForm::Long,
                         rendering: Rendering::default(),
                         ..Default::default()
@@ -1212,7 +1212,7 @@ mod tests {
                 })),
                 template: Some(vec![
                     TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author,
+                        contributor: ContributorRole::Author.into(),
                         form: ContributorForm::Short,
                         rendering: Rendering::default(),
                         ..Default::default()

--- a/crates/citum-engine/src/api/session.rs
+++ b/crates/citum-engine/src/api/session.rs
@@ -703,7 +703,7 @@ mod tests {
             citation: Some(CitationSpec {
                 template: Some(vec![
                     TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author,
+                        contributor: ContributorRole::Author.into(),
                         form: ContributorForm::Short,
                         rendering: Rendering::default(),
                         ..Default::default()
@@ -1047,7 +1047,7 @@ mod tests {
             citation: Some(CitationSpec {
                 integral: Some(Box::new(CitationSpec {
                     template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author,
+                        contributor: ContributorRole::Author.into(),
                         form: ContributorForm::Long,
                         rendering: Rendering::default(),
                         ..Default::default()
@@ -1056,7 +1056,7 @@ mod tests {
                 })),
                 template: Some(vec![
                     TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author,
+                        contributor: ContributorRole::Author.into(),
                         form: ContributorForm::Short,
                         rendering: Rendering::default(),
                         ..Default::default()

--- a/crates/citum-engine/src/api/warnings.rs
+++ b/crates/citum-engine/src/api/warnings.rs
@@ -130,14 +130,16 @@ pub fn unknown_enum_warnings(processor: &Processor) -> Vec<Warning> {
         }
 
         for contributor in reference.all_contributor_entries() {
-            if let ReferenceRole::Unknown(s) = &contributor.role {
-                warnings.push(Warning {
-                    level: WarningLevel::Warning,
-                    code: "unknown_enum_variant".to_string(),
-                    citation_id: None,
-                    ref_id: Some(ref_id.clone()),
-                    message: format!("Reference '{ref_id}' uses unknown contributor role '{s}'; this role may be ignored during rendering."),
-                });
+            for role in contributor.roles.as_slice() {
+                if let ReferenceRole::Unknown(s) = role {
+                    warnings.push(Warning {
+                        level: WarningLevel::Warning,
+                        code: "unknown_enum_variant".to_string(),
+                        citation_id: None,
+                        ref_id: Some(ref_id.clone()),
+                        message: format!("Reference '{ref_id}' uses unknown contributor role '{s}'; this role may be ignored during rendering."),
+                    });
+                }
             }
         }
     }
@@ -286,14 +288,16 @@ fn scan_template_for_unknowns(
                 }
             }
             TemplateComponent::Contributor(c) => {
-                if let TemplateRole::Unknown(s) = &c.contributor {
-                    warnings.push(Warning {
-                        level: WarningLevel::Warning,
-                        code: "unknown_enum_variant".to_string(),
-                        citation_id: None,
-                        ref_id: None,
-                        message: format!("Style {location} uses unknown contributor role '{s}'; this role may be ignored."),
-                    });
+                for role in c.contributor.as_slice() {
+                    if let TemplateRole::Unknown(s) = role {
+                        warnings.push(Warning {
+                            level: WarningLevel::Warning,
+                            code: "unknown_enum_variant".to_string(),
+                            citation_id: None,
+                            ref_id: None,
+                            message: format!("Style {location} uses unknown contributor role '{s}'; this role may be ignored."),
+                        });
+                    }
                 }
                 if let Some(label) = &c.label {
                     let term = label.term.as_str();

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -43,7 +43,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //!     citation: Some(CitationSpec {
 //!         template: Some(vec![
 //!             TemplateComponent::Contributor(TemplateContributor {
-//!                 contributor: ContributorRole::Author,
+//!                 contributor: ContributorRole::Author.into(),
 //!                 form: ContributorForm::Short,
 //!                 rendering: Rendering::default(),
 //!                 ..Default::default()

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -184,7 +184,7 @@ impl Processor {
             .as_ref()
             .map(citum_schema::GroupSortEntry::resolve);
         let bibliography_config = self.get_bibliography_config();
-        let disambiguator = if let Some(sort) = resolved_sort.as_ref() {
+        let mut disambiguator = if let Some(sort) = resolved_sort.as_ref() {
             Disambiguator::with_group_sort(
                 &group_bibliography,
                 &bibliography_config,
@@ -200,6 +200,13 @@ impl Processor {
                 &self.locale,
             )
         };
+
+        if let Some(spec) = self.style.citation.as_ref() {
+            disambiguator = disambiguator.with_citation_spec(spec);
+        }
+        if let Some(spec) = self.style.bibliography.as_ref() {
+            disambiguator = disambiguator.with_bibliography_spec(spec);
+        }
 
         Some(disambiguator.calculate_hints())
     }
@@ -381,7 +388,11 @@ impl Processor {
         let cited_ids = &run.state().cited_ids;
         let evaluator = SelectorEvaluator::new(cited_ids);
         let bibliography_config = self.get_bibliography_config();
-        let sorter = ReferenceSorter::with_bibliography_config(&self.locale, &bibliography_config);
+        let mut sorter =
+            ReferenceSorter::with_bibliography_config(&self.locale, &bibliography_config);
+        if let Some(spec) = self.style.bibliography.as_ref() {
+            sorter = sorter.with_bibliography_spec(spec);
+        }
 
         let mut assigned = HashSet::new();
         let mut result = String::new();
@@ -934,7 +945,11 @@ impl Processor {
         let cited_ids = &run.state().cited_ids;
         let evaluator = SelectorEvaluator::new(cited_ids);
         let bibliography_config = self.get_bibliography_config();
-        let sorter = ReferenceSorter::with_bibliography_config(&self.locale, &bibliography_config);
+        let mut sorter =
+            ReferenceSorter::with_bibliography_config(&self.locale, &bibliography_config);
+        if let Some(spec) = self.style.bibliography.as_ref() {
+            sorter = sorter.with_bibliography_spec(spec);
+        }
 
         let matching_refs = self.collect_matching_group_refs(spine, assigned, &evaluator, group);
         Self::mark_group_members_assigned(assigned, &matching_refs);

--- a/crates/citum-engine/src/processor/bibliography/mod.rs
+++ b/crates/citum-engine/src/processor/bibliography/mod.rs
@@ -462,7 +462,8 @@ impl Processor {
     ///
     /// Used for subsequent author substitution in bibliographies.
     pub fn contributors_match(&self, prev: &Reference, current: &Reference) -> bool {
-        let matcher = Matcher::new(&self.style, &self.default_config);
+        let config = self.style.options.as_ref().unwrap_or(&self.default_config);
+        let matcher = Matcher::new(&self.style, config, &self.locale);
         matcher.contributors_match(prev, current)
     }
 

--- a/crates/citum-engine/src/processor/bibliography/tests.rs
+++ b/crates/citum-engine/src/processor/bibliography/tests.rs
@@ -91,7 +91,7 @@ fn author_date_style() -> Style {
             }),
             template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Long,
                     ..Default::default()
                 }),
@@ -131,7 +131,7 @@ fn numeric_style() -> Style {
             ..Default::default()
         }),
         TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
+            contributor: ContributorRole::Author.into(),
             form: ContributorForm::Long,
             ..Default::default()
         }),

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -317,13 +317,16 @@ impl Processor {
         }
 
         let bibliography_config = self.get_bibliography_config();
-        let local_hints = Disambiguator::new(
+        let mut disambiguator = Disambiguator::new(
             &scoped_bibliography,
             config,
             &bibliography_config,
             &self.locale,
-        )
-        .calculate_hints();
+        );
+        if let Some(spec) = self.style.citation.as_ref() {
+            disambiguator = disambiguator.with_citation_spec(spec);
+        }
+        let local_hints = disambiguator.calculate_hints();
 
         for item in items {
             let Some(local) = local_hints.get(&item.id) else {

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -6,14 +6,13 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use crate::reference::{Bibliography, Reference};
 use crate::values::ProcHints;
 use citum_schema::options::{Config, GivennameRule};
+use citum_schema::reference::Title;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 
 use crate::sorting::ReferenceSorter;
 use citum_schema::grouping::GroupSort;
 use citum_schema::locale::Locale;
-use citum_schema::options::{Substitute, SubstituteKey};
-use citum_schema::reference::{ClassExtension, Title};
 
 /// Handles disambiguation logic for author-date citations.
 ///
@@ -63,6 +62,9 @@ pub struct Disambiguator<'a> {
     sort_config: &'a Config,
     locale: &'a Locale,
     group_sort: Option<&'a GroupSort>,
+    citation_spec: Option<&'a citum_schema::CitationSpec>,
+    citation_primary_may_be_list: bool,
+    bibliography_spec: Option<&'a citum_schema::BibliographySpec>,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -152,6 +154,9 @@ impl<'a> Disambiguator<'a> {
             sort_config,
             locale,
             group_sort: None,
+            citation_spec: None,
+            citation_primary_may_be_list: false,
+            bibliography_spec: None,
         }
     }
 
@@ -174,7 +179,25 @@ impl<'a> Disambiguator<'a> {
             sort_config,
             locale,
             group_sort: Some(group_sort),
+            citation_spec: None,
+            citation_primary_may_be_list: false,
+            bibliography_spec: None,
         }
+    }
+
+    /// Resolve disambiguation names from the effective citation template.
+    #[must_use]
+    pub fn with_citation_spec(mut self, spec: &'a citum_schema::CitationSpec) -> Self {
+        self.citation_spec = Some(spec);
+        self.citation_primary_may_be_list = crate::sorting::citation_may_have_list_primary(spec);
+        self
+    }
+
+    /// Resolve year-suffix sort keys from the effective bibliography template.
+    #[must_use]
+    pub fn with_bibliography_spec(mut self, spec: &'a citum_schema::BibliographySpec) -> Self {
+        self.bibliography_spec = Some(spec);
+        self
     }
 
     /// Calculate processing hints for disambiguation across all references.
@@ -267,13 +290,45 @@ impl<'a> Disambiguator<'a> {
         refs: &[&'b Reference],
         needs_title_key: bool,
     ) -> ReferenceCache<'b> {
+        let substitute = citum_schema::options::SubstituteConfig::resolve_or_default(
+            self.config.substitute.as_ref(),
+        );
         refs.iter()
             .enumerate()
             .map(|(index, reference)| {
-                let names = reference.author().map_or_else(Vec::new, |authors| {
-                    self.render_name_for_disambiguation(&authors)
-                });
-                let author_key = self.build_author_slot_key(reference, &names);
+                let names = if self.citation_primary_may_be_list {
+                    self.citation_spec
+                        .and_then(|spec| {
+                            crate::sorting::primary_contributor_for_citation(spec, reference)
+                        })
+                        .filter(|component| component.contributor.is_multiple())
+                        .map_or_else(
+                            || {
+                                crate::values::contributor::substitute::effective_primary_names(
+                                    reference,
+                                    substitute.as_ref(),
+                                    self.config,
+                                    self.locale,
+                                )
+                            },
+                            |component| {
+                                crate::values::contributor::merged::semantic_names(
+                                    &component,
+                                    reference,
+                                    self.config,
+                                    self.locale,
+                                )
+                            },
+                        )
+                } else {
+                    crate::values::contributor::substitute::effective_primary_names(
+                        reference,
+                        substitute.as_ref(),
+                        self.config,
+                        self.locale,
+                    )
+                };
+                let author_key = self.build_author_slot_key(reference, &names, substitute.as_ref());
                 let group_key = self.build_group_key(index, reference, &author_key);
                 // Year-suffix letters (a, b, c…) must follow the effective bibliography
                 // sort order. Reuse the bibliography title sort key (leading-article
@@ -306,55 +361,24 @@ impl<'a> Disambiguator<'a> {
         &self,
         reference: &Reference,
         author_names: &[crate::reference::FlatName],
+        substitute: &citum_schema::options::Substitute,
     ) -> String {
         let author_key = self.build_author_key(author_names);
         if !author_key.is_empty() {
             return author_key;
         }
 
-        let substitute = self
-            .config
-            .substitute
-            .as_ref()
-            .map(citum_schema::options::SubstituteConfig::resolve)
-            .unwrap_or_default();
-
-        self.build_substitute_author_key(reference, &substitute)
-            .unwrap_or_default()
-    }
-
-    fn build_substitute_author_key(
-        &self,
-        reference: &Reference,
-        substitute: &Substitute,
-    ) -> Option<String> {
-        for key in &substitute.template {
-            let resolved = match key {
-                SubstituteKey::CollectionEditor => reference
-                    .contributor(citum_schema::reference::ContributorRole::Unknown(
-                        "collection-editor".to_string(),
-                    ))
-                    .map(|names| {
-                        self.build_author_key(&self.render_name_for_disambiguation(&names))
-                    }),
-                SubstituteKey::Editor => reference.editor().map(|names| {
-                    self.build_author_key(&self.render_name_for_disambiguation(&names))
-                }),
-                SubstituteKey::Translator => reference.translator().map(|names| {
-                    self.build_author_key(&self.render_name_for_disambiguation(&names))
-                }),
-                SubstituteKey::ParentSerial => {
-                    resolve_parent_serial_title(reference).map(Self::title_substitute_key)
-                }
-                SubstituteKey::Title => reference.title().map(Self::title_substitute_key),
-            };
-
-            if let Some(key) = resolved.filter(|key| !key.is_empty()) {
-                return Some(key);
-            }
+        match crate::values::contributor::substitute::effective_primary(
+            reference,
+            substitute,
+            self.config,
+            self.locale,
+        ) {
+            Some(crate::values::contributor::substitute::EffectivePrimary::Title {
+                title, ..
+            }) => Self::title_substitute_key(title),
+            _ => String::new(),
         }
-
-        None
     }
 
     /// Calculates how many references in `refs` share the same `author_key`.
@@ -729,11 +753,17 @@ impl<'a> Disambiguator<'a> {
         group: &[&'b CachedReference<'b>],
     ) -> Vec<&'b CachedReference<'b>> {
         if let Some(sort_spec) = self.group_sort {
-            let sorter = ReferenceSorter::with_bibliography_config(self.locale, self.sort_config);
+            let mut sorter =
+                ReferenceSorter::with_bibliography_config(self.locale, self.sort_config);
+            if let Some(spec) = self.bibliography_spec {
+                sorter = sorter.with_bibliography_spec(spec);
+            } else if let Some(spec) = self.citation_spec {
+                sorter = sorter.with_citation_spec(spec);
+            }
             // Pre-sort by title_key so that entries which compare equal under the primary
             // sort_spec retain a stable, deterministic order (title ascending as tiebreaker).
-            // ReferenceSorter::sort_references uses sort_by (stable), so the pre-sort order is
-            // preserved for entries that compare equal under the primary key.
+            // `sort_by_keys` uses sort_by (stable), so the pre-sort order is preserved for
+            // entries that compare equal under the primary key.
             let mut pre_sorted: Vec<&CachedReference<'_>> = group.to_vec();
             pre_sorted.sort_by(|a, b| {
                 let a_title = a.data.title_key.as_deref().unwrap_or_default();
@@ -742,17 +772,9 @@ impl<'a> Disambiguator<'a> {
                     year_suffix_date_key(a.reference).cmp(&year_suffix_date_key(b.reference))
                 })
             });
-            pre_sorted.sort_by(|a, b| {
-                for sort_key in &sort_spec.template {
-                    let cmp = sorter.compare_by_key(a.reference, b.reference, sort_key);
-                    if cmp != std::cmp::Ordering::Equal {
-                        return cmp;
-                    }
-                }
-
-                std::cmp::Ordering::Equal
-            });
-            pre_sorted
+            sorter.sort_by_keys(pre_sorted, &sort_spec.template, |cached| {
+                Some(cached.reference)
+            })
         } else {
             let mut sorted: Vec<&CachedReference<'_>> = group.to_vec();
             sorted.sort_by(|a, b| {
@@ -841,23 +863,6 @@ impl<'a> Disambiguator<'a> {
         }
 
         groups
-    }
-
-    /// Flattens a contributor to names using the style's active multilingual display
-    /// mode, so the collision key reflects the same surface form the style renders
-    /// (DISAMBIGUATION.md §4). Monolingual contributors fall through to the original.
-    fn render_name_for_disambiguation(
-        &self,
-        contributor: &citum_schema::reference::Contributor,
-    ) -> Vec<crate::reference::FlatName> {
-        let ml = self.config.multilingual.as_ref();
-        crate::values::resolve_multilingual_name(
-            contributor,
-            ml.and_then(|m| m.name_mode.as_ref()),
-            ml.and_then(|m| m.preferred_transliteration.as_deref()),
-            ml.and_then(|m| m.preferred_script.as_ref()),
-            &self.locale.locale,
-        )
     }
 
     /// Generates a normalized author string used for grouping and et-al detection.
@@ -1021,15 +1026,6 @@ impl<'a> Disambiguator<'a> {
             .map_or(ReferenceCacheKey::Index(index), |id| {
                 ReferenceCacheKey::Id(id.to_string())
             })
-    }
-}
-
-fn resolve_parent_serial_title(reference: &Reference) -> Option<Title> {
-    match reference.extension() {
-        ClassExtension::SerialComponent(_)
-        | ClassExtension::LegalCase(_)
-        | ClassExtension::Treaty(_) => reference.container_title(),
-        _ => None,
     }
 }
 

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -57,7 +57,7 @@ fn make_author_date_style() -> Style {
         citation: Some(CitationSpec {
             template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
                     ..Default::default()
                 }),
@@ -74,7 +74,7 @@ fn make_author_date_style() -> Style {
         bibliography: Some(BibliographySpec {
             template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Long,
                     ..Default::default()
                 }),
@@ -137,7 +137,7 @@ fn make_note_style() -> Style {
         bibliography: Some(BibliographySpec {
             template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Long,
                     ..Default::default()
                 }),
@@ -181,7 +181,7 @@ fn make_integral_name_style(scope: IntegralNameScope, contexts: IntegralNameCont
         citation: Some(CitationSpec {
             template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
                     ..Default::default()
                 }),
@@ -194,7 +194,7 @@ fn make_integral_name_style(scope: IntegralNameScope, contexts: IntegralNameCont
             ]),
             integral: Some(Box::new(CitationSpec {
                 template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Long,
                     ..Default::default()
                 })]),
@@ -206,7 +206,7 @@ fn make_integral_name_style(scope: IntegralNameScope, contexts: IntegralNameCont
         bibliography: Some(BibliographySpec {
             template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Long,
                     ..Default::default()
                 }),
@@ -507,7 +507,7 @@ fn test_repro_djot_rendering() {
         citation: Some(CitationSpec {
             template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
                     ..Default::default()
                 }),
@@ -522,7 +522,7 @@ fn test_repro_djot_rendering() {
             integral: Some(Box::new(citum_schema::CitationSpec {
                 template: Some(vec![
                     TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author,
+                        contributor: ContributorRole::Author.into(),
                         form: ContributorForm::Short,
                         ..Default::default()
                     }),

--- a/crates/citum-engine/src/processor/matching.rs
+++ b/crates/citum-engine/src/processor/matching.rs
@@ -11,7 +11,9 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 use crate::reference::Reference;
 use citum_schema::Style;
-use citum_schema::options::{Config, Substitute, SubstituteKey};
+use citum_schema::locale::Locale;
+use citum_schema::options::{Config, Substitute};
+use std::borrow::Cow;
 
 /// Matcher for determining if references share the same primary contributors.
 ///
@@ -20,83 +22,65 @@ use citum_schema::options::{Config, Substitute, SubstituteKey};
 pub struct Matcher<'a> {
     /// The active citation style.
     style: &'a Style,
-    /// The default configuration used as a fallback.
-    default_config: &'a Config,
+    /// The effective style configuration used for name resolution and fallbacks.
+    config: &'a Config,
+    /// The locale used to resolve multilingual and merged-list names.
+    locale: &'a Locale,
 }
 
 impl<'a> Matcher<'a> {
-    /// Build a matcher from the active style and default configuration.
+    /// Build a matcher from the active style, effective configuration, and locale.
     #[must_use]
-    pub fn new(style: &'a Style, default_config: &'a Config) -> Self {
+    pub fn new(style: &'a Style, config: &'a Config, locale: &'a Locale) -> Self {
         Self {
             style,
-            default_config,
+            config,
+            locale,
         }
     }
 
     /// Check if primary contributors (authors/editors) match between two references.
-    /// Uses the style's substitution logic to determine the primary contributor.
+    ///
+    /// Delegates to the shared effective-primary resolver
+    /// ([`crate::values::contributor::substitute::effective_primary_names`]) so
+    /// matching honors type overrides and merged-role candidates identically to
+    /// rendering, sorting, and disambiguation. Two references match only when
+    /// both resolve non-empty, equal name lists; a title-substitute result
+    /// (empty names) never matches.
     #[must_use]
     pub fn contributors_match(&self, prev: &Reference, current: &Reference) -> bool {
         let substitute = self.get_substitute_config();
-        let prev_contributors = self.get_primary_contributors(prev, &substitute);
-        let curr_contributors = self.get_primary_contributors(current, &substitute);
-
-        match (prev_contributors, curr_contributors) {
-            (Some(p), Some(c)) => p == c,
-            _ => false,
-        }
+        let prev_names = crate::values::contributor::substitute::effective_primary_names(
+            prev,
+            substitute.as_ref(),
+            self.config,
+            self.locale,
+        );
+        let curr_names = crate::values::contributor::substitute::effective_primary_names(
+            current,
+            substitute.as_ref(),
+            self.config,
+            self.locale,
+        );
+        !prev_names.is_empty() && !curr_names.is_empty() && prev_names == curr_names
     }
 
     /// Gets the substitute configuration from the style or falls back to defaults.
     ///
     /// Resolves the substitute template from the style's options if available,
     /// otherwise falls back to the default configuration's substitute settings.
-    fn get_substitute_config(&self) -> Substitute {
-        self.style
+    fn get_substitute_config(&self) -> Cow<'_, Substitute> {
+        if let Some(config) = self
+            .style
             .options
             .as_ref()
             .and_then(|o| o.substitute.as_ref())
-            .map(citum_schema::options::SubstituteConfig::resolve)
-            .or_else(|| {
-                self.default_config
-                    .substitute
-                    .as_ref()
-                    .map(citum_schema::options::SubstituteConfig::resolve)
-            })
-            .unwrap_or_default()
-    }
-
-    /// Get the primary contributors for a reference based on the style's substitution order.
-    /// Follows the substitute template: Author is always first, then the configured fallbacks.
-    fn get_primary_contributors(
-        &self,
-        reference: &Reference,
-        substitute: &Substitute,
-    ) -> Option<crate::reference::Contributor> {
-        // Author is always the primary contributor
-        if let Some(author) = reference.author() {
-            return Some(author);
+        {
+            return config.resolve_ref();
         }
-
-        // Fall back through the substitute template order
-        for key in &substitute.template {
-            let contributor = match key {
-                SubstituteKey::CollectionEditor => {
-                    reference.contributor(citum_schema::reference::ContributorRole::Unknown(
-                        "collection-editor".to_string(),
-                    ))
-                }
-                SubstituteKey::Editor => reference.editor(),
-                SubstituteKey::Translator => reference.translator(),
-                SubstituteKey::ParentSerial => None,
-                SubstituteKey::Title => None, // Title is not a contributor
-            };
-            if contributor.is_some() {
-                return contributor;
-            }
-        }
-
-        None
+        self.config.substitute.as_ref().map_or_else(
+            || Cow::Owned(Substitute::default()),
+            citum_schema::options::SubstituteConfig::resolve_ref,
+        )
     }
 }

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -1378,13 +1378,61 @@ fn author_group_delimiter_affix(component: &TemplateComponent) -> Option<String>
 
 fn component_starts_with_author(component: &TemplateComponent) -> bool {
     match component {
-        TemplateComponent::Contributor(contributor) => {
-            contributor.contributor == citum_schema::template::ContributorRole::Author
-        }
+        TemplateComponent::Contributor(contributor) => contributor
+            .contributor
+            .contains(&citum_schema::template::ContributorRole::Author),
         TemplateComponent::Group(group) => group
             .group
             .first()
             .is_some_and(component_starts_with_author),
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use citum_schema::template::{
+        ContributorRole, DelimiterPunctuation, TemplateContributor, TemplateGroup,
+    };
+
+    #[test]
+    fn author_group_delimiter_affix_recognizes_merged_leading_author_component() {
+        // given a group whose leading component is a merged [author, editor]
+        // contributor list rather than a scalar author component
+        let group = TemplateComponent::Group(TemplateGroup {
+            group: vec![TemplateComponent::Contributor(TemplateContributor {
+                contributor: vec![ContributorRole::Author, ContributorRole::Editor].into(),
+                ..Default::default()
+            })],
+            delimiter: Some(DelimiterPunctuation::Comma),
+            ..Default::default()
+        });
+
+        // when resolving the leading author-group delimiter affix
+        let affix = author_group_delimiter_affix(&group);
+
+        // then the merged component is recognized as starting with author
+        assert_eq!(affix, Some(", ".to_string()));
+    }
+
+    #[test]
+    fn author_group_delimiter_affix_ignores_merged_component_without_author() {
+        // given a group whose leading component is a merged [editor,
+        // translator] contributor list that never declares author
+        let group = TemplateComponent::Group(TemplateGroup {
+            group: vec![TemplateComponent::Contributor(TemplateContributor {
+                contributor: vec![ContributorRole::Editor, ContributorRole::Translator].into(),
+                ..Default::default()
+            })],
+            delimiter: Some(DelimiterPunctuation::Comma),
+            ..Default::default()
+        });
+
+        // when resolving the leading author-group delimiter affix
+        let affix = author_group_delimiter_affix(&group);
+
+        // then no affix is produced since the group does not start with author
+        assert_eq!(affix, None);
     }
 }

--- a/crates/citum-engine/src/processor/rendering/helpers.rs
+++ b/crates/citum-engine/src/processor/rendering/helpers.rs
@@ -97,7 +97,7 @@ pub fn has_contributor_component(component: &TemplateComponent) -> bool {
 /// leads with a non-author contributor (the grouping component).
 pub fn remove_first_contributor_with_role(
     component: TemplateComponent,
-    role: &citum_schema::template::ContributorRole,
+    role: &citum_schema::template::ContributorRoles,
 ) -> (Option<TemplateComponent>, bool) {
     match component {
         TemplateComponent::Contributor(ref c) if &c.contributor == role => (None, true),

--- a/crates/citum-engine/src/processor/rendering/mod.rs
+++ b/crates/citum-engine/src/processor/rendering/mod.rs
@@ -746,7 +746,10 @@ pub fn get_variable_key(component: &TemplateComponent) -> Option<String> {
     }
 
     match component {
-        TemplateComponent::Contributor(c) => make_key("contributor", &c.contributor, &c.rendering),
+        TemplateComponent::Contributor(c) => c.contributor.as_single().map_or_else(
+            || make_key("contributor", &c.contributor, &c.rendering),
+            |role| make_key("contributor", role, &c.rendering),
+        ),
         TemplateComponent::Date(d) => make_key("date", &d.date, &d.rendering),
         TemplateComponent::Variable(v) => make_key("variable", &v.variable, &v.rendering),
         TemplateComponent::Title(t) => {

--- a/crates/citum-engine/src/processor/rendering/tests.rs
+++ b/crates/citum-engine/src/processor/rendering/tests.rs
@@ -48,7 +48,7 @@ fn grouped_author_date_style() -> Style {
         citation: Some(CitationSpec {
             template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
                     rendering: Rendering::default(),
                     ..Default::default()
@@ -87,7 +87,7 @@ fn explicit_author_year_group_style() -> Style {
                 TemplateComponent::Group(TemplateGroup {
                     group: vec![
                         TemplateComponent::Contributor(TemplateContributor {
-                            contributor: ContributorRole::Author,
+                            contributor: ContributorRole::Author.into(),
                             form: ContributorForm::Short,
                             rendering: Rendering::default(),
                             ..Default::default()
@@ -137,7 +137,7 @@ fn explicit_author_year_group_with_locator_delimiter_style() -> Style {
                 TemplateComponent::Group(TemplateGroup {
                     group: vec![
                         TemplateComponent::Contributor(TemplateContributor {
-                            contributor: ContributorRole::Author,
+                            contributor: ContributorRole::Author.into(),
                             form: ContributorForm::Short,
                             rendering: Rendering::default(),
                             ..Default::default()
@@ -188,7 +188,7 @@ fn integral_name_style() -> Style {
         citation: Some(CitationSpec {
             integral: Some(Box::new(CitationSpec {
                 template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Long,
                     rendering: Rendering::default(),
                     ..Default::default()
@@ -197,7 +197,7 @@ fn integral_name_style() -> Style {
             })),
             template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
                     rendering: Rendering::default(),
                     ..Default::default()
@@ -312,7 +312,7 @@ fn test_variable_key_includes_context() {
 fn test_substituted_contributor_keys_block_contextual_duplicate_components() {
     let mut tracker = TemplateComponentTracker::default();
     let translated_component = TemplateComponent::Contributor(TemplateContributor {
-        contributor: ContributorRole::Translator,
+        contributor: ContributorRole::Translator.into(),
         form: ContributorForm::Long,
         rendering: Rendering {
             suffix: Some(", translator".to_string()),
@@ -359,11 +359,12 @@ fn test_strip_author_component_nested_list() {
     let nested = TemplateComponent::Group(TemplateGroup {
         group: vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form: ContributorForm::Short,
                 and: None,
                 shorten: None,
                 label: None,
+                merge: None,
                 name_order: None,
                 name_form: None,
                 delimiter: None,
@@ -785,7 +786,7 @@ fn test_type_specific_rendering() {
         TypeSelector::from_str("article-journal").unwrap(),
         vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form: ContributorForm::Short,
                 ..Default::default()
             }),
@@ -806,7 +807,7 @@ fn test_type_specific_rendering() {
         TypeSelector::from_str("book").unwrap(),
         vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form: ContributorForm::Short,
                 ..Default::default()
             }),
@@ -973,7 +974,7 @@ fn test_bibliography_type_specific_rendering() {
         TypeSelector::from_str("interview").unwrap(),
         vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form: ContributorForm::Long,
                 name_order: Some(NameOrder::FamilyFirst),
                 ..Default::default()
@@ -998,7 +999,7 @@ fn test_bibliography_type_specific_rendering() {
                 ..Default::default()
             }),
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Interviewer,
+                contributor: ContributorRole::Interviewer.into(),
                 form: ContributorForm::Long,
                 name_order: Some(NameOrder::FamilyFirst),
                 rendering: Rendering {
@@ -1120,7 +1121,7 @@ fn sentence_initial_date_group_preserves_no_date_term_case() {
     });
     let style = bibliography_style_with_template(vec![
         TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
+            contributor: ContributorRole::Author.into(),
             form: ContributorForm::Long,
             name_order: Some(NameOrder::FamilyFirst),
             ..Default::default()
@@ -1202,7 +1203,7 @@ fn sentence_initial_group_still_capitalizes_leading_contributor_role_prose() {
     });
     let style = bibliography_style_with_template(vec![TemplateComponent::Group(TemplateGroup {
         group: vec![TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Editor,
+            contributor: ContributorRole::Editor.into(),
             form: ContributorForm::Verb,
             name_order: Some(NameOrder::GivenFirst),
             ..Default::default()

--- a/crates/citum-engine/src/processor/setup.rs
+++ b/crates/citum-engine/src/processor/setup.rs
@@ -560,17 +560,23 @@ impl Processor {
         let bibliography_config = self.get_bibliography_config();
         let mut sorted_refs = match self.resolved_bibliography_sort() {
             Some((sort_spec, true)) => {
-                let sorter = crate::sorting::ReferenceSorter::with_bibliography_config(
+                let mut sorter = crate::sorting::ReferenceSorter::with_bibliography_config(
                     &self.locale,
                     &bibliography_config,
                 );
+                if let Some(spec) = self.style.bibliography.as_ref() {
+                    sorter = sorter.with_bibliography_spec(spec);
+                }
                 sorter.sort_references_with_id_tiebreak(references, &sort_spec)
             }
             Some((sort_spec, false)) => {
-                let sorter = crate::sorting::ReferenceSorter::with_bibliography_config(
+                let mut sorter = crate::sorting::ReferenceSorter::with_bibliography_config(
                     &self.locale,
                     &bibliography_config,
                 );
+                if let Some(spec) = self.style.bibliography.as_ref() {
+                    sorter = sorter.with_bibliography_spec(spec);
+                }
                 sorter.sort_references(references, &sort_spec)
             }
             None => references,
@@ -598,7 +604,7 @@ impl Processor {
         spec: &citum_schema::CitationSpec,
     ) -> Vec<CitationItem> {
         if let Some(sort_spec) = &spec.sort {
-            let mut items_with_refs: Vec<(CitationItem, Option<&Reference>)> = items
+            let items_with_refs: Vec<(CitationItem, Option<&Reference>)> = items
                 .into_iter()
                 .map(|item| {
                     let reference = self.bibliography.get(&item.id);
@@ -607,26 +613,16 @@ impl Processor {
                 .collect();
 
             let resolved_sort = sort_spec.resolve();
-            let sorter = crate::sorting::ReferenceSorter::new(&self.locale);
-            items_with_refs.sort_by(|left, right| match (left.1, right.1) {
-                (Some(left_reference), Some(right_reference)) => {
-                    for sort_key in &resolved_sort.template {
-                        let cmp = sorter.compare_by_key(left_reference, right_reference, sort_key);
-                        if cmp != std::cmp::Ordering::Equal {
-                            return cmp;
-                        }
-                    }
-                    std::cmp::Ordering::Equal
-                }
-                (Some(_), None) => std::cmp::Ordering::Less,
-                (None, Some(_)) => std::cmp::Ordering::Greater,
-                (None, None) => std::cmp::Ordering::Equal,
-            });
+            let citation_config = self.get_citation_config();
+            let sorter = crate::sorting::ReferenceSorter::with_bibliography_config(
+                &self.locale,
+                &citation_config,
+            )
+            .with_citation_spec(spec);
+            let sorted =
+                sorter.sort_by_keys(items_with_refs, &resolved_sort.template, |item| item.1);
 
-            return items_with_refs
-                .into_iter()
-                .map(|(item, _reference)| item)
-                .collect();
+            return sorted.into_iter().map(|(item, _reference)| item).collect();
         }
 
         items
@@ -642,7 +638,7 @@ impl Processor {
         let bibliography_config = self.get_bibliography_config();
         let bibliography_sort = self.resolved_bibliography_sort();
 
-        let disambiguator = if let Some((resolved_sort, _id_tiebreak)) = &bibliography_sort {
+        let mut disambiguator = if let Some((resolved_sort, _id_tiebreak)) = &bibliography_sort {
             Disambiguator::with_group_sort(
                 &self.bibliography,
                 config,
@@ -658,6 +654,13 @@ impl Processor {
                 &self.locale,
             )
         };
+
+        if let Some(citation_spec) = self.style.citation.as_ref() {
+            disambiguator = disambiguator.with_citation_spec(citation_spec);
+        }
+        if let Some(bibliography_spec) = self.style.bibliography.as_ref() {
+            disambiguator = disambiguator.with_bibliography_spec(bibliography_spec);
+        }
 
         disambiguator.calculate_hints()
     }

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -46,7 +46,7 @@ fn make_style() -> Style {
             options: None,
             template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
                     name_order: None,
                     delimiter: None,
@@ -67,7 +67,7 @@ fn make_style() -> Style {
             options: None,
             template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Long,
                     name_order: None,
                     delimiter: None,
@@ -335,7 +335,7 @@ fn make_grouped_compound_selection_style() -> Style {
                     ..Default::default()
                 }),
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Long,
                     name_order: None,
                     delimiter: None,
@@ -671,7 +671,7 @@ fn test_process_citation_treats_trimmed_none_delimiter_as_empty() {
     style.citation = Some(CitationSpec {
         template: Some(vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form: ContributorForm::Short,
                 ..Default::default()
             }),
@@ -712,7 +712,7 @@ fn test_citation_locator_label_renders_term() {
         template: Some(vec![
             citum_schema::TemplateComponent::Contributor(
                 citum_schema::template::TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
                     ..Default::default()
                 },
@@ -763,7 +763,7 @@ fn test_citation_locator_label_renders_term_with_loaded_locale() {
         template: Some(vec![
             citum_schema::TemplateComponent::Contributor(
                 citum_schema::template::TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
                     ..Default::default()
                 },
@@ -817,7 +817,7 @@ fn test_citation_locator_can_suppress_label() {
         template: Some(vec![
             citum_schema::TemplateComponent::Contributor(
                 citum_schema::template::TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
                     ..Default::default()
                 },
@@ -878,7 +878,7 @@ fn test_citation_locator_can_strip_label_periods() {
         template: Some(vec![
             citum_schema::TemplateComponent::Contributor(
                 citum_schema::template::TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
                     ..Default::default()
                 },
@@ -2756,7 +2756,7 @@ fn test_label_integral_citation_uses_author_text() {
     style.citation = Some(citum_schema::CitationSpec {
         template: Some(vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form: ContributorForm::Short,
                 name_order: None,
                 delimiter: None,
@@ -2891,7 +2891,7 @@ fn test_same_author_integral_multi_cite_collapses_to_grouped_years() {
         delimiter: Some(" ".to_string()),
         template: Some(vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form: ContributorForm::Short,
                 rendering: Rendering::default(),
                 ..Default::default()
@@ -2963,7 +2963,7 @@ fn test_same_author_non_integral_multi_cite_collapses_to_grouped_years() {
     style.citation = Some(CitationSpec {
         template: Some(vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form: ContributorForm::Short,
                 rendering: Rendering::default(),
                 ..Default::default()
@@ -3034,7 +3034,7 @@ fn test_same_author_integral_multi_cite_respects_bracket_wrap() {
         delimiter: Some(" ".to_string()),
         template: Some(vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form: ContributorForm::Short,
                 rendering: Rendering::default(),
                 ..Default::default()
@@ -3103,7 +3103,7 @@ fn test_integral_locator_does_not_duplicate_group_delimiter() {
     style.citation = Some(CitationSpec {
         template: Some(vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form: ContributorForm::Short,
                 rendering: Rendering::default(),
                 ..Default::default()
@@ -3315,7 +3315,7 @@ fn test_grouped_numeric_bibliography_rerender_preserves_numbers_and_substitution
             ..Default::default()
         }),
         TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
+            contributor: ContributorRole::Author.into(),
             form: ContributorForm::Long,
             name_order: None,
             delimiter: None,
@@ -5464,7 +5464,7 @@ fn test_grouped_integral_citation_renders_all_items() {
     style.citation = Some(CitationSpec {
         template: Some(vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form: ContributorForm::Short,
                 name_order: None,
                 delimiter: None,
@@ -5483,7 +5483,7 @@ fn test_grouped_integral_citation_renders_all_items() {
         integral: Some(Box::new(CitationSpec {
             template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
                     name_order: None,
                     delimiter: None,
@@ -5550,7 +5550,7 @@ fn test_grouped_integral_citation_preserves_later_item_prefixes() {
     style.citation = Some(CitationSpec {
         template: Some(vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form: ContributorForm::Short,
                 name_order: None,
                 delimiter: None,
@@ -5567,7 +5567,7 @@ fn test_grouped_integral_citation_preserves_later_item_prefixes() {
         integral: Some(Box::new(CitationSpec {
             template: Some(vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
                     name_order: None,
                     delimiter: None,
@@ -5642,7 +5642,7 @@ fn test_label_integral_citation_includes_label() {
     style.citation = Some(CitationSpec {
         template: Some(vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form: ContributorForm::Short,
                 name_order: None,
                 delimiter: None,

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -647,7 +647,7 @@ mod tests {
         let c1 = ProcTemplateComponent {
             template_component: TemplateComponent::Contributor(
                 citum_schema::template::TemplateContributor {
-                    contributor: citum_schema::template::ContributorRole::Editor,
+                    contributor: citum_schema::template::ContributorRole::Editor.into(),
                     rendering: Rendering {
                         wrap: Some(WrapConfig {
                             punctuation: WrapPunctuation::Parentheses,
@@ -830,7 +830,7 @@ mod tests {
         let c1 = ProcTemplateComponent {
             template_component: TemplateComponent::Contributor(
                 citum_schema::template::TemplateContributor {
-                    contributor: citum_schema::template::ContributorRole::Author,
+                    contributor: citum_schema::template::ContributorRole::Author.into(),
                     rendering: Rendering {
                         suffix: Some(", ".to_string()),
                         ..Default::default()

--- a/crates/citum-engine/src/render/citation.rs
+++ b/crates/citum-engine/src/render/citation.rs
@@ -180,7 +180,7 @@ mod tests {
         let template = vec![
             ProcTemplateComponent {
                 template_component: TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
                     name_order: None,
                     delimiter: None,

--- a/crates/citum-engine/src/render/component.rs
+++ b/crates/citum-engine/src/render/component.rs
@@ -72,7 +72,15 @@ fn resolve_semantic_class(component: &ProcTemplateComponent) -> Option<String> {
             | TitleType::CollectionTitle => Some("citum-container-title".to_string()),
             _ => Some("citum-title".to_string()),
         },
-        TemplateComponent::Contributor(c) => Some(format!("citum-{}", c.contributor.as_str())),
+        TemplateComponent::Contributor(c) => Some(format!(
+            "citum-{}",
+            c.contributor
+                .as_slice()
+                .iter()
+                .map(citum_schema::template::ContributorRole::as_str)
+                .collect::<Vec<_>>()
+                .join("-")
+        )),
         TemplateComponent::Date(d) => Some(format!(
             "citum-{}",
             match d.date {
@@ -262,7 +270,8 @@ pub fn get_effective_rendering(component: &ProcTemplateComponent) -> Rendering {
             TemplateComponent::Contributor(c) => {
                 if let Some(contributors_config) = &config.contributors
                     && let Some(role_config) = &contributors_config.role
-                    && let Some(role_rendering) = role_config.role_rendering(&c.contributor)
+                    && let Some(primary_role) = c.contributor.as_slice().first()
+                    && let Some(role_rendering) = role_config.role_rendering(primary_role)
                 {
                     effective.merge(&role_rendering.to_rendering());
                 }

--- a/crates/citum-engine/src/sort_support.rs
+++ b/crates/citum-engine/src/sort_support.rs
@@ -7,7 +7,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 use std::cmp::Ordering;
 
-use crate::reference::Reference;
+use crate::reference::{FlatName, Reference};
 use citum_schema::grouping::NameSortOrder;
 use citum_schema::locale::Locale;
 use citum_schema::options::{Config, SortingLocale, SortingMultilingualMode};
@@ -189,6 +189,22 @@ pub(crate) fn author_sort_key_opt_with_options(
         .filter(|key| !key.is_empty())
 }
 
+/// Build a sort key from the first name in an already-resolved merged list.
+#[must_use]
+pub(crate) fn flat_names_sort_key(names: &[FlatName], name_order: NameSortOrder) -> Option<String> {
+    let name = names.first()?;
+    if let Some(literal) = non_empty_str(name.literal.as_deref()) {
+        return non_empty_normalized(literal);
+    }
+    let family = non_empty_str(name.family.as_deref()).unwrap_or_default();
+    let given = non_empty_str(name.given.as_deref()).unwrap_or_default();
+    let value = match name_order {
+        NameSortOrder::FamilyGiven => format!("{family}\u{0}{given}"),
+        NameSortOrder::GivenFamily => format!("{given}\u{0}{family}"),
+    };
+    non_empty_normalized(&value)
+}
+
 /// Build the normalized title sort key with configured multilingual behavior.
 #[must_use]
 pub(crate) fn title_sort_key_with_options(
@@ -214,7 +230,8 @@ pub(crate) fn normalize_sort_text(text: &str) -> String {
     text.to_string()
 }
 
-fn contributor_sort_key(
+/// Build a configured sort key directly from a resolved contributor payload.
+pub(crate) fn contributor_sort_key(
     contributor: &Contributor,
     name_order: NameSortOrder,
     options: &SortKeyOptions,

--- a/crates/citum-engine/src/sorting.rs
+++ b/crates/citum-engine/src/sorting.rs
@@ -25,9 +25,14 @@ use citum_schema::reference::ClassExtension;
 
 use crate::reference::Reference;
 use crate::sort_support::{
-    SortKeyOptions, TextCollator, author_sort_key_opt_with_options, collator_locale_id,
-    normalize_sort_text, title_sort_key_with_options,
+    SortKeyOptions, TextCollator, collator_locale_id, flat_names_sort_key, normalize_sort_text,
+    title_sort_key_with_options,
 };
+
+enum PrimaryContributorSpec<'a> {
+    Citation(&'a citum_schema::CitationSpec),
+    Bibliography(&'a citum_schema::BibliographySpec),
+}
 
 fn compare_optional_years(a_year: Option<i32>, b_year: Option<i32>) -> std::cmp::Ordering {
     match (a_year, b_year) {
@@ -43,6 +48,9 @@ pub struct ReferenceSorter<'a> {
     locale: &'a Locale,
     text_collator: TextCollator,
     sort_key_options: SortKeyOptions,
+    config: Option<&'a Config>,
+    primary_contributor_spec: Option<PrimaryContributorSpec<'a>>,
+    primary_contributor_may_be_list: bool,
 }
 
 struct CachedReference<'a> {
@@ -91,17 +99,39 @@ impl<'a> ReferenceSorter<'a> {
             locale,
             text_collator: TextCollator::new(locale),
             sort_key_options: SortKeyOptions::uniform(),
+            config: None,
+            primary_contributor_spec: None,
+            primary_contributor_may_be_list: false,
         }
     }
 
     /// Create a bibliography sorter using the effective bibliography config.
     #[must_use]
-    pub fn with_bibliography_config(locale: &'a Locale, config: &Config) -> Self {
+    pub fn with_bibliography_config(locale: &'a Locale, config: &'a Config) -> Self {
         Self {
             locale,
             text_collator: TextCollator::new_for_locale_id(collator_locale_id(locale, config)),
             sort_key_options: SortKeyOptions::from_config(config),
+            config: Some(config),
+            primary_contributor_spec: None,
+            primary_contributor_may_be_list: false,
         }
+    }
+
+    /// Use the effective bibliography template to resolve list-form author keys.
+    #[must_use]
+    pub fn with_bibliography_spec(mut self, spec: &'a citum_schema::BibliographySpec) -> Self {
+        self.primary_contributor_spec = Some(PrimaryContributorSpec::Bibliography(spec));
+        self.primary_contributor_may_be_list = bibliography_may_have_list_primary(spec);
+        self
+    }
+
+    /// Use the effective citation template to resolve list-form author keys.
+    #[must_use]
+    pub fn with_citation_spec(mut self, spec: &'a citum_schema::CitationSpec) -> Self {
+        self.primary_contributor_spec = Some(PrimaryContributorSpec::Citation(spec));
+        self.primary_contributor_may_be_list = citation_may_have_list_primary(spec);
+        self
     }
 
     /// Sort references according to a group sort specification.
@@ -146,7 +176,7 @@ impl<'a> ReferenceSorter<'a> {
         sort_spec: &GroupSort,
         id_tiebreak: bool,
     ) -> Vec<&'b Reference> {
-        let compiled_keys = self.compile_sort_keys(sort_spec);
+        let compiled_keys = self.compile_sort_keys(&sort_spec.template);
         if compiled_keys.is_empty() {
             return references;
         }
@@ -199,6 +229,50 @@ impl<'a> ReferenceSorter<'a> {
         self.compare_by_key_with_context(a, b, sort_key)
     }
 
+    /// Stably sort arbitrary items by a `GroupSort` template, precomputing
+    /// each item's sort key set once instead of re-deriving it (author,
+    /// title, issued resolution) on every pairwise comparison.
+    ///
+    /// This generalizes the Schwartzian-transform caching
+    /// [`Self::sort_references_impl`] applies to `&Reference` slices to any
+    /// item type, via a reference-extraction closure — letting comparator
+    /// call sites that don't sort bare `&Reference` (year-suffix ordering,
+    /// citation-item ordering) share the same cached comparison instead of
+    /// calling [`Self::compare_by_key`] from scratch on every pair.
+    ///
+    /// Items whose extractor returns `None` sort after every item with a
+    /// resolved reference; ties (including `None` vs `None`) preserve their
+    /// relative order (`sort_by` is stable).
+    pub(crate) fn sort_by_keys<T>(
+        &self,
+        mut items: Vec<T>,
+        template: &[GroupSortKey],
+        reference_of: impl Fn(&T) -> Option<&Reference>,
+    ) -> Vec<T> {
+        let compiled_keys = self.compile_sort_keys(template);
+        let mut decorated = items
+            .drain(..)
+            .map(|item| {
+                let sort_values = reference_of(&item).map(|reference| {
+                    compiled_keys
+                        .iter()
+                        .map(|sort_key| self.cache_sort_value(reference, sort_key))
+                        .collect::<Vec<_>>()
+                });
+                (item, sort_values)
+            })
+            .collect::<Vec<_>>();
+
+        decorated.sort_by(|(_, a), (_, b)| match (a, b) {
+            (Some(a), Some(b)) => self.compare_cached_values(a, b, &compiled_keys),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        });
+
+        decorated.into_iter().map(|(item, _)| item).collect()
+    }
+
     fn compare_by_key_with_context(
         &self,
         a: &Reference,
@@ -245,9 +319,8 @@ impl<'a> ReferenceSorter<'a> {
         }
     }
 
-    fn compile_sort_keys<'b>(&self, sort_spec: &'b GroupSort) -> Vec<CompiledSortKey<'b>> {
-        sort_spec
-            .template
+    fn compile_sort_keys<'b>(&self, template: &'b [GroupSortKey]) -> Vec<CompiledSortKey<'b>> {
+        template
             .iter()
             .map(|sort_key| match &sort_key.key {
                 GroupSortKeyType::RefType => CompiledSortKey::RefType {
@@ -310,12 +383,25 @@ impl<'a> ReferenceSorter<'a> {
         b: &CachedReference<'_>,
         compiled_keys: &[CompiledSortKey<'_>],
     ) -> std::cmp::Ordering {
+        self.compare_cached_values(&a.sort_values, &b.sort_values, compiled_keys)
+    }
+
+    /// Compare two precomputed sort-value sequences key by key, honoring
+    /// each key's ascending/descending direction and stopping at the first
+    /// non-equal comparison. Shared by [`Self::compare_cached_references`]
+    /// (bibliography sorts) and [`Self::sort_by_keys`] (generic item sorts).
+    fn compare_cached_values(
+        &self,
+        a: &[CachedSortValue],
+        b: &[CachedSortValue],
+        compiled_keys: &[CompiledSortKey<'_>],
+    ) -> std::cmp::Ordering {
         for (index, sort_key) in compiled_keys.iter().enumerate() {
             #[allow(
                 clippy::indexing_slicing,
                 reason = "index is derived from compiled_keys"
             )]
-            let cmp = self.compare_cached_value(&a.sort_values[index], &b.sort_values[index]);
+            let cmp = self.compare_cached_value(&a[index], &b[index]);
             let cmp = if Self::is_ascending(sort_key) {
                 cmp
             } else {
@@ -402,13 +488,86 @@ impl<'a> ReferenceSorter<'a> {
         reference: &Reference,
         name_order: NameSortOrder,
     ) -> Option<String> {
-        author_sort_key_opt_with_options(
+        let default_config = Config::default();
+        let config = self.config.unwrap_or(&default_config);
+
+        if let Some(component) = self.primary_contributor_component(reference)
+            && component.contributor.is_multiple()
+        {
+            let names = crate::values::contributor::merged::semantic_names(
+                &component,
+                reference,
+                config,
+                self.locale,
+            );
+            if let Some(key) = flat_names_sort_key(&names, name_order) {
+                return Some(key);
+            }
+            // An empty merged template component (e.g. a type variant's
+            // `[writer, director]` primary with neither present) falls
+            // through to the effective-primary resolver below instead of
+            // jumping straight to the title key, so sorting can still walk
+            // the substitute chain the render path uses
+            // (`merged.rs::resolve_empty_list`) and land on, say, an editor.
+        }
+        let substitute =
+            citum_schema::options::SubstituteConfig::resolve_or_default(config.substitute.as_ref());
+        let primary_key = match crate::values::contributor::substitute::effective_primary(
             reference,
-            name_order,
+            substitute.as_ref(),
+            config,
             self.locale,
-            true,
-            &self.sort_key_options,
-        )
+        ) {
+            Some(crate::values::contributor::substitute::EffectivePrimary::Contributor {
+                contributor,
+                ..
+            }) => crate::sort_support::contributor_sort_key(
+                &contributor,
+                name_order,
+                &self.sort_key_options,
+            ),
+            Some(crate::values::contributor::substitute::EffectivePrimary::Merged(roles)) => {
+                let names = crate::values::contributor::merged::semantic_names(
+                    &citum_schema::template::TemplateContributor {
+                        contributor: roles,
+                        ..Default::default()
+                    },
+                    reference,
+                    config,
+                    self.locale,
+                );
+                flat_names_sort_key(&names, name_order)
+            }
+            Some(crate::values::contributor::substitute::EffectivePrimary::Title { .. }) | None => {
+                None
+            }
+        };
+        primary_key.or_else(|| {
+            Some(title_sort_key_with_options(
+                reference,
+                self.locale,
+                &self.sort_key_options,
+            ))
+            .filter(|key| !key.is_empty())
+        })
+    }
+
+    fn primary_contributor_component(
+        &self,
+        reference: &Reference,
+    ) -> Option<citum_schema::template::TemplateContributor> {
+        if !self.primary_contributor_may_be_list {
+            return None;
+        }
+        let language = reference.language().map(|language| language.to_string());
+        match self.primary_contributor_spec.as_ref()? {
+            PrimaryContributorSpec::Citation(spec) => {
+                primary_contributor_for_citation(spec, reference)
+            }
+            PrimaryContributorSpec::Bibliography(spec) => {
+                primary_contributor_for_bibliography(spec, reference, language.as_deref())
+            }
+        }
     }
 
     /// Public helper retained for tests/debugging.
@@ -459,6 +618,122 @@ impl<'a> ReferenceSorter<'a> {
             _ => String::new(),
         }
     }
+}
+
+fn first_contributor_component_ref(
+    template: &[citum_schema::template::TemplateComponent],
+) -> Option<&citum_schema::template::TemplateContributor> {
+    for component in template {
+        match component {
+            citum_schema::template::TemplateComponent::Contributor(contributor) => {
+                return Some(contributor);
+            }
+            citum_schema::template::TemplateComponent::Group(group) => {
+                if let Some(contributor) = first_contributor_component_ref(&group.group) {
+                    return Some(contributor);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn first_contributor_component(
+    template: &[citum_schema::template::TemplateComponent],
+) -> Option<citum_schema::template::TemplateContributor> {
+    first_contributor_component_ref(template).cloned()
+}
+
+fn template_has_list_primary(template: &[citum_schema::template::TemplateComponent]) -> bool {
+    first_contributor_component_ref(template)
+        .is_some_and(|component| component.contributor.is_multiple())
+}
+
+fn variants_may_have_list_primary(variants: &citum_schema::template::TemplateVariants) -> bool {
+    variants
+        .values()
+        .any(|variant| variant.as_template().is_none_or(template_has_list_primary))
+}
+
+/// Return whether any template reachable from this citation spec (base,
+/// locale overrides, type variants, or integral/non-integral/subsequent/ibid
+/// forms) declares a merged-list primary contributor component.
+pub(crate) fn citation_may_have_list_primary(spec: &citum_schema::CitationSpec) -> bool {
+    spec.template
+        .as_deref()
+        .is_some_and(template_has_list_primary)
+        || spec
+            .template_ref
+            .as_ref()
+            .and_then(citum_schema::template::TemplateReference::citation_template)
+            .as_deref()
+            .is_some_and(template_has_list_primary)
+        || spec.locales.as_ref().is_some_and(|locales| {
+            locales
+                .iter()
+                .any(|localized| template_has_list_primary(&localized.template))
+        })
+        || spec
+            .type_variants
+            .as_ref()
+            .is_some_and(variants_may_have_list_primary)
+        || spec
+            .integral
+            .as_deref()
+            .is_some_and(citation_may_have_list_primary)
+        || spec
+            .non_integral
+            .as_deref()
+            .is_some_and(citation_may_have_list_primary)
+        || spec
+            .subsequent
+            .as_deref()
+            .is_some_and(citation_may_have_list_primary)
+        || spec
+            .ibid
+            .as_deref()
+            .is_some_and(citation_may_have_list_primary)
+}
+
+fn bibliography_may_have_list_primary(spec: &citum_schema::BibliographySpec) -> bool {
+    spec.template
+        .as_deref()
+        .is_some_and(template_has_list_primary)
+        || spec
+            .template_ref
+            .as_ref()
+            .and_then(citum_schema::template::TemplateReference::bibliography_template)
+            .as_deref()
+            .is_some_and(template_has_list_primary)
+        || spec.locales.as_ref().is_some_and(|locales| {
+            locales
+                .iter()
+                .any(|localized| template_has_list_primary(&localized.template))
+        })
+        || spec
+            .type_variants
+            .as_ref()
+            .is_some_and(variants_may_have_list_primary)
+}
+
+/// Resolve the first contributor component from a reference's effective citation template.
+pub(crate) fn primary_contributor_for_citation(
+    spec: &citum_schema::CitationSpec,
+    reference: &Reference,
+) -> Option<citum_schema::template::TemplateContributor> {
+    let language = reference.language().map(|language| language.to_string());
+    let template = spec.resolve_template_for_type(&reference.ref_type(), language.as_deref())?;
+    first_contributor_component(&template)
+}
+
+fn primary_contributor_for_bibliography(
+    spec: &citum_schema::BibliographySpec,
+    reference: &Reference,
+    language: Option<&str>,
+) -> Option<citum_schema::template::TemplateContributor> {
+    let template = spec.resolve_template_for_type(&reference.ref_type(), language)?;
+    first_contributor_component(&template)
 }
 
 #[cfg(test)]

--- a/crates/citum-engine/src/values/contributor/labels.rs
+++ b/crates/citum-engine/src/values/contributor/labels.rs
@@ -37,15 +37,28 @@ pub(super) struct RoleLabelTermOptions {
     pub text_case: Option<citum_schema::options::titles::TextCase>,
 }
 
+/// Inputs shared by contributor role-label resolution paths.
+pub(super) struct RoleLabelContext<'a, 'options, F: OutputFormat<Output = String>> {
+    pub(super) component: &'a TemplateContributor,
+    pub(super) role: &'a ContributorRole,
+    pub(super) reference: &'a Reference,
+    pub(super) names_count: usize,
+    pub(super) effective_rendering: &'a Rendering,
+    pub(super) options: &'a RenderOptions<'options>,
+    pub(super) fmt: &'a F,
+    pub(super) role_omitted: bool,
+}
+
 fn requested_role_gender(
     component: &TemplateContributor,
+    role: &ContributorRole,
     reference: &Reference,
 ) -> Option<RoleGenderRequest> {
     if let Some(gender) = &component.gender {
         return Some(RoleGenderRequest::Specific(gender.clone()));
     }
 
-    let data_role = contributor_role_to_reference_role(&component.contributor)?;
+    let data_role = contributor_role_to_reference_role(role)?;
 
     let entries = reference.contributor_entries(&data_role);
     let mut genders = entries
@@ -173,7 +186,7 @@ pub(super) fn resolve_role_label_preset<F: OutputFormat<Output = String>>(
 ///
 /// Used so a style can render, e.g., "Eds." from the locale's "eds." (IEEE).
 /// `language` gates English-only transforms via [`resolve_text_case`].
-fn apply_label_case(
+pub(super) fn apply_label_case(
     term: String,
     text_case: Option<citum_schema::options::titles::TextCase>,
     language: &str,
@@ -196,16 +209,11 @@ pub(crate) const RECOGNIZED_LABEL_TERMS: &[&str] = &["chair", "editor", "transla
 
 fn resolve_explicit_label<F: OutputFormat<Output = String>>(
     label_config: &citum_schema::template::RoleLabel,
-    component: &TemplateContributor,
-    reference: &Reference,
-    names_count: usize,
-    effective_rendering: &Rendering,
-    options: &RenderOptions<'_>,
-    fmt: &F,
+    context: &RoleLabelContext<'_, '_, F>,
 ) -> (Option<String>, Option<String>) {
-    use citum_schema::template::{LabelPlacement, RoleLabelForm};
+    use citum_schema::template::RoleLabelForm;
 
-    let plural = names_count > 1;
+    let plural = context.names_count > 1;
     let term_form = match label_config.form {
         RoleLabelForm::Short => TermForm::Short,
         RoleLabelForm::Long => TermForm::Long,
@@ -215,21 +223,54 @@ fn resolve_explicit_label<F: OutputFormat<Output = String>>(
         "chair" => Some(ContributorRole::Chair),
         "editor" => Some(ContributorRole::Editor),
         "translator" => Some(ContributorRole::Translator),
-        _ => Some(component.contributor.clone()),
+        _ => Some(context.role.clone()),
     };
 
-    let requested_gender = requested_role_gender(component, reference);
+    let requested_gender =
+        requested_role_gender(context.component, context.role, context.reference);
     let term_text = role
         .and_then(|r| {
-            resolve_role_term_by_request(options.locale, &r, plural, term_form, requested_gender)
+            resolve_role_term_by_request(
+                context.options.locale,
+                &r,
+                plural,
+                term_form,
+                requested_gender,
+            )
         })
-        .map(|t| apply_label_case(t, label_config.text_case, options.locale.locale.as_str()));
+        .map(|t| {
+            apply_label_case(
+                t,
+                label_config.text_case,
+                context.options.locale.locale.as_str(),
+            )
+        });
+
+    place_explicit_term::<F>(
+        label_config,
+        term_text,
+        context.effective_rendering,
+        context.options,
+        context.fmt,
+    )
+}
+
+/// Place an already-resolved term using an explicit role-label configuration.
+pub(super) fn place_explicit_term<F: OutputFormat<Output = String>>(
+    label_config: &citum_schema::template::RoleLabel,
+    term_text: Option<String>,
+    effective_rendering: &Rendering,
+    options: &RenderOptions<'_>,
+    fmt: &F,
+) -> (Option<String>, Option<String>) {
+    use citum_schema::template::LabelPlacement;
 
     // Explicit label affixes override the placement-derived defaults,
     // mirroring CSL 1.0 `cs:label` prefix/suffix (e.g. `" ("`/`")"`).
-    let (default_before, default_after) = match label_config.placement {
-        LabelPlacement::Prefix => ("", " "),
-        LabelPlacement::Suffix => (", ", ""),
+    let (default_before, default_after) = match (&label_config.placement, &label_config.wrap) {
+        (LabelPlacement::Suffix, Some(_)) => (" ", ""),
+        (LabelPlacement::Prefix, _) => ("", " "),
+        (LabelPlacement::Suffix, None) => (", ", ""),
     };
     let before = label_config.prefix.as_deref().unwrap_or(default_before);
     let after = label_config.suffix.as_deref().unwrap_or(default_after);
@@ -237,17 +278,63 @@ fn resolve_explicit_label<F: OutputFormat<Output = String>>(
     match label_config.placement {
         LabelPlacement::Prefix => (
             term_text.map(|t| {
-                super::format_role_term::<F>(&t, fmt, effective_rendering, options, before, after)
+                super::format_wrapped_role_term::<F>(
+                    &t,
+                    fmt,
+                    effective_rendering,
+                    options,
+                    before,
+                    after,
+                    label_config.wrap.as_deref(),
+                )
             }),
             None,
         ),
         LabelPlacement::Suffix => (
             None,
             term_text.map(|t| {
-                super::format_role_term::<F>(&t, fmt, effective_rendering, options, before, after)
+                super::format_wrapped_role_term::<F>(
+                    &t,
+                    fmt,
+                    effective_rendering,
+                    options,
+                    before,
+                    after,
+                    label_config.wrap.as_deref(),
+                )
             }),
         ),
     }
+}
+
+fn configured_structural_label<F: OutputFormat<Output = String>>(
+    context: &RoleLabelContext<'_, '_, F>,
+) -> Option<citum_schema::template::RoleLabel> {
+    if context.options.context != RenderContext::Bibliography {
+        return None;
+    }
+    let contributors = context.options.config.contributors.as_ref()?;
+    let build = |presentation: &citum_schema::options::RoleLabelPresentation| {
+        citum_schema::template::RoleLabel {
+            term: context.role.as_str().to_string(),
+            form: presentation.form.clone(),
+            placement: presentation.placement.clone(),
+            text_case: presentation.text_case,
+            wrap: presentation.wrap.clone(),
+            prefix: presentation.prefix.clone(),
+            suffix: presentation.suffix.clone(),
+        }
+    };
+
+    if let Some(presentation) = contributors.role_label_presentation(context.role) {
+        return Some(build(presentation));
+    }
+    contributors
+        .role
+        .as_ref()?
+        .defaults?
+        .presentation_for(context.role)
+        .map(|presentation| build(&presentation))
 }
 
 /// Resolve the role-label prefix and suffix for a formatted contributor.
@@ -255,25 +342,35 @@ fn resolve_explicit_label<F: OutputFormat<Output = String>>(
 /// Returns `(prefix, suffix)` strings to wrap the formatted name list.
 /// Precedence: explicit `label` config > configured role presets > form-based defaults.
 pub(super) fn resolve_role_labels<F: OutputFormat<Output = String>>(
-    component: &TemplateContributor,
-    reference: &Reference,
-    names_count: usize,
-    effective_rendering: &Rendering,
-    options: &RenderOptions<'_>,
-    fmt: &F,
-    role_omitted: bool,
+    context: RoleLabelContext<'_, '_, F>,
 ) -> (Option<String>, Option<String>) {
-    if let Some(label_config) = &component.label {
-        return resolve_explicit_label(
-            label_config,
-            component,
-            reference,
-            names_count,
-            effective_rendering,
-            options,
-            fmt,
-        );
+    if let Some(label_config) = &context.component.label {
+        return resolve_explicit_label(label_config, &context);
     }
+    // `role.omit` also suppresses a configured style-wide structural label
+    // (an explicit `role_label_presentation` override or a `role.defaults`
+    // preset bundle), subject to the same verb-form exception applied below
+    // to the remaining preset tiers: a `form: verb`/`form: verb-short`
+    // component's label is structural, not decorative, and is never omitted.
+    let verb_form = matches!(
+        context.component.form,
+        ContributorForm::Verb | ContributorForm::VerbShort
+    );
+    if (!context.role_omitted || verb_form)
+        && let Some(label) = configured_structural_label(&context)
+    {
+        return resolve_explicit_label(&label, &context);
+    }
+    let RoleLabelContext {
+        component,
+        role,
+        reference,
+        names_count,
+        effective_rendering,
+        options,
+        fmt,
+        role_omitted,
+    } = context;
 
     // `role.omit` suppresses the *decorative* default/preset label (e.g. a
     // trailing "(Trans.)"), not a `form: verb`/`form: verb-short` label: the
@@ -294,11 +391,11 @@ pub(super) fn resolve_role_labels<F: OutputFormat<Output = String>>(
         .config
         .contributors
         .as_ref()
-        .and_then(|contributors| contributors.effective_role_label_preset(&component.contributor))
+        .and_then(|contributors| contributors.effective_role_label_preset(role))
     {
-        let requested_gender = requested_role_gender(component, reference);
+        let requested_gender = requested_role_gender(component, role, reference);
         return resolve_role_label_preset(
-            &component.contributor,
+            role,
             preset,
             names_count,
             RoleLabelTermOptions {
@@ -323,11 +420,11 @@ pub(super) fn resolve_role_labels<F: OutputFormat<Output = String>>(
             .config
             .contributors
             .as_ref()
-            .and_then(|contributors| contributors.default_role_label_preset(&component.contributor))
+            .and_then(|contributors| contributors.default_role_label_preset(role))
     {
-        let requested_gender = requested_role_gender(component, reference);
+        let requested_gender = requested_role_gender(component, role, reference);
         return resolve_role_label_preset(
-            &component.contributor,
+            role,
             preset,
             names_count,
             RoleLabelTermOptions {
@@ -342,8 +439,8 @@ pub(super) fn resolve_role_labels<F: OutputFormat<Output = String>>(
 
     // Form-based defaults: verb forms carry their structural verb phrase;
     // no other form receives an automatic label.
-    match (&component.form, &component.contributor) {
-        (ContributorForm::Verb | ContributorForm::VerbShort, role) => {
+    match &component.form {
+        ContributorForm::Verb | ContributorForm::VerbShort => {
             let plural = names_count > 1;
             let term_form = match component.form {
                 ContributorForm::VerbShort => TermForm::VerbShort,

--- a/crates/citum-engine/src/values/contributor/merged.rs
+++ b/crates/citum-engine/src/values/contributor/merged.rs
@@ -1,0 +1,783 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Cross-role contributor assembly and rendering.
+
+use std::collections::HashSet;
+
+use citum_schema::locale::TermForm;
+use citum_schema::options::RoleLabelPreset;
+use citum_schema::reference::Contributor;
+use citum_schema::template::{
+    ContributorForm, ContributorLabelMode, ContributorMerge, ContributorMergeOrder,
+    ContributorRole, LabelPlacement, Rendering, RoleLabel, RoleLabelForm, TemplateContributor,
+};
+
+use super::names::{NameDecoration, NamesOverrides};
+use super::{contributor_for_role, contributor_role_to_reference_role};
+use crate::reference::{FlatName, Reference};
+use crate::render::format::OutputFormat;
+use crate::values::{ProcHints, ProcValues, RenderContext, RenderOptions};
+
+#[derive(Debug, Clone)]
+struct MergedName {
+    name: FlatName,
+    roles: Vec<ContributorRole>,
+}
+
+/// Render a list-form contributor component.
+pub(super) fn values<F: OutputFormat<Output = String>>(
+    component: &TemplateContributor,
+    reference: &Reference,
+    hints: &ProcHints,
+    options: &RenderOptions<'_>,
+    effective_rendering: &Rendering,
+    fmt: &F,
+) -> Option<ProcValues<F::Output>> {
+    let roles = component.contributor.as_slice();
+    let primary_role = roles.first()?;
+    let merge = effective_merge(component, &options.config);
+    let substitute = citum_schema::options::SubstituteConfig::resolve_or_default(
+        options.config.substitute.as_ref(),
+    );
+    let mut suppressed_roles = suppressed_roles(reference, roles, &options.config);
+    suppressed_roles.extend(substitute_suppressed_roles(
+        reference,
+        roles,
+        substitute.as_ref(),
+    ));
+    let entries = assemble_names(
+        reference,
+        roles,
+        &merge,
+        &suppressed_roles,
+        &options.config,
+        options.locale,
+        options.suppress_author,
+    );
+
+    if entries.is_empty() {
+        return resolve_empty_list::<F>(
+            component,
+            primary_role,
+            reference,
+            hints,
+            options,
+            effective_rendering,
+            fmt,
+        );
+    }
+
+    let names = entries
+        .iter()
+        .map(|entry| entry.name.clone())
+        .collect::<Vec<_>>();
+    let name_overrides = NamesOverrides {
+        name_order: component.name_order.as_ref().or_else(|| {
+            options
+                .config
+                .contributors
+                .as_ref()?
+                .effective_role_name_order(primary_role)
+        }),
+        sort_separator: component.sort_separator.as_ref(),
+        shorten: component
+            .shorten
+            .as_ref()
+            .or_else(|| options.config.contributors.as_ref()?.shorten.as_ref()),
+        and: component.and.as_ref(),
+        initialize_with: effective_rendering.initialize_with.as_ref(),
+        name_form: component.name_form.or(effective_rendering.name_form),
+    };
+    let selected_indices =
+        super::names::selected_name_indices(names.len(), name_overrides.shorten, hints);
+    let decorations = build_decorations::<F>(
+        &entries,
+        &selected_indices,
+        &DecorationContext {
+            component,
+            reference,
+            merge: &merge,
+            effective_rendering,
+            options,
+            fmt,
+        },
+    );
+    let formatted = super::names::format_names_decorated(
+        &names,
+        &component.form,
+        options,
+        &name_overrides,
+        hints,
+        &decorations,
+    );
+    let formatted = crate::values::apply_abbreviation(formatted, options.abbreviation_map);
+
+    Some(ProcValues {
+        value: fmt.text(&formatted),
+        prefix: None,
+        suffix: None,
+        url: crate::values::resolve_effective_url(
+            component.links.as_ref(),
+            options.config.links.as_ref(),
+            reference,
+            citum_schema::options::LinkAnchor::Component,
+        ),
+        substituted_key: None,
+        pre_formatted: true,
+    })
+}
+
+fn assemble_names(
+    reference: &Reference,
+    roles: &[ContributorRole],
+    merge: &ContributorMerge,
+    suppressed_roles: &HashSet<ContributorRole>,
+    config: &citum_schema::options::Config,
+    locale: &citum_schema::locale::Locale,
+    suppress_author: bool,
+) -> Vec<MergedName> {
+    let ordered_roles = match merge.order {
+        ContributorMergeOrder::Document => None,
+        ContributorMergeOrder::Role => Some(roles),
+    };
+    let mut result = Vec::new();
+
+    if let Some(ordered_roles) = ordered_roles {
+        for role in ordered_roles {
+            if should_skip_role(role, suppressed_roles, suppress_author) {
+                continue;
+            }
+            for entry in reference
+                .all_contributor_entries()
+                .iter()
+                .filter(|entry| entry_has_template_role(entry, role))
+            {
+                let active_roles = matched_template_roles(entry, roles)
+                    .into_iter()
+                    .filter(|matched| !should_skip_role(matched, suppressed_roles, suppress_author))
+                    .collect::<Vec<_>>();
+                if merge.combine_same_person {
+                    if active_roles.first() == Some(role) {
+                        append_contributor(
+                            &entry.contributor,
+                            &active_roles,
+                            config,
+                            locale,
+                            &mut result,
+                        );
+                    }
+                } else {
+                    append_contributor(
+                        &entry.contributor,
+                        std::slice::from_ref(role),
+                        config,
+                        locale,
+                        &mut result,
+                    );
+                }
+            }
+        }
+    } else {
+        for entry in reference.all_contributor_entries() {
+            let matched_roles = matched_template_roles(entry, roles);
+            if matched_roles.is_empty() {
+                continue;
+            }
+            let active_roles = matched_roles
+                .into_iter()
+                .filter(|role| !should_skip_role(role, suppressed_roles, suppress_author))
+                .collect::<Vec<_>>();
+            if active_roles.is_empty() {
+                continue;
+            }
+            if merge.combine_same_person {
+                append_contributor(
+                    &entry.contributor,
+                    &active_roles,
+                    config,
+                    locale,
+                    &mut result,
+                );
+            } else {
+                for role in active_roles {
+                    append_contributor(
+                        &entry.contributor,
+                        std::slice::from_ref(&role),
+                        config,
+                        locale,
+                        &mut result,
+                    );
+                }
+            }
+        }
+
+        // Legacy reference shapes can expose author/editor/translator through
+        // dedicated accessors without a unified entry. Add only roles absent
+        // from the document-order vector.
+        for role in roles {
+            if reference.all_contributor_entries().iter().any(|entry| {
+                contributor_role_to_reference_role(role)
+                    .as_ref()
+                    .is_some_and(|data_role| entry.roles.contains(data_role))
+            }) || should_skip_role(role, suppressed_roles, suppress_author)
+            {
+                continue;
+            }
+            if let Some(contributor) = contributor_for_role(reference, role) {
+                append_contributor(
+                    &contributor,
+                    std::slice::from_ref(role),
+                    config,
+                    locale,
+                    &mut result,
+                );
+            }
+        }
+    }
+    result
+}
+
+fn matched_template_roles(
+    entry: &citum_schema::reference::ContributorEntry,
+    declared_roles: &[ContributorRole],
+) -> Vec<ContributorRole> {
+    declared_roles
+        .iter()
+        .filter(|role| entry_has_template_role(entry, role))
+        .cloned()
+        .collect()
+}
+
+fn entry_has_template_role(
+    entry: &citum_schema::reference::ContributorEntry,
+    role: &ContributorRole,
+) -> bool {
+    contributor_role_to_reference_role(role)
+        .as_ref()
+        .is_some_and(|data_role| entry.roles.contains(data_role))
+}
+
+fn should_skip_role(
+    role: &ContributorRole,
+    suppressed_roles: &HashSet<ContributorRole>,
+    suppress_author: bool,
+) -> bool {
+    suppressed_roles.contains(role) || (matches!(role, ContributorRole::Author) && suppress_author)
+}
+
+fn append_contributor(
+    contributor: &Contributor,
+    roles: &[ContributorRole],
+    config: &citum_schema::options::Config,
+    locale: &citum_schema::locale::Locale,
+    result: &mut Vec<MergedName>,
+) {
+    let resolved = semantic_contributor_names(contributor, config, locale);
+    for name in resolved {
+        result.push(MergedName {
+            name,
+            roles: roles.to_vec(),
+        });
+    }
+}
+
+/// Resolve one contributor into the multilingual display names used by semantic consumers.
+pub(crate) fn semantic_contributor_names(
+    contributor: &Contributor,
+    config: &citum_schema::options::Config,
+    locale: &citum_schema::locale::Locale,
+) -> Vec<FlatName> {
+    let multilingual = config.multilingual.as_ref();
+    crate::values::resolve_multilingual_name(
+        contributor,
+        multilingual.and_then(|value| value.name_mode.as_ref()),
+        multilingual.and_then(|value| value.preferred_transliteration.as_deref()),
+        multilingual.and_then(|value| value.preferred_script.as_ref()),
+        &locale.locale,
+    )
+}
+
+fn suppressed_roles(
+    reference: &Reference,
+    declared_roles: &[ContributorRole],
+    config: &citum_schema::options::Config,
+) -> HashSet<ContributorRole> {
+    let Some(config) = config.contributors.as_ref() else {
+        return HashSet::new();
+    };
+    config
+        .suppress
+        .iter()
+        .filter(|rule| declared_roles.contains(&rule.role))
+        .filter_map(|rule| {
+            let subject = identity_set(reference, &rule.role);
+            let comparison = identity_set(reference, &rule.when_identical_to);
+            (!subject.is_empty() && subject == comparison).then(|| rule.role.clone())
+        })
+        .collect()
+}
+
+/// Return whether a configured exact-set rule suppresses `role` for `reference`.
+pub(super) fn is_role_suppressed(
+    reference: &Reference,
+    role: &ContributorRole,
+    config: &citum_schema::options::Config,
+) -> bool {
+    let Some(config) = config.contributors.as_ref() else {
+        return false;
+    };
+    config.suppress.iter().any(|rule| {
+        if &rule.role != role {
+            return false;
+        }
+        let subject = identity_set(reference, role);
+        let comparison = identity_set(reference, &rule.when_identical_to);
+        !subject.is_empty() && subject == comparison
+    })
+}
+
+/// Resolve the effective merged names used by sorting and disambiguation.
+pub(crate) fn semantic_names(
+    component: &TemplateContributor,
+    reference: &Reference,
+    config: &citum_schema::options::Config,
+    locale: &citum_schema::locale::Locale,
+) -> Vec<FlatName> {
+    let roles = component.contributor.as_slice();
+    if roles.len() < 2 {
+        return Vec::new();
+    }
+    let merge = effective_merge(component, config);
+    let substitute =
+        citum_schema::options::SubstituteConfig::resolve_or_default(config.substitute.as_ref());
+    let mut suppressed = suppressed_roles(reference, roles, config);
+    suppressed.extend(substitute_suppressed_roles(
+        reference,
+        roles,
+        substitute.as_ref(),
+    ));
+    let entries = assemble_names(reference, roles, &merge, &suppressed, config, locale, false);
+    entries.into_iter().map(|entry| entry.name).collect()
+}
+
+/// Return the declared roles excluded from merged assembly because a
+/// primary contributor role elsewhere consumes them via `role-substitute`
+/// fallback (see `docs/specs/ROLE_SUBSTITUTE_FALLBACK.md`).
+fn substitute_suppressed_roles(
+    reference: &Reference,
+    declared_roles: &[ContributorRole],
+    substitute: &citum_schema::options::Substitute,
+) -> HashSet<ContributorRole> {
+    declared_roles
+        .iter()
+        .filter(|role| {
+            super::substitute::is_role_suppressed_by_substitute(role, substitute, reference)
+        })
+        .cloned()
+        .collect()
+}
+
+/// Resolve the effective merge configuration, borrowing the component-level
+/// or style-wide block when present and only owning the default otherwise.
+fn effective_merge<'a>(
+    component: &'a TemplateContributor,
+    config: &'a citum_schema::options::Config,
+) -> std::borrow::Cow<'a, ContributorMerge> {
+    config.contributors.as_ref().map_or_else(
+        || {
+            component.merge.as_ref().map_or_else(
+                || std::borrow::Cow::Owned(ContributorMerge::default()),
+                std::borrow::Cow::Borrowed,
+            )
+        },
+        |contributors| contributors.effective_merge(component.merge.as_ref()),
+    )
+}
+
+fn identity_set(reference: &Reference, role: &ContributorRole) -> HashSet<usize> {
+    let Some(data_role) = contributor_role_to_reference_role(role) else {
+        return HashSet::new();
+    };
+    reference
+        .all_contributor_entries()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, entry)| entry.roles.contains(&data_role).then_some(index))
+        .collect()
+}
+
+struct DecorationContext<'a, 'options, F: OutputFormat<Output = String>> {
+    component: &'a TemplateContributor,
+    reference: &'a Reference,
+    merge: &'a ContributorMerge,
+    effective_rendering: &'a Rendering,
+    options: &'a RenderOptions<'options>,
+    fmt: &'a F,
+}
+
+fn build_decorations<F: OutputFormat<Output = String>>(
+    entries: &[MergedName],
+    selected_indices: &[usize],
+    context: &DecorationContext<'_, '_, F>,
+) -> Vec<NameDecoration> {
+    let mut decorations = vec![NameDecoration::default(); entries.len()];
+    let mut index = 0;
+    while let Some(entry) = entries.get(index) {
+        let mode = effective_label_mode(entry, context.merge);
+        let run_end = if mode == ContributorLabelMode::Collective {
+            entries
+                .get(index + 1..)
+                .unwrap_or_default()
+                .iter()
+                .position(|candidate| candidate.roles != entry.roles)
+                .map_or(entries.len(), |offset| index + 1 + offset)
+        } else {
+            index + 1
+        };
+        let selected_run = selected_indices
+            .iter()
+            .copied()
+            .filter(|selected| (index..run_end).contains(selected))
+            .collect::<Vec<_>>();
+        if mode != ContributorLabelMode::None && !selected_run.is_empty() {
+            let plural = mode == ContributorLabelMode::Collective && run_end - index > 1;
+            let (prefix, suffix) = resolve_entry_label::<F>(&entry.roles, plural, context);
+            if let Some(decoration) = selected_run
+                .first()
+                .and_then(|first| decorations.get_mut(*first))
+            {
+                decoration.prefix = prefix.unwrap_or_default();
+            }
+            if let Some(decoration) = selected_run
+                .last()
+                .and_then(|last| decorations.get_mut(*last))
+            {
+                decoration.suffix = suffix.unwrap_or_default();
+            }
+        }
+        index = run_end;
+    }
+    decorations
+}
+
+fn effective_label_mode(entry: &MergedName, merge: &ContributorMerge) -> ContributorLabelMode {
+    entry
+        .roles
+        .first()
+        .and_then(|role| merge.roles.get(role))
+        .and_then(|role| role.labels)
+        .unwrap_or(merge.labels)
+}
+
+#[derive(Debug, Clone)]
+struct LabelPresentation {
+    form: TermForm,
+    placement: LabelPlacement,
+    text_case: Option<citum_schema::options::titles::TextCase>,
+    wrap: Option<citum_schema::template::WrapConfig>,
+    before: String,
+    after: String,
+}
+
+fn resolve_entry_label<F: OutputFormat<Output = String>>(
+    roles: &[ContributorRole],
+    plural: bool,
+    context: &DecorationContext<'_, '_, F>,
+) -> (Option<String>, Option<String>) {
+    let Some(primary_role) = roles.first() else {
+        return (None, None);
+    };
+    let explicit = context
+        .merge
+        .roles
+        .get(primary_role)
+        .and_then(|role| role.label.as_ref());
+
+    if roles.len() == 1 {
+        let mut single = context.component.clone();
+        single.contributor = primary_role.clone().into();
+        single.merge = None;
+        single.label = explicit.cloned();
+        return super::labels::resolve_role_labels::<F>(super::labels::RoleLabelContext {
+            component: &single,
+            role: primary_role,
+            reference: context.reference,
+            names_count: usize::from(plural) + 1,
+            effective_rendering: context.effective_rendering,
+            options: context.options,
+            fmt: context.fmt,
+            role_omitted: super::is_role_label_omitted(context.options, primary_role),
+        });
+    }
+
+    let Some(presentation) =
+        label_presentation(context.component, primary_role, explicit, context.options)
+    else {
+        return (None, None);
+    };
+    let term = resolve_combined_term(
+        roles,
+        plural,
+        &presentation.form,
+        context.merge,
+        context.options,
+    );
+    let term = term.map(|term| {
+        super::labels::apply_label_case(
+            term,
+            presentation.text_case,
+            context.options.locale.locale.as_str(),
+        )
+    });
+    place_term::<F>(
+        term,
+        &presentation,
+        context.effective_rendering,
+        context.options,
+        context.fmt,
+    )
+}
+
+fn structural_label_presentation(
+    form: RoleLabelForm,
+    placement: LabelPlacement,
+    text_case: Option<citum_schema::options::titles::TextCase>,
+    wrap: Option<&citum_schema::template::WrapConfig>,
+    prefix: Option<&str>,
+    suffix: Option<&str>,
+) -> LabelPresentation {
+    let (before, after) = match (&placement, wrap) {
+        (LabelPlacement::Suffix, Some(_)) => (prefix.unwrap_or(" "), suffix.unwrap_or_default()),
+        (LabelPlacement::Prefix, _) => (prefix.unwrap_or_default(), suffix.unwrap_or(" ")),
+        (LabelPlacement::Suffix, None) => (prefix.unwrap_or(", "), suffix.unwrap_or_default()),
+    };
+    LabelPresentation {
+        form: match form {
+            RoleLabelForm::Short => TermForm::Short,
+            RoleLabelForm::Long => TermForm::Long,
+        },
+        placement,
+        text_case,
+        wrap: wrap.cloned(),
+        before: before.to_string(),
+        after: after.to_string(),
+    }
+}
+
+fn label_presentation(
+    component: &TemplateContributor,
+    role: &ContributorRole,
+    explicit: Option<&RoleLabel>,
+    options: &RenderOptions<'_>,
+) -> Option<LabelPresentation> {
+    if let Some(label) = explicit {
+        return Some(structural_label_presentation(
+            label.form.clone(),
+            label.placement.clone(),
+            label.text_case,
+            label.wrap.as_deref(),
+            label.prefix.as_deref(),
+            label.suffix.as_deref(),
+        ));
+    }
+
+    // `role.omit` suppresses configured style-wide structural labels (an
+    // explicit `role_label_presentation` override or a `role.defaults`
+    // preset bundle) below, mirroring the scalar path
+    // (`labels::resolve_role_labels`), subject to the same verb-form
+    // exception: a `form: verb`/`form: verb-short` component's label is
+    // structural, not decorative, and is never omitted.
+    let role_omitted = super::is_role_label_omitted(options, role);
+    let verb_form = matches!(
+        component.form,
+        ContributorForm::Verb | ContributorForm::VerbShort
+    );
+    let role_omitted_hides_structural_label = role_omitted && !verb_form;
+
+    if !role_omitted_hides_structural_label
+        && options.context == RenderContext::Bibliography
+        && let Some(label) = options
+            .config
+            .contributors
+            .as_ref()
+            .and_then(|contributors| contributors.role_label_presentation(role))
+    {
+        return Some(structural_label_presentation(
+            label.form.clone(),
+            label.placement.clone(),
+            label.text_case,
+            label.wrap.as_deref(),
+            label.prefix.as_deref(),
+            label.suffix.as_deref(),
+        ));
+    }
+
+    if !role_omitted_hides_structural_label
+        && options.context == RenderContext::Bibliography
+        && let Some(label) = options
+            .config
+            .contributors
+            .as_ref()
+            .and_then(|contributors| contributors.role.as_ref())
+            .and_then(|role_options| role_options.defaults)
+            .and_then(|defaults| defaults.presentation_for(role))
+    {
+        return Some(structural_label_presentation(
+            label.form,
+            label.placement,
+            label.text_case,
+            label.wrap.as_deref(),
+            label.prefix.as_deref(),
+            label.suffix.as_deref(),
+        ));
+    }
+
+    let preset = (options.context == RenderContext::Bibliography)
+        .then(|| {
+            options
+                .config
+                .contributors
+                .as_ref()
+                .and_then(|contributors| contributors.effective_role_label_preset(role))
+        })
+        .flatten()
+        .or_else(|| {
+            (options.context == RenderContext::Bibliography).then_some(())?;
+            options
+                .config
+                .contributors
+                .as_ref()?
+                .default_role_label_preset(role)
+        });
+    if let Some(preset) = preset {
+        return presentation_for_preset(preset, role_omitted, &component.form);
+    }
+    match component.form {
+        ContributorForm::Verb => {
+            presentation_for_preset(RoleLabelPreset::VerbPrefix, false, &component.form)
+        }
+        ContributorForm::VerbShort => {
+            presentation_for_preset(RoleLabelPreset::VerbShortPrefix, false, &component.form)
+        }
+        _ => None,
+    }
+}
+
+fn presentation_for_preset(
+    preset: RoleLabelPreset,
+    role_omitted: bool,
+    form: &ContributorForm,
+) -> Option<LabelPresentation> {
+    if role_omitted && !matches!(form, ContributorForm::Verb | ContributorForm::VerbShort) {
+        return None;
+    }
+    let (term_form, placement, before, after) = match preset {
+        RoleLabelPreset::None => return None,
+        RoleLabelPreset::VerbPrefix => (TermForm::Verb, LabelPlacement::Prefix, "", " "),
+        RoleLabelPreset::VerbShortPrefix => (TermForm::VerbShort, LabelPlacement::Prefix, "", " "),
+        RoleLabelPreset::ShortSuffix => (TermForm::Short, LabelPlacement::Suffix, " (", ")"),
+        RoleLabelPreset::ShortSuffixComma => (TermForm::Short, LabelPlacement::Suffix, ", ", ""),
+        RoleLabelPreset::LongSuffix => (TermForm::Long, LabelPlacement::Suffix, ", ", ""),
+    };
+    Some(LabelPresentation {
+        form: term_form,
+        placement,
+        text_case: None,
+        wrap: None,
+        before: before.to_string(),
+        after: after.to_string(),
+    })
+}
+
+fn resolve_combined_term(
+    roles: &[ContributorRole],
+    plural: bool,
+    form: &TermForm,
+    merge: &ContributorMerge,
+    options: &RenderOptions<'_>,
+) -> Option<String> {
+    options
+        .locale
+        .resolved_role_combination_term(roles, plural, form, None)
+        .or_else(|| {
+            let connector = merge
+                .role_conjunction
+                .as_deref()
+                .unwrap_or_else(|| options.locale.role_conjunction());
+            let terms = roles
+                .iter()
+                .map(|role| options.locale.resolved_role_term(role, plural, form, None))
+                .collect::<Option<Vec<_>>>()?;
+            Some(terms.join(connector))
+        })
+}
+
+fn place_term<F: OutputFormat<Output = String>>(
+    term: Option<String>,
+    presentation: &LabelPresentation,
+    effective_rendering: &Rendering,
+    options: &RenderOptions<'_>,
+    fmt: &F,
+) -> (Option<String>, Option<String>) {
+    let placed = term.map(|term| {
+        super::format_wrapped_role_term::<F>(
+            &term,
+            fmt,
+            effective_rendering,
+            options,
+            &presentation.before,
+            &presentation.after,
+            presentation.wrap.as_ref(),
+        )
+    });
+    match presentation.placement {
+        LabelPlacement::Prefix => (placed, None),
+        LabelPlacement::Suffix => (None, placed),
+    }
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Empty-list substitution shares the contributor rendering context."
+)]
+fn resolve_empty_list<F: OutputFormat<Output = String>>(
+    component: &TemplateContributor,
+    primary_role: &ContributorRole,
+    reference: &Reference,
+    hints: &ProcHints,
+    options: &RenderOptions<'_>,
+    effective_rendering: &Rendering,
+    fmt: &F,
+) -> Option<ProcValues<F::Output>> {
+    let substitute = citum_schema::options::SubstituteConfig::resolve_or_default(
+        options.config.substitute.as_ref(),
+    );
+    let mut scalar = component.clone();
+    scalar.contributor = primary_role.clone().into();
+    scalar.merge = None;
+    if matches!(primary_role, ContributorRole::Author) {
+        super::substitute::resolve_author_substitute::<F>(
+            &scalar,
+            hints,
+            options,
+            reference,
+            effective_rendering,
+            fmt,
+            substitute.as_ref(),
+        )
+    } else {
+        super::substitute::resolve_role_substitute::<F>(
+            primary_role,
+            &scalar,
+            hints,
+            options,
+            reference,
+            effective_rendering,
+            fmt,
+            substitute.as_ref(),
+        )
+    }
+}

--- a/crates/citum-engine/src/values/contributor/mod.rs
+++ b/crates/citum-engine/src/values/contributor/mod.rs
@@ -9,8 +9,9 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! role labels, et-al formatting, and multilingual name resolution.
 
 pub(crate) mod labels;
+pub(crate) mod merged;
 pub mod names;
-mod substitute;
+pub(crate) mod substitute;
 
 use crate::reference::Reference;
 use crate::values::{ComponentValues, ProcHints, ProcValues, RenderContext, RenderOptions};
@@ -39,7 +40,7 @@ pub(super) fn contributor_for_role(
 }
 
 /// Map a template contributor role to the corresponding reference contributor role.
-pub(super) fn contributor_role_to_reference_role(
+pub(crate) fn contributor_role_to_reference_role(
     role: &ContributorRole,
 ) -> Option<citum_schema::reference::ContributorRole> {
     match role {
@@ -56,6 +57,7 @@ pub(super) fn contributor_role_to_reference_role(
         ContributorRole::Director => Some(citum_schema::reference::ContributorRole::Director),
         ContributorRole::Composer => Some(citum_schema::reference::ContributorRole::Composer),
         ContributorRole::Writer => Some(citum_schema::reference::ContributorRole::Writer),
+        ContributorRole::Producer => Some(citum_schema::reference::ContributorRole::Producer),
         ContributorRole::Illustrator => Some(citum_schema::reference::ContributorRole::Illustrator),
         ContributorRole::Inventor => Some(citum_schema::reference::ContributorRole::Unknown(
             "inventor".to_string(),
@@ -124,6 +126,15 @@ pub(super) fn format_role_term<F: crate::render::format::OutputFormat<Output = S
     prefix: &str,
     suffix: &str,
 ) -> String {
+    let term_str = normalized_role_term(term, effective_rendering, options);
+    fmt.text(&format!("{prefix}{term_str}{suffix}"))
+}
+
+fn normalized_role_term(
+    term: &str,
+    effective_rendering: &citum_schema::template::Rendering,
+    options: &RenderOptions<'_>,
+) -> String {
     let term_str = if crate::values::should_strip_periods(effective_rendering, options) {
         crate::values::strip_trailing_periods(term)
     } else {
@@ -134,13 +145,41 @@ pub(super) fn format_role_term<F: crate::render::format::OutputFormat<Output = S
     // `pre_formatted`, which skips the generic title/value text-case pass,
     // so a style that positions the verb label as its own clause (e.g.
     // after a `". "` prefix) must opt in here explicitly.
-    let term_str = match effective_rendering.text_case {
+    match effective_rendering.text_case {
         Some(citum_schema::options::titles::TextCase::CapitalizeFirst) => {
             crate::values::text_case::capitalize_first_word(&term_str)
         }
         _ => term_str,
+    }
+}
+
+/// Format a role term with optional structural wrapping.
+///
+/// The unwrapped path delegates to [`format_role_term`] to preserve its exact
+/// escaping and affix behavior. Wrapped labels apply inner affixes, wrapping
+/// punctuation, and finally the outer label affixes.
+pub(super) fn format_wrapped_role_term<F: crate::render::format::OutputFormat<Output = String>>(
+    term: &str,
+    fmt: &F,
+    effective_rendering: &citum_schema::template::Rendering,
+    options: &RenderOptions<'_>,
+    prefix: &str,
+    suffix: &str,
+    wrap: Option<&citum_schema::template::WrapConfig>,
+) -> String {
+    let Some(wrap) = wrap else {
+        return format_role_term(term, fmt, effective_rendering, options, prefix, suffix);
     };
-    fmt.text(&format!("{prefix}{term_str}{suffix}"))
+    let term = normalized_role_term(term, effective_rendering, options);
+    let content = fmt.text(&term);
+    let content = fmt.inner_affix(
+        wrap.inner_prefix.as_deref().unwrap_or_default(),
+        content,
+        wrap.inner_suffix.as_deref().unwrap_or_default(),
+    );
+    let marks = crate::render::format::QuoteMarks::from(&options.locale.grammar_options);
+    let content = fmt.wrap_punctuation(&wrap.punctuation, content, &marks);
+    format!("{}{content}{}", fmt.text(prefix), fmt.text(suffix))
 }
 
 /// Apply the integral-citation subsequent-form rewrite to a contributor on a
@@ -156,7 +195,7 @@ fn apply_integral_subsequent_form(
     if !matches!(options.mode, citum_schema::citation::CitationMode::Integral) {
         return;
     }
-    if !matches!(component.contributor, ContributorRole::Author) {
+    if !component.contributor.contains(&ContributorRole::Author) {
         return;
     }
     if !matches!(
@@ -177,6 +216,7 @@ fn apply_integral_subsequent_form(
 /// Build name overrides and format all names for a contributor component.
 fn format_contributor_names(
     component: &TemplateContributor,
+    role: &ContributorRole,
     names_vec: &[crate::reference::FlatName],
     effective_rendering: &citum_schema::template::Rendering,
     options: &RenderOptions<'_>,
@@ -187,7 +227,7 @@ fn format_contributor_names(
             .config
             .contributors
             .as_ref()?
-            .effective_role_name_order(&component.contributor)
+            .effective_role_name_order(role)
     });
     let effective_shorten = component
         .shorten
@@ -230,37 +270,55 @@ impl ComponentValues for TemplateContributor {
         // Apply integral-citation subsequent-form (FullThenShort rule)
         apply_integral_subsequent_form(&mut component, hints, options);
 
-        // Respect explicit suppression before any contributor substitution logic.
+        // Respect explicit suppression before either contributor rendering path.
         if effective_rendering.suppress == Some(true) {
             return None;
         }
 
-        let contributor = match &component.contributor {
-            ContributorRole::Author => {
-                if options.suppress_author {
-                    None
-                } else {
-                    contributor_for_role(reference, &component.contributor)
-                }
-            }
-            _ => contributor_for_role(reference, &component.contributor),
+        let Some(role) = component.contributor.as_single().cloned() else {
+            return merged::values::<F>(
+                &component,
+                reference,
+                hints,
+                options,
+                &effective_rendering,
+                &fmt,
+            );
         };
 
-        // Resolve substitute config once for all substitute/suppression checks below.
-        let default_substitute = citum_schema::options::SubstituteConfig::default();
-        let substitute_config = options
-            .config
-            .substitute
-            .as_ref()
-            .unwrap_or(&default_substitute);
-        let substitute = substitute_config.resolve();
+        if merged::is_role_suppressed(reference, &role, &options.config) {
+            return None;
+        }
 
-        // Check if this role is suppressed by role-substitute configuration
-        if substitute::is_role_suppressed_by_substitute(
-            &component.contributor,
-            &substitute,
-            reference,
-        ) {
+        // Resolve substitute config once for all substitute/suppression checks below.
+        let substitute = citum_schema::options::SubstituteConfig::resolve_or_default(
+            options.config.substitute.as_ref(),
+        );
+
+        // The author slot is resolved as one effective-primary value so
+        // rendering, sorting, and disambiguation share type overrides and
+        // semantic-author precedence.
+        if matches!(role, ContributorRole::Author) {
+            if options.suppress_author {
+                return None;
+            }
+            return substitute::resolve_author_substitute::<F>(
+                &component,
+                hints,
+                options,
+                reference,
+                &effective_rendering,
+                &fmt,
+                substitute.as_ref(),
+            );
+        }
+
+        let contributor = contributor_for_role(reference, &role);
+
+        // Check if this secondary role is suppressed by role-substitute
+        // configuration. Primary-slot overrides deliberately promote roles
+        // that may also appear in these secondary fallback chains.
+        if substitute::is_role_suppressed_by_substitute(&role, substitute.as_ref(), reference) {
             return None;
         }
 
@@ -271,54 +329,41 @@ impl ComponentValues for TemplateContributor {
             Vec::new()
         };
 
-        // If author is suppressed, don't attempt substitution or formatting.
-        if names_vec.is_empty()
-            && matches!(component.contributor, ContributorRole::Author)
-            && options.suppress_author
-        {
-            return None;
-        }
-
-        // Handle substitution if author is empty.
-        if names_vec.is_empty() && matches!(component.contributor, ContributorRole::Author) {
-            return substitute::resolve_author_substitute::<F>(
-                &component,
-                hints,
-                options,
-                reference,
-                &effective_rendering,
-                &fmt,
-                &substitute,
-            );
-        }
-
         // Handle role-substitute if this role is empty.
         if names_vec.is_empty() {
             return substitute::resolve_role_substitute::<F>(
-                &component.contributor,
+                &role,
                 &component,
                 hints,
                 options,
                 reference,
                 &effective_rendering,
                 &fmt,
-                &substitute,
+                substitute.as_ref(),
             );
         }
 
-        let formatted =
-            format_contributor_names(&component, &names_vec, &effective_rendering, options, hints);
-
-        let role_omitted = is_role_label_omitted(options, &component.contributor);
-        let (role_prefix, role_suffix) = labels::resolve_role_labels::<F>(
+        let formatted = format_contributor_names(
             &component,
-            reference,
-            names_vec.len(),
+            &role,
+            &names_vec,
             &effective_rendering,
             options,
-            &fmt,
-            role_omitted,
+            hints,
         );
+
+        let role_omitted = is_role_label_omitted(options, &role);
+        let (role_prefix, role_suffix) =
+            labels::resolve_role_labels::<F>(labels::RoleLabelContext {
+                component: &component,
+                role: &role,
+                reference,
+                names_count: names_vec.len(),
+                effective_rendering: &effective_rendering,
+                options,
+                fmt: &fmt,
+                role_omitted,
+            });
 
         let is_pre_formatted = role_prefix.is_some() || role_suffix.is_some();
         let formatted = crate::values::apply_abbreviation(formatted, options.abbreviation_map);

--- a/crates/citum-engine/src/values/contributor/names.rs
+++ b/crates/citum-engine/src/values/contributor/names.rs
@@ -56,16 +56,31 @@ pub struct NamesOverrides<'a> {
     pub name_form: Option<NameForm>,
 }
 
-/// Partition names into (`first_names`, `use_et_al`, `last_names`) based on et-al options.
-fn partition_et_al<'a>(
-    names: &'a [crate::reference::FlatName],
-    shorten: Option<&'a ShortenListOptions>,
-    hints: &'a ProcHints,
-) -> (
-    Vec<&'a crate::reference::FlatName>,
-    bool,
-    Vec<&'a crate::reference::FlatName>,
-) {
+/// Prefix and suffix attached to a selected name before list joining.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct NameDecoration {
+    /// Text emitted immediately before the formatted name.
+    pub(super) prefix: String,
+    /// Text emitted immediately after the formatted name.
+    pub(super) suffix: String,
+}
+
+/// Return the original indexes retained by et-al selection.
+pub(super) fn selected_name_indices(
+    name_count: usize,
+    shorten: Option<&ShortenListOptions>,
+    hints: &ProcHints,
+) -> Vec<usize> {
+    let (first, _, last) = partition_et_al_indices(name_count, shorten, hints);
+    first.into_iter().chain(last).collect()
+}
+
+/// Partition name indexes into (`first`, `use_et_al`, `last`) based on et-al options.
+fn partition_et_al_indices(
+    name_count: usize,
+    shorten: Option<&ShortenListOptions>,
+    hints: &ProcHints,
+) -> (Vec<usize>, bool, Vec<usize>) {
     if let Some(opts) = shorten {
         // Determine effective min/use_first based on citation position.
         let is_subsequent = matches!(
@@ -96,27 +111,49 @@ fn partition_et_al<'a>(
         };
 
         // Apply et-al only if the list exceeds the minimum threshold
-        if names.len() >= effective_min_threshold {
-            if effective_min >= names.len() {
-                (names.iter().collect::<Vec<_>>(), false, Vec::new())
+        if name_count >= effective_min_threshold {
+            if effective_min >= name_count {
+                ((0..name_count).collect(), false, Vec::new())
             } else {
-                let first: Vec<&crate::reference::FlatName> =
-                    names.iter().take(effective_min).collect();
-                let last: Vec<&crate::reference::FlatName> = if let Some(ul) = opts.use_last {
+                let first = (0..effective_min).collect();
+                let last = if let Some(ul) = opts.use_last {
                     let take_last = ul as usize;
-                    let skip = std::cmp::max(effective_min, names.len().saturating_sub(take_last));
-                    names.iter().skip(skip).collect()
+                    let skip = std::cmp::max(effective_min, name_count.saturating_sub(take_last));
+                    (skip..name_count).collect()
                 } else {
                     Vec::new()
                 };
                 (first, true, last)
             }
         } else {
-            (names.iter().collect::<Vec<_>>(), false, Vec::new())
+            ((0..name_count).collect(), false, Vec::new())
         }
     } else {
-        (names.iter().collect::<Vec<_>>(), false, Vec::new())
+        ((0..name_count).collect(), false, Vec::new())
     }
+}
+
+/// Partition names into (`first_names`, `use_et_al`, `last_names`) based on et-al options.
+fn partition_et_al<'a>(
+    names: &'a [crate::reference::FlatName],
+    shorten: Option<&ShortenListOptions>,
+    hints: &ProcHints,
+) -> (
+    Vec<&'a crate::reference::FlatName>,
+    bool,
+    Vec<&'a crate::reference::FlatName>,
+) {
+    let (first, use_et_al, last) = partition_et_al_indices(names.len(), shorten, hints);
+    (
+        first
+            .into_iter()
+            .filter_map(|index| names.get(index))
+            .collect(),
+        use_et_al,
+        last.into_iter()
+            .filter_map(|index| names.get(index))
+            .collect(),
+    )
 }
 
 /// Join a list of formatted names with a conjunction and Oxford-comma rules.
@@ -293,6 +330,19 @@ pub fn format_names(
     overrides: &NamesOverrides<'_>,
     hints: &ProcHints,
 ) -> String {
+    format_names_decorated(names, form, options, overrides, hints, &[])
+}
+
+/// Format names with per-entry decorations applied before list joining.
+#[must_use]
+pub(super) fn format_names_decorated(
+    names: &[crate::reference::FlatName],
+    form: &ContributorForm,
+    options: &RenderOptions<'_>,
+    overrides: &NamesOverrides<'_>,
+    hints: &ProcHints,
+    decorations: &[NameDecoration],
+) -> String {
     if names.is_empty() {
         return String::new();
     }
@@ -353,48 +403,23 @@ pub fn format_names(
 
     let delimiter = config.and_then(|c| c.delimiter.as_deref()).unwrap_or(", ");
 
-    let formatted_first: Vec<String> = first_names
-        .iter()
-        .enumerate()
-        .map(|(i, name)| {
-            let expand =
-                hints.expand_given_names && !(hints.expand_given_names_primary_only && i > 0);
-            format_single_name(name, form, i, &ctx, expand)
-        })
-        .collect();
-
-    let formatted_last: Vec<String> = last_names
-        .iter()
-        .enumerate()
-        .map(|(i, name)| {
-            let original_idx = names.len() - last_names.len() + i;
-            let expand = hints.expand_given_names
-                && !(hints.expand_given_names_primary_only && original_idx > 0);
-            format_single_name(name, form, original_idx, &ctx, expand)
-        })
-        .collect();
+    let (formatted_first, formatted_last) = format_selected_names(
+        names,
+        &first_names,
+        &last_names,
+        form,
+        &ctx,
+        hints,
+        decorations,
+    );
 
     // Determine "and" setting: use override if provided, else global config
     let and_option = overrides
         .and
         .or_else(|| config.and_then(|c| c.and.as_ref()));
 
-    // Determine conjunction between last two names
-    // Default (None or no config) means no conjunction, matching CSL behavior
-    let and_str = match and_option {
-        Some(AndOptions::Text) => Some(locale.and_term(false)),
-        Some(AndOptions::Symbol) => Some(locale.and_term(true)),
-        Some(AndOptions::None) | None => None, // No conjunction
-        _ => None,                             // Catch-all for future non_exhaustive variants
-    };
-    // When "et al." is applied, most styles expect comma-separated shown names
-    // before the abbreviation (e.g., "Smith, Jones, et al."), not a final
-    // conjunction ("Smith, Jones, and Brown, et al.").
-    let and_str = if use_et_al && formatted_last.is_empty() {
-        None
-    } else {
-        and_str
-    };
+    let and_str =
+        resolve_name_conjunction(and_option, locale, use_et_al, !formatted_last.is_empty());
 
     // Check if delimiter should precede last name (Oxford comma)
     let delimiter_precedes_last = config.and_then(|c| c.delimiter_precedes_last.as_ref());
@@ -430,6 +455,71 @@ pub fn format_names(
         &ctx,
         locale,
     )
+}
+
+fn resolve_name_conjunction<'a>(
+    and_option: Option<&AndOptions>,
+    locale: &'a citum_schema::locale::Locale,
+    use_et_al: bool,
+    has_retained_last_names: bool,
+) -> Option<&'a str> {
+    if use_et_al && !has_retained_last_names {
+        return None;
+    }
+    match and_option {
+        Some(AndOptions::Text) => Some(locale.and_term(false)),
+        Some(AndOptions::Symbol) => Some(locale.and_term(true)),
+        Some(AndOptions::None) | None => None,
+        _ => None,
+    }
+}
+
+fn format_selected_names(
+    names: &[crate::reference::FlatName],
+    first_names: &[&crate::reference::FlatName],
+    last_names: &[&crate::reference::FlatName],
+    form: &ContributorForm,
+    context: &NameFormatContext<'_>,
+    hints: &ProcHints,
+    decorations: &[NameDecoration],
+) -> (Vec<String>, Vec<String>) {
+    let formatted_first = first_names
+        .iter()
+        .enumerate()
+        .map(|(index, name)| {
+            let expand =
+                hints.expand_given_names && !(hints.expand_given_names_primary_only && index > 0);
+            decorate_name(
+                format_single_name(name, form, index, context, expand),
+                index,
+                decorations,
+            )
+        })
+        .collect();
+    let formatted_last = last_names
+        .iter()
+        .enumerate()
+        .map(|(index, name)| {
+            let original_index = names.len() - last_names.len() + index;
+            let expand = hints.expand_given_names
+                && !(hints.expand_given_names_primary_only && original_index > 0);
+            decorate_name(
+                format_single_name(name, form, original_index, context, expand),
+                original_index,
+                decorations,
+            )
+        })
+        .collect();
+    (formatted_first, formatted_last)
+}
+
+fn decorate_name(value: String, index: usize, decorations: &[NameDecoration]) -> String {
+    match decorations.get(index) {
+        Some(decoration) if !decoration.prefix.is_empty() || !decoration.suffix.is_empty() => {
+            format!("{}{value}{}", decoration.prefix, decoration.suffix)
+        }
+        _ => value,
+    }
 }
 
 /// Initialize a given name by extracting initials.

--- a/crates/citum-engine/src/values/contributor/substitute.rs
+++ b/crates/citum-engine/src/values/contributor/substitute.rs
@@ -14,12 +14,30 @@ use crate::render::format::OutputFormat;
 use crate::values::text_case::apply_text_case;
 use crate::values::title::resolve_substitute_text_case;
 use crate::values::{ProcHints, ProcValues, RenderContext, RenderOptions};
-use citum_schema::options::{RoleLabelPreset, SubstituteKey, SubstituteTitleQuoteMode};
-use citum_schema::reference::Title;
-use citum_schema::reference::{ClassExtension, ContributorRole as DataRole};
-use citum_schema::template::{
-    ContributorRole, Rendering, TemplateComponent, TemplateContributor, TitleType,
+use citum_schema::options::{
+    RoleLabelPreset, SubstituteField, SubstituteKey, SubstituteTitleQuoteMode,
 };
+use citum_schema::reference::Title;
+use citum_schema::reference::{
+    AudioVisualType, ClassExtension, Contributor, ContributorRole as DataRole,
+};
+use citum_schema::template::{
+    ContributorRole, ContributorRoles, Rendering, TemplateComponent, TemplateContributor, TitleType,
+};
+
+/// Resolved value occupying the style's effective primary-contributor slot.
+#[derive(Debug, Clone)]
+pub(crate) enum EffectivePrimary {
+    /// A scalar contributor payload, including existing semantic-author fallback.
+    Contributor {
+        contributor: Box<Contributor>,
+        role: ContributorRole,
+    },
+    /// An ordered cross-role candidate assembled from the native contributor vector.
+    Merged(ContributorRoles),
+    /// A title field used after contributor candidates are exhausted.
+    Title { title: Title, kind: TitleType },
+}
 
 enum ResolvedRole {
     BuiltIn(ContributorRole),
@@ -184,25 +202,23 @@ pub(super) fn resolve_multilingual_for_contrib(
     )
 }
 
-/// Resolve substitute-path role labels for a rendered fallback contributor.
-fn resolve_substitute_role_labels<F: OutputFormat<Output = String>>(
-    component: &TemplateContributor,
-    role: &ResolvedRole,
+struct SubstituteRoleLabelContext<'a, 'b, F> {
+    component: &'a TemplateContributor,
+    role: &'a ResolvedRole,
     names_count: usize,
-    options: &RenderOptions<'_>,
-    effective_rendering: &Rendering,
-    fmt: &F,
-    substitute: &citum_schema::options::Substitute,
-) -> (Option<String>, Option<String>) {
-    if options.context != RenderContext::Bibliography
-        || role
-            .built_in()
-            .is_some_and(|known| super::is_role_label_omitted(options, known))
-    {
-        return (None, None);
-    }
+    reference: &'a Reference,
+    options: &'a RenderOptions<'b>,
+    effective_rendering: &'a Rendering,
+    fmt: &'a F,
+    substitute: &'a citum_schema::options::Substitute,
+}
 
-    let preset = substitute
+fn substitute_role_label_preset(
+    role: &ResolvedRole,
+    options: &RenderOptions<'_>,
+    substitute: &citum_schema::options::Substitute,
+) -> Option<RoleLabelPreset> {
+    substitute
         .contributor_role_form
         .as_deref()
         .and_then(|form| match form {
@@ -212,15 +228,74 @@ fn resolve_substitute_role_labels<F: OutputFormat<Output = String>>(
             _ => None,
         })
         .or_else(|| {
-            options
-                .config
-                .contributors
-                .as_ref()
-                .and_then(|contributors| {
-                    role.built_in()
-                        .and_then(|known| contributors.effective_role_label_preset(known))
-                })
+            let contributors = options.config.contributors.as_ref()?;
+            role.built_in()
+                .and_then(|known| contributors.effective_role_label_preset(known))
+        })
+        .or_else(|| {
+            let contributors = options.config.contributors.as_ref()?;
+            role.built_in()
+                .and_then(|known| contributors.default_role_label_preset(known))
+        })
+}
+
+/// Resolve substitute-path role labels for a rendered fallback contributor.
+fn resolve_substitute_role_labels<F: OutputFormat<Output = String>>(
+    context: &SubstituteRoleLabelContext<'_, '_, F>,
+) -> (Option<String>, Option<String>) {
+    let SubstituteRoleLabelContext {
+        component,
+        role,
+        names_count,
+        reference,
+        options,
+        effective_rendering,
+        fmt,
+        substitute,
+    } = context;
+    if matches!(role.built_in(), Some(ContributorRole::Author)) {
+        return (None, None);
+    }
+    if options.context != RenderContext::Bibliography
+        || role
+            .built_in()
+            .is_some_and(|known| super::is_role_label_omitted(options, known))
+    {
+        return (None, None);
+    }
+
+    if substitute.contributor_role_form.is_none()
+        && substitute.contributor_role_case.is_none()
+        && let Some(known) = role.built_in()
+        && options
+            .config
+            .contributors
+            .as_ref()
+            .is_some_and(|contributors| {
+                contributors.role_label_presentation(known).is_some()
+                    || contributors
+                        .role
+                        .as_ref()
+                        .and_then(|role_options| role_options.defaults)
+                        .and_then(|defaults| defaults.presentation_for(known))
+                        .is_some()
+            })
+    {
+        let mut role_component = (*component).clone();
+        role_component.contributor = known.clone().into();
+        return super::labels::resolve_role_labels::<F>(super::labels::RoleLabelContext {
+            component: &role_component,
+            role: known,
+            reference,
+            names_count: *names_count,
+            effective_rendering,
+            options,
+            fmt: *fmt,
+            role_omitted: super::is_role_label_omitted(options, known),
         });
+    }
+
+    let preset = substitute_role_label_preset(role, options, substitute);
 
     preset
         .and_then(|selected| {
@@ -237,7 +312,7 @@ fn resolve_substitute_role_labels<F: OutputFormat<Output = String>>(
                 super::labels::resolve_role_label_preset::<F>(
                     known,
                     selected,
-                    names_count,
+                    *names_count,
                     super::labels::RoleLabelTermOptions {
                         gender: None,
                         text_case: substitute.contributor_role_case,
@@ -272,6 +347,33 @@ fn resolve_named_substitute<F: OutputFormat<Output = String>>(
         return None;
     }
 
+    // Preserve the scalar author fast path. Semantic authors are not
+    // substitutes, do not carry role labels, and should avoid constructing a
+    // substituted variable key on every bibliography render.
+    if matches!(role.built_in(), Some(ContributorRole::Author)) {
+        let formatted = super::format_contributor_names(
+            component,
+            &ContributorRole::Author,
+            &names_vec,
+            effective_rendering,
+            options,
+            hints,
+        );
+        return Some(ProcValues {
+            value: crate::values::apply_abbreviation(formatted, options.abbreviation_map),
+            prefix: None,
+            suffix: None,
+            url: crate::values::resolve_effective_url(
+                component.links.as_ref(),
+                options.config.links.as_ref(),
+                reference,
+                citum_schema::options::LinkAnchor::Component,
+            ),
+            substituted_key: None,
+            pre_formatted: false,
+        });
+    }
+
     let effective_name_order = component.name_order.as_ref().or_else(|| {
         role.built_in().and_then(|known| {
             options
@@ -298,15 +400,16 @@ fn resolve_named_substitute<F: OutputFormat<Output = String>>(
     };
     let formatted =
         super::names::format_names(&names_vec, &component.form, options, &name_overrides, hints);
-    let (prefix, suffix) = resolve_substitute_role_labels::<F>(
+    let (prefix, suffix) = resolve_substitute_role_labels::<F>(&SubstituteRoleLabelContext {
         component,
         role,
-        names_vec.len(),
+        names_count: names_vec.len(),
+        reference,
         options,
         effective_rendering,
         fmt,
         substitute,
-    );
+    });
 
     let url = crate::values::resolve_effective_url(
         component.links.as_ref(),
@@ -319,7 +422,7 @@ fn resolve_named_substitute<F: OutputFormat<Output = String>>(
         || Some(format!("contributor:{}", role.key())),
         |known| {
             get_variable_key(&TemplateComponent::Contributor(TemplateContributor {
-                contributor: known.clone(),
+                contributor: known.clone().into(),
                 rendering: component.rendering.clone(),
                 ..Default::default()
             }))
@@ -554,6 +657,197 @@ fn resolve_parent_serial_title(reference: &Reference) -> Option<Title> {
     }
 }
 
+fn native_type_key(reference: &Reference) -> Option<&'static str> {
+    reference
+        .as_audio_visual()
+        .and_then(|work| match work.r#type {
+            AudioVisualType::Film => Some("film"),
+            AudioVisualType::Episode => Some("episode"),
+            AudioVisualType::Recording => Some("recording"),
+            AudioVisualType::Broadcast => Some("broadcast"),
+            _ => None,
+        })
+}
+
+fn exact_type_candidates<'a>(
+    reference: &Reference,
+    substitute: &'a citum_schema::options::Substitute,
+) -> Option<&'a [SubstituteKey]> {
+    if let Some(candidates) =
+        native_type_key(reference).and_then(|key| substitute.overrides.get(key))
+    {
+        return Some(candidates.as_slice());
+    }
+
+    substitute
+        .overrides
+        .get(&reference.ref_type())
+        .map(Vec::as_slice)
+}
+
+fn contributor_for_candidate(reference: &Reference, role: &ContributorRole) -> Option<Contributor> {
+    lookup_role_contributor(reference, &ResolvedRole::BuiltIn(role.clone()))
+}
+
+/// An [`EffectivePrimary`] candidate paired with the multilingual names that
+/// justify selecting it, resolved together in a single pass.
+///
+/// `resolve_candidate` needs a candidate's names only to test whether it is
+/// non-empty (to decide whether the candidate qualifies); keeping the
+/// resolved vector alongside the selected variant lets
+/// [`effective_primary_names`] reuse it instead of re-running the same
+/// (potentially expensive, suppression-aware) name assembly a second time.
+struct EffectivePrimaryResolution {
+    primary: EffectivePrimary,
+    names: Vec<crate::reference::FlatName>,
+}
+
+fn resolve_candidate(
+    candidate: &SubstituteKey,
+    reference: &Reference,
+    config: &citum_schema::options::Config,
+    locale: &citum_schema::locale::Locale,
+) -> Option<EffectivePrimaryResolution> {
+    match candidate {
+        SubstituteKey::Contributor(candidate) => {
+            if let Some(role) = candidate.contributor.as_single() {
+                contributor_for_candidate(reference, role).and_then(|contributor| {
+                    let names =
+                        super::merged::semantic_contributor_names(&contributor, config, locale);
+                    (!names.is_empty()).then(|| EffectivePrimaryResolution {
+                        primary: EffectivePrimary::Contributor {
+                            contributor: Box::new(contributor),
+                            role: role.clone(),
+                        },
+                        names,
+                    })
+                })
+            } else {
+                let component = TemplateContributor {
+                    contributor: candidate.contributor.clone(),
+                    ..Default::default()
+                };
+                let names = super::merged::semantic_names(&component, reference, config, locale);
+                (!names.is_empty()).then(|| EffectivePrimaryResolution {
+                    primary: EffectivePrimary::Merged(candidate.contributor.clone()),
+                    names,
+                })
+            }
+        }
+        SubstituteKey::Field(field) => match field {
+            SubstituteField::CollectionEditor => contributor_for_candidate(
+                reference,
+                &ContributorRole::CollectionEditor,
+            )
+            .and_then(|contributor| {
+                let names = super::merged::semantic_contributor_names(&contributor, config, locale);
+                (!names.is_empty()).then(|| EffectivePrimaryResolution {
+                    primary: EffectivePrimary::Contributor {
+                        contributor: Box::new(contributor),
+                        role: ContributorRole::CollectionEditor,
+                    },
+                    names,
+                })
+            }),
+            SubstituteField::Editor => reference.editor().and_then(|contributor| {
+                let names = super::merged::semantic_contributor_names(&contributor, config, locale);
+                (!names.is_empty()).then(|| EffectivePrimaryResolution {
+                    primary: EffectivePrimary::Contributor {
+                        contributor: Box::new(contributor),
+                        role: ContributorRole::Editor,
+                    },
+                    names,
+                })
+            }),
+            SubstituteField::ParentSerial => {
+                resolve_parent_serial_title(reference).map(|title| EffectivePrimaryResolution {
+                    primary: EffectivePrimary::Title {
+                        title,
+                        kind: TitleType::ParentSerial,
+                    },
+                    names: Vec::new(),
+                })
+            }
+            SubstituteField::Title => reference.title().map(|title| EffectivePrimaryResolution {
+                primary: EffectivePrimary::Title {
+                    title,
+                    kind: TitleType::Primary,
+                },
+                names: Vec::new(),
+            }),
+            SubstituteField::Translator => reference.translator().and_then(|contributor| {
+                let names = super::merged::semantic_contributor_names(&contributor, config, locale);
+                (!names.is_empty()).then(|| EffectivePrimaryResolution {
+                    primary: EffectivePrimary::Contributor {
+                        contributor: Box::new(contributor),
+                        role: ContributorRole::Translator,
+                    },
+                    names,
+                })
+            }),
+        },
+    }
+}
+
+/// Resolve the effective-primary candidate and its names together, computing
+/// each candidate's name assembly at most once. Shared by [`effective_primary`]
+/// and [`effective_primary_names`] so neither re-derives the other's work.
+fn resolve_effective_primary(
+    reference: &Reference,
+    substitute: &citum_schema::options::Substitute,
+    config: &citum_schema::options::Config,
+    locale: &citum_schema::locale::Locale,
+) -> Option<EffectivePrimaryResolution> {
+    if let Some(candidates) = exact_type_candidates(reference, substitute) {
+        for candidate in candidates {
+            if let Some(resolved) = resolve_candidate(candidate, reference, config, locale) {
+                return Some(resolved);
+            }
+        }
+    }
+
+    if let Some(contributor) = reference.author() {
+        let names = super::merged::semantic_contributor_names(&contributor, config, locale);
+        if !names.is_empty() {
+            return Some(EffectivePrimaryResolution {
+                primary: EffectivePrimary::Contributor {
+                    contributor: Box::new(contributor),
+                    role: ContributorRole::Author,
+                },
+                names,
+            });
+        }
+    }
+
+    substitute
+        .template
+        .iter()
+        .find_map(|candidate| resolve_candidate(candidate, reference, config, locale))
+}
+
+/// Resolve the single effective-primary value shared by rendering and semantic consumers.
+pub(crate) fn effective_primary(
+    reference: &Reference,
+    substitute: &citum_schema::options::Substitute,
+    config: &citum_schema::options::Config,
+    locale: &citum_schema::locale::Locale,
+) -> Option<EffectivePrimary> {
+    resolve_effective_primary(reference, substitute, config, locale)
+        .map(|resolved| resolved.primary)
+}
+
+/// Resolve effective-primary names for sorting, matching, and disambiguation.
+pub(crate) fn effective_primary_names(
+    reference: &Reference,
+    substitute: &citum_schema::options::Substitute,
+    config: &citum_schema::options::Config,
+    locale: &citum_schema::locale::Locale,
+) -> Vec<crate::reference::FlatName> {
+    resolve_effective_primary(reference, substitute, config, locale)
+        .map(|resolved| resolved.names)
+        .unwrap_or_default()
+}
+
 /// Attempt to substitute an empty author field with editor, title, or translator.
 ///
 /// Returns `Some(ProcValues)` if a substitute was found, `None` if the chain
@@ -567,84 +861,51 @@ pub(super) fn resolve_author_substitute<F: OutputFormat<Output = String>>(
     fmt: &F,
     substitute: &citum_schema::options::Substitute,
 ) -> Option<ProcValues<F::Output>> {
-    for key in &substitute.template {
-        match key {
-            SubstituteKey::CollectionEditor => {
-                if let Some(result) = resolve_contributor_substitute_for_role(
-                    &ResolvedRole::BuiltIn(ContributorRole::CollectionEditor),
-                    component,
-                    hints,
-                    options,
-                    reference,
-                    effective_rendering,
-                    fmt,
-                    substitute,
-                ) {
-                    return Some(result);
-                }
-            }
-            SubstituteKey::Editor => {
-                if let Some(result) = resolve_contributor_substitute_for_role(
-                    &ResolvedRole::BuiltIn(ContributorRole::Editor),
-                    component,
-                    hints,
-                    options,
-                    reference,
-                    effective_rendering,
-                    fmt,
-                    substitute,
-                ) {
-                    return Some(result);
-                }
-            }
-            SubstituteKey::ParentSerial => {
-                if let Some(title) = resolve_parent_serial_title(reference) {
-                    return Some(resolve_title_substitute(
-                        title,
-                        &TitleType::ParentSerial,
-                        component,
-                        options,
-                        reference,
-                        fmt,
-                        false,
-                    ));
-                }
-            }
-            SubstituteKey::Title => {
-                if let Some(title) = reference.title() {
-                    let quote_in_citation = match substitute.title_quote {
-                        Some(SubstituteTitleQuoteMode::ByCategory) => {
-                            resolve_category_quote(reference, options)
-                        }
-                        Some(SubstituteTitleQuoteMode::Always) | None => true,
-                    };
-                    return Some(resolve_title_substitute(
-                        title,
-                        &TitleType::Primary,
-                        component,
-                        options,
-                        reference,
-                        fmt,
-                        quote_in_citation,
-                    ));
-                }
-            }
-            SubstituteKey::Translator => {
-                if let Some(result) = resolve_contributor_substitute_for_role(
-                    &ResolvedRole::BuiltIn(ContributorRole::Translator),
-                    component,
-                    hints,
-                    options,
-                    reference,
-                    effective_rendering,
-                    fmt,
-                    substitute,
-                ) {
-                    return Some(result);
-                }
-            }
+    match effective_primary(reference, substitute, &options.config, options.locale) {
+        Some(EffectivePrimary::Contributor { contributor, role }) => resolve_named_substitute(
+            &ResolvedRole::BuiltIn(role),
+            &contributor,
+            component,
+            hints,
+            options,
+            reference,
+            effective_rendering,
+            fmt,
+            substitute,
+        ),
+        Some(EffectivePrimary::Merged(roles)) => {
+            let mut merged = component.clone();
+            merged.contributor = roles;
+            merged.merge = None;
+            let mut values = super::merged::values(
+                &merged,
+                reference,
+                hints,
+                options,
+                effective_rendering,
+                fmt,
+            )?;
+            values.substituted_key = Some("contributor:effective-primary".to_string());
+            Some(values)
         }
+        Some(EffectivePrimary::Title { title, kind }) => {
+            let quote_in_citation = matches!(kind, TitleType::Primary)
+                && match substitute.title_quote {
+                    Some(SubstituteTitleQuoteMode::ByCategory) => {
+                        resolve_category_quote(reference, options)
+                    }
+                    Some(SubstituteTitleQuoteMode::Always) | None => true,
+                };
+            Some(resolve_title_substitute(
+                title,
+                &kind,
+                component,
+                options,
+                reference,
+                fmt,
+                quote_in_citation,
+            ))
+        }
+        None => None,
     }
-
-    None
 }

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -89,7 +89,7 @@ fn make_editor_reference(genders: &[ContributorGender]) -> Reference {
         .iter()
         .enumerate()
         .map(|(idx, gender)| ContributorEntry {
-            role: citum_schema::reference::ContributorRole::Editor,
+            roles: citum_schema::reference::ContributorRole::Editor.into(),
             contributor: Contributor::StructuredName(StructuredName {
                 family: format!("Editor{idx}").into(),
                 given: format!("Nombre{idx}").into(),
@@ -117,7 +117,7 @@ fn make_custom_role_reference(
         .iter()
         .enumerate()
         .map(|(idx, gender)| ContributorEntry {
-            role: role.clone(),
+            roles: role.clone().into(),
             contributor: Contributor::StructuredName(StructuredName {
                 family: format!("Persona{idx}").into(),
                 given: format!("Nombre{idx}").into(),
@@ -283,9 +283,10 @@ fn test_contributor_values() {
     let hints = ProcHints::default();
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Author,
+        contributor: ContributorRole::Author.into(),
         form: ContributorForm::Short,
         label: None,
+        merge: None,
         name_order: None,
         name_form: None,
         delimiter: None,
@@ -339,7 +340,7 @@ fn test_family_first_except_last_inverts_all_but_last_name() {
     let hints = ProcHints::default();
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Author,
+        contributor: ContributorRole::Author.into(),
         form: ContributorForm::Long,
         name_order: Some(NameOrder::FamilyFirstExceptLast),
         ..Default::default()
@@ -376,13 +377,14 @@ fn test_spanish_role_label_uses_feminine_form_for_single_editor() {
     let hints = ProcHints::default();
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Editor,
+        contributor: ContributorRole::Editor.into(),
         form: ContributorForm::Long,
         label: Some(RoleLabel {
             term: "editor".to_string(),
             form: RoleLabelForm::Long,
             placement: LabelPlacement::Suffix,
             text_case: None,
+            wrap: None,
             prefix: None,
             suffix: None,
         }),
@@ -418,13 +420,14 @@ fn test_spanish_role_label_uses_plural_feminine_form_for_matching_group() {
     let hints = ProcHints::default();
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Editor,
+        contributor: ContributorRole::Editor.into(),
         form: ContributorForm::Long,
         label: Some(RoleLabel {
             term: "editor".to_string(),
             form: RoleLabelForm::Long,
             placement: LabelPlacement::Suffix,
             text_case: None,
+            wrap: None,
             prefix: None,
             suffix: None,
         }),
@@ -460,13 +463,14 @@ fn test_spanish_role_label_prefers_common_form_for_mixed_group() {
     let hints = ProcHints::default();
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Editor,
+        contributor: ContributorRole::Editor.into(),
         form: ContributorForm::Long,
         label: Some(RoleLabel {
             term: "editor".to_string(),
             form: RoleLabelForm::Long,
             placement: LabelPlacement::Suffix,
             text_case: None,
+            wrap: None,
             prefix: None,
             suffix: None,
         }),
@@ -516,13 +520,14 @@ roles:
     let hints = ProcHints::default();
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Editor,
+        contributor: ContributorRole::Editor.into(),
         form: ContributorForm::Long,
         label: Some(RoleLabel {
             term: "editor".to_string(),
             form: RoleLabelForm::Long,
             placement: LabelPlacement::Suffix,
             text_case: None,
+            wrap: None,
             prefix: None,
             suffix: None,
         }),
@@ -557,13 +562,14 @@ fn test_french_role_label_uses_feminine_form_for_single_contributor() {
     let hints = ProcHints::default();
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Editor,
+        contributor: ContributorRole::Editor.into(),
         form: ContributorForm::Long,
         label: Some(RoleLabel {
             term: "editor".to_string(),
             form: RoleLabelForm::Long,
             placement: LabelPlacement::Suffix,
             text_case: None,
+            wrap: None,
             prefix: None,
             suffix: None,
         }),
@@ -598,13 +604,14 @@ fn test_arabic_role_label_uses_feminine_form_for_single_contributor() {
     let hints = ProcHints::default();
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Editor,
+        contributor: ContributorRole::Editor.into(),
         form: ContributorForm::Long,
         label: Some(RoleLabel {
             term: "editor".to_string(),
             form: RoleLabelForm::Long,
             placement: LabelPlacement::Suffix,
             text_case: None,
+            wrap: None,
             prefix: None,
             suffix: None,
         }),
@@ -640,13 +647,14 @@ fn test_french_role_label_falls_back_to_masculine_plural_for_mixed_group() {
     let hints = ProcHints::default();
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Editor,
+        contributor: ContributorRole::Editor.into(),
         form: ContributorForm::Long,
         label: Some(RoleLabel {
             term: "editor".to_string(),
             form: RoleLabelForm::Long,
             placement: LabelPlacement::Suffix,
             text_case: None,
+            wrap: None,
             prefix: None,
             suffix: None,
         }),
@@ -682,13 +690,14 @@ fn test_arabic_role_label_falls_back_to_verbal_noun_for_mixed_group() {
     let hints = ProcHints::default();
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Editor,
+        contributor: ContributorRole::Editor.into(),
         form: ContributorForm::Long,
         label: Some(RoleLabel {
             term: "editor".to_string(),
             form: RoleLabelForm::Long,
             placement: LabelPlacement::Suffix,
             text_case: None,
+            wrap: None,
             prefix: None,
             suffix: None,
         }),
@@ -722,7 +731,7 @@ fn test_arabic_role_label_falls_back_to_roles_common_when_gender_missing() {
 
     // Reference with no gender info
     let contributors = vec![ContributorEntry {
-        role: citum_schema::reference::ContributorRole::Editor,
+        roles: citum_schema::reference::ContributorRole::Editor.into(),
         contributor: Contributor::StructuredName(StructuredName {
             family: "Editor".into(),
             given: "Name".into(),
@@ -743,13 +752,14 @@ fn test_arabic_role_label_falls_back_to_roles_common_when_gender_missing() {
     let hints = ProcHints::default();
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Editor,
+        contributor: ContributorRole::Editor.into(),
         form: ContributorForm::Long,
         label: Some(RoleLabel {
             term: "editor".to_string(),
             form: RoleLabelForm::Long,
             placement: LabelPlacement::Suffix,
             text_case: None,
+            wrap: None,
             prefix: None,
             suffix: None,
         }),
@@ -788,13 +798,14 @@ fn test_collection_editor_role_label_derives_gender_from_reference_data() {
     let hints = ProcHints::default();
 
     let component = TemplateContributor {
-        contributor: ContributorRole::CollectionEditor,
+        contributor: ContributorRole::CollectionEditor.into(),
         form: ContributorForm::Long,
         label: Some(RoleLabel {
             term: "collection-editor".to_string(),
             form: RoleLabelForm::Long,
             placement: LabelPlacement::Suffix,
             text_case: None,
+            wrap: None,
             prefix: None,
             suffix: None,
         }),
@@ -984,7 +995,7 @@ fn test_message_component_renders_grouped_container_argument() {
             MessageArgSource::Group(TemplateGroup {
                 group: vec![
                     TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Editor,
+                        contributor: ContributorRole::Editor.into(),
                         form: ContributorForm::Long,
                         name_order: Some(NameOrder::FamilyFirst),
                         ..Default::default()
@@ -1243,7 +1254,7 @@ fn test_message_component_renders_embedded_container_author_group() {
             MessageArgSource::Group(TemplateGroup {
                 group: vec![
                     TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::ContainerAuthor,
+                        contributor: ContributorRole::ContainerAuthor.into(),
                         form: ContributorForm::Long,
                         name_order: Some(NameOrder::GivenFirst),
                         ..Default::default()
@@ -1319,7 +1330,7 @@ fn test_message_component_renders_legacy_container_author_group() {
             MessageArgSource::Group(TemplateGroup {
                 group: vec![
                     TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::ContainerAuthor,
+                        contributor: ContributorRole::ContainerAuthor.into(),
                         form: ContributorForm::Long,
                         name_order: Some(NameOrder::GivenFirst),
                         ..Default::default()
@@ -1431,9 +1442,10 @@ fn test_et_al() {
     });
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Author,
+        contributor: ContributorRole::Author.into(),
         form: ContributorForm::Short,
         label: None,
+        merge: None,
         name_order: None,
         name_form: None,
         delimiter: None,
@@ -1491,9 +1503,10 @@ fn test_et_al_delimiter_never() {
     });
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Author,
+        contributor: ContributorRole::Author.into(),
         form: ContributorForm::Short,
         label: None,
+        merge: None,
         name_order: None,
         name_form: None,
         delimiter: None,
@@ -1551,7 +1564,7 @@ fn test_role_substitute_uses_custom_fallback_roles_without_silent_drop() {
     let hints = ProcHints::default();
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Editor,
+        contributor: ContributorRole::Editor.into(),
         form: ContributorForm::Long,
         ..Default::default()
     };
@@ -1601,9 +1614,10 @@ fn test_et_al_delimiter_always() {
     });
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Author,
+        contributor: ContributorRole::Author.into(),
         form: ContributorForm::Short,
         label: None,
+        merge: None,
         name_order: None,
         name_form: None,
         delimiter: None,
@@ -1956,7 +1970,7 @@ fn test_et_al_use_last() {
     });
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Author,
+        contributor: ContributorRole::Author.into(),
         form: ContributorForm::Short,
         links: None,
         ..Default::default()
@@ -2011,7 +2025,7 @@ fn test_et_al_use_last_overlap() {
     });
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Author,
+        contributor: ContributorRole::Author.into(),
         form: ContributorForm::Short,
         links: None,
         ..Default::default()
@@ -2073,7 +2087,7 @@ fn test_et_al_use_last_multiple_first_names_delimiter() {
     });
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Author,
+        contributor: ContributorRole::Author.into(),
         form: ContributorForm::Short,
         links: None,
         ..Default::default()
@@ -2131,7 +2145,7 @@ fn test_et_al_uses_configured_delimiter() {
     });
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Author,
+        contributor: ContributorRole::Author.into(),
         form: ContributorForm::Short,
         links: None,
         ..Default::default()
@@ -3121,7 +3135,7 @@ fn test_role_label_preset_applies_to_translator_component() {
         abbreviation_map: None,
     };
     let component = TemplateContributor {
-        contributor: ContributorRole::Translator,
+        contributor: ContributorRole::Translator.into(),
         form: ContributorForm::Long,
         links: None,
         ..Default::default()
@@ -3172,7 +3186,7 @@ fn test_translator_substitute_uses_locale_aware_role_label() {
         abbreviation_map: None,
     };
     let component = TemplateContributor {
-        contributor: ContributorRole::Author,
+        contributor: ContributorRole::Author.into(),
         form: ContributorForm::Long,
         links: None,
         ..Default::default()
@@ -3228,7 +3242,7 @@ fn test_editor_substitute_suppresses_verb_prefix_role_label() {
         abbreviation_map: None,
     };
     let component = TemplateContributor {
-        contributor: ContributorRole::Author,
+        contributor: ContributorRole::Author.into(),
         form: ContributorForm::Long,
         links: None,
         ..Default::default()
@@ -3281,7 +3295,7 @@ fn test_editor_component_keeps_verb_prefix_role_label() {
         abbreviation_map: None,
     };
     let component = TemplateContributor {
-        contributor: ContributorRole::Editor,
+        contributor: ContributorRole::Editor.into(),
         form: ContributorForm::Long,
         links: None,
         ..Default::default()
@@ -3331,7 +3345,7 @@ fn test_role_substitute_normalizes_primary_role_lookup_keys() {
     let hints = ProcHints::default();
 
     let component = TemplateContributor {
-        contributor: ContributorRole::ContainerAuthor,
+        contributor: ContributorRole::ContainerAuthor.into(),
         form: ContributorForm::Long,
         ..Default::default()
     };
@@ -3398,7 +3412,7 @@ fn test_role_specific_name_order_applies_in_substitute_path() {
         abbreviation_map: None,
     };
     let component = TemplateContributor {
-        contributor: ContributorRole::Author,
+        contributor: ContributorRole::Author.into(),
         form: ContributorForm::Long,
         links: None,
         ..Default::default()
@@ -3481,7 +3495,7 @@ fn test_template_list_term_suppression() {
                 ..Default::default()
             }),
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Editor,
+                contributor: ContributorRole::Editor.into(),
                 ..Default::default()
             }),
         ],
@@ -3571,7 +3585,7 @@ fn test_strip_periods_global_config() {
     };
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Editor,
+        contributor: ContributorRole::Editor.into(),
         form: ContributorForm::Long,
         ..Default::default()
     };
@@ -3617,7 +3631,7 @@ fn test_strip_periods_component_override() {
 
     // Component overrides global setting
     let component = TemplateContributor {
-        contributor: ContributorRole::Editor,
+        contributor: ContributorRole::Editor.into(),
         form: ContributorForm::Long,
         rendering: Rendering {
             strip_periods: Some(true),
@@ -3665,7 +3679,7 @@ fn test_strip_periods_no_strip_by_default() {
     };
 
     let component = TemplateContributor {
-        contributor: ContributorRole::Editor,
+        contributor: ContributorRole::Editor.into(),
         form: ContributorForm::Long,
         ..Default::default()
     };

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -1068,7 +1068,7 @@ fn build_inline_article_journal_detail_group_style() -> Style {
         bibliography: Some(BibliographySpec {
             template: Some(vec![
                 TemplateComponent::Contributor(citum_schema::template::TemplateContributor {
-                    contributor: citum_schema::template::ContributorRole::Author,
+                    contributor: citum_schema::template::ContributorRole::Author.into(),
                     form: citum_schema::template::ContributorForm::Long,
                     rendering: Rendering {
                         suffix: Some(". ".to_string()),
@@ -2564,7 +2564,7 @@ fn make_two_author_and_style(
         bibliography: Some(BibliographySpec {
             template: Some(vec![TemplateComponent::Contributor(
                 citum_schema::template::TemplateContributor {
-                    contributor: citum_schema::template::ContributorRole::Author,
+                    contributor: citum_schema::template::ContributorRole::Author.into(),
                     form: citum_schema::template::ContributorForm::Long,
                     name_order,
                     ..Default::default()
@@ -5177,4 +5177,30 @@ fn explicit_label_affixes_override_placement_defaults() {
     let result = processor.render_bibliography();
 
     assert_eq!(result, "John Smith, Jane Doe (Eds.)");
+}
+
+#[test]
+fn explicit_label_wrap_uses_structural_punctuation_and_suffix_spacing() {
+    let yaml = "info:\n  title: Label Wrap Test\nbibliography:\n  template:\n    - contributor: editor\n      form: long\n      label:\n        term: editor\n        form: short\n        placement: suffix\n        wrap: parentheses\n        text-case: capitalize-first\n";
+    let style = citum_schema::Style::from_yaml_str(yaml).expect("style should parse");
+    let bib = citum_schema::bib_map![
+        "ITEM-1" => make_multi_editor_only_book("ITEM-1", "Title", "2020", vec![("Smith", "John"), ("Doe", "Jane")]),
+    ];
+    let processor = Processor::new(style, bib);
+    let result = processor.render_bibliography();
+
+    assert_eq!(result, "John Smith, Jane Doe (Eds.)");
+}
+
+#[test]
+fn explicit_label_wrap_preserves_prefix_placement_spacing() {
+    let yaml = "info:\n  title: Prefix Label Wrap Test\nbibliography:\n  template:\n    - contributor: editor\n      form: long\n      label:\n        term: editor\n        form: short\n        placement: prefix\n        wrap: parentheses\n        text-case: capitalize-first\n";
+    let style = citum_schema::Style::from_yaml_str(yaml).expect("style should parse");
+    let bib = citum_schema::bib_map![
+        "ITEM-1" => make_multi_editor_only_book("ITEM-1", "Title", "2020", vec![("Smith", "John"), ("Doe", "Jane")]),
+    ];
+    let processor = Processor::new(style, bib);
+    let result = processor.render_bibliography();
+
+    assert_eq!(result, "(Eds.) John Smith, Jane Doe");
 }

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -2694,7 +2694,7 @@ fn test_personal_communication_citation_rendering_is_style_driven() {
             template: Some(vec![
                 citum_schema::template::TemplateComponent::Contributor(
                     citum_schema::template::TemplateContributor {
-                        contributor: citum_schema::template::ContributorRole::Author,
+                        contributor: citum_schema::template::ContributorRole::Author.into(),
                         form: citum_schema::template::ContributorForm::Long,
                         name_order: Some(citum_schema::template::NameOrder::GivenFirst),
                         rendering: citum_schema::template::Rendering {

--- a/crates/citum-engine/tests/cross_role_contributors.rs
+++ b/crates/citum-engine/tests/cross_role_contributors.rs
@@ -1,0 +1,1308 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+#![allow(
+    missing_docs,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    reason = "Panicking is appropriate in integration tests."
+)]
+
+use citum_engine::Processor;
+use citum_schema::{
+    Style,
+    citation::{Citation, CitationItem},
+    reference::InputReference,
+};
+use indexmap::IndexMap;
+
+const STYLE_HEADER: &str = r#"
+info:
+  id: cross-role-test
+  title: Cross-role test
+options:
+  contributors:
+    delimiter: ", "
+    and: symbol
+    name-form: initials
+    initialize-with: ". "
+"#;
+
+fn render_bibliography(template: &str, references: &str) -> String {
+    let style = Style::from_yaml_str(&format!(
+        "{STYLE_HEADER}\nbibliography:\n  template:\n{}",
+        indent(template, 4)
+    ))
+    .expect("cross-role style should parse");
+    let references: Vec<InputReference> =
+        serde_yaml::from_str(references).expect("cross-role references should parse");
+    let bibliography = references
+        .into_iter()
+        .map(|reference| {
+            let id = reference
+                .id()
+                .expect("reference id should exist")
+                .to_string();
+            (id, reference)
+        })
+        .collect::<IndexMap<_, _>>();
+    Processor::new(style, bibliography).render_bibliography()
+}
+
+fn processor(style: &str, references: &str) -> Processor {
+    let style = Style::from_yaml_str(style).expect("cross-role style should parse");
+    let references: Vec<InputReference> =
+        serde_yaml::from_str(references).expect("cross-role references should parse");
+    let bibliography = references
+        .into_iter()
+        .map(|reference| {
+            let id = reference
+                .id()
+                .expect("reference id should exist")
+                .to_string();
+            (id, reference)
+        })
+        .collect::<IndexMap<_, _>>();
+    Processor::new(style, bibliography)
+}
+
+fn indent(value: &str, spaces: usize) -> String {
+    let prefix = " ".repeat(spaces);
+    value
+        .trim()
+        .lines()
+        .map(|line| format!("{prefix}{line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn document_order_uses_one_conjunction_across_distinct_roles() {
+    let rendered = render_bibliography(
+        r#"
+- contributor: [writer, director]
+  form: long
+  name-order: family-first
+  merge:
+    labels: individual
+    roles:
+      writer:
+        label: {term: writer, form: long, placement: suffix, text-case: capitalize-first, wrap: parentheses}
+      director:
+        label: {term: director, form: long, placement: suffix, text-case: capitalize-first, wrap: parentheses}
+"#,
+        r#"
+- id: episode
+  class: audio-visual
+  type: broadcast
+  contributors:
+    - roles: [writer]
+      contributor: {family: Kogen, given: Jay}
+    - roles: [writer]
+      contributor: {family: Wolodarsky, given: Wallace}
+    - roles: [director]
+      contributor: {family: Kirkland, given: Mark}
+"#,
+    );
+
+    assert_eq!(
+        rendered,
+        "Kogen, J. (Writer), Wolodarsky, W. (Writer), & Kirkland, M. (Director)"
+    );
+}
+
+#[test]
+fn explicit_multi_role_entry_uses_authored_combined_term() {
+    let rendered = render_bibliography(
+        r#"
+- contributor: [writer, director]
+  form: long
+  name-order: family-first
+  merge:
+    labels: individual
+    roles:
+      writer:
+        label: {term: writer-director, form: long, placement: suffix, text-case: title, wrap: parentheses}
+"#,
+        r#"
+- id: episode
+  class: audio-visual
+  type: broadcast
+  contributors:
+    - roles: [writer, director]
+      contributor: {family: Whedon, given: Joss}
+"#,
+    );
+
+    assert_eq!(rendered, "Whedon, J. (Writer & Director)");
+}
+
+#[test]
+fn partial_cross_role_identity_combines_only_the_explicit_shared_entry() {
+    let rendered = render_bibliography(
+        r#"
+- contributor: [writer, director]
+  form: long
+  name-order: family-first
+  merge:
+    labels: individual
+    roles:
+      writer:
+        label: {term: writer, form: long, placement: suffix, text-case: title, prefix: " (", suffix: ")"}
+      director:
+        label: {term: director, form: long, placement: suffix, text-case: title, prefix: " (", suffix: ")"}
+"#,
+        r#"
+- id: episode
+  class: audio-visual
+  type: broadcast
+  contributors:
+    - roles: [writer, director]
+      contributor: {family: Whedon, given: Joss}
+    - roles: [writer]
+      contributor: {family: Minear, given: Tim}
+    - roles: [director]
+      contributor: {family: Greenwalt, given: David}
+"#,
+    );
+
+    assert_eq!(
+        rendered,
+        "Whedon, J. (Writer & Director), Minear, T. (Writer), & Greenwalt, D. (Director)"
+    );
+}
+
+#[test]
+fn equal_separate_native_entries_do_not_imply_shared_identity() {
+    let rendered = render_bibliography(
+        r#"
+- contributor: [writer, director]
+  form: long
+  name-order: family-first
+  merge:
+    labels: none
+"#,
+        r#"
+- id: episode
+  class: audio-visual
+  type: broadcast
+  contributors:
+    - roles: [writer]
+      contributor: {family: Doe, given: Jane}
+    - roles: [director]
+      contributor: {family: Doe, given: Jane}
+"#,
+    );
+
+    assert_eq!(rendered, "Doe, J. & Doe, J.");
+}
+
+#[test]
+fn disabled_combination_expands_an_explicit_multi_role_entry() {
+    let rendered = render_bibliography(
+        r#"
+- contributor: [writer, director]
+  form: long
+  name-order: family-first
+  merge:
+    labels: none
+    combine-same-person: false
+"#,
+        r#"
+- id: episode
+  class: audio-visual
+  type: broadcast
+  contributors:
+    - roles: [writer, director]
+      contributor: {family: Doe, given: Jane}
+"#,
+    );
+
+    assert_eq!(rendered, "Doe, J. & Doe, J.");
+}
+
+#[test]
+fn suppression_uses_non_empty_exact_identity_sets_in_both_rendering_contexts() {
+    let style = r#"
+info: {id: suppression-test, title: Suppression test}
+options:
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+    suppress:
+      - role: translator
+        when-identical-to: editor
+citation:
+  template:
+    - contributor: editor
+      form: long
+      name-order: family-first
+    - contributor: translator
+      form: long
+      name-order: family-first
+      prefix: "; "
+bibliography:
+  template:
+    - contributor: editor
+      form: long
+      name-order: family-first
+    - contributor: translator
+      form: long
+      name-order: family-first
+      prefix: "; "
+"#;
+    let references = r#"
+- id: exact
+  class: monograph
+  type: book
+  contributors:
+    - roles: [editor, translator]
+      contributor: {family: Doe, given: Jane}
+"#;
+    let processor = processor(style, references);
+    let citation = Citation {
+        items: vec![CitationItem {
+            id: "exact".to_string(),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    assert_eq!(processor.render_bibliography(), "Doe, J.");
+    assert_eq!(
+        processor
+            .process_citation(&citation)
+            .expect("suppressed citation should render"),
+        "Doe, J."
+    );
+}
+
+#[test]
+fn suppression_collapses_a_dependent_descriptor_group() {
+    let style = r#"
+info: {id: suppression-group-test, title: Suppression group test}
+options:
+  contributors:
+    suppress:
+      - role: performer
+        when-identical-to: composer
+bibliography:
+  template:
+    - contributor: composer
+      form: long
+    - group:
+        - contributor: performer
+          form: long
+      prefix: " [Recorded by "
+      suffix: "]"
+"#;
+    let references = r#"
+- id: song
+  class: audio-visual
+  type: recording
+  contributors:
+    - roles: [composer, performer]
+      contributor: {family: Doe, given: Jane}
+"#;
+
+    assert_eq!(
+        processor(style, references).render_bibliography(),
+        "Jane Doe"
+    );
+}
+
+#[test]
+fn suppression_does_not_fire_for_absent_or_partially_overlapping_roles() {
+    let style = r#"
+info: {id: suppression-boundary-test, title: Suppression boundary test}
+options:
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+    and: symbol
+    suppress:
+      - role: translator
+        when-identical-to: editor
+bibliography:
+  template:
+    - contributor: [editor, translator]
+      form: long
+      name-order: family-first
+      merge: {labels: none}
+"#;
+    let references = r#"
+- id: absent-comparison
+  class: monograph
+  type: book
+  contributors:
+    - roles: [translator]
+      contributor: {family: Able, given: Amy}
+- id: partial-overlap
+  class: monograph
+  type: book
+  contributors:
+    - roles: [editor, translator]
+      contributor: {family: Baker, given: Bea}
+    - roles: [editor]
+      contributor: {family: Clark, given: Cora}
+- id: equal-looking-separate
+  class: monograph
+  type: book
+  contributors:
+    - roles: [editor]
+      contributor: {family: Doe, given: Jane}
+    - roles: [translator]
+      contributor: {family: Doe, given: Jane}
+"#;
+    let rendered = processor(style, references).render_bibliography();
+
+    assert_eq!(
+        rendered,
+        "Able, A.\n\nBaker, B. & Clark, C.\n\nDoe, J. & Doe, J."
+    );
+}
+
+#[test]
+fn missing_combined_term_uses_component_role_conjunction() {
+    let rendered = render_bibliography(
+        r#"
+- contributor: [writer, producer]
+  form: long
+  name-order: family-first
+  merge:
+    labels: individual
+    role-conjunction: " / "
+    roles:
+      writer:
+        label: {term: writer-producer, form: long, placement: suffix, wrap: parentheses}
+"#,
+        r#"
+- id: episode
+  class: audio-visual
+  type: broadcast
+  contributors:
+    - roles: [writer, producer]
+      contributor: {family: Doe, given: Jane}
+"#,
+    );
+
+    assert_eq!(rendered, "Doe, J. (writer / producer)");
+}
+
+#[test]
+fn role_order_collective_labels_pluralize_only_matching_role_runs() {
+    let rendered = render_bibliography(
+        r#"
+- contributor: [writer, director]
+  form: long
+  name-order: family-first
+  merge:
+    order: role
+    labels: collective
+    roles:
+      writer:
+        label: {term: writer, form: long, placement: suffix, text-case: capitalize-first, prefix: " (", suffix: ")"}
+      director:
+        label: {term: director, form: long, placement: suffix, text-case: capitalize-first, prefix: " (", suffix: ")"}
+"#,
+        r#"
+- id: episode
+  class: audio-visual
+  type: broadcast
+  contributors:
+    - roles: [writer]
+      contributor: {family: Able, given: Amy}
+    - roles: [director]
+      contributor: {family: Baker, given: Bea}
+    - roles: [writer]
+      contributor: {family: Clark, given: Cora}
+"#,
+    );
+
+    assert_eq!(
+        rendered,
+        "Able, A., Clark, C. (Writers), & Baker, B. (Director)"
+    );
+}
+
+#[test]
+fn role_order_collective_verb_labels_prefix_each_role_run() {
+    let rendered = render_bibliography(
+        r#"
+- contributor: [writer, director]
+  form: verb
+  merge:
+    order: role
+    labels: collective
+"#,
+        r#"
+- id: episode
+  class: audio-visual
+  type: broadcast
+  contributors:
+    - roles: [director]
+      contributor: {family: Baker, given: Bea}
+    - roles: [writer]
+      contributor: {family: Able, given: Amy}
+"#,
+    );
+
+    assert_eq!(rendered, "Written by A. Able & directed by B. Baker");
+}
+
+#[test]
+fn document_order_collective_labels_preserve_interleaved_runs() {
+    let rendered = render_bibliography(
+        r#"
+- contributor: [writer, director]
+  form: long
+  name-order: family-first
+  merge:
+    labels: collective
+    roles:
+      writer:
+        label: {term: writer, form: long, placement: suffix, text-case: capitalize-first, prefix: " (", suffix: ")"}
+      director:
+        label: {term: director, form: long, placement: suffix, text-case: capitalize-first, prefix: " (", suffix: ")"}
+"#,
+        r#"
+- id: episode
+  class: audio-visual
+  type: broadcast
+  contributors:
+    - roles: [writer]
+      contributor: {family: Able, given: Amy}
+    - roles: [director]
+      contributor: {family: Baker, given: Bea}
+    - roles: [writer]
+      contributor: {family: Clark, given: Cora}
+"#,
+    );
+
+    assert_eq!(
+        rendered,
+        "Able, A. (Writer), Baker, B. (Director), & Clark, C. (Writer)"
+    );
+}
+
+#[test]
+fn et_al_threshold_is_calculated_after_explicit_role_combination() {
+    let rendered = render_bibliography(
+        r#"
+- contributor: [writer, director]
+  form: long
+  name-order: family-first
+  shorten: {min: 4, use-first: 1}
+  merge: {labels: none}
+"#,
+        r#"
+- id: episode
+  class: audio-visual
+  type: broadcast
+  contributors:
+    - roles: [writer, director]
+      contributor: {family: Able, given: Amy}
+    - roles: [writer]
+      contributor: {family: Baker, given: Bea}
+    - roles: [director]
+      contributor: {family: Clark, given: Cora}
+"#,
+    );
+
+    assert_eq!(rendered, "Able, A., Baker, B., & Clark, C.");
+}
+
+#[test]
+fn collective_label_decorates_the_selected_run_before_et_al_joining() {
+    let rendered = render_bibliography(
+        r#"
+- contributor: [writer, director]
+  form: long
+  name-order: family-first
+  shorten: {min: 3, use-first: 1}
+  merge:
+    labels: collective
+    roles:
+      writer:
+        label: {term: writer, form: long, placement: suffix, text-case: title, prefix: " (", suffix: ")"}
+"#,
+        r#"
+- id: episode
+  class: audio-visual
+  type: broadcast
+  contributors:
+    - roles: [writer]
+      contributor: {family: Able, given: Amy}
+    - roles: [writer]
+      contributor: {family: Baker, given: Bea}
+    - roles: [writer]
+      contributor: {family: Clark, given: Cora}
+"#,
+    );
+
+    assert_eq!(rendered, "Able, A. (Writers) et al.");
+}
+
+#[test]
+fn editor_translator_uses_the_canonical_combined_locale_term() {
+    let rendered = render_bibliography(
+        r#"
+- contributor: [editor, translator]
+  form: long
+  name-order: family-first
+  merge:
+    labels: collective
+    roles:
+      editor:
+        label: {term: editor-translator, form: short, placement: suffix, prefix: ", "}
+"#,
+        r#"
+- id: book
+  class: monograph
+  type: book
+  contributors:
+    - roles: [editor, translator]
+      contributor: {family: Doe, given: Jane}
+"#,
+    );
+
+    assert_eq!(rendered, "Doe, J., ed. & trans.");
+}
+
+#[test]
+fn bibliography_author_sort_uses_nested_list_primary_from_type_variant() {
+    let style = r#"
+info: {id: merged-sort-test, title: Merged sort test}
+options:
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+bibliography:
+  sort:
+    template:
+      - key: author
+  template:
+    - title: primary
+  type-variants:
+    broadcast:
+      - group:
+          - contributor: [writer, director]
+            form: long
+            name-order: family-first
+            merge: {labels: none}
+"#;
+    let references = r#"
+- id: first-input
+  class: audio-visual
+  type: broadcast
+  title: Alpha title
+  contributors:
+    - roles: [writer]
+      contributor: {family: Zulu, given: Zoe}
+- id: second-input
+  class: audio-visual
+  type: broadcast
+  title: Zulu title
+  contributors:
+    - roles: [director]
+      contributor: {family: Able, given: Amy}
+"#;
+
+    assert_eq!(
+        processor(style, references).render_bibliography(),
+        "Able, A.\n\nZulu, Z."
+    );
+}
+
+#[test]
+fn name_year_disambiguation_uses_the_list_primary_instead_of_semantic_author() {
+    let style = r#"
+info: {id: merged-disambiguation-test, title: Merged disambiguation test}
+options:
+  processing:
+    disambiguate:
+      names: false
+      add-givenname: false
+      year-suffix: true
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+citation:
+  multi-cite-delimiter: "; "
+  template:
+    - contributor: [writer, director]
+      form: short
+      merge: {labels: none}
+    - date: issued
+      form: year
+      prefix: " "
+"#;
+    let references = r#"
+- id: first
+  class: audio-visual
+  type: broadcast
+  issued: "2020"
+  contributors:
+    - roles: [author]
+      contributor: {family: Alpha, given: Alice}
+    - roles: [writer, director]
+      contributor: {family: Doe, given: Jane}
+- id: second
+  class: audio-visual
+  type: broadcast
+  issued: "2020"
+  contributors:
+    - roles: [author]
+      contributor: {family: Zulu, given: Zoe}
+    - roles: [writer, director]
+      contributor: {family: Doe, given: Jane}
+"#;
+    let processor = processor(style, references);
+    let citation = Citation {
+        items: vec![
+            CitationItem {
+                id: "first".to_string(),
+                ..Default::default()
+            },
+            CitationItem {
+                id: "second".to_string(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    assert_eq!(
+        processor
+            .process_citation(&citation)
+            .expect("merged-primary citation should render"),
+        "Doe 2020a; Doe 2020b"
+    );
+}
+
+fn apa_processor(references: &str) -> Processor {
+    processor(
+        include_str!("../../citum-schema-style/embedded/styles/apa-7th.yaml"),
+        references,
+    )
+}
+
+#[test]
+fn apa_episode_promotes_writer_and_director_from_native_roles() {
+    let references =
+        include_str!("../../../tests/fixtures/audiovisual/apa-episode-cross-role.yaml");
+    let processor = apa_processor(references);
+
+    assert_eq!(
+        processor.render_bibliography(),
+        "Barris, K. (Writer & Director). (2017, January 11). Lemons [TV series episode]."
+    );
+    assert_eq!(
+        processor
+            .process_citation(&Citation {
+                items: vec![CitationItem {
+                    id: "lemons".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            })
+            .expect("APA episode citation should render"),
+        "(Barris, 2017)"
+    );
+}
+
+#[test]
+fn apa_film_promotes_directors_with_a_collective_plural_label() {
+    let references = include_str!("../../../tests/fixtures/audiovisual/apa-film-directors.yaml");
+
+    assert_eq!(
+        apa_processor(references).render_bibliography(),
+        "Docter, P., & Del Carmen, R. (Directors). (2015). _Inside out_ [Film]. Walt Disney Pictures; Pixar Animation Studios."
+    );
+}
+
+#[test]
+fn native_override_precedes_legacy_alias_and_uses_available_merged_roles() {
+    let style = r#"
+info: {id: primary-override-test, title: Primary override test}
+options:
+  substitute:
+    template: [editor, title, translator]
+    overrides:
+      episode:
+        - contributor: [writer, director]
+      broadcast:
+        - contributor: producer
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+    merge: {labels: none}
+bibliography:
+  template:
+    - contributor: author
+      form: long
+      name-order: family-first
+"#;
+    let references = r#"
+- id: partial
+  class: audio-visual
+  type: episode
+  title: Partial roles
+  contributors:
+    - role: author
+      contributor: {family: Semantic, given: Alice}
+    - role: writer
+      contributor: {family: Writer, given: Wendy}
+    - role: producer
+      contributor: {family: Producer, given: Paul}
+"#;
+
+    assert_eq!(
+        processor(style, references).render_bibliography(),
+        "Writer, W."
+    );
+}
+
+#[test]
+fn effective_primary_override_drives_sorting_and_disambiguation() {
+    let style = r#"
+info: {id: primary-semantic-test, title: Primary semantic test}
+options:
+  processing:
+    disambiguate: {names: false, add-givenname: false, year-suffix: true}
+  substitute:
+    overrides:
+      episode:
+        - contributor: [writer, director]
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+    merge: {labels: none}
+citation:
+  multi-cite-delimiter: "; "
+  template:
+    - contributor: author
+      form: short
+    - date: issued
+      form: year
+      prefix: " "
+bibliography:
+  sort: author-date-title
+  template:
+    - contributor: author
+      form: long
+      name-order: family-first
+"#;
+    let references = r#"
+- id: zulu-input
+  class: audio-visual
+  type: episode
+  issued: "2020"
+  contributors:
+    - role: author
+      contributor: {family: Alpha, given: Alice}
+    - roles: [writer, director]
+      contributor: {family: Doe, given: Jane}
+- id: able-input
+  class: audio-visual
+  type: episode
+  issued: "2020"
+  contributors:
+    - role: author
+      contributor: {family: Zulu, given: Zoe}
+    - roles: [writer, director]
+      contributor: {family: Doe, given: Jane}
+- id: sort-zulu
+  class: audio-visual
+  type: episode
+  contributors:
+    - role: author
+      contributor: {family: Able, given: Amy}
+    - role: writer
+      contributor: {family: Zulu, given: Zoe}
+- id: sort-able
+  class: audio-visual
+  type: episode
+  contributors:
+    - role: author
+      contributor: {family: Zulu, given: Zoe}
+    - role: writer
+      contributor: {family: Able, given: Amy}
+"#;
+    let processor = processor(style, references);
+    let citation = Citation {
+        items: vec![
+            CitationItem {
+                id: "zulu-input".to_string(),
+                ..Default::default()
+            },
+            CitationItem {
+                id: "able-input".to_string(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    assert_eq!(
+        processor.render_bibliography(),
+        "Able, A.\n\nDoe, J.\n\nDoe, J.\n\nZulu, Z."
+    );
+    assert_eq!(
+        processor
+            .process_citation(&citation)
+            .expect("effective-primary citation should render"),
+        "Doe 2020a; Doe 2020b"
+    );
+}
+
+// --- Review-fix regression tests ---
+//
+// NOTE: `role_substitute_suppression_*` below exercise
+// `is_role_suppressed_by_substitute` (ROLE_SUBSTITUTE_FALLBACK.md): a
+// fallback role is suppressed elsewhere in the template exactly when its
+// configured *primary* role has its own data (see
+// `crates/citum-engine/src/values/contributor/substitute.rs`). This is the
+// opposite polarity of "primary role empty, filled by the fallback" — that
+// case is already handled by the unrelated rendered-variable tracker
+// (`TemplateComponentTracker`), not by this suppression check.
+
+#[test]
+fn role_substitute_suppression_excludes_role_from_merged_list_when_primary_role_present() {
+    let style = r#"
+info: {id: role-substitute-merge-present-test, title: Role substitute merge present test}
+options:
+  substitute:
+    role-substitute:
+      container-author: [editor]
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+    and: symbol
+bibliography:
+  template:
+    - contributor: [editor, translator]
+      form: long
+      name-order: family-first
+      merge: {labels: none}
+"#;
+    let references = r#"
+- id: primary-present
+  class: monograph
+  type: book
+  contributors:
+    - roles: [container-author]
+      contributor: {family: Container, given: Cara}
+    - roles: [editor]
+      contributor: {family: Edit, given: Ed}
+    - roles: [translator]
+      contributor: {family: Trans, given: Tara}
+"#;
+
+    assert_eq!(
+        processor(style, references).render_bibliography(),
+        "Trans, T."
+    );
+}
+
+#[test]
+fn role_substitute_suppression_retains_role_in_merged_list_when_primary_role_absent() {
+    let style = r#"
+info: {id: role-substitute-merge-absent-test, title: Role substitute merge absent test}
+options:
+  substitute:
+    role-substitute:
+      container-author: [editor]
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+    and: symbol
+bibliography:
+  template:
+    - contributor: [editor, translator]
+      form: long
+      name-order: family-first
+      merge: {labels: none}
+"#;
+    let references = r#"
+- id: primary-absent
+  class: monograph
+  type: book
+  contributors:
+    - roles: [editor]
+      contributor: {family: Edit, given: Ed}
+    - roles: [translator]
+      contributor: {family: Trans, given: Tara}
+"#;
+
+    assert_eq!(
+        processor(style, references).render_bibliography(),
+        "Edit, E. & Trans, T."
+    );
+}
+
+#[test]
+fn subsequent_author_substitute_uses_type_override_for_contributor_matching() {
+    // `writer` (not `director`) is deliberately chosen: `Reference::author()`
+    // already has a built-in Film/Episode compatibility fallback to
+    // `director` (`citum-schema-data/src/reference/accessors.rs`), which
+    // would make both references resolve a shared primary contributor
+    // through that pre-existing path alone and mask whether the matcher
+    // actually consults `options.substitute.overrides`. `writer` carries no
+    // such built-in fallback, so a match here can only come from the
+    // type override.
+    let style = r#"
+info: {id: matcher-override-test, title: Matcher override test}
+options:
+  substitute:
+    overrides:
+      film:
+        - contributor: writer
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+bibliography:
+  options:
+    subsequent-author-substitute: "———"
+  sort:
+    template:
+      - key: title
+  template:
+    - contributor: author
+      form: long
+      name-order: family-first
+    - title: primary
+      prefix: ", "
+"#;
+    let references = r#"
+- id: alpha-film
+  class: audio-visual
+  type: film
+  title: Alpha Film
+  contributors:
+    - roles: [writer]
+      contributor: {family: Doe, given: Jane}
+- id: beta-film
+  class: audio-visual
+  type: film
+  title: Beta Film
+  contributors:
+    - roles: [writer]
+      contributor: {family: Doe, given: Jane}
+"#;
+
+    assert_eq!(
+        processor(style, references).render_bibliography(),
+        "Doe, J., Alpha Film\n\n———, Beta Film"
+    );
+}
+
+#[test]
+fn subsequent_author_substitute_never_matches_via_title_fallback() {
+    let style = r#"
+info: {id: matcher-title-test, title: Matcher title test}
+options:
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+bibliography:
+  options:
+    subsequent-author-substitute: "———"
+  sort:
+    template:
+      - key: issued
+  template:
+    - contributor: author
+      form: long
+      name-order: family-first
+    - date: issued
+      form: year
+      prefix: " ("
+      suffix: ")"
+"#;
+    let references = r#"
+- id: first
+  class: monograph
+  type: book
+  title: Same Title
+  issued: "2020"
+- id: second
+  class: monograph
+  type: book
+  title: Same Title
+  issued: "2021"
+"#;
+
+    assert_eq!(
+        processor(style, references).render_bibliography(),
+        "Same Title (2020)\n\nSame Title (2021)"
+    );
+}
+
+#[test]
+fn role_omit_suppresses_a_configured_structural_label_preset() {
+    let style = r#"
+info: {id: role-omit-scalar-test, title: Role omit scalar test}
+options:
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+    role:
+      defaults: apa
+      omit: [director]
+bibliography:
+  template:
+    - contributor: director
+      form: long
+      name-order: family-first
+"#;
+    let references = r#"
+- id: kubrick-film
+  class: audio-visual
+  type: film
+  contributors:
+    - roles: [director]
+      contributor: {family: Kubrick, given: Stanley}
+"#;
+
+    assert_eq!(
+        processor(style, references).render_bibliography(),
+        "Kubrick, S."
+    );
+}
+
+#[test]
+fn configured_structural_label_preset_renders_when_role_is_not_omitted() {
+    let style = r#"
+info: {id: role-show-scalar-test, title: Role show scalar test}
+options:
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+    role:
+      defaults: apa
+bibliography:
+  template:
+    - contributor: director
+      form: long
+      name-order: family-first
+"#;
+    let references = r#"
+- id: kubrick-film
+  class: audio-visual
+  type: film
+  contributors:
+    - roles: [director]
+      contributor: {family: Kubrick, given: Stanley}
+"#;
+
+    assert_eq!(
+        processor(style, references).render_bibliography(),
+        "Kubrick, S. (Director)"
+    );
+}
+
+#[test]
+fn role_omit_suppresses_a_configured_structural_label_for_a_combined_merged_entry() {
+    let style = r#"
+info: {id: role-omit-merged-test, title: Role omit merged test}
+options:
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+    role:
+      defaults: apa
+      omit: [writer]
+bibliography:
+  template:
+    - contributor: [writer, director]
+      form: long
+      name-order: family-first
+      merge: {labels: individual}
+"#;
+    let references = r#"
+- id: episode
+  class: audio-visual
+  type: broadcast
+  contributors:
+    - roles: [writer, director]
+      contributor: {family: Whedon, given: Joss}
+"#;
+
+    assert_eq!(
+        processor(style, references).render_bibliography(),
+        "Whedon, J."
+    );
+}
+
+#[test]
+fn configured_structural_label_renders_for_a_combined_merged_entry_when_role_is_not_omitted() {
+    let style = r#"
+info: {id: role-show-merged-test, title: Role show merged test}
+options:
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+    role:
+      defaults: apa
+bibliography:
+  template:
+    - contributor: [writer, director]
+      form: long
+      name-order: family-first
+      merge: {labels: individual}
+"#;
+    let references = r#"
+- id: episode
+  class: audio-visual
+  type: broadcast
+  contributors:
+    - roles: [writer, director]
+      contributor: {family: Whedon, given: Joss}
+"#;
+
+    assert_eq!(
+        processor(style, references).render_bibliography(),
+        "Whedon, J. (Writer & Director)"
+    );
+}
+
+#[test]
+fn empty_editor_list_falls_through_to_title_substitute() {
+    let style = r#"
+info: {id: empty-editor-substitute-test, title: Empty editor substitute test}
+options:
+  substitute:
+    template: [editor, title]
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+bibliography:
+  template:
+    - contributor: author
+      form: long
+      name-order: family-first
+"#;
+    let references = r#"
+- id: empty-editor
+  class: monograph
+  type: book
+  title: Substituted Title
+  editor: []
+"#;
+
+    assert_eq!(
+        processor(style, references).render_bibliography(),
+        "Substituted Title"
+    );
+}
+
+#[test]
+fn merged_sort_key_falls_through_to_effective_primary_when_merged_component_is_empty() {
+    let style = r#"
+info: {id: merged-sort-fallback-test, title: Merged sort fallback test}
+options:
+  substitute:
+    template: [editor, title]
+  contributors:
+    name-form: initials
+    initialize-with: ". "
+bibliography:
+  sort:
+    template:
+      - key: author
+  template:
+    - contributor: [writer, director]
+      form: long
+      merge: {labels: none}
+    - title: primary
+"#;
+    let references = r#"
+- id: zulu-input
+  class: monograph
+  type: book
+  title: Zulu Book
+  contributors:
+    - roles: [editor]
+      contributor: {family: Able, given: Amy}
+- id: able-input
+  class: monograph
+  type: book
+  title: Able Book
+  contributors:
+    - roles: [editor]
+      contributor: {family: Zulu, given: Zoe}
+"#;
+
+    // zulu-input's editor ("Able, Amy") sorts before able-input's editor
+    // ("Zulu, Zoe"), even though the titles alone would sort the opposite
+    // way — proving the sort key fell through to the effective-primary
+    // resolver instead of stopping at the empty merged list.
+    assert_eq!(
+        processor(style, references).render_bibliography(),
+        "Zulu Book\n\nAble Book"
+    );
+}
+
+#[test]
+fn migrated_names_merge_labels_every_declared_role_not_just_the_first() {
+    // Regression for the CSL `<names variable="editor translator"><label
+    // form="short" prefix=", "/></names>` migration shape: the converter
+    // must label EVERY declared role (editor and translator), not only
+    // `roles.first()`. Different people in each role must each keep their
+    // own role label; a shared person combining both roles still resolves
+    // the locale's authored `editor-translator` combined term.
+    let rendered = render_bibliography(
+        r#"
+- contributor: [editor, translator]
+  form: long
+  name-order: family-first
+  merge:
+    order: role
+    labels: collective
+    roles:
+      editor:
+        label: {term: editor, form: short, placement: suffix, prefix: ", "}
+      translator:
+        label: {term: translator, form: short, placement: suffix, prefix: ", "}
+"#,
+        r#"
+- id: different-people
+  class: monograph
+  type: book
+  contributors:
+    - roles: [editor]
+      contributor: {family: Editor, given: Edna}
+    - roles: [translator]
+      contributor: {family: Translator, given: Tara}
+"#,
+    );
+    assert_eq!(rendered, "Editor, E., ed. & Translator, T., trans.");
+
+    let rendered_same_person = render_bibliography(
+        r#"
+- contributor: [editor, translator]
+  form: long
+  name-order: family-first
+  merge:
+    order: role
+    labels: collective
+    roles:
+      editor:
+        label: {term: editor, form: short, placement: suffix, prefix: ", "}
+      translator:
+        label: {term: translator, form: short, placement: suffix, prefix: ", "}
+"#,
+        r#"
+- id: same-person
+  class: monograph
+  type: book
+  contributors:
+    - roles: [editor, translator]
+      contributor: {family: Both, given: Blake}
+"#,
+    );
+    assert_eq!(rendered_same_person, "Both, B., ed. & trans.");
+}

--- a/crates/citum-engine/tests/forward_compatibility.rs
+++ b/crates/citum-engine/tests/forward_compatibility.rs
@@ -131,8 +131,8 @@ fn template_has_unknowns(components: &[TemplateComponent]) -> bool {
             }
             TemplateComponent::Contributor(c) => {
                 if matches!(
-                    c.contributor,
-                    citum_schema::template::ContributorRole::Unknown(_)
+                    c.contributor.as_single(),
+                    Some(citum_schema::template::ContributorRole::Unknown(_))
                 ) {
                     return true;
                 }
@@ -182,7 +182,13 @@ fn parse_bibliography(yaml: &str) -> Outcome {
                     || reference
                         .all_contributor_entries()
                         .iter()
-                        .any(|c| matches!(c.role, ContributorRole::Unknown(_)))
+                        .any(|contributor| {
+                            contributor
+                                .roles
+                                .as_slice()
+                                .iter()
+                                .any(|role| matches!(role, ContributorRole::Unknown(_)))
+                        })
             });
 
             if has_unknown {
@@ -205,9 +211,9 @@ const STYLE_HEAD: &str =
     "version: \"0.51\"\ninfo:\n  id: forward-compat-fixture\n  title: Forward compat fixture\n";
 
 fn case_attribute_enum_in_template() -> Outcome {
-    // ContributorRole gains hypothetical `producer`.
+    // ContributorRole gains a hypothetical future role.
     let yaml = format!(
-        "{STYLE_HEAD}bibliography:\n  template:\n    - contributor: producer\n      form: long\n"
+        "{STYLE_HEAD}bibliography:\n  template:\n    - contributor: future-contributor\n      form: long\n"
     );
     parse_style(&yaml)
 }

--- a/crates/citum-engine/tests/i18n.rs
+++ b/crates/citum-engine/tests/i18n.rs
@@ -108,7 +108,7 @@ fn make_german_translator_role_style() -> Style {
         bibliography: Some(BibliographySpec {
             template: Some(vec![
                 citum_schema::template::TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Long,
                     ..Default::default()
                 }),
@@ -131,7 +131,7 @@ fn make_german_translator_role_style() -> Style {
                     ..Default::default()
                 }),
                 citum_schema::template::TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Translator,
+                    contributor: ContributorRole::Translator.into(),
                     form: ContributorForm::Long,
                     name_order: Some(NameOrder::GivenFirst),
                     ..Default::default()

--- a/crates/citum-engine/tests/metadata.rs
+++ b/crates/citum-engine/tests/metadata.rs
@@ -55,7 +55,7 @@ fn build_name_style(form: ContributorForm, shorten: Option<ShortenListOptions>) 
         }),
         citation: Some(CitationSpec {
             template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form,
                 ..Default::default()
             })]),

--- a/crates/citum-engine/tests/regression_interview.rs
+++ b/crates/citum-engine/tests/regression_interview.rs
@@ -46,7 +46,7 @@ fn test_apa_interview_fidelity_regression() {
             ..Default::default()
         })),
         contributors: vec![ContributorEntry {
-            role: ContributorRole::Interviewer,
+            roles: ContributorRole::Interviewer.into(),
             contributor: Contributor::StructuredName(StructuredName {
                 family: "Young-Bruehl".into(),
                 given: "Elisabeth".into(),

--- a/crates/citum-migrate/src/assembly.rs
+++ b/crates/citum-migrate/src/assembly.rs
@@ -901,7 +901,7 @@ mod tests {
 
     fn explicit_author_component() -> TemplateComponent {
         TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
+            contributor: ContributorRole::Author.into(),
             form: ContributorForm::Long,
             name_order: Some(NameOrder::FamilyFirstOnly),
             name_form: Some(NameForm::Initials),

--- a/crates/citum-migrate/src/bib_postprocess.rs
+++ b/crates/citum-migrate/src/bib_postprocess.rs
@@ -255,7 +255,7 @@ mod tests {
     fn inferred_type_variants_recover_missing_primary_title() {
         let default_template = vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 ..Default::default()
             }),
             TemplateComponent::Date(TemplateDate {
@@ -272,7 +272,7 @@ mod tests {
             TypeSelector::Single("article-newspaper".to_string()),
             vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     ..Default::default()
                 }),
                 TemplateComponent::Date(TemplateDate {
@@ -314,7 +314,7 @@ mod tests {
     fn inferred_type_variants_recover_missing_publisher() {
         let default_template = vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 ..Default::default()
             }),
             TemplateComponent::Date(TemplateDate {
@@ -339,7 +339,7 @@ mod tests {
             TypeSelector::Single("book".to_string()),
             vec![
                 TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author,
+                    contributor: ContributorRole::Author.into(),
                     ..Default::default()
                 }),
                 TemplateComponent::Title(TemplateTitle {

--- a/crates/citum-migrate/src/fixups/gating.rs
+++ b/crates/citum-migrate/src/fixups/gating.rs
@@ -180,14 +180,18 @@ fn is_accessed_term(component: &TemplateComponent) -> bool {
 /// Whether `component` carries container/host data introduced by an `in` term.
 fn is_container_component(component: &TemplateComponent) -> bool {
     match component {
-        TemplateComponent::Contributor(contributor) => matches!(
-            contributor.contributor,
-            ContributorRole::Editor
-                | ContributorRole::Translator
-                | ContributorRole::ContainerAuthor
-                | ContributorRole::CollectionEditor
-                | ContributorRole::EditorialDirector
-        ),
+        TemplateComponent::Contributor(contributor) => {
+            contributor.contributor.as_slice().iter().any(|role| {
+                matches!(
+                    role,
+                    ContributorRole::Editor
+                        | ContributorRole::Translator
+                        | ContributorRole::ContainerAuthor
+                        | ContributorRole::CollectionEditor
+                        | ContributorRole::EditorialDirector
+                )
+            })
+        }
         TemplateComponent::Title(title) => matches!(
             title.title,
             TitleType::ContainerTitle | TitleType::ParentSerial | TitleType::ParentMonograph
@@ -219,7 +223,14 @@ mod tests {
 
     fn editor() -> TemplateComponent {
         TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Editor,
+            contributor: ContributorRole::Editor.into(),
+            ..Default::default()
+        })
+    }
+
+    fn merged_editor_translator() -> TemplateComponent {
+        TemplateComponent::Contributor(TemplateContributor {
+            contributor: vec![ContributorRole::Editor, ContributorRole::Translator].into(),
             ..Default::default()
         })
     }
@@ -254,6 +265,30 @@ mod tests {
     #[test]
     fn given_root_in_term_before_container_when_gated_then_wrapped_in_group() {
         let mut template = vec![in_term(), editor(), parent_serial(), issued_date()];
+        gate_leaked_in_term(&mut template);
+        assert_eq!(template.len(), 2);
+        let TemplateComponent::Group(group) = &template[0] else {
+            panic!("expected leading in-term group");
+        };
+        assert_eq!(group.group.len(), 3);
+        assert!(matches!(
+            &group.group[0],
+            TemplateComponent::Term(term) if term.term == GeneralTerm::In
+        ));
+        assert!(matches!(&template[1], TemplateComponent::Date(_)));
+    }
+
+    #[test]
+    fn given_root_in_term_before_merged_container_role_when_gated_then_wrapped_in_group() {
+        // A list-form [editor, translator] component is still a container
+        // companion: the `in` term must be grouped with it rather than
+        // dropped, mirroring the scalar-editor case above.
+        let mut template = vec![
+            in_term(),
+            merged_editor_translator(),
+            parent_serial(),
+            issued_date(),
+        ];
         gate_leaked_in_term(&mut template);
         assert_eq!(template.len(), 2);
         let TemplateComponent::Group(group) = &template[0] else {

--- a/crates/citum-migrate/src/fixups/media.rs
+++ b/crates/citum-migrate/src/fixups/media.rs
@@ -203,7 +203,7 @@ pub(super) fn ensure_inferred_media_type_templates(
         }));
         template.push(TemplateComponent::Contributor(
             citum_schema::template::TemplateContributor {
-                contributor: citum_schema::template::ContributorRole::Director,
+                contributor: citum_schema::template::ContributorRole::Director.into(),
                 form: citum_schema::template::ContributorForm::Long,
                 rendering: Rendering {
                     prefix: Some("Directed by ".to_string()),
@@ -221,7 +221,7 @@ pub(super) fn ensure_inferred_media_type_templates(
         let mut template = base_media_template_from_bibliography(bibliography_template);
         template.push(TemplateComponent::Contributor(
             citum_schema::template::TemplateContributor {
-                contributor: citum_schema::template::ContributorRole::Interviewer,
+                contributor: citum_schema::template::ContributorRole::Interviewer.into(),
                 form: citum_schema::template::ContributorForm::Long,
                 ..Default::default()
             },

--- a/crates/citum-migrate/src/ir.rs
+++ b/crates/citum-migrate/src/ir.rs
@@ -73,9 +73,15 @@ pub enum Variable {
     EditorialDirector,
     Illustrator,
     Interviewer,
+    Guest,
+    Host,
+    Narrator,
     OriginalAuthor,
+    Performer,
+    Producer,
     Recipient,
     ReviewedAuthor,
+    Writer,
     Translator,
     Accessed,
     AvailableDate,
@@ -256,7 +262,8 @@ pub struct DateBlock {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NamesBlock {
-    pub variable: Variable,
+    /// Ordered CSL name variables rendered by this names node.
+    pub variables: Vec<Variable>,
     #[serde(flatten)]
     pub options: NamesOptions,
     #[serde(flatten)]

--- a/crates/citum-migrate/src/lineage.rs
+++ b/crates/citum-migrate/src/lineage.rs
@@ -969,7 +969,7 @@ mod tests {
             citation: Some(citum_schema::CitationSpec {
                 template: Some(vec![
                     TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author,
+                        contributor: ContributorRole::Author.into(),
                         form: ContributorForm::Short,
                         ..Default::default()
                     }),
@@ -984,7 +984,7 @@ mod tests {
             bibliography: Some(citum_schema::BibliographySpec {
                 template: Some(vec![
                     TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author,
+                        contributor: ContributorRole::Author.into(),
                         form: ContributorForm::Long,
                         ..Default::default()
                     }),

--- a/crates/citum-migrate/src/main_tests.rs
+++ b/crates/citum-migrate/src/main_tests.rs
@@ -11,8 +11,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 use citum_migrate::{compilation, fixups::normalize_author_date_locator_citation_component};
 use citum_schema::template::{
-    DateVariable, NumberVariable, Rendering, SimpleVariable, TemplateComponent, TemplateDate,
-    TemplateNumber, TemplateVariable,
+    ContributorLabelMode, ContributorMergeOrder, ContributorRole, DateVariable, NumberVariable,
+    Rendering, SimpleVariable, TemplateComponent, TemplateDate, TemplateNumber, TemplateVariable,
 };
 use csl_legacy::{
     model::{CslNode, Formatting, Group, Layout, Text},
@@ -83,7 +83,7 @@ fn author_date_locator_prefers_group_delimiter() {
     };
     let mut template = vec![
         TemplateComponent::Contributor(citum_schema::template::TemplateContributor {
-            contributor: citum_schema::template::ContributorRole::Author,
+            contributor: citum_schema::template::ContributorRole::Author.into(),
             form: citum_schema::template::ContributorForm::Short,
             name_order: Some(citum_schema::template::NameOrder::FamilyFirst),
             ..Default::default()
@@ -157,6 +157,100 @@ fn compile_from_xml_maps_citation_label_variable_into_citation_template() {
         "citation-label should compile to a citation-label number component, got: {:?}",
         out.citation
     );
+}
+
+#[test]
+fn compile_from_xml_preserves_all_names_variables_as_a_merged_component() {
+    let legacy_style = parse_legacy_style(
+        r#"
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text">
+  <info>
+    <title>multi-variable-names-test</title>
+    <id>https://example.org/multi-variable-names-test</id>
+  </info>
+  <bibliography>
+    <layout>
+      <names variable="editor translator">
+        <name and="text"/>
+        <label form="short" prefix=", "/>
+      </names>
+    </layout>
+  </bibliography>
+</style>
+"#,
+    );
+
+    let mut options = citum_schema::options::Config::default();
+    let tracker = citum_migrate::provenance::ProvenanceTracker::new(false);
+    let out = compilation::compile_from_xml(&legacy_style, &mut options, false, &tracker);
+    let contributor = out
+        .bibliography
+        .iter()
+        .find_map(|component| match component {
+            TemplateComponent::Contributor(contributor) => Some(contributor),
+            _ => None,
+        })
+        .expect("multi-variable names should compile to a contributor component");
+    let merge = contributor
+        .merge
+        .as_ref()
+        .expect("multi-variable names should retain merge metadata");
+
+    assert_eq!(
+        contributor.contributor.as_slice(),
+        &[ContributorRole::Editor, ContributorRole::Translator]
+    );
+    assert_eq!(merge.order, ContributorMergeOrder::Role);
+    assert_eq!(merge.labels, ContributorLabelMode::Collective);
+    assert!(merge.combine_same_person);
+    assert_eq!(
+        merge
+            .roles
+            .get(&ContributorRole::Editor)
+            .and_then(|role| role.label.as_ref())
+            .map(|label| label.term.as_str()),
+        Some("editor")
+    );
+    assert_eq!(
+        merge
+            .roles
+            .get(&ContributorRole::Translator)
+            .and_then(|role| role.label.as_ref())
+            .map(|label| label.term.as_str()),
+        Some("translator")
+    );
+
+    let actual = serde_yaml::to_value(TemplateComponent::Contributor(contributor.clone()))
+        .expect("compiled component should serialize");
+    let expected: serde_yaml::Value = serde_yaml::from_str(
+        r#"
+contributor: [editor, translator]
+form: long
+merge:
+  order: role
+  labels: collective
+  roles:
+    editor:
+      labels: collective
+      label:
+        term: editor
+        form: short
+        placement: suffix
+        prefix: ", "
+    translator:
+      labels: collective
+      label:
+        term: translator
+        form: short
+        placement: suffix
+        prefix: ", "
+  combine-same-person: true
+and: text
+suppress: false
+"#,
+    )
+    .expect("expected component YAML should parse");
+    assert_eq!(actual, expected);
 }
 
 #[test]

--- a/crates/citum-migrate/src/passes/sqi_refinement.rs
+++ b/crates/citum-migrate/src/passes/sqi_refinement.rs
@@ -513,9 +513,16 @@ fn inherited_name_order_matches(
     defaults: &ContributorConfig,
     name_order: &NameOrder,
 ) -> bool {
-    if defaults
-        .effective_role_name_order(&contributor.contributor)
-        .is_some_and(|default| default == name_order)
+    // Scalar components compact when their single role's effective default
+    // matches; list-form components (e.g. merged [editor, translator]) only
+    // compact when EVERY declared role's effective default agrees, since a
+    // single explicit override can't be pushed onto a role whose own
+    // default differs.
+    let roles = contributor.contributor.as_slice();
+    if !roles.is_empty()
+        && roles
+            .iter()
+            .all(|role| defaults.effective_role_name_order(role) == Some(name_order))
     {
         return true;
     }
@@ -604,7 +611,10 @@ mod tests {
     use super::*;
     use citum_engine::{Processor, reference::Bibliography};
     use citum_schema::{
-        options::{NameForm, TextCase, TitleRendering, TitlesConfig, classified_ref_types},
+        options::{
+            NameForm, RoleOptions, RoleRendering, TextCase, TitleRendering, TitlesConfig,
+            classified_ref_types,
+        },
         template::{
             ContributorForm, ContributorRole, TemplateGroup, TemplateTitle, TemplateVariable,
         },
@@ -613,7 +623,7 @@ mod tests {
 
     fn author(and: Option<AndOptions>) -> TemplateComponent {
         TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
+            contributor: ContributorRole::Author.into(),
             form: ContributorForm::Long,
             and,
             ..TemplateContributor::default()
@@ -622,7 +632,7 @@ mod tests {
 
     fn author_with_name_options() -> TemplateComponent {
         TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
+            contributor: ContributorRole::Author.into(),
             form: ContributorForm::Long,
             name_order: Some(NameOrder::FamilyFirstOnly),
             name_form: Some(NameForm::Initials),
@@ -861,12 +871,73 @@ mod tests {
     }
 
     #[test]
+    fn list_form_contributor_name_order_compacts_only_when_every_role_matches() {
+        // A merged [editor, translator] component's explicit name-order
+        // should compact only when it agrees with EVERY declared role's
+        // effective default, not just the first one.
+        let mut roles = std::collections::HashMap::new();
+        roles.insert(
+            "editor".to_string(),
+            RoleRendering {
+                name_order: Some(NameOrder::FamilyFirstOnly),
+                ..RoleRendering::default()
+            },
+        );
+        roles.insert(
+            "translator".to_string(),
+            RoleRendering {
+                name_order: Some(NameOrder::FamilyFirstOnly),
+                ..RoleRendering::default()
+            },
+        );
+        let options = citum_schema::options::Config {
+            contributors: Some(ContributorConfig {
+                role: Some(RoleOptions {
+                    roles: Some(roles),
+                    ..RoleOptions::default()
+                }),
+                ..ContributorConfig::default()
+            }),
+            ..citum_schema::options::Config::default()
+        };
+
+        let merged = TemplateComponent::Contributor(TemplateContributor {
+            contributor: vec![ContributorRole::Editor, ContributorRole::Translator].into(),
+            form: ContributorForm::Long,
+            name_order: Some(NameOrder::FamilyFirstOnly),
+            ..TemplateContributor::default()
+        });
+        let style = Style {
+            options: Some(options),
+            bibliography: Some(BibliographySpec {
+                template: Some(vec![merged]),
+                ..BibliographySpec::default()
+            }),
+            ..Style::default()
+        };
+
+        let refined = refine_style(style);
+        let template = refined
+            .bibliography
+            .as_ref()
+            .and_then(|bibliography| bibliography.template.as_ref())
+            .expect("bibliography template should exist");
+        let TemplateComponent::Contributor(contributor) = &template[0] else {
+            panic!("component should be contributor");
+        };
+        assert_eq!(
+            contributor.name_order, None,
+            "explicit name-order matching every declared role's default should compact"
+        );
+    }
+
+    #[test]
     fn bibliography_full_variants_are_diffed_before_pruning() {
         let mut type_variants = indexmap::IndexMap::new();
         type_variants.insert(
             TypeSelector::Single("book".to_string()),
             TemplateVariant::Full(vec![TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 form: ContributorForm::Long,
                 and: None,
                 ..TemplateContributor::default()

--- a/crates/citum-migrate/src/synthesis/operators.rs
+++ b/crates/citum-migrate/src/synthesis/operators.rs
@@ -289,12 +289,13 @@ mod tests {
     fn sample_template() -> Vec<TemplateComponent> {
         vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Editor,
+                contributor: ContributorRole::Editor.into(),
                 label: Some(RoleLabel {
                     term: "editor".to_string(),
                     form: RoleLabelForm::Short,
                     placement: Default::default(),
                     text_case: None,
+                    wrap: None,
                     prefix: None,
                     suffix: None,
                 }),

--- a/crates/citum-migrate/src/template_compiler/formatting.rs
+++ b/crates/citum-migrate/src/template_compiler/formatting.rs
@@ -233,7 +233,7 @@ pub(super) fn extract_source_order(node: &Node) -> Option<usize> {
             match node {
                 Node::Variable(v) => format!("Variable({:?})", v.variable),
                 Node::Date(d) => format!("Date({:?})", d.variable),
-                Node::Names(n) => format!("Names({:?})", n.variable),
+                Node::Names(n) => format!("Names({:?})", n.variables),
                 Node::Group(_) => "Group".to_string(),
                 Node::Text { value } => format!("Text({value})"),
                 Node::Condition(_) => "Condition".to_string(),

--- a/crates/citum-migrate/src/template_compiler/node_compiler.rs
+++ b/crates/citum-migrate/src/template_compiler/node_compiler.rs
@@ -23,38 +23,7 @@ impl TemplateCompiler {
 
     /// Compile a Names block into a Contributor component.
     pub(super) fn compile_names(&self, names: &crate::ir::NamesBlock) -> Option<TemplateComponent> {
-        // Try to map the primary variable to a role
-        let primary_role = self.map_variable_to_role(&names.variable);
-
-        // Check if we should use a substitute instead of the primary
-        // Rare contributor roles (composer, illustrator) often have author as first substitute
-        let role = {
-            let role = primary_role?;
-            // If primary is a rare role and we have substitutes, prefer the first common one
-            let rare_roles = [
-                ContributorRole::Composer,
-                ContributorRole::Illustrator,
-                ContributorRole::Interviewer,
-                ContributorRole::Inventor,
-                ContributorRole::Counsel,
-                ContributorRole::CollectionEditor,
-                ContributorRole::EditorialDirector,
-                ContributorRole::OriginalAuthor,
-                ContributorRole::ReviewedAuthor,
-            ];
-
-            if rare_roles.contains(&role) && !names.options.substitute.is_empty() {
-                // Try to find a common role in the substitute list
-                names
-                    .options
-                    .substitute
-                    .iter()
-                    .find_map(|var| self.map_variable_to_role(var))
-                    .unwrap_or(role) // Fallback to primary if no valid substitute
-            } else {
-                role
-            }
-        };
+        let mut roles = self.resolve_names_roles(names)?;
 
         let form = match names.options.mode {
             Some(crate::ir::NameMode::Short) => ContributorForm::Short,
@@ -105,9 +74,17 @@ impl TemplateCompiler {
             None => None,
         };
 
+        let merge = Self::compile_names_merge(names, &roles);
+        let contributor = if roles.len() == 1 {
+            roles.remove(0).into()
+        } else {
+            roles.into()
+        };
+
         Some(TemplateComponent::Contributor(TemplateContributor {
-            contributor: role,
+            contributor,
             form,
+            merge,
             name_order,
             delimiter: names.options.delimiter.clone(),
             sort_separator: names.options.sort_separator.clone(),
@@ -118,6 +95,96 @@ impl TemplateCompiler {
         }))
     }
 
+    fn resolve_names_roles(&self, names: &crate::ir::NamesBlock) -> Option<Vec<ContributorRole>> {
+        let mut roles = names
+            .variables
+            .iter()
+            .filter_map(|variable| self.map_variable_to_role(variable))
+            .collect::<Vec<_>>();
+        let primary_role = roles.first()?.clone();
+        let rare_roles = [
+            ContributorRole::Composer,
+            ContributorRole::Illustrator,
+            ContributorRole::Interviewer,
+            ContributorRole::Inventor,
+            ContributorRole::Counsel,
+            ContributorRole::CollectionEditor,
+            ContributorRole::EditorialDirector,
+            ContributorRole::OriginalAuthor,
+            ContributorRole::ReviewedAuthor,
+        ];
+        if roles.len() == 1
+            && rare_roles.contains(&primary_role)
+            && let Some(replacement) = names
+                .options
+                .substitute
+                .iter()
+                .find_map(|variable| self.map_variable_to_role(variable))
+            && let Some(role) = roles.first_mut()
+        {
+            *role = replacement;
+        }
+        Some(roles)
+    }
+
+    fn compile_names_merge(
+        names: &crate::ir::NamesBlock,
+        roles: &[ContributorRole],
+    ) -> Option<citum_schema::template::ContributorMerge> {
+        if roles.len() < 2 {
+            return None;
+        }
+        let mut role_overrides = std::collections::HashMap::new();
+        if let Some(label) = &names.options.label {
+            let (form, placement) = match label.form {
+                crate::ir::LabelForm::Short | crate::ir::LabelForm::Symbol => (
+                    citum_schema::template::RoleLabelForm::Short,
+                    citum_schema::template::LabelPlacement::Suffix,
+                ),
+                crate::ir::LabelForm::Verb | crate::ir::LabelForm::VerbShort => (
+                    citum_schema::template::RoleLabelForm::Long,
+                    citum_schema::template::LabelPlacement::Prefix,
+                ),
+                crate::ir::LabelForm::Long => (
+                    citum_schema::template::RoleLabelForm::Long,
+                    citum_schema::template::LabelPlacement::Suffix,
+                ),
+            };
+            // Label every declared role individually: the engine resolves
+            // authored combined terms (e.g. `editor-translator`) from the
+            // locale automatically for combined entries, and resolves
+            // single-role labels by the entry's actual role.
+            for role in roles {
+                role_overrides.insert(
+                    role.clone(),
+                    citum_schema::template::ContributorMergeRole {
+                        labels: Some(citum_schema::template::ContributorLabelMode::Collective),
+                        label: Some(citum_schema::template::RoleLabel {
+                            term: role.as_str().to_string(),
+                            form: form.clone(),
+                            placement: placement.clone(),
+                            text_case: None,
+                            wrap: None,
+                            prefix: label.formatting.prefix.clone(),
+                            suffix: label.formatting.suffix.clone(),
+                        }),
+                    },
+                );
+            }
+        }
+        Some(citum_schema::template::ContributorMerge {
+            order: citum_schema::template::ContributorMergeOrder::Role,
+            labels: if names.options.label.is_some() {
+                citum_schema::template::ContributorLabelMode::Collective
+            } else {
+                citum_schema::template::ContributorLabelMode::None
+            },
+            roles: role_overrides,
+            combine_same_person: true,
+            role_conjunction: None,
+        })
+    }
+
     /// Map a Variable to `ContributorRole`.
     pub(super) fn map_variable_to_role(&self, var: &Variable) -> Option<ContributorRole> {
         match var {
@@ -125,6 +192,12 @@ impl TemplateCompiler {
             Variable::Editor => Some(ContributorRole::Editor),
             Variable::Translator => Some(ContributorRole::Translator),
             Variable::Director => Some(ContributorRole::Director),
+            Variable::Writer => Some(ContributorRole::Writer),
+            Variable::Producer => Some(ContributorRole::Producer),
+            Variable::Performer => Some(ContributorRole::Performer),
+            Variable::Guest => Some(ContributorRole::Guest),
+            Variable::Host => Some(ContributorRole::Unknown("host".to_string())),
+            Variable::Narrator => Some(ContributorRole::Unknown("narrator".to_string())),
             Variable::Composer => Some(ContributorRole::Composer),
             Variable::Illustrator => Some(ContributorRole::Illustrator),
             Variable::Interviewer => Some(ContributorRole::Interviewer),
@@ -192,7 +265,7 @@ impl TemplateCompiler {
         // First, check if it's a contributor role
         if let Some(role) = self.map_variable_to_role(&var.variable) {
             return Some(TemplateComponent::Contributor(TemplateContributor {
-                contributor: role,
+                contributor: role.into(),
                 form: ContributorForm::Long,
                 name_order: None, // Use global setting by default
                 delimiter: None,

--- a/crates/citum-migrate/src/template_diff.rs
+++ b/crates/citum-migrate/src/template_diff.rs
@@ -734,14 +734,14 @@ mod tests {
     fn template_v3_diff_generator_emits_rendering_modify() {
         let default_template = vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 ..Default::default()
             }),
             title_component(),
         ];
         let target_template = vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 ..Default::default()
             }),
             TemplateComponent::Title(TemplateTitle {
@@ -773,7 +773,7 @@ mod tests {
     fn template_v3_diff_generator_emits_structural_remove_and_add() {
         let default_template = vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 ..Default::default()
             }),
             title_component(),
@@ -784,7 +784,7 @@ mod tests {
         ];
         let target_template = vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 ..Default::default()
             }),
             TemplateComponent::Date(citum_schema::template::TemplateDate {
@@ -832,7 +832,7 @@ mod tests {
     fn template_v3_diff_generator_can_extend_prior_variant() {
         let default_template = vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 ..Default::default()
             }),
             title_component(),
@@ -843,7 +843,7 @@ mod tests {
         ];
         let book_template = vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 ..Default::default()
             }),
             TemplateComponent::Title(TemplateTitle {
@@ -857,7 +857,7 @@ mod tests {
         ];
         let chapter_template = vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 ..Default::default()
             }),
             TemplateComponent::Title(TemplateTitle {
@@ -912,7 +912,7 @@ mod tests {
     fn rare_parent_near_tie_loses_to_default_template() {
         let default_template = vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 ..Default::default()
             }),
             title_component(),
@@ -923,14 +923,14 @@ mod tests {
         ];
         let encyclopedia_template = vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 ..Default::default()
             }),
             title_component(),
         ];
         let webpage_template = vec![
             TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 ..Default::default()
             }),
             title_component(),

--- a/crates/citum-migrate/src/upsampler/mapping.rs
+++ b/crates/citum-migrate/src/upsampler/mapping.rs
@@ -158,10 +158,13 @@ impl Upsampler {
                 }
                 LNode::Substitute(sub) => {
                     for sub_node in &sub.children {
-                        if let LNode::Names(sub_names) = sub_node
-                            && let Some(sub_var) = self.map_variable(&sub_names.variable)
-                        {
-                            options.substitute.push(sub_var);
+                        if let LNode::Names(sub_names) = sub_node {
+                            options.substitute.extend(
+                                sub_names
+                                    .variable
+                                    .split_whitespace()
+                                    .filter_map(|variable| self.map_variable(variable)),
+                            );
                         }
                     }
                 }
@@ -176,20 +179,16 @@ impl Upsampler {
             return None;
         }
 
-        #[allow(clippy::indexing_slicing, reason = "vars is not empty")]
-        let variable = self.map_variable(vars[0])?;
+        let variables = vars
+            .iter()
+            .filter_map(|variable| self.map_variable(variable))
+            .collect::<Vec<_>>();
+        let variable = variables.first()?.clone();
 
         let mut options = ir::NamesOptions {
             delimiter: n.delimiter.clone(),
             ..Default::default()
         };
-
-        // If multiple variables were provided, add the others to substitute
-        for v in vars.iter().skip(1) {
-            if let Some(var) = self.map_variable(v) {
-                options.substitute.push(var);
-            }
-        }
 
         // Extract et-al defaults from Names node, falling back to upsampler defaults
         let mut et_al_min = n.et_al_min.or(self.et_al_min);
@@ -238,7 +237,7 @@ impl Upsampler {
             );
         }
         Some(ir::Node::Names(ir::NamesBlock {
-            variable,
+            variables,
             options,
             formatting: FormattingOptions::default(),
             source_order: n.macro_call_order,
@@ -645,6 +644,12 @@ impl Upsampler {
             "collection-editor" => Some(Variable::CollectionEditor),
             "composer" => Some(Variable::Composer),
             "director" => Some(Variable::Director),
+            "script-writer" => Some(Variable::Writer),
+            "producer" => Some(Variable::Producer),
+            "performer" => Some(Variable::Performer),
+            "guest" => Some(Variable::Guest),
+            "host" => Some(Variable::Host),
+            "narrator" => Some(Variable::Narrator),
             "interviewer" => Some(Variable::Interviewer),
             "recipient" => Some(Variable::Recipient),
             "reviewed-author" => Some(Variable::ReviewedAuthor),

--- a/crates/citum-migrate/tests/bibliography_layout_order.rs
+++ b/crates/citum-migrate/tests/bibliography_layout_order.rs
@@ -52,7 +52,10 @@ fn compile_bibliography_base(xml: &str) -> Vec<TemplateComponent> {
 /// Short identification key for a component, for order assertions.
 fn component_key(component: &TemplateComponent) -> String {
     match component {
-        TemplateComponent::Contributor(c) => format!("contributor:{:?}", c.contributor),
+        TemplateComponent::Contributor(c) => c.contributor.as_single().map_or_else(
+            || format!("contributor:{:?}", c.contributor.as_slice()),
+            |role| format!("contributor:{role:?}"),
+        ),
         TemplateComponent::Date(d) => format!("date:{:?}", d.date),
         TemplateComponent::Title(t) => format!("title:{:?}", t.title),
         TemplateComponent::Number(n) => format!("number:{:?}", n.number),

--- a/crates/citum-migrate/tests/variable_once.rs
+++ b/crates/citum-migrate/tests/variable_once.rs
@@ -38,14 +38,14 @@ fn test_contributor_cross_list_duplicate_removed() {
     let mut components = vec![
         TemplateComponent::Group(TemplateGroup {
             group: vec![TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 ..Default::default()
             })],
             ..Default::default()
         }),
         TemplateComponent::Group(TemplateGroup {
             group: vec![TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author,
+                contributor: ContributorRole::Author.into(),
                 ..Default::default()
             })],
             ..Default::default()

--- a/crates/citum-schema-data/src/reference/accessors.rs
+++ b/crates/citum-schema-data/src/reference/accessors.rs
@@ -446,7 +446,7 @@ impl InputReference {
     pub fn contributor_entries(&self, role: &ContributorRole) -> Vec<&ContributorEntry> {
         self.all_contributor_entries()
             .iter()
-            .filter(|entry| &entry.role == role)
+            .filter(|entry| entry.roles.contains(role))
             .collect()
     }
 
@@ -1627,7 +1627,7 @@ fn collect_contributors_by_role(
 ) -> Option<Contributor> {
     let mut matches = entries
         .iter()
-        .filter(|e| &e.role == role)
+        .filter(|entry| entry.roles.contains(role))
         .map(|e| &e.contributor);
     let first = matches.next()?;
     let Some(second) = matches.next() else {

--- a/crates/citum-schema-data/src/reference/contributor.rs
+++ b/crates/citum-schema-data/src/reference/contributor.rs
@@ -213,14 +213,96 @@ crate::tolerant_enum! {
     }
 }
 
+/// One or more distinct roles explicitly assigned to a contributor entry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[cfg_attr(feature = "bindings", derive(Type))]
+#[serde(transparent)]
+pub struct ContributorRoles(
+    #[cfg_attr(feature = "schema", schemars(length(min = 1)))] Vec<ContributorRole>,
+);
+
+impl ContributorRoles {
+    /// Return the roles in their authored order.
+    #[must_use]
+    pub fn as_slice(&self) -> &[ContributorRole] {
+        &self.0
+    }
+
+    /// Return whether this entry carries `role`.
+    #[must_use]
+    pub fn contains(&self, role: &ContributorRole) -> bool {
+        self.0.contains(role)
+    }
+
+    /// Add a role when it is not already present.
+    #[cfg(feature = "legacy-convert")]
+    pub(crate) fn insert(&mut self, role: ContributorRole) {
+        if !self.contains(&role) {
+            self.0.push(role);
+        }
+    }
+}
+
+impl From<ContributorRole> for ContributorRoles {
+    fn from(role: ContributorRole) -> Self {
+        Self(vec![role])
+    }
+}
+
+impl PartialEq<ContributorRole> for ContributorRoles {
+    fn eq(&self, other: &ContributorRole) -> bool {
+        self.as_slice() == std::slice::from_ref(other)
+    }
+}
+
+impl TryFrom<Vec<ContributorRole>> for ContributorRoles {
+    type Error = &'static str;
+
+    fn try_from(roles: Vec<ContributorRole>) -> Result<Self, Self::Error> {
+        if roles.is_empty() {
+            return Err("contributor roles must not be empty");
+        }
+        let mut distinct = Vec::with_capacity(roles.len());
+        for role in &roles {
+            if distinct.contains(role) {
+                return Err("contributor roles must be distinct");
+            }
+            distinct.push(role.clone());
+        }
+        Ok(Self(roles))
+    }
+}
+
+impl<'de> Deserialize<'de> for ContributorRoles {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum AuthoredRoles {
+            Single(ContributorRole),
+            Multiple(Vec<ContributorRole>),
+        }
+
+        let roles = match AuthoredRoles::deserialize(deserializer)? {
+            AuthoredRoles::Single(role) => vec![role],
+            AuthoredRoles::Multiple(roles) => roles,
+        };
+        Self::try_from(roles).map_err(serde::de::Error::custom)
+    }
+}
+
 /// A single entry in a reference's contributors list.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[cfg_attr(feature = "bindings", derive(Type))]
 #[serde(rename_all = "kebab-case")]
 pub struct ContributorEntry {
-    /// The role this contributor plays in relation to the work.
-    pub role: ContributorRole,
+    /// The explicit roles this contributor plays in relation to the work.
+    #[serde(rename = "roles", alias = "role")]
+    pub roles: ContributorRoles,
     /// The contributor (name, organization, or list).
     pub contributor: Contributor,
     /// The grammatical gender used for role-label agreement.

--- a/crates/citum-schema-data/src/reference/conversion/mod.rs
+++ b/crates/citum-schema-data/src/reference/conversion/mod.rs
@@ -43,6 +43,7 @@ use crate::reference::{
     RefID, WorkCore, WorkRelation,
 };
 use std::collections::HashMap;
+use unicode_normalization::UnicodeNormalization;
 use url::Url;
 
 /// Fold legacy named contributor fields (recipient and interviewer) into a contributors vec.
@@ -67,12 +68,167 @@ fn push_legacy_contributor(
     src: Option<Vec<csl_legacy::csl_json::Name>>,
 ) {
     if let Some(names) = src {
-        entries.push(ContributorEntry {
-            role,
-            contributor: Contributor::from(names),
-            gender: None,
+        let Contributor::ContributorList(list) = Contributor::from(names) else {
+            return;
+        };
+        let mut unmatched = Vec::new();
+        for contributor in list.0 {
+            let identity = legacy_contributor_identity(&contributor);
+            if let Some((entry_index, member_index)) = identity
+                .as_ref()
+                .and_then(|identity| find_legacy_contributor(entries, &role, identity))
+                && merge_legacy_contributor_role(entries, entry_index, member_index, role.clone())
+            {
+                continue;
+            }
+            unmatched.push(contributor);
+        }
+        if !unmatched.is_empty() {
+            let contributor = if unmatched.len() == 1 {
+                let Some(contributor) = unmatched.pop() else {
+                    return;
+                };
+                contributor
+            } else {
+                Contributor::ContributorList(ContributorList(unmatched))
+            };
+            entries.push(ContributorEntry {
+                roles: role.into(),
+                contributor,
+                gender: None,
+            });
+        }
+    }
+}
+
+fn find_legacy_contributor(
+    entries: &[ContributorEntry],
+    role: &ContributorRole,
+    identity: &LegacyContributorIdentity,
+) -> Option<(usize, Option<usize>)> {
+    entries.iter().enumerate().find_map(|(entry_index, entry)| {
+        if entry.roles.contains(role) {
+            return None;
+        }
+        match &entry.contributor {
+            Contributor::ContributorList(list) => list
+                .0
+                .iter()
+                .position(|contributor| {
+                    legacy_contributor_identity(contributor).as_ref() == Some(identity)
+                })
+                .map(|member_index| (entry_index, Some(member_index))),
+            contributor => (legacy_contributor_identity(contributor).as_ref() == Some(identity))
+                .then_some((entry_index, None)),
+        }
+    })
+}
+
+fn merge_legacy_contributor_role(
+    entries: &mut Vec<ContributorEntry>,
+    entry_index: usize,
+    member_index: Option<usize>,
+    role: ContributorRole,
+) -> bool {
+    let Some(member_index) = member_index else {
+        if let Some(entry) = entries.get_mut(entry_index) {
+            entry.roles.insert(role);
+            return true;
+        }
+        return false;
+    };
+    if entry_index >= entries.len() {
+        return false;
+    }
+
+    let ContributorEntry {
+        roles,
+        contributor,
+        gender,
+    } = entries.remove(entry_index);
+    let Contributor::ContributorList(mut list) = contributor else {
+        entries.insert(
+            entry_index,
+            ContributorEntry {
+                roles,
+                contributor,
+                gender,
+            },
+        );
+        return false;
+    };
+    if member_index >= list.0.len() {
+        entries.insert(
+            entry_index,
+            ContributorEntry {
+                roles,
+                contributor: Contributor::ContributorList(list),
+                gender,
+            },
+        );
+        return false;
+    }
+
+    let mut after = list.0.split_off(member_index + 1);
+    let Some(matched) = list.0.pop() else {
+        return false;
+    };
+    let mut matched_roles = roles.clone();
+    matched_roles.insert(role);
+    let mut replacement = Vec::with_capacity(3);
+    if !list.0.is_empty() {
+        replacement.push(ContributorEntry {
+            roles: roles.clone(),
+            contributor: Contributor::ContributorList(list),
+            gender,
         });
     }
+    replacement.push(ContributorEntry {
+        roles: matched_roles,
+        contributor: matched,
+        gender,
+    });
+    if !after.is_empty() {
+        replacement.push(ContributorEntry {
+            roles,
+            contributor: Contributor::ContributorList(ContributorList(std::mem::take(&mut after))),
+            gender,
+        });
+    }
+    entries.splice(entry_index..entry_index, replacement);
+    true
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum LegacyContributorIdentity {
+    Structured(Vec<String>),
+    Literal(String),
+}
+
+fn legacy_contributor_identity(contributor: &Contributor) -> Option<LegacyContributorIdentity> {
+    let name = contributor.to_names_vec().into_iter().next()?;
+    if let Some(literal) = normalized_identity_part(name.literal.as_deref()) {
+        return Some(LegacyContributorIdentity::Literal(literal));
+    }
+    let parts = [
+        name.given.as_deref(),
+        name.family.as_deref(),
+        name.suffix.as_deref(),
+        name.dropping_particle.as_deref(),
+        name.non_dropping_particle.as_deref(),
+    ]
+    .into_iter()
+    .map(|part| normalized_identity_part(part).unwrap_or_default())
+    .collect::<Vec<_>>();
+    parts
+        .iter()
+        .any(|part| !part.is_empty())
+        .then_some(LegacyContributorIdentity::Structured(parts))
+}
+
+fn normalized_identity_part(value: Option<&str>) -> Option<String> {
+    let trimmed = value?.trim();
+    (!trimmed.is_empty()).then(|| trimmed.nfc().collect())
 }
 
 fn legacy_extra_names(
@@ -742,13 +898,13 @@ mod tests {
             component
                 .contributors
                 .iter()
-                .any(|entry| entry.role == ContributorRole::Writer)
+                .any(|entry| entry.roles.contains(&ContributorRole::Writer))
         );
         assert!(
             component
                 .contributors
                 .iter()
-                .any(|entry| entry.role == ContributorRole::Performer)
+                .any(|entry| entry.roles.contains(&ContributorRole::Performer))
         );
     }
 
@@ -829,7 +985,7 @@ mod tests {
         assert!(
             work.contributors
                 .iter()
-                .any(|entry| entry.role == ContributorRole::Producer)
+                .any(|entry| entry.roles.contains(&ContributorRole::Producer))
         );
     }
 
@@ -866,12 +1022,12 @@ mod tests {
         let composer_count = monograph
             .contributors
             .iter()
-            .filter(|entry| entry.role == ContributorRole::Composer)
+            .filter(|entry| entry.roles.contains(&ContributorRole::Composer))
             .count();
         let producer_count = monograph
             .contributors
             .iter()
-            .filter(|entry| entry.role == ContributorRole::Producer)
+            .filter(|entry| entry.roles.contains(&ContributorRole::Producer))
             .count();
 
         assert_eq!(

--- a/crates/citum-schema-data/src/reference/conversion/scholarly.rs
+++ b/crates/citum-schema-data/src/reference/conversion/scholarly.rs
@@ -399,7 +399,7 @@ pub(super) fn from_collection_component_ref(
     }
     if let Some(container_author) = container_author.clone() {
         contributors.push(ContributorEntry {
-            role: ContributorRole::Unknown("container-author".to_string()),
+            roles: ContributorRole::Unknown("container-author".to_string()).into(),
             contributor: container_author,
             gender: None,
         });
@@ -725,6 +725,14 @@ pub(super) fn from_serial_component_ref(
         &mut contributors,
         ContributorRole::Writer,
         legacy_extra_names(&legacy, "script-writer"),
+    );
+    push_legacy_contributor(
+        &mut contributors,
+        ContributorRole::Director,
+        legacy
+            .director
+            .clone()
+            .or_else(|| legacy_extra_names(&legacy, "director")),
     );
     push_legacy_contributor(
         &mut contributors,
@@ -1069,7 +1077,7 @@ pub(super) fn from_event_ref(
     push_legacy_contributor(&mut contributors, ContributorRole::Host, host_names);
     if let Some(organizer_name) = legacy.publisher.clone() {
         contributors.push(ContributorEntry {
-            role: ContributorRole::Unknown("organizer".to_string()),
+            roles: ContributorRole::Unknown("organizer".to_string()).into(),
             contributor: Contributor::SimpleName(SimpleName {
                 name: organizer_name.into(),
                 location: None,

--- a/crates/citum-schema-data/src/reference/tests.rs
+++ b/crates/citum-schema-data/src/reference/tests.rs
@@ -50,7 +50,7 @@ fn test_parse_csl_json_structural_author_populates_canonical_contributors() {
             monograph
                 .contributors
                 .iter()
-                .any(|entry| entry.role == ContributorRole::Author),
+                .any(|entry| entry.roles.contains(&ContributorRole::Author)),
             "legacy author should populate canonical contributors"
         ),
         other => panic!("expected monograph, got {:?}", other),
@@ -101,7 +101,7 @@ fn test_parse_csl_json_motion_picture_produces_audio_visual() {
                 work.core
                     .contributors
                     .iter()
-                    .any(|entry| entry.role == ContributorRole::Director)
+                    .any(|entry| entry.roles.contains(&ContributorRole::Director))
             );
         }
         other => panic!("expected audio-visual work, got {:?}", other),
@@ -167,7 +167,7 @@ fn test_parse_csl_json_broadcast_with_producers_stays_serial_component() {
                 component
                     .contributors
                     .iter()
-                    .any(|entry| entry.role == ContributorRole::Producer)
+                    .any(|entry| entry.roles.contains(&ContributorRole::Producer))
             );
             let container_title =
                 component
@@ -296,13 +296,13 @@ fn test_parse_csl_json_broadcast_preserves_writer_cast_network_and_duration() {
                 component
                     .contributors
                     .iter()
-                    .any(|entry| entry.role == ContributorRole::Writer)
+                    .any(|entry| entry.roles.contains(&ContributorRole::Writer))
             );
             assert!(
                 component
                     .contributors
                     .iter()
-                    .any(|entry| entry.role == ContributorRole::Performer)
+                    .any(|entry| entry.roles.contains(&ContributorRole::Performer))
             );
         }
         other => panic!("expected serial component, got {:?}", other),
@@ -399,10 +399,9 @@ fn test_parse_csl_json_event_note_type_routes_to_event_with_chair_and_session() 
         Some(Title::Single("Society conference".to_string()))
     );
     assert!(
-        event
-            .contributors
-            .iter()
-            .any(|entry| entry.role == ContributorRole::Unknown("chair".to_string())),
+        event.contributors.iter().any(|entry| entry
+            .roles
+            .contains(&ContributorRole::Unknown("chair".to_string()))),
         "chair should be preserved as a custom contributor role"
     );
     assert_eq!(
@@ -1026,7 +1025,7 @@ issued: "1962"
         assert!(
             m.contributors
                 .iter()
-                .any(|e| e.role == ContributorRole::Author),
+                .any(|e| e.roles.contains(&ContributorRole::Author)),
             "author shorthand not folded into contributors"
         );
     } else {
@@ -1056,7 +1055,7 @@ issued: "2020"
         let author_count = m
             .contributors
             .iter()
-            .filter(|e| e.role == ContributorRole::Author)
+            .filter(|e| e.roles.contains(&ContributorRole::Author))
             .count();
         assert_eq!(author_count, 1, "duplicate author entry after fold");
     } else {
@@ -1259,14 +1258,11 @@ fn conversion_retains_av_interview_metadata() {
     assert_eq!(reference.medium(), Some("television".to_string()));
 
     match reference.contributor(ContributorRole::Interviewer) {
-        Some(Contributor::ContributorList(list)) => match &list.0[0] {
-            Contributor::StructuredName(name) => {
-                assert_eq!(name.family.to_string(), "Colbert");
-                assert_eq!(name.given.to_string(), "Stephen");
-            }
-            other => panic!("expected structured interviewer, got {:?}", other),
-        },
-        other => panic!("expected interviewer list, got {:?}", other),
+        Some(Contributor::StructuredName(name)) => {
+            assert_eq!(name.family.to_string(), "Colbert");
+            assert_eq!(name.given.to_string(), "Stephen");
+        }
+        other => panic!("expected structured interviewer, got {:?}", other),
     }
 }
 
@@ -1410,7 +1406,9 @@ fn conversion_chapter_without_named_parent_keeps_volume_but_avoids_empty_contain
         component
             .contributors
             .iter()
-            .any(|entry| entry.role == ContributorRole::Editor)
+            .any(|entry| entry.roles.as_slice().len() == 2
+                && entry.roles.contains(&ContributorRole::Editor)
+                && entry.roles.contains(&ContributorRole::Translator))
     );
 
     let collection = match component.container.as_ref() {
@@ -1427,7 +1425,7 @@ fn conversion_chapter_without_named_parent_keeps_volume_but_avoids_empty_contain
         collection
             .contributors
             .iter()
-            .all(|entry| entry.role != ContributorRole::Editor)
+            .all(|entry| entry.roles != ContributorRole::Editor)
     );
     assert!(
         collection
@@ -1735,5 +1733,208 @@ fn conversion_maps_original_relation_for_legal_case_references() {
             .as_ref()
             .and_then(|publisher| publisher.place.clone()),
         Some(Place::from("Boston"))
+    );
+}
+
+#[test]
+fn contributor_roles_are_explicit_and_legacy_scalar_role_is_accepted() {
+    let canonical = r#"
+class: audio-visual
+type: broadcast
+contributors:
+  - roles: [writer, director]
+    contributor: {family: Whedon, given: Joss}
+"#;
+    let reference: InputReference = serde_yaml::from_str(canonical).unwrap();
+    let entry = reference.all_contributor_entries().first().unwrap();
+    assert_eq!(
+        entry.roles.as_slice(),
+        &[ContributorRole::Writer, ContributorRole::Director]
+    );
+
+    let legacy_scalar = canonical.replace("roles: [writer, director]", "role: writer");
+    let reference: InputReference = serde_yaml::from_str(&legacy_scalar).unwrap();
+    let serialized = serde_yaml::to_string(&reference).unwrap();
+    let value: serde_yaml::Value = serde_yaml::from_str(&serialized).unwrap();
+    let contributors = value
+        .get("contributors")
+        .and_then(serde_yaml::Value::as_sequence)
+        .unwrap();
+    assert!(contributors[0].get("roles").is_some());
+    assert!(contributors[0].get("role").is_none());
+}
+
+#[test]
+fn contributor_roles_reject_empty_and_duplicate_lists() {
+    for authored_roles in ["[]", "[writer, writer]"] {
+        let yaml = format!(
+            r#"
+class: audio-visual
+type: broadcast
+contributors:
+  - roles: {authored_roles}
+    contributor: {{family: Doe, given: Jane}}
+"#
+        );
+        assert!(serde_yaml::from_str::<InputReference>(&yaml).is_err());
+    }
+}
+
+#[test]
+fn equal_native_role_shorthands_remain_separate_without_explicit_membership() {
+    let reference: InputReference = serde_yaml::from_str(
+        r#"
+class: monograph
+type: book
+editor: {family: Doe, given: Jane}
+translator: {family: Doe, given: Jane}
+"#,
+    )
+    .unwrap();
+    let entries = reference.all_contributor_entries();
+
+    assert_eq!(entries.len(), 2);
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry.roles.contains(&ContributorRole::Editor))
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry.roles.contains(&ContributorRole::Translator))
+    );
+}
+
+#[test]
+#[allow(
+    clippy::unicode_not_nfc,
+    reason = "decomposed Unicode is the behavior under test"
+)]
+fn legacy_conversion_encodes_nfc_equal_cross_role_names_once() {
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(
+        r#"{
+          "id": "episode",
+          "type": "broadcast",
+          "director": [{"family": "Café", "given": "Jane"}],
+          "script-writer": [{"family": "Café ", "given": " Jane "}]
+        }"#,
+    )
+    .unwrap();
+    let reference: InputReference = legacy.into();
+    let entries = reference.all_contributor_entries();
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0].roles.as_slice(),
+        &[ContributorRole::Writer, ContributorRole::Director]
+    );
+}
+
+#[test]
+fn legacy_conversion_splits_a_shared_name_without_reordering_its_role_list() {
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(
+        r#"{
+          "id": "episode",
+          "type": "broadcast",
+          "director": [{"family": "Alpha", "given": "Ann"}],
+          "script-writer": [
+            {"family": "Alpha", "given": "Ann"},
+            {"family": "Beta", "given": "Bob"}
+          ]
+        }"#,
+    )
+    .unwrap();
+    let reference: InputReference = legacy.into();
+    let entries = reference.all_contributor_entries();
+
+    assert_eq!(entries.len(), 2);
+    assert_eq!(
+        entries[0].roles.as_slice(),
+        &[ContributorRole::Writer, ContributorRole::Director]
+    );
+    assert_eq!(
+        entries[0].contributor.to_names_vec()[0].family.as_deref(),
+        Some("Alpha")
+    );
+    assert_eq!(
+        entries[1].contributor.to_names_vec()[0].family.as_deref(),
+        Some("Beta")
+    );
+}
+
+#[test]
+fn legacy_song_conversion_encodes_shared_composer_performer_membership() {
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(
+        r#"{
+          "id": "song",
+          "type": "song",
+          "composer": [{"family": "Rivera", "given": "Alex"}],
+          "performer": [{"family": "Rivera", "given": "Alex"}]
+        }"#,
+    )
+    .unwrap();
+    let reference: InputReference = legacy.into();
+    let entries = reference.all_contributor_entries();
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0].roles.as_slice(),
+        &[ContributorRole::Composer, ContributorRole::Performer]
+    );
+}
+
+#[test]
+fn legacy_conversion_preserves_same_role_duplicates_and_form_boundaries() {
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(
+        r#"{
+          "id": "episode",
+          "type": "broadcast",
+          "director": [{"literal": "Jane Doe"}],
+          "script-writer": [
+            {"family": "Doe", "given": "Jane"},
+            {"family": "Doe", "given": "Jane"}
+          ]
+        }"#,
+    )
+    .unwrap();
+    let reference: InputReference = legacy.into();
+    let entries = reference.all_contributor_entries();
+
+    assert_eq!(entries.len(), 2);
+    assert_eq!(
+        entries
+            .iter()
+            .filter(|entry| entry.roles.contains(&ContributorRole::Writer))
+            .flat_map(|entry| entry.contributor.to_names_vec())
+            .count(),
+        2
+    );
+    assert!(
+        entries
+            .iter()
+            .all(|entry| entry.roles.as_slice().len() == 1)
+    );
+}
+
+#[test]
+fn legacy_conversion_rejects_fuzzy_cross_role_identity_matches() {
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(
+        r#"{
+          "id": "episode",
+          "type": "broadcast",
+          "director": [{"family": "Doe", "given": "Jane"}],
+          "script-writer": [{"family": "Doe", "given": "Janet"}]
+        }"#,
+    )
+    .unwrap();
+    let reference: InputReference = legacy.into();
+    let entries = reference.all_contributor_entries();
+
+    assert_eq!(entries.len(), 2);
+    assert!(
+        entries
+            .iter()
+            .all(|entry| entry.roles.as_slice().len() == 1)
     );
 }

--- a/crates/citum-schema-data/src/reference/types/structural.rs
+++ b/crates/citum-schema-data/src/reference/types/structural.rs
@@ -35,10 +35,10 @@ fn fold_contributors(
         if let Some(c) = maybe_c
             && !contributors
                 .iter()
-                .any(|e| &e.role == role && &e.contributor == *c)
+                .any(|entry| entry.roles.contains(role) && &entry.contributor == *c)
         {
             contributors.push(ContributorEntry {
-                role: role.clone(),
+                roles: role.clone().into(),
                 contributor: (*c).clone(),
                 gender: None,
             });
@@ -54,7 +54,7 @@ fn collect_contributors_by_role(
 ) -> Option<Contributor> {
     let matching: Vec<&Contributor> = entries
         .iter()
-        .filter(|entry| &entry.role == role)
+        .filter(|entry| entry.roles.contains(role))
         .map(|entry| &entry.contributor)
         .collect();
 

--- a/crates/citum-schema-style/embedded/locales/en-US.yaml
+++ b/crates/citum-schema-style/embedded/locales/en-US.yaml
@@ -245,6 +245,16 @@ roles:
     short: trans.
     verb: translated by
     verb-short: trans. by
+  writer:
+    long:
+      singular: writer
+      plural: writers
+    verb: written by
+  writer-director:
+    long:
+      singular: writer & director
+      plural: writers & directors
+    verb: written & directed by
 terms:
   accessed:
     long: accessed
@@ -256,6 +266,8 @@ terms:
   and:
     long: and
     symbol: "&"
+  role-conjunction:
+    long: " & "
   and others:
     long: and others
   anonymous:
@@ -907,6 +919,7 @@ messages:
   # Conjunctions and connectors
   term.and: "and"
   term.and-symbol: "&"
+  term.role-conjunction: " & "
   term.et-al: "et al."
   term.and-others: "and others"
   # Date and access terms
@@ -1078,6 +1091,7 @@ vocab:
     manuscript: "Manuscript"
     photograph: "Photograph"
     television: "Television"
+    tv-series-episode: "TV series episode"
     radio: "Radio"
     streaming: "Streaming"
     online: "Online"

--- a/crates/citum-schema-style/embedded/styles/apa-7th.yaml
+++ b/crates/citum-schema-style/embedded/styles/apa-7th.yaml
@@ -39,14 +39,29 @@ options:
       - editor
       - title
       - translator
+    overrides:
+      episode:
+        - contributor: [writer, director]
+      film:
+        - contributor: director
     role-substitute:
       container-author:
         - editor
         - editorial-director
+      writer:
+        - author
   contributors:
     name-form: initials
     initialize-with: ". "
-    role: short-suffix
+    role:
+      defaults: apa
+    merge:
+      order: document
+      labels: individual
+      roles:
+        director:
+          labels: collective
+      combine-same-person: true
     demote-non-dropping-particle: never
     delimiter-precedes-last: always
     and: symbol

--- a/crates/citum-schema-style/src/embedded/chicago.rs
+++ b/crates/citum-schema-style/src/embedded/chicago.rs
@@ -18,7 +18,7 @@ use crate::{
 pub fn author_date_citation() -> Vec<TemplateComponent> {
     vec![
         TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
+            contributor: ContributorRole::Author.into(),
             form: ContributorForm::Short,
             and: Some(AndOptions::Text),
             ..Default::default()

--- a/crates/citum-schema-style/src/embedded/harvard.rs
+++ b/crates/citum-schema-style/src/embedded/harvard.rs
@@ -18,7 +18,7 @@ use crate::{
 pub fn citation() -> Vec<TemplateComponent> {
     vec![
         TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
+            contributor: ContributorRole::Author.into(),
             form: ContributorForm::Short,
             and: Some(AndOptions::Text),
             ..Default::default()

--- a/crates/citum-schema-style/src/embedded/ieee.rs
+++ b/crates/citum-schema-style/src/embedded/ieee.rs
@@ -32,7 +32,7 @@ pub fn bibliography() -> Vec<TemplateComponent> {
         ),
         // Author
         TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author,
+            contributor: ContributorRole::Author.into(),
             form: ContributorForm::Long,
             and: Some(AndOptions::Text),
             rendering: crate::template::Rendering {

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -82,8 +82,9 @@ pub use style::{
 };
 pub use style_base::StyleBase;
 pub use template::{
-    LocalizedTemplateSpec, Rendering, Template, TemplateAddOperation, TemplateComponent,
-    TemplateComponentSelector, TemplateContributor, TemplateDate, TemplateGroup,
+    ContributorLabelMode, ContributorMerge, ContributorMergeOrder, ContributorMergeRole,
+    ContributorRoles, LocalizedTemplateSpec, Rendering, Template, TemplateAddOperation,
+    TemplateComponent, TemplateComponentSelector, TemplateContributor, TemplateDate, TemplateGroup,
     TemplateModifyOperation, TemplateNumber, TemplatePreset, TemplateReference,
     TemplateRemoveOperation, TemplateTerm, TemplateTitle, TemplateVariable, TemplateVariant,
     TemplateVariantDiff, TemplateVariants, TypeSelector, VerticalAlign, WrapConfig,

--- a/crates/citum-schema-style/src/lint.rs
+++ b/crates/citum-schema-style/src/lint.rs
@@ -544,9 +544,11 @@ fn collect_contributor_requirements(
     config: &Config,
     requirements: &mut Vec<LocaleRequirement>,
 ) {
+    let roles = contributor.contributor.as_slice();
+    let primary_role = roles.first().cloned().unwrap_or_default();
+
     if let Some(label) = &contributor.label {
-        let role =
-            role_label_term_to_role(&label.term).unwrap_or_else(|| contributor.contributor.clone());
+        let role = role_label_term_to_role(&label.term).unwrap_or(primary_role);
         let form = match label.form {
             RoleLabelForm::Short => TermForm::Short,
             RoleLabelForm::Long => TermForm::Long,
@@ -558,9 +560,10 @@ fn collect_contributor_requirements(
         return;
     }
 
-    let configured_preset = config.contributors.as_ref().and_then(|contributors| {
-        contributors.effective_role_label_preset(&contributor.contributor)
-    });
+    let configured_preset = config
+        .contributors
+        .as_ref()
+        .and_then(|contributors| contributors.effective_role_label_preset(&primary_role));
     if let Some(role_label_preset) = configured_preset {
         let form = match role_label_preset {
             crate::options::RoleLabelPreset::None => return,
@@ -570,46 +573,56 @@ fn collect_contributor_requirements(
             | crate::options::RoleLabelPreset::ShortSuffixComma => TermForm::Short,
             crate::options::RoleLabelPreset::LongSuffix => TermForm::Long,
         };
-        requirements.push(LocaleRequirement {
-            path: path.to_string(),
-            kind: LocaleRequirementKind::Role {
-                role: contributor.contributor.clone(),
-                form,
-            },
-        });
+        for role in roles {
+            requirements.push(LocaleRequirement {
+                path: path.to_string(),
+                kind: LocaleRequirementKind::Role {
+                    role: role.clone(),
+                    form: form.clone(),
+                },
+            });
+        }
         return;
     }
 
     match contributor.form {
-        ContributorForm::Verb => requirements.push(LocaleRequirement {
-            path: path.to_string(),
-            kind: LocaleRequirementKind::Role {
-                role: contributor.contributor.clone(),
-                form: TermForm::Verb,
-            },
-        }),
-        ContributorForm::VerbShort => requirements.push(LocaleRequirement {
-            path: path.to_string(),
-            kind: LocaleRequirementKind::Role {
-                role: contributor.contributor.clone(),
-                form: TermForm::VerbShort,
-            },
-        }),
-        ContributorForm::Long
-            if matches!(
-                contributor.contributor,
-                ContributorRole::Editor | ContributorRole::Translator
-            ) =>
-        {
-            requirements.push(LocaleRequirement {
-                path: path.to_string(),
-                kind: LocaleRequirementKind::Role {
-                    role: contributor.contributor.clone(),
-                    form: TermForm::Short,
-                },
-            });
+        ContributorForm::Verb => {
+            collect_role_requirements(roles, path, TermForm::Verb, requirements);
+        }
+        ContributorForm::VerbShort => {
+            collect_role_requirements(roles, path, TermForm::VerbShort, requirements);
+        }
+        ContributorForm::Long => {
+            for role in roles.iter().filter(|role| {
+                matches!(role, ContributorRole::Editor | ContributorRole::Translator)
+            }) {
+                requirements.push(LocaleRequirement {
+                    path: path.to_string(),
+                    kind: LocaleRequirementKind::Role {
+                        role: role.clone(),
+                        form: TermForm::Short,
+                    },
+                });
+            }
         }
         _ => {}
+    }
+}
+
+fn collect_role_requirements(
+    roles: &[ContributorRole],
+    path: &str,
+    form: TermForm,
+    requirements: &mut Vec<LocaleRequirement>,
+) {
+    for role in roles {
+        requirements.push(LocaleRequirement {
+            path: path.to_string(),
+            kind: LocaleRequirementKind::Role {
+                role: role.clone(),
+                form: form.clone(),
+            },
+        });
     }
 }
 
@@ -1050,7 +1063,7 @@ mod tests {
         let style = Style {
             citation: Some(CitationSpec {
                 template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Editor,
+                    contributor: ContributorRole::Editor.into(),
                     form: ContributorForm::Verb,
                     ..Default::default()
                 })]),

--- a/crates/citum-schema-style/src/locale/message_ids.rs
+++ b/crates/citum-schema-style/src/locale/message_ids.rs
@@ -22,6 +22,7 @@ impl Locale {
     pub(super) fn general_term_to_message_id(term: &GeneralTerm) -> &str {
         match term {
             GeneralTerm::And => "and",
+            GeneralTerm::RoleConjunction => "role-conjunction",
             GeneralTerm::EtAl => "et-al",
             GeneralTerm::AndOthers => "and-others",
             GeneralTerm::Accessed => "accessed",
@@ -140,6 +141,7 @@ impl Locale {
     pub(super) fn general_message_id(term: &GeneralTerm, form: &TermForm) -> Option<&'static str> {
         match (term, form) {
             (GeneralTerm::And, _) => Some("term.and"),
+            (GeneralTerm::RoleConjunction, _) => Some("term.role-conjunction"),
             (GeneralTerm::EtAl, _) => Some("term.et-al"),
             (GeneralTerm::AndOthers, _) => Some("term.and-others"),
             (GeneralTerm::Accessed, _) => Some("term.accessed"),

--- a/crates/citum-schema-style/src/locale/mod.rs
+++ b/crates/citum-schema-style/src/locale/mod.rs
@@ -58,6 +58,10 @@ pub struct Locale {
     #[serde(default)]
     #[cfg_attr(feature = "schema", schemars(skip))]
     pub roles: HashMap<ContributorRole, ContributorTerm>,
+    /// Authored terms for combinations such as `writer-director`.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[cfg_attr(feature = "schema", schemars(skip))]
+    pub role_combinations: HashMap<String, ContributorTerm>,
     /// Locator terms (page, chapter, etc.).
     #[serde(default)]
     #[cfg_attr(feature = "schema", schemars(skip))]
@@ -121,6 +125,7 @@ impl Default for Locale {
             locale: String::default(),
             dates: DateTerms::default(),
             roles: HashMap::default(),
+            role_combinations: HashMap::default(),
             locators: HashMap::default(),
             terms: Terms::default(),
             punctuation_in_quote: false,
@@ -145,6 +150,7 @@ impl fmt::Debug for Locale {
             .field("locale", &self.locale)
             .field("dates", &self.dates)
             .field("roles", &self.roles)
+            .field("role_combinations", &self.role_combinations)
             .field("locators", &self.locators)
             .field("terms", &self.terms)
             .field("punctuation_in_quote", &self.punctuation_in_quote)

--- a/crates/citum-schema-style/src/locale/raw_conversion.rs
+++ b/crates/citum-schema-style/src/locale/raw_conversion.rs
@@ -284,13 +284,20 @@ impl Locale {
         }
 
         for (key, role_term) in &raw.roles {
+            let contributor_term = ContributorTerm {
+                singular: Self::extract_simple_term(&role_term.long, &role_term.short, false),
+                plural: Self::extract_simple_term(&role_term.long, &role_term.short, true),
+                verb: Self::extract_verb_term(&role_term.verb, &role_term.verb_short),
+            };
             if let Some(role) = Self::parse_role_name(key) {
-                let contributor_term = ContributorTerm {
-                    singular: Self::extract_simple_term(&role_term.long, &role_term.short, false),
-                    plural: Self::extract_simple_term(&role_term.long, &role_term.short, true),
-                    verb: Self::extract_verb_term(&role_term.verb, &role_term.verb_short),
-                };
                 locale.roles.insert(role, contributor_term);
+            } else {
+                let canonical = if key == "editortranslator" {
+                    "editor-translator".to_string()
+                } else {
+                    Self::normalize_term_key(key)
+                };
+                locale.role_combinations.insert(canonical, contributor_term);
             }
         }
 
@@ -392,6 +399,7 @@ impl Locale {
             "performer" => Some(ContributorRole::Performer),
             "composer" => Some(ContributorRole::Composer),
             "writer" => Some(ContributorRole::Writer),
+            "producer" => Some(ContributorRole::Producer),
             _ => None,
         }
     }
@@ -553,6 +561,7 @@ impl Locale {
             "available-at" => Some(GeneralTerm::AvailableAt),
             "ibid" => Some(GeneralTerm::Ibid),
             "and" => Some(GeneralTerm::And),
+            "role-conjunction" => Some(GeneralTerm::RoleConjunction),
             "et-al" => Some(GeneralTerm::EtAl),
             "and-others" => Some(GeneralTerm::AndOthers),
             "forthcoming" => Some(GeneralTerm::Forthcoming),

--- a/crates/citum-schema-style/src/locale/terms.rs
+++ b/crates/citum-schema-style/src/locale/terms.rs
@@ -191,6 +191,59 @@ impl Locale {
             .map(ToOwned::to_owned)
     }
 
+    /// Resolve an authored term for an ordered combination of contributor roles.
+    #[must_use]
+    pub fn resolved_role_combination_term(
+        &self,
+        roles: &[ContributorRole],
+        plural: bool,
+        form: &TermForm,
+        requested_gender: Option<GrammaticalGender>,
+    ) -> Option<String> {
+        if roles.len() < 2 {
+            return None;
+        }
+        let key = if roles.len() == 2
+            && roles.contains(&ContributorRole::Editor)
+            && roles.contains(&ContributorRole::Translator)
+        {
+            "editor-translator".to_string()
+        } else {
+            roles
+                .iter()
+                .map(ContributorRole::as_str)
+                .collect::<Vec<_>>()
+                .join("-")
+        };
+        let term = self.role_combinations.get(&key)?;
+        let simple = if plural { &term.plural } else { &term.singular };
+        let value = match *form {
+            TermForm::Long => Self::resolve_gendered_value(&simple.long, requested_gender),
+            TermForm::Short => {
+                Self::resolve_gendered_value(&simple.short, requested_gender.clone())
+                    .filter(|value| !value.is_empty())
+                    .or_else(|| Self::resolve_gendered_value(&simple.long, requested_gender))
+            }
+            TermForm::Verb => Self::resolve_gendered_value(&term.verb.long, requested_gender),
+            TermForm::VerbShort => {
+                Self::resolve_gendered_value(&term.verb.short, requested_gender.clone())
+                    .filter(|value| !value.is_empty())
+                    .or_else(|| Self::resolve_gendered_value(&term.verb.long, requested_gender))
+            }
+            _ => Self::resolve_gendered_value(&simple.long, requested_gender),
+        };
+        value
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    }
+
+    /// Return the locale connector used to compose a missing combined-role term.
+    #[must_use]
+    pub fn role_conjunction(&self) -> &str {
+        self.general_term(&GeneralTerm::RoleConjunction, &TermForm::Long, None)
+            .unwrap_or(" & ")
+    }
+
     /// Get a locator term.
     pub fn locator_term(
         &self,

--- a/crates/citum-schema-style/src/locale/types.rs
+++ b/crates/citum-schema-style/src/locale/types.rs
@@ -209,6 +209,8 @@ crate::str_enum! {
         Ibid = "ibid",
         /// The conjunction "and" (e.g., "Smith and Jones").
         And = "and",
+        /// Verbatim connector used between terms in a combined contributor role.
+        RoleConjunction = "role-conjunction",
         /// The abbreviation for omitted additional names (e.g., "et al.").
         EtAl = "et-al",
         /// The phrase "and others" (generic use).

--- a/crates/citum-schema-style/src/macros.rs
+++ b/crates/citum-schema-style/src/macros.rs
@@ -124,7 +124,7 @@ macro_rules! tc_contributor {
     ($role:ident, $form:ident $(, $key:ident = $val:expr)*) => {
         $crate::template::TemplateComponent::Contributor(
             $crate::template::TemplateContributor {
-                contributor: $crate::template::ContributorRole::$role,
+                contributor: $crate::template::ContributorRole::$role.into(),
                 form: $crate::template::ContributorForm::$form,
                 rendering: $crate::template::Rendering {
                     $( $key: Some($val.into()), )*

--- a/crates/citum-schema-style/src/options/contributors.rs
+++ b/crates/citum-schema-style/src/options/contributors.rs
@@ -81,6 +81,12 @@ pub struct ContributorConfig {
     )]
     #[cfg_attr(feature = "schema", schemars(with = "Option<RoleOptionsEntry>"))]
     pub role: Option<RoleOptions>,
+    /// Style-wide defaults for merged cross-role contributor candidates.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merge: Option<crate::template::ContributorMerge>,
+    /// Role pairs for which an identical secondary role renders empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub suppress: Vec<ContributorSuppressionRule>,
     /// Handling of non-dropping particles (e.g., "van" in "van Gogh").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub demote_non_dropping_particle: Option<DemoteNonDroppingParticle>,
@@ -139,6 +145,12 @@ impl ContributorConfig {
         if other.role.is_some() {
             self.role = other.role.clone();
         }
+        if other.merge.is_some() {
+            self.merge = other.merge.clone();
+        }
+        if !other.suppress.is_empty() {
+            self.suppress = other.suppress.clone();
+        }
         if other.demote_non_dropping_particle.is_some() {
             self.demote_non_dropping_particle = other.demote_non_dropping_particle;
         }
@@ -191,6 +203,42 @@ impl ContributorConfig {
         self.role_rendering(role)
             .and_then(|rendering| rendering.name_order.as_ref())
     }
+
+    /// Return the structural label presentation configured for a role.
+    pub fn role_label_presentation(
+        &self,
+        role: &crate::template::ContributorRole,
+    ) -> Option<&RoleLabelPresentation> {
+        self.role_rendering(role)
+            .and_then(|rendering| rendering.label.as_ref())
+    }
+
+    /// Resolve component merge configuration over style-wide defaults.
+    ///
+    /// Borrows the component-level or style-wide merge block when either is
+    /// present, only allocating an owned default (`ContributorMerge` carries
+    /// a `HashMap`) when neither is configured.
+    #[must_use]
+    pub fn effective_merge<'a>(
+        &'a self,
+        component: Option<&'a crate::template::ContributorMerge>,
+    ) -> std::borrow::Cow<'a, crate::template::ContributorMerge> {
+        match component.or(self.merge.as_ref()) {
+            Some(merge) => std::borrow::Cow::Borrowed(merge),
+            None => std::borrow::Cow::Owned(crate::template::ContributorMerge::default()),
+        }
+    }
+}
+
+/// Suppress one contributor role when its people exactly match another role.
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct ContributorSuppressionRule {
+    /// Contributor role that renders empty when the rule matches.
+    pub role: crate::template::ContributorRole,
+    /// Role whose non-empty person set must exactly match `role`.
+    pub when_identical_to: crate::template::ContributorRole,
 }
 
 /// Named role-label presets for secondary contributor rendering.
@@ -241,9 +289,8 @@ impl RoleLabelPreset {
 pub enum RoleLabelDefaults {
     /// No automatic role labels (the engine default when unset).
     None,
-    /// APA-style convention: abbreviated suffix for editors only, rendered
-    /// with the locale's short editor term (`" (ed.)"` in en-US; apply a
-    /// `text-case` transform for capitalized `" (Ed.)"`).
+    /// APA-style convention: parenthesized editor, writer, and director
+    /// descriptions in the bibliography primary-contributor slot.
     Apa,
     /// MLA convention: word-form comma-joined suffix (`", editor"`) for
     /// its documented role set (editor, translator, director,
@@ -257,9 +304,13 @@ impl RoleLabelDefaults {
         use crate::template::ContributorRole;
         match self {
             Self::None => None,
-            Self::Apa => {
-                matches!(role, ContributorRole::Editor).then_some(RoleLabelPreset::ShortSuffix)
-            }
+            Self::Apa => match role {
+                ContributorRole::Editor => Some(RoleLabelPreset::ShortSuffix),
+                ContributorRole::Writer | ContributorRole::Director => {
+                    Some(RoleLabelPreset::LongSuffix)
+                }
+                _ => None,
+            },
             Self::Mla => matches!(
                 role,
                 ContributorRole::Editor
@@ -270,6 +321,30 @@ impl RoleLabelDefaults {
             )
             .then_some(RoleLabelPreset::LongSuffix),
         }
+    }
+
+    /// Resolve a complete bibliography label presentation supplied by this bundle.
+    #[must_use]
+    pub fn presentation_for(
+        &self,
+        role: &crate::template::ContributorRole,
+    ) -> Option<RoleLabelPresentation> {
+        use crate::template::{ContributorRole, LabelPlacement, RoleLabelForm, WrapPunctuation};
+        let (form, text_case) = match (self, role) {
+            (Self::Apa, ContributorRole::Writer | ContributorRole::Director) => (
+                RoleLabelForm::Long,
+                Some(crate::options::titles::TextCase::Title),
+            ),
+            _ => return None,
+        };
+        Some(RoleLabelPresentation {
+            form,
+            placement: LabelPlacement::Suffix,
+            text_case,
+            wrap: Some(Box::new(WrapPunctuation::Parentheses.into())),
+            prefix: None,
+            suffix: None,
+        })
     }
 }
 
@@ -422,6 +497,9 @@ pub struct RoleRendering {
     /// Per-role label preset override.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preset: Option<RoleLabelPreset>,
+    /// Structural label presentation for this role without repeating its term.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<RoleLabelPresentation>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -434,6 +512,31 @@ pub struct RoleRendering {
     pub small_caps: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name_order: Option<crate::template::NameOrder>,
+}
+
+/// Style-wide role-label presentation independent of a contributor template.
+#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct RoleLabelPresentation {
+    /// Term form used for the role label.
+    #[serde(default)]
+    pub form: crate::template::RoleLabelForm,
+    /// Placement relative to the contributor name or name run.
+    #[serde(default)]
+    pub placement: crate::template::LabelPlacement,
+    /// Optional case transformation for the localized role term.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text_case: Option<crate::options::titles::TextCase>,
+    /// Optional punctuation wrapped around the localized role term.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wrap: Option<Box<crate::template::WrapConfig>>,
+    /// Optional outer prefix overriding the placement-derived default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefix: Option<String>,
+    /// Optional outer suffix overriding the placement-derived default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suffix: Option<String>,
 }
 
 impl RoleRendering {
@@ -558,13 +661,21 @@ mod tests {
     }
 
     #[test]
-    fn role_label_defaults_apa_labels_editor_only() {
+    fn role_label_defaults_apa_labels_primary_audiovisual_roles() {
         // given the `apa` bundle
         let apa = RoleLabelDefaults::Apa;
-        // then editor gets the abbreviated suffix and other roles nothing
+        // then editor and APA audiovisual primary roles receive labels
         assert_eq!(
             apa.preset_for(&ContributorRole::Editor),
             Some(RoleLabelPreset::ShortSuffix)
+        );
+        assert_eq!(
+            apa.preset_for(&ContributorRole::Writer),
+            Some(RoleLabelPreset::LongSuffix)
+        );
+        assert_eq!(
+            apa.preset_for(&ContributorRole::Director),
+            Some(RoleLabelPreset::LongSuffix)
         );
         assert_eq!(apa.preset_for(&ContributorRole::Translator), None);
         assert_eq!(apa.preset_for(&ContributorRole::Chair), None);
@@ -598,6 +709,43 @@ mod tests {
         assert_eq!(opts.defaults, Some(RoleLabelDefaults::Apa));
         let out = serde_yaml::to_string(&opts).expect("serializable role options");
         assert_eq!(out, "defaults: apa\n");
+    }
+
+    #[test]
+    fn style_wide_merge_and_role_presentation_round_trip() {
+        let yaml = r#"role:
+  defaults: apa
+  roles:
+    director:
+      label:
+        form: long
+        placement: suffix
+        text-case: title
+        wrap: parentheses
+merge:
+  order: role
+  labels: collective
+  combine-same-person: true
+"#;
+
+        let config: ContributorConfig =
+            serde_yaml::from_str(yaml).expect("valid contributor defaults");
+
+        assert_eq!(
+            config.merge.as_ref().map(|merge| merge.labels),
+            Some(crate::template::ContributorLabelMode::Collective)
+        );
+        assert!(
+            config
+                .role_label_presentation(&ContributorRole::Director)
+                .and_then(|label| label.wrap.as_ref())
+                .is_some()
+        );
+        let serialized = serde_yaml::to_string(&config).expect("serializable defaults");
+        assert_eq!(
+            serde_yaml::from_str::<ContributorConfig>(&serialized).expect("round-trippable"),
+            config
+        );
     }
 
     #[test]

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -25,9 +25,10 @@ pub use bibliography::{
     BibliographyPartitionMode, BibliographySortPartitioning, SubsequentAuthorSubstituteRule,
 };
 pub use contributors::{
-    AndOptions, AndOtherOptions, ContributorConfig, ContributorConfigEntry, DelimiterPrecedesLast,
-    DemoteNonDroppingParticle, DisplayAsSort, NameForm, RoleLabelDefaults, RoleLabelPreset,
-    RoleOptions, RoleOptionsEntry, RoleRendering, ShortenListOptions,
+    AndOptions, AndOtherOptions, ContributorConfig, ContributorConfigEntry,
+    ContributorSuppressionRule, DelimiterPrecedesLast, DemoteNonDroppingParticle, DisplayAsSort,
+    NameForm, RoleLabelDefaults, RoleLabelPresentation, RoleLabelPreset, RoleOptions,
+    RoleOptionsEntry, RoleRendering, ShortenListOptions,
 };
 pub use dates::{DateConfig, DateConfigEntry, NoDateForm};
 pub use integral_name_memory::{
@@ -54,7 +55,10 @@ pub use scoped::{
     RepeatedAuthorRendering, TitleTerminator,
 };
 pub use sorting::{SortingConfig, SortingLocale, SortingMultilingualMode};
-pub use substitute::{Substitute, SubstituteConfig, SubstituteKey, SubstituteTitleQuoteMode};
+pub use substitute::{
+    Substitute, SubstituteConfig, SubstituteContributor, SubstituteField, SubstituteKey,
+    SubstituteTitleQuoteMode,
+};
 
 use crate::template::DelimiterPunctuation;
 #[cfg(feature = "schema")]

--- a/crates/citum-schema-style/src/options/substitute.rs
+++ b/crates/citum-schema-style/src/options/substitute.rs
@@ -6,6 +6,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 /// Substitution rules for missing author data.
@@ -32,6 +33,22 @@ impl SubstituteConfig {
             SubstituteConfig::Preset(preset) => preset.config(),
             SubstituteConfig::Explicit(config) => config.clone(),
         }
+    }
+
+    /// Resolve this config without cloning an explicit configuration.
+    pub fn resolve_ref(&self) -> Cow<'_, Substitute> {
+        match self {
+            SubstituteConfig::Preset(preset) => Cow::Owned(preset.config()),
+            SubstituteConfig::Explicit(config) => Cow::Borrowed(config),
+        }
+    }
+
+    /// Resolve an optional config, allocating only when a default or preset is required.
+    pub fn resolve_or_default(config: Option<&Self>) -> Cow<'_, Substitute> {
+        config.map_or_else(
+            || Cow::Owned(Substitute::default()),
+            SubstituteConfig::resolve_ref,
+        )
     }
 
     /// Merge an override substitute config over a base config.
@@ -97,9 +114,9 @@ impl Default for Substitute {
             contributor_role_form: None,
             contributor_role_case: None,
             template: vec![
-                SubstituteKey::Editor,
-                SubstituteKey::Title,
-                SubstituteKey::Translator,
+                SubstituteKey::Field(SubstituteField::Editor),
+                SubstituteKey::Field(SubstituteField::Title),
+                SubstituteKey::Field(SubstituteField::Translator),
             ],
             overrides: HashMap::new(),
             role_substitute: HashMap::new(),
@@ -151,17 +168,59 @@ impl Substitute {
     }
 }
 
-/// Fields that can be used as author substitutes.
+/// One candidate in an effective-primary substitution chain.
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "lowercase")]
+#[serde(untagged)]
 pub enum SubstituteKey {
+    /// A legacy scalar field candidate such as `editor` or `title`.
+    Field(SubstituteField),
+    /// A scalar or merged contributor-role candidate.
+    Contributor(SubstituteContributor),
+}
+
+#[allow(
+    non_upper_case_globals,
+    reason = "preserve the legacy SubstituteKey constant API"
+)]
+impl SubstituteKey {
+    /// Legacy `collection-editor` scalar candidate.
+    pub const CollectionEditor: Self = Self::Field(SubstituteField::CollectionEditor);
+    /// Legacy `editor` scalar candidate.
+    pub const Editor: Self = Self::Field(SubstituteField::Editor);
+    /// Legacy `parent-serial` scalar candidate.
+    pub const ParentSerial: Self = Self::Field(SubstituteField::ParentSerial);
+    /// Legacy `title` scalar candidate.
+    pub const Title: Self = Self::Field(SubstituteField::Title);
+    /// Legacy `translator` scalar candidate.
+    pub const Translator: Self = Self::Field(SubstituteField::Translator);
+}
+
+/// A contributor-role candidate in an effective-primary substitution chain.
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct SubstituteContributor {
+    /// One contributor role or an ordered list of roles to promote.
+    pub contributor: crate::template::ContributorRoles,
+}
+
+/// Legacy scalar fields accepted in substitution chains.
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "lowercase")]
+pub enum SubstituteField {
+    /// The collection editor contributor role.
     #[serde(rename = "collection-editor")]
     CollectionEditor,
+    /// The editor contributor role.
     Editor,
+    /// The parent serial title.
     #[serde(rename = "parent-serial")]
     ParentSerial,
+    /// The primary title.
     Title,
+    /// The translator contributor role.
     Translator,
 }
 
@@ -178,8 +237,26 @@ pub enum SubstituteKey {
     reason = "Panicking is acceptable and often desired in tests."
 )]
 mod tests {
-    use super::{Substitute, SubstituteConfig, SubstituteKey};
+    use super::{Substitute, SubstituteConfig, SubstituteField, SubstituteKey};
+    use std::borrow::Cow;
     use std::collections::HashMap;
+
+    #[test]
+    fn explicit_substitute_resolution_borrows_while_presets_are_owned() {
+        let explicit = SubstituteConfig::Explicit(Substitute::default());
+        let preset = SubstituteConfig::Preset(crate::presets::SubstitutePreset::Standard);
+
+        assert!(matches!(explicit.resolve_ref(), Cow::Borrowed(_)));
+        assert!(matches!(preset.resolve_ref(), Cow::Owned(_)));
+        assert!(matches!(
+            SubstituteConfig::resolve_or_default(Some(&explicit)),
+            Cow::Borrowed(_)
+        ));
+        assert!(matches!(
+            SubstituteConfig::resolve_or_default(None),
+            Cow::Owned(_)
+        ));
+    }
 
     #[test]
     fn merged_substitute_configs_preserve_role_substitute_chains() {
@@ -201,10 +278,39 @@ mod tests {
         assert_eq!(
             merged.template,
             vec![
-                SubstituteKey::Editor,
-                SubstituteKey::Title,
-                SubstituteKey::Translator
+                SubstituteKey::Field(SubstituteField::Editor),
+                SubstituteKey::Field(SubstituteField::Title),
+                SubstituteKey::Field(SubstituteField::Translator)
             ]
+        );
+    }
+
+    #[test]
+    fn substitution_candidates_round_trip_scalar_and_merged_roles() {
+        let yaml = r#"template:
+  - editor
+  - contributor: director
+overrides:
+  episode:
+    - contributor: [writer, director]
+"#;
+
+        let parsed: Substitute = serde_yaml::from_str(yaml).expect("valid substitution yaml");
+
+        assert_eq!(
+            parsed.template[0],
+            SubstituteKey::Field(SubstituteField::Editor)
+        );
+        assert_eq!(
+            parsed.template[1],
+            SubstituteKey::Contributor(super::SubstituteContributor {
+                contributor: crate::template::ContributorRole::Director.into(),
+            })
+        );
+        let serialized = serde_yaml::to_string(&parsed).expect("serializable");
+        assert_eq!(
+            serde_yaml::from_str::<Substitute>(&serialized).expect("round-trippable"),
+            parsed
         );
     }
 }

--- a/crates/citum-schema-style/src/presets.rs
+++ b/crates/citum-schema-style/src/presets.rs
@@ -665,7 +665,9 @@ pub enum SubstitutePreset {
 impl SubstitutePreset {
     /// Convert this preset to a concrete `Substitute`.
     pub fn config(&self) -> Substitute {
-        use SubstituteKey::{Editor, Title, Translator};
+        let editor = SubstituteKey::Editor;
+        let title = SubstituteKey::Title;
+        let translator = SubstituteKey::Translator;
 
         // Build a substitute from an optional role-label form and a template
         // order; all presets share empty overrides/role-substitute/unknowns.
@@ -676,22 +678,22 @@ impl SubstitutePreset {
         };
 
         match self {
-            SubstitutePreset::Standard => build(None, vec![Editor, Title, Translator]),
-            SubstitutePreset::EditorFirst => build(None, vec![Editor, Translator, Title]),
-            SubstitutePreset::TitleFirst => build(None, vec![Title, Editor, Translator]),
-            SubstitutePreset::EditorShort => build(Some("short"), vec![Editor]),
-            SubstitutePreset::EditorLong => build(Some("long"), vec![Editor]),
+            SubstitutePreset::Standard => build(None, vec![editor, title, translator]),
+            SubstitutePreset::EditorFirst => build(None, vec![editor, translator, title]),
+            SubstitutePreset::TitleFirst => build(None, vec![title, editor, translator]),
+            SubstitutePreset::EditorShort => build(Some("short"), vec![editor]),
+            SubstitutePreset::EditorLong => build(Some("long"), vec![editor]),
             SubstitutePreset::EditorTranslatorShort => {
-                build(Some("short"), vec![Editor, Translator])
+                build(Some("short"), vec![editor, translator])
             }
-            SubstitutePreset::EditorTranslatorLong => build(Some("long"), vec![Editor, Translator]),
-            SubstitutePreset::EditorTitleShort => build(Some("short"), vec![Editor, Title]),
-            SubstitutePreset::EditorTitleLong => build(Some("long"), vec![Editor, Title]),
+            SubstitutePreset::EditorTranslatorLong => build(Some("long"), vec![editor, translator]),
+            SubstitutePreset::EditorTitleShort => build(Some("short"), vec![editor, title]),
+            SubstitutePreset::EditorTitleLong => build(Some("long"), vec![editor, title]),
             SubstitutePreset::EditorTranslatorTitleShort => {
-                build(Some("short"), vec![Editor, Translator, Title])
+                build(Some("short"), vec![editor, translator, title])
             }
             SubstitutePreset::EditorTranslatorTitleLong => {
-                build(Some("long"), vec![Editor, Translator, Title])
+                build(Some("long"), vec![editor, translator, title])
             }
         }
     }

--- a/crates/citum-schema-style/src/style/diagnostics.rs
+++ b/crates/citum-schema-style/src/style/diagnostics.rs
@@ -344,6 +344,7 @@ fn component_allowed_fields(kind: &str) -> &'static [&'static str] {
             "contributor",
             "form",
             "label",
+            "merge",
             "name-order",
             "name-form",
             "delimiter",

--- a/crates/citum-schema-style/src/style/sections/bibliography.rs
+++ b/crates/citum-schema-style/src/style/sections/bibliography.rs
@@ -138,4 +138,20 @@ impl BibliographySpec {
             })
             .or_else(|| self.resolve_template())
     }
+
+    /// Resolve the bibliography template for a reference type and language.
+    pub fn resolve_template_for_type(
+        &self,
+        ref_type: &str,
+        language: Option<&str>,
+    ) -> Option<Template> {
+        if let Some(type_variants) = &self.type_variants {
+            for (selector, variant) in type_variants {
+                if selector.matches(ref_type) {
+                    return variant.clone().into_template();
+                }
+            }
+        }
+        self.resolve_template_for_language(language)
+    }
 }

--- a/crates/citum-schema-style/src/style/validation.rs
+++ b/crates/citum-schema-style/src/style/validation.rs
@@ -56,6 +56,14 @@ impl Style {
     pub fn validate_resource_limits(&self) -> Result<(), String> {
         let mut budget = TemplateResourceBudget::default();
 
+        if let Some(substitute) = self
+            .options
+            .as_ref()
+            .and_then(|options| options.substitute.as_ref())
+        {
+            validate_substitute_candidates(substitute, "options.substitute")?;
+        }
+
         if let Some(templates) = &self.templates {
             for (name, template) in templates {
                 budget.check_template(template, &format!("templates.{name}"), 0)?;
@@ -116,6 +124,47 @@ impl Style {
 
         Ok(())
     }
+}
+
+fn validate_substitute_candidates(
+    config: &crate::options::SubstituteConfig,
+    location: &str,
+) -> Result<(), String> {
+    let resolved = config.resolve();
+    validate_candidate_list(&resolved.template, &format!("{location}.template"))?;
+    for (reference_type, candidates) in &resolved.overrides {
+        validate_candidate_list(
+            candidates,
+            &format!("{location}.overrides.{reference_type}"),
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_candidate_list(
+    candidates: &[crate::options::SubstituteKey],
+    location: &str,
+) -> Result<(), String> {
+    for (index, candidate) in candidates.iter().enumerate() {
+        let crate::options::SubstituteKey::Contributor(candidate) = candidate else {
+            continue;
+        };
+        let crate::template::ContributorRoles::Multiple(roles) = &candidate.contributor else {
+            continue;
+        };
+        if roles.len() < 2 {
+            return Err(format!(
+                "{location}[{index}].contributor must contain at least two roles in list form"
+            ));
+        }
+        let distinct = roles.iter().collect::<std::collections::HashSet<_>>();
+        if distinct.len() != roles.len() {
+            return Err(format!(
+                "{location}[{index}].contributor role list must not contain duplicates"
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn forbidden_profile_template_path(raw_yaml: Option<&serde_yaml::Value>) -> Option<String> {
@@ -281,8 +330,40 @@ impl TemplateResourceBudget {
                     }
                 }
             }
-            TemplateComponent::Contributor(_)
-            | TemplateComponent::Title(_)
+            TemplateComponent::Contributor(contributor) => match &contributor.contributor {
+                crate::template::ContributorRoles::Single(_) => {
+                    if contributor.merge.is_some() {
+                        return Err(format!(
+                            "{location}.merge is valid only for a contributor role list"
+                        ));
+                    }
+                }
+                crate::template::ContributorRoles::Multiple(roles) => {
+                    if roles.len() < 2 {
+                        return Err(format!(
+                            "{location}.contributor must contain at least two roles in list form"
+                        ));
+                    }
+                    let distinct = roles.iter().collect::<std::collections::HashSet<_>>();
+                    if distinct.len() != roles.len() {
+                        return Err(format!(
+                            "{location}.contributor role list must not contain duplicates"
+                        ));
+                    }
+                    if contributor.label.is_some() {
+                        return Err(format!("{location}.label is valid only for a single role"));
+                    }
+                    if let Some(merge) = &contributor.merge
+                        && let Some(role) = merge.roles.keys().find(|role| !roles.contains(role))
+                    {
+                        return Err(format!(
+                            "{location}.merge.roles contains undeclared role {}",
+                            role.as_str()
+                        ));
+                    }
+                }
+            },
+            TemplateComponent::Title(_)
             | TemplateComponent::Number(_)
             | TemplateComponent::Variable(_)
             | TemplateComponent::Term(_)
@@ -347,6 +428,13 @@ impl TemplateResourceBudget {
         location: &str,
         depth: usize,
     ) -> Result<(), String> {
+        if let Some(substitute) = spec
+            .options
+            .as_ref()
+            .and_then(|options| options.substitute.as_ref())
+        {
+            validate_substitute_candidates(substitute, &format!("{location}.options.substitute"))?;
+        }
         if let Some(template) = &spec.template {
             self.check_template(template, &format!("{location}.template"), depth)?;
         }
@@ -376,6 +464,13 @@ impl TemplateResourceBudget {
         location: &str,
         depth: usize,
     ) -> Result<(), String> {
+        if let Some(substitute) = spec
+            .options
+            .as_ref()
+            .and_then(|options| options.substitute.as_ref())
+        {
+            validate_substitute_candidates(substitute, &format!("{location}.options.substitute"))?;
+        }
         if let Some(template) = &spec.template {
             self.check_template(template, &format!("{location}.template"), depth)?;
         }

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -678,10 +678,15 @@ pub struct RoleLabel {
     /// requires). When unset the term is rendered as the locale stores it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub text_case: Option<crate::options::titles::TextCase>,
+    /// Optional punctuation wrapped around the resolved label term.
+    ///
+    /// The wrap is applied before the label's outer `prefix` and `suffix`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wrap: Option<Box<WrapConfig>>,
     /// Optional affix rendered before the label term, overriding the
-    /// placement-derived default (`", "` for suffix placement, empty for
-    /// prefix placement). Mirrors CSL 1.0 `cs:label` `prefix` (e.g. `" ("`
-    /// for elsevier's `" (Eds.)"`).
+    /// placement-derived default (a space for a wrapped suffix label, `", "`
+    /// for an unwrapped suffix label, and empty for prefix placement). Mirrors
+    /// CSL 1.0 `cs:label` `prefix` (e.g. `" ("` for elsevier's `" (Eds.)"`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
     /// Optional affix rendered after the label term, overriding the
@@ -711,18 +716,165 @@ pub enum LabelPlacement {
     Suffix,
 }
 
+/// One contributor role or an ordered list of roles rendered as one name list.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(untagged)]
+pub enum ContributorRoles {
+    /// A conventional single-role contributor component.
+    Single(ContributorRole),
+    /// Two or more contributor roles rendered as a merged list.
+    Multiple(#[cfg_attr(feature = "schema", schemars(length(min = 2)))] Vec<ContributorRole>),
+}
+
+impl Default for ContributorRoles {
+    fn default() -> Self {
+        Self::Single(ContributorRole::Author)
+    }
+}
+
+impl ContributorRoles {
+    /// Return all declared roles in authoring order.
+    #[must_use]
+    pub fn as_slice(&self) -> &[ContributorRole] {
+        match self {
+            Self::Single(role) => std::slice::from_ref(role),
+            Self::Multiple(roles) => roles,
+        }
+    }
+
+    /// Return the role when this is the scalar form.
+    #[must_use]
+    pub fn as_single(&self) -> Option<&ContributorRole> {
+        match self {
+            Self::Single(role) => Some(role),
+            Self::Multiple(_) => None,
+        }
+    }
+
+    /// Return whether this is the list form.
+    #[must_use]
+    pub fn is_multiple(&self) -> bool {
+        matches!(self, Self::Multiple(_))
+    }
+
+    /// Return whether the declaration contains `role`.
+    #[must_use]
+    pub fn contains(&self, role: &ContributorRole) -> bool {
+        self.as_slice().contains(role)
+    }
+}
+
+impl From<ContributorRole> for ContributorRoles {
+    fn from(role: ContributorRole) -> Self {
+        Self::Single(role)
+    }
+}
+
+impl From<Vec<ContributorRole>> for ContributorRoles {
+    fn from(roles: Vec<ContributorRole>) -> Self {
+        Self::Multiple(roles)
+    }
+}
+
+impl PartialEq<ContributorRole> for ContributorRoles {
+    fn eq(&self, other: &ContributorRole) -> bool {
+        self.as_single() == Some(other)
+    }
+}
+
+/// Ordering policy for a merged contributor list.
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum ContributorMergeOrder {
+    /// Preserve the unified reference contributor order.
+    #[default]
+    Document,
+    /// Group entries by the component's declared role order.
+    Role,
+}
+
+/// Role-label placement mode for merged contributor entries.
+#[derive(Debug, Default, Deserialize, Serialize, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum ContributorLabelMode {
+    /// Attach a singular role label to every rendered person.
+    #[default]
+    Individual,
+    /// Attach one singular or plural label to each contiguous role run.
+    Collective,
+    /// Render names without role labels.
+    None,
+}
+
+/// Per-role overrides within a merged contributor list.
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct ContributorMergeRole {
+    /// Override the merged list's default label mode for this role.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub labels: Option<ContributorLabelMode>,
+    /// Override label term, form, placement, case, and affixes for this role.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<RoleLabel>,
+}
+
+/// Configuration for rendering multiple contributor roles as one name list.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct ContributorMerge {
+    /// Effective ordering of entries in the merged list.
+    #[serde(default)]
+    pub order: ContributorMergeOrder,
+    /// Default role-label mode for entries in the merged list.
+    #[serde(default)]
+    pub labels: ContributorLabelMode,
+    /// Optional per-role label overrides.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub roles: HashMap<ContributorRole, ContributorMergeRole>,
+    /// Whether identical people in different roles render as one entry.
+    #[serde(default = "default_combine_same_person")]
+    pub combine_same_person: bool,
+    /// Verbatim connector used when composing a missing combined-role term.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role_conjunction: Option<String>,
+}
+
+fn default_combine_same_person() -> bool {
+    true
+}
+
+impl Default for ContributorMerge {
+    fn default() -> Self {
+        Self {
+            order: ContributorMergeOrder::Document,
+            labels: ContributorLabelMode::Individual,
+            roles: HashMap::new(),
+            combine_same_person: true,
+            role_conjunction: None,
+        }
+    }
+}
+
 /// A contributor component for rendering names.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Default)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct TemplateContributor {
-    /// Which contributor role to render (author, editor, etc.).
-    pub contributor: ContributorRole,
+    /// Which contributor role or ordered role list to render.
+    pub contributor: ContributorRoles,
     /// How to display the contributor (long names, short, with label, etc.).
     pub form: ContributorForm,
     /// Optional role label configuration (e.g., "eds." for editors).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<RoleLabel>,
+    /// Configuration used when `contributor` is an ordered role list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merge: Option<ContributorMerge>,
     /// Override the global name order for this specific component.
     /// Use to show editors as "Given Family" even when global setting is "Family, Given".
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -808,6 +960,7 @@ crate::str_enum! {
         Counsel = "counsel",
         Composer = "composer",
         Writer = "writer",
+        Producer = "producer",
         CollectionEditor = "collection-editor",
         ContainerAuthor = "container-author",
         EditorialDirector = "editorial-director",
@@ -1194,7 +1347,7 @@ pub enum MessageArgSource {
     /// A literal string argument.
     Literal { literal: String },
     /// A rendered contributor argument.
-    Contributor(TemplateContributor),
+    Contributor(Box<TemplateContributor>),
     /// A rendered date argument.
     Date(TemplateDate),
     /// A rendered group argument.
@@ -1216,7 +1369,9 @@ impl MessageArgSource {
     pub fn as_template_component(&self) -> Option<TemplateComponent> {
         match self {
             Self::Literal { .. } => None,
-            Self::Contributor(component) => Some(TemplateComponent::Contributor(component.clone())),
+            Self::Contributor(component) => {
+                Some(TemplateComponent::Contributor(component.as_ref().clone()))
+            }
             Self::Date(component) => Some(TemplateComponent::Date(component.clone())),
             Self::Group(component) => Some(TemplateComponent::Group(component.clone())),
             Self::Title(component) => Some(TemplateComponent::Title(component.clone())),

--- a/crates/citum-schema-style/src/tests.rs
+++ b/crates/citum-schema-style/src/tests.rs
@@ -814,7 +814,7 @@ fn template_v3_nested_citation_diff_can_use_outer_template() {
         citation: Some(CitationSpec {
             template: Some(vec![
                 TemplateComponent::Contributor(template::TemplateContributor {
-                    contributor: template::ContributorRole::Author,
+                    contributor: template::ContributorRole::Author.into(),
                     ..Default::default()
                 }),
                 TemplateComponent::Title(template::TemplateTitle {
@@ -1818,4 +1818,275 @@ fn is_template_affix_key(key: &str) -> bool {
 
 fn is_allowed_non_prose_affix(key: &str, text: &str) -> bool {
     (key == "prefix" && text.contains("https://doi.org/")) || (key == "delimiter" && text == "none")
+}
+
+#[test]
+fn contributor_role_scalar_and_list_round_trip_without_shape_loss() {
+    for yaml in [
+        "contributor: author\nform: long\n",
+        "contributor: [writer, director]\nform: long\n",
+    ] {
+        let component: template::TemplateContributor = serde_yaml::from_str(yaml).unwrap();
+        let serialized = serde_yaml::to_string(&component).unwrap();
+        let reparsed: template::TemplateContributor = serde_yaml::from_str(&serialized).unwrap();
+        assert_eq!(component, reparsed);
+    }
+}
+
+#[test]
+fn role_label_wrap_round_trips_without_affix_substitution() {
+    let yaml = r#"
+contributor: writer
+form: long
+label:
+  term: writer
+  form: long
+  placement: suffix
+  wrap: parentheses
+"#;
+    let component: template::TemplateContributor = serde_yaml::from_str(yaml).unwrap();
+    let serialized = serde_yaml::to_string(&component).unwrap();
+    let reparsed: template::TemplateContributor = serde_yaml::from_str(&serialized).unwrap();
+
+    assert_eq!(component, reparsed);
+    assert!(matches!(
+        component.label.and_then(|label| label.wrap).as_deref(),
+        Some(&template::WrapConfig {
+            punctuation: template::WrapPunctuation::Parentheses,
+            inner_prefix: None,
+            inner_suffix: None,
+        })
+    ));
+}
+
+#[test]
+fn contributor_list_defaults_merge_behavior_when_block_is_absent() {
+    let component: template::TemplateContributor =
+        serde_yaml::from_str("contributor: [writer, director]\nform: long\n").unwrap();
+
+    assert!(component.contributor.is_multiple());
+    assert_eq!(component.merge, None);
+    assert_eq!(
+        template::ContributorMerge::default().order,
+        template::ContributorMergeOrder::Document
+    );
+    assert!(template::ContributorMerge::default().combine_same_person);
+}
+
+#[test]
+fn contributor_list_semantic_validation_rejects_invalid_combinations() {
+    let invalid_components = [
+        "- contributor: author\n  merge: {}",
+        "- contributor: [writer]",
+        "- contributor: [writer, writer]",
+        "- contributor: [writer, director]\n  label: {term: writer}",
+        "- contributor: [writer, director]\n  merge:\n    roles:\n      producer: {labels: none}",
+    ];
+    for template in invalid_components {
+        let yaml = format!(
+            "info:\n  title: Invalid contributor test\nbibliography:\n  template:\n{}\n",
+            template
+                .lines()
+                .map(|line| format!("    {line}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        assert!(
+            Style::from_yaml_str(&yaml).is_err(),
+            "accepted invalid template:\n{template}"
+        );
+    }
+}
+
+#[test]
+fn contributor_list_resource_validation_reports_authored_field_paths() {
+    fn style_with_contributor(contributor: &str) -> Style {
+        Style::from_yaml_str(&format!(
+            "info:\n  title: Contributor validation test\nbibliography:\n  template:\n    - contributor: {contributor}\n      form: long\n"
+        ))
+        .expect("base contributor style should parse")
+    }
+
+    fn contributor_mut(style: &mut Style) -> &mut template::TemplateContributor {
+        let component = style
+            .bibliography
+            .as_mut()
+            .and_then(|bibliography| bibliography.template.as_mut())
+            .and_then(|template| template.first_mut())
+            .expect("test style should contain a bibliography component");
+        let template::TemplateComponent::Contributor(contributor) = component else {
+            panic!("test component should be a contributor");
+        };
+        contributor
+    }
+
+    let mut scalar = style_with_contributor("author");
+    contributor_mut(&mut scalar).merge = Some(template::ContributorMerge::default());
+    assert_eq!(
+        scalar.validate_resource_limits(),
+        Err("bibliography.template.merge is valid only for a contributor role list".into())
+    );
+
+    let mut list_with_label = style_with_contributor("[writer, director]");
+    contributor_mut(&mut list_with_label).label =
+        Some(serde_yaml::from_str("term: writer").expect("test role label should deserialize"));
+    assert_eq!(
+        list_with_label.validate_resource_limits(),
+        Err("bibliography.template.label is valid only for a single role".into())
+    );
+
+    let mut list_with_undeclared_override = style_with_contributor("[writer, director]");
+    let mut merge = template::ContributorMerge::default();
+    merge.roles.insert(
+        template::ContributorRole::Producer,
+        template::ContributorMergeRole::default(),
+    );
+    contributor_mut(&mut list_with_undeclared_override).merge = Some(merge);
+    assert_eq!(
+        list_with_undeclared_override.validate_resource_limits(),
+        Err("bibliography.template.merge.roles contains undeclared role producer".into())
+    );
+}
+
+#[test]
+fn producer_is_a_known_style_contributor_role() {
+    let component: template::TemplateContributor =
+        serde_yaml::from_str("contributor: producer\nform: long\n").unwrap();
+
+    assert_eq!(
+        component.contributor.as_single(),
+        Some(&template::ContributorRole::Producer)
+    );
+}
+
+#[test]
+fn en_us_resolves_combined_roles_alias_and_connector() {
+    let mut locale = locale::Locale::en_us();
+    let writer_director = [
+        template::ContributorRole::Writer,
+        template::ContributorRole::Director,
+    ];
+    assert_eq!(
+        locale.resolved_role_combination_term(
+            &writer_director,
+            false,
+            &locale::TermForm::Long,
+            None,
+        ),
+        Some("writer & director".to_string())
+    );
+    assert_eq!(
+        locale.resolved_role_combination_term(
+            &writer_director,
+            true,
+            &locale::TermForm::Long,
+            None,
+        ),
+        Some("writers & directors".to_string())
+    );
+    assert_eq!(
+        locale
+            .messages
+            .get("term.role-conjunction")
+            .map(String::as_str),
+        Some(" & ")
+    );
+    locale
+        .messages
+        .insert("term.role-conjunction".to_string(), " + ".to_string());
+    assert_eq!(locale.role_conjunction(), " + ");
+    locale.messages.remove("term.role-conjunction");
+    assert_eq!(locale.role_conjunction(), " & ");
+    assert!(locale.role_combinations.contains_key("editor-translator"));
+    assert!(!locale.role_combinations.contains_key("editortranslator"));
+    assert_eq!(
+        locale.resolved_role_combination_term(
+            &[
+                template::ContributorRole::Translator,
+                template::ContributorRole::Editor,
+            ],
+            false,
+            &locale::TermForm::Short,
+            None,
+        ),
+        Some("ed. & trans.".to_string())
+    );
+}
+
+#[test]
+fn invalid_merge_label_mode_is_rejected_in_unused_type_variant() {
+    let yaml = r#"
+info: {id: invalid-merge-mode, title: Invalid merge mode}
+bibliography:
+  type-variants:
+    episode:
+      - contributor: [writer, director]
+        merge:
+          labels: combined
+  template:
+    - contributor: author
+"#;
+
+    Style::from_yaml_str(yaml).expect_err("invalid label mode must fail style loading");
+}
+
+#[test]
+fn substitution_candidate_role_lists_require_distinct_roles() {
+    let yaml = r#"
+info: {id: invalid-substitution-roles, title: Invalid substitution roles}
+options:
+  substitute:
+    overrides:
+      episode:
+        - contributor: [writer, writer]
+bibliography:
+  template:
+    - contributor: author
+"#;
+
+    Style::from_yaml_str(yaml).expect_err("duplicate substitution roles must fail style loading");
+}
+
+#[cfg(feature = "schema")]
+#[test]
+fn contributor_list_schema_exposes_scalar_list_and_merge_shapes() {
+    let schema = serde_json::to_value(schemars::schema_for!(template::TemplateContributor))
+        .expect("contributor schema should serialize");
+
+    assert_eq!(
+        schema.pointer("/$defs/ContributorRoles/anyOf/0/$ref"),
+        Some(&serde_json::json!("#/$defs/ContributorRole"))
+    );
+    assert_eq!(
+        schema.pointer("/$defs/ContributorRoles/anyOf/1/minItems"),
+        Some(&serde_json::json!(2))
+    );
+    assert_eq!(
+        schema.pointer("/properties/merge/anyOf/0/$ref"),
+        Some(&serde_json::json!("#/$defs/ContributorMerge"))
+    );
+    assert_eq!(
+        schema.pointer("/$defs/ContributorMerge/properties/combine-same-person/default"),
+        Some(&serde_json::json!(true))
+    );
+    assert_eq!(
+        schema.pointer("/$defs/RoleLabel/properties/wrap/anyOf/0/$ref"),
+        Some(&serde_json::json!("#/$defs/WrapConfig"))
+    );
+}
+
+#[cfg(feature = "schema")]
+#[test]
+fn substitute_schema_exposes_scalar_and_contributor_candidates() {
+    let schema = serde_json::to_value(schemars::schema_for!(options::SubstituteKey))
+        .expect("substitution candidate schema should serialize");
+
+    assert_eq!(
+        schema.pointer("/anyOf/0/$ref"),
+        Some(&serde_json::json!("#/$defs/SubstituteField"))
+    );
+    assert_eq!(
+        schema.pointer("/anyOf/1/$ref"),
+        Some(&serde_json::json!("#/$defs/SubstituteContributor"))
+    );
 }

--- a/docs/guides/AUTHORING_LOCALES.md
+++ b/docs/guides/AUTHORING_LOCALES.md
@@ -3,8 +3,8 @@
 This guide tells you when and how to add MessageFormat 2 (MF2) entries to a
 Citum locale file in the
 [embedded locale directory](../../crates/citum-schema-style/embedded/locales/).
-It is the practical companion to
-[`docs/specs/LOCALE_MESSAGES.md`](../specs/LOCALE_MESSAGES.md).
+It is the practical companion to the
+[locale messages specification](../specs/LOCALE_MESSAGES.md).
 
 ## Status
 
@@ -96,6 +96,7 @@ limitation applies to other gendered locales, including French and Arabic.
 | `term.volume-label`, `term.volume-label-long` | `$count` | |
 | `term.section-label`, `term.section-label-long` | `$count` | |
 | `term.figure-label` | `$count` | |
+| `term.role-conjunction` | — | Connector for dynamically composed combined-role labels; include surrounding spacing. |
 | `term.note-label`, `term.note-label-long` | `$count` | |
 | `term.archive-collection-label` | none | Archive hierarchy: collection name |
 | `term.archive-series-label` | none | Archive hierarchy: series name |

--- a/docs/schemas/bib.json
+++ b/docs/schemas/bib.json
@@ -3783,9 +3783,9 @@
       "description": "A single entry in a reference's contributors list.",
       "type": "object",
       "properties": {
-        "role": {
-          "description": "The role this contributor plays in relation to the work.",
-          "$ref": "#/$defs/ContributorRole"
+        "roles": {
+          "description": "The explicit roles this contributor plays in relation to the work.",
+          "$ref": "#/$defs/ContributorRoles"
         },
         "contributor": {
           "description": "The contributor (name, organization, or list).",
@@ -3804,9 +3804,17 @@
         }
       },
       "required": [
-        "role",
+        "roles",
         "contributor"
       ]
+    },
+    "ContributorRoles": {
+      "description": "One or more distinct roles explicitly assigned to a contributor entry.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ContributorRole"
+      },
+      "minItems": 1
     },
     "ContributorRole": {
       "description": "A contributor role for use in the unified contributors list.",

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -322,6 +322,11 @@
           "const": "and"
         },
         {
+          "description": "Verbatim connector used between terms in a combined contributor role.",
+          "type": "string",
+          "const": "role-conjunction"
+        },
+        {
           "description": "The abbreviation for omitted additional names (e.g., \"et al.\").",
           "type": "string",
           "const": "et-al"
@@ -733,8 +738,8 @@
       "type": "object",
       "properties": {
         "contributor": {
-          "description": "Which contributor role to render (author, editor, etc.).",
-          "$ref": "#/$defs/ContributorRole"
+          "description": "Which contributor role or ordered role list to render.",
+          "$ref": "#/$defs/ContributorRoles"
         },
         "form": {
           "description": "How to display the contributor (long names, short, with label, etc.).",
@@ -745,6 +750,17 @@
           "anyOf": [
             {
               "$ref": "#/$defs/RoleLabel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "merge": {
+          "description": "Configuration used when `contributor` is an ordered role list.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContributorMerge"
             },
             {
               "type": "null"
@@ -942,6 +958,23 @@
         "form"
       ]
     },
+    "ContributorRoles": {
+      "description": "One contributor role or an ordered list of roles rendered as one name list.",
+      "anyOf": [
+        {
+          "description": "A conventional single-role contributor component.",
+          "$ref": "#/$defs/ContributorRole"
+        },
+        {
+          "description": "Two or more contributor roles rendered as a merged list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ContributorRole"
+          },
+          "minItems": 2
+        }
+      ]
+    },
     "ContributorRole": {
       "description": "Contributor roles.",
       "oneOf": [
@@ -963,6 +996,7 @@
             "counsel",
             "composer",
             "writer",
+            "producer",
             "collection-editor",
             "container-author",
             "editorial-director",
@@ -1014,8 +1048,19 @@
             }
           ]
         },
+        "wrap": {
+          "description": "Optional punctuation wrapped around the resolved label term.\n\nThe wrap is applied before the label's outer `prefix` and `suffix`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "prefix": {
-          "description": "Optional affix rendered before the label term, overriding the\nplacement-derived default (`\", \"` for suffix placement, empty for\nprefix placement). Mirrors CSL 1.0 `cs:label` `prefix` (e.g. `\" (\"`\nfor elsevier's `\" (Eds.)\"`).",
+          "description": "Optional affix rendered before the label term, overriding the\nplacement-derived default (a space for a wrapped suffix label, `\", \"`\nfor an unwrapped suffix label, and empty for prefix placement). Mirrors\nCSL 1.0 `cs:label` `prefix` (e.g. `\" (\"` for elsevier's `\" (Eds.)\"`).",
           "type": [
             "string",
             "null"
@@ -1093,6 +1138,142 @@
           "const": "as-is"
         }
       ]
+    },
+    "WrapConfig": {
+      "description": "Wrapping punctuation and optional inner affixes applied around a rendered value.\n\nCombines the wrap punctuation with optional text that appears inside the wrap\n(between the wrap character and the rendered content).",
+      "type": "object",
+      "properties": {
+        "punctuation": {
+          "description": "The wrapping punctuation style.",
+          "$ref": "#/$defs/WrapPunctuation"
+        },
+        "inner-prefix": {
+          "description": "Text inserted after the opening wrap character but before the content.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "inner-suffix": {
+          "description": "Text inserted after the content but before the closing wrap character.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "punctuation"
+      ]
+    },
+    "WrapPunctuation": {
+      "description": "Punctuation to wrap a component in.",
+      "type": "string",
+      "enum": [
+        "parentheses",
+        "brackets",
+        "quotes"
+      ]
+    },
+    "ContributorMerge": {
+      "description": "Configuration for rendering multiple contributor roles as one name list.",
+      "type": "object",
+      "properties": {
+        "order": {
+          "description": "Effective ordering of entries in the merged list.",
+          "$ref": "#/$defs/ContributorMergeOrder",
+          "default": "document"
+        },
+        "labels": {
+          "description": "Default role-label mode for entries in the merged list.",
+          "$ref": "#/$defs/ContributorLabelMode",
+          "default": "individual"
+        },
+        "roles": {
+          "description": "Optional per-role label overrides.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ContributorMergeRole"
+          }
+        },
+        "combine-same-person": {
+          "description": "Whether identical people in different roles render as one entry.",
+          "type": "boolean",
+          "default": true
+        },
+        "role-conjunction": {
+          "description": "Verbatim connector used when composing a missing combined-role term.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ContributorMergeOrder": {
+      "description": "Ordering policy for a merged contributor list.",
+      "oneOf": [
+        {
+          "description": "Preserve the unified reference contributor order.",
+          "type": "string",
+          "const": "document"
+        },
+        {
+          "description": "Group entries by the component's declared role order.",
+          "type": "string",
+          "const": "role"
+        }
+      ]
+    },
+    "ContributorLabelMode": {
+      "description": "Role-label placement mode for merged contributor entries.",
+      "oneOf": [
+        {
+          "description": "Attach a singular role label to every rendered person.",
+          "type": "string",
+          "const": "individual"
+        },
+        {
+          "description": "Attach one singular or plural label to each contiguous role run.",
+          "type": "string",
+          "const": "collective"
+        },
+        {
+          "description": "Render names without role labels.",
+          "type": "string",
+          "const": "none"
+        }
+      ]
+    },
+    "ContributorMergeRole": {
+      "description": "Per-role overrides within a merged contributor list.",
+      "type": "object",
+      "properties": {
+        "labels": {
+          "description": "Override the merged list's default label mode for this role.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContributorLabelMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
+          "description": "Override label term, form, placement, case, and affixes for this role.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoleLabel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "NameOrder": {
       "description": "Name display order.",
@@ -1259,42 +1440,6 @@
           "type": "string",
           "const": "subscript"
         }
-      ]
-    },
-    "WrapConfig": {
-      "description": "Wrapping punctuation and optional inner affixes applied around a rendered value.\n\nCombines the wrap punctuation with optional text that appears inside the wrap\n(between the wrap character and the rendered content).",
-      "type": "object",
-      "properties": {
-        "punctuation": {
-          "description": "The wrapping punctuation style.",
-          "$ref": "#/$defs/WrapPunctuation"
-        },
-        "inner-prefix": {
-          "description": "Text inserted after the opening wrap character but before the content.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "inner-suffix": {
-          "description": "Text inserted after the content but before the closing wrap character.",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "punctuation"
-      ]
-    },
-    "WrapPunctuation": {
-      "description": "Punctuation to wrap a component in.",
-      "type": "string",
-      "enum": [
-        "parentheses",
-        "brackets",
-        "quotes"
       ]
     },
     "LinksConfig": {

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -415,8 +415,8 @@
       "type": "object",
       "properties": {
         "contributor": {
-          "description": "Which contributor role to render (author, editor, etc.).",
-          "$ref": "#/$defs/ContributorRole"
+          "description": "Which contributor role or ordered role list to render.",
+          "$ref": "#/$defs/ContributorRoles"
         },
         "form": {
           "description": "How to display the contributor (long names, short, with label, etc.).",
@@ -427,6 +427,17 @@
           "anyOf": [
             {
               "$ref": "#/$defs/RoleLabel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "merge": {
+          "description": "Configuration used when `contributor` is an ordered role list.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContributorMerge"
             },
             {
               "type": "null"
@@ -624,6 +635,23 @@
         "form"
       ]
     },
+    "ContributorRoles": {
+      "description": "One contributor role or an ordered list of roles rendered as one name list.",
+      "anyOf": [
+        {
+          "description": "A conventional single-role contributor component.",
+          "$ref": "#/$defs/ContributorRole"
+        },
+        {
+          "description": "Two or more contributor roles rendered as a merged list.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ContributorRole"
+          },
+          "minItems": 2
+        }
+      ]
+    },
     "ContributorRole": {
       "description": "Contributor roles.",
       "oneOf": [
@@ -645,6 +673,7 @@
             "counsel",
             "composer",
             "writer",
+            "producer",
             "collection-editor",
             "container-author",
             "editorial-director",
@@ -696,8 +725,19 @@
             }
           ]
         },
+        "wrap": {
+          "description": "Optional punctuation wrapped around the resolved label term.\n\nThe wrap is applied before the label's outer `prefix` and `suffix`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "prefix": {
-          "description": "Optional affix rendered before the label term, overriding the\nplacement-derived default (`\", \"` for suffix placement, empty for\nprefix placement). Mirrors CSL 1.0 `cs:label` `prefix` (e.g. `\" (\"`\nfor elsevier's `\" (Eds.)\"`).",
+          "description": "Optional affix rendered before the label term, overriding the\nplacement-derived default (a space for a wrapped suffix label, `\", \"`\nfor an unwrapped suffix label, and empty for prefix placement). Mirrors\nCSL 1.0 `cs:label` `prefix` (e.g. `\" (\"` for elsevier's `\" (Eds.)\"`).",
           "type": [
             "string",
             "null"
@@ -775,6 +815,142 @@
           "const": "as-is"
         }
       ]
+    },
+    "WrapConfig": {
+      "description": "Wrapping punctuation and optional inner affixes applied around a rendered value.\n\nCombines the wrap punctuation with optional text that appears inside the wrap\n(between the wrap character and the rendered content).",
+      "type": "object",
+      "properties": {
+        "punctuation": {
+          "description": "The wrapping punctuation style.",
+          "$ref": "#/$defs/WrapPunctuation"
+        },
+        "inner-prefix": {
+          "description": "Text inserted after the opening wrap character but before the content.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "inner-suffix": {
+          "description": "Text inserted after the content but before the closing wrap character.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "punctuation"
+      ]
+    },
+    "WrapPunctuation": {
+      "description": "Punctuation to wrap a component in.",
+      "type": "string",
+      "enum": [
+        "parentheses",
+        "brackets",
+        "quotes"
+      ]
+    },
+    "ContributorMerge": {
+      "description": "Configuration for rendering multiple contributor roles as one name list.",
+      "type": "object",
+      "properties": {
+        "order": {
+          "description": "Effective ordering of entries in the merged list.",
+          "$ref": "#/$defs/ContributorMergeOrder",
+          "default": "document"
+        },
+        "labels": {
+          "description": "Default role-label mode for entries in the merged list.",
+          "$ref": "#/$defs/ContributorLabelMode",
+          "default": "individual"
+        },
+        "roles": {
+          "description": "Optional per-role label overrides.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ContributorMergeRole"
+          }
+        },
+        "combine-same-person": {
+          "description": "Whether identical people in different roles render as one entry.",
+          "type": "boolean",
+          "default": true
+        },
+        "role-conjunction": {
+          "description": "Verbatim connector used when composing a missing combined-role term.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ContributorMergeOrder": {
+      "description": "Ordering policy for a merged contributor list.",
+      "oneOf": [
+        {
+          "description": "Preserve the unified reference contributor order.",
+          "type": "string",
+          "const": "document"
+        },
+        {
+          "description": "Group entries by the component's declared role order.",
+          "type": "string",
+          "const": "role"
+        }
+      ]
+    },
+    "ContributorLabelMode": {
+      "description": "Role-label placement mode for merged contributor entries.",
+      "oneOf": [
+        {
+          "description": "Attach a singular role label to every rendered person.",
+          "type": "string",
+          "const": "individual"
+        },
+        {
+          "description": "Attach one singular or plural label to each contiguous role run.",
+          "type": "string",
+          "const": "collective"
+        },
+        {
+          "description": "Render names without role labels.",
+          "type": "string",
+          "const": "none"
+        }
+      ]
+    },
+    "ContributorMergeRole": {
+      "description": "Per-role overrides within a merged contributor list.",
+      "type": "object",
+      "properties": {
+        "labels": {
+          "description": "Override the merged list's default label mode for this role.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContributorLabelMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
+          "description": "Override label term, form, placement, case, and affixes for this role.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoleLabel"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "NameOrder": {
       "description": "Name display order.",
@@ -941,42 +1117,6 @@
           "type": "string",
           "const": "subscript"
         }
-      ]
-    },
-    "WrapConfig": {
-      "description": "Wrapping punctuation and optional inner affixes applied around a rendered value.\n\nCombines the wrap punctuation with optional text that appears inside the wrap\n(between the wrap character and the rendered content).",
-      "type": "object",
-      "properties": {
-        "punctuation": {
-          "description": "The wrapping punctuation style.",
-          "$ref": "#/$defs/WrapPunctuation"
-        },
-        "inner-prefix": {
-          "description": "Text inserted after the opening wrap character but before the content.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "inner-suffix": {
-          "description": "Text inserted after the content but before the closing wrap character.",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "punctuation"
-      ]
-    },
-    "WrapPunctuation": {
-      "description": "Punctuation to wrap a component in.",
-      "type": "string",
-      "enum": [
-        "parentheses",
-        "brackets",
-        "quotes"
       ]
     },
     "LinksConfig": {
@@ -2614,6 +2754,11 @@
           "const": "and"
         },
         {
+          "description": "Verbatim connector used between terms in a combined contributor role.",
+          "type": "string",
+          "const": "role-conjunction"
+        },
+        {
           "description": "The abbreviation for omitted additional names (e.g., \"et al.\").",
           "type": "string",
           "const": "et-al"
@@ -3198,14 +3343,60 @@
       "unevaluatedProperties": false
     },
     "SubstituteKey": {
-      "description": "Fields that can be used as author substitutes.",
-      "type": "string",
-      "enum": [
-        "collection-editor",
-        "editor",
-        "parent-serial",
-        "title",
-        "translator"
+      "description": "One candidate in an effective-primary substitution chain.",
+      "anyOf": [
+        {
+          "description": "A legacy scalar field candidate such as `editor` or `title`.",
+          "$ref": "#/$defs/SubstituteField"
+        },
+        {
+          "description": "A scalar or merged contributor-role candidate.",
+          "$ref": "#/$defs/SubstituteContributor"
+        }
+      ]
+    },
+    "SubstituteField": {
+      "description": "Legacy scalar fields accepted in substitution chains.",
+      "oneOf": [
+        {
+          "description": "The collection editor contributor role.",
+          "type": "string",
+          "const": "collection-editor"
+        },
+        {
+          "description": "The editor contributor role.",
+          "type": "string",
+          "const": "editor"
+        },
+        {
+          "description": "The parent serial title.",
+          "type": "string",
+          "const": "parent-serial"
+        },
+        {
+          "description": "The primary title.",
+          "type": "string",
+          "const": "title"
+        },
+        {
+          "description": "The translator contributor role.",
+          "type": "string",
+          "const": "translator"
+        }
+      ]
+    },
+    "SubstituteContributor": {
+      "description": "A contributor-role candidate in an effective-primary substitution chain.",
+      "type": "object",
+      "properties": {
+        "contributor": {
+          "description": "One contributor role or an ordered list of roles to promote.",
+          "$ref": "#/$defs/ContributorRoles"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "contributor"
       ]
     },
     "SubstituteTitleQuoteMode": {
@@ -4107,6 +4298,24 @@
             }
           ]
         },
+        "merge": {
+          "description": "Style-wide defaults for merged cross-role contributor candidates.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContributorMerge"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "Role pairs for which an identical secondary role renders empty.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ContributorSuppressionRule"
+          }
+        },
         "demote-non-dropping-particle": {
           "description": "Handling of non-dropping particles (e.g., \"van\" in \"van Gogh\").",
           "anyOf": [
@@ -4285,6 +4494,17 @@
             }
           ]
         },
+        "label": {
+          "description": "Structural label presentation for this role without repeating its term.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoleLabelPresentation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "prefix": {
           "type": [
             "string",
@@ -4327,6 +4547,59 @@
         }
       }
     },
+    "RoleLabelPresentation": {
+      "description": "Style-wide role-label presentation independent of a contributor template.",
+      "type": "object",
+      "properties": {
+        "form": {
+          "description": "Term form used for the role label.",
+          "$ref": "#/$defs/RoleLabelForm",
+          "default": "short"
+        },
+        "placement": {
+          "description": "Placement relative to the contributor name or name run.",
+          "$ref": "#/$defs/LabelPlacement",
+          "default": "suffix"
+        },
+        "text-case": {
+          "description": "Optional case transformation for the localized role term.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "wrap": {
+          "description": "Optional punctuation wrapped around the localized role term.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Optional outer prefix overriding the placement-derived default.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suffix": {
+          "description": "Optional outer suffix overriding the placement-derived default.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "RoleLabelDefaults": {
       "description": "Named bundles of per-role default label presets, matching a style\nguide's documented bibliography-context convention.\n\nApplied only where a style has no explicit `label`, no configured\npreset, and no `role.omit` for the role, and only when rendering in\nbibliography context — no examined style guide (APA, MLA, Chicago,\nVancouver/NLM) carries a role label into the in-text citation. See\ndiv-012 in `docs/adjudication/DIVERGENCE_REGISTER.md`.",
       "oneOf": [
@@ -4336,7 +4609,7 @@
           "const": "none"
         },
         {
-          "description": "APA-style convention: abbreviated suffix for editors only, rendered\nwith the locale's short editor term (`\" (ed.)\"` in en-US; apply a\n`text-case` transform for capitalized `\" (Ed.)\"`).",
+          "description": "APA-style convention: parenthesized editor, writer, and director\ndescriptions in the bibliography primary-contributor slot.",
           "type": "string",
           "const": "apa"
         },
@@ -4345,6 +4618,25 @@
           "type": "string",
           "const": "mla"
         }
+      ]
+    },
+    "ContributorSuppressionRule": {
+      "description": "Suppress one contributor role when its people exactly match another role.",
+      "type": "object",
+      "properties": {
+        "role": {
+          "description": "Contributor role that renders empty when the rule matches.",
+          "$ref": "#/$defs/ContributorRole"
+        },
+        "when-identical-to": {
+          "description": "Role whose non-empty person set must exactly match `role`.",
+          "$ref": "#/$defs/ContributorRole"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "role",
+        "when-identical-to"
       ]
     },
     "DemoteNonDroppingParticle": {

--- a/docs/specs/CROSS_ROLE_CONTRIBUTOR_LISTS.md
+++ b/docs/specs/CROSS_ROLE_CONTRIBUTOR_LISTS.md
@@ -137,7 +137,9 @@ options:
 
 Component `merge` and label declarations remain explicit higher-precedence
 exceptions for generic migrated CSL structures whose primary-slot meaning
-cannot safely be inferred.
+cannot safely be inferred. A component-level `merge:` block replaces the
+style-wide `options.contributors.merge` defaults wholesale — there is no
+per-field layering between the two.
 
 ### Entry ordering (sub-problem A)
 
@@ -230,7 +232,11 @@ role-list order) resolves as:
    by`, …) with full form and plural coverage; `writer-director` is added with
    this feature. Authored terms win because combined labels are not reliably
    composable — abbreviation level, capitalization, and word order may differ
-   from the constituent terms.
+   from the constituent terms. The editor+translator pair is a CSL
+   `editortranslator` compatibility affordance: it resolves its authored term
+   order-insensitively, so both `[editor, translator]` and
+   `[translator, editor]` map to the same `editor-translator` key. Every other
+   combination uses a strict declared-order hyphen-joined key.
 2. **Composed fallback** — when no authored term exists, the constituent role
    terms (each resolved at the label form in effect) are joined with a
    connector inserted verbatim: `merge.role-conjunction` when set on the
@@ -317,6 +323,12 @@ label instead of suppression uses `combine-same-person` and declares no
   from the merged list.
 - **Suppress-author** — `options.suppress_author` removes the author role from
   merged assembly while preserving any other declared roles.
+- **Empty merged component** — when every declared role of a merged component
+  resolves to no entries, the component falls back to the substitution chain
+  keyed on its first declared role: an author-first component falls back
+  through the author-substitute chain, and any other component falls back
+  through the role-substitute chain
+  ([`ROLE_SUBSTITUTE_FALLBACK.md`](./ROLE_SUBSTITUTE_FALLBACK.md)).
 - **Sorting** — the component's sort key is the merged list in rendered order,
   after same-person combination, same as any name list.
 - **Disambiguation** — names in a merged list participate in name-based
@@ -404,6 +416,9 @@ label instead of suppression uses `combine-same-person` and declares no
 
 ## Changelog
 
+- 2026-07-15: Documented empty-merged-component substitution fallback,
+  component-level `merge:` replacing style-wide merge defaults wholesale, and
+  editor-translator combined-term order-insensitivity.
 - 2026-07-13: Activated version 1.0 after implementation and acceptance testing.
 - 2026-07-13: Made native contributor role membership explicit and moved
   legacy name matching to the CSL-JSON conversion boundary.

--- a/docs/specs/CROSS_ROLE_CONTRIBUTOR_LISTS.md
+++ b/docs/specs/CROSS_ROLE_CONTRIBUTOR_LISTS.md
@@ -1,13 +1,14 @@
 # Cross-Role Contributor Lists Specification
 
-**Status:** Draft
-**Version:** 0.1
+**Status:** Active
+**Version:** 1.0
 **Date:** 2026-07-13
 **Supersedes:** None
 **Related:** bean `csl26-7ip9`,
 [CSL schema#442](https://github.com/citation-style-language/schema/issues/442),
 [`SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md`](./SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md),
 [`ROLE_LABEL_DEFAULTS.md`](./ROLE_LABEL_DEFAULTS.md),
+[`PRIMARY_CONTRIBUTOR_SUBSTITUTION.md`](./PRIMARY_CONTRIBUTOR_SUBSTITUTION.md),
 [`ROLE_SUBSTITUTE_FALLBACK.md`](./ROLE_SUBSTITUTE_FALLBACK.md),
 [`CONTRIBUTOR_PHRASE_MESSAGES.md`](./CONTRIBUTOR_PHRASE_MESSAGES.md)
 
@@ -22,7 +23,7 @@ cannot express per-name labels. The motivating requirements come from APA 7
 multimedia references, which need all three behaviors at once:
 
 ```
-Kogen, J. (Writer), Wolodarsky, W. (Writer), & Kirkland, M. (Director). (1992).
+Kogen, J. (Writer), Wolodarsky, W. (Writer), & Kirkland, M. (Director). (1993).
 Whedon, J. (Writer & Director). (2003).
 ```
 
@@ -33,8 +34,10 @@ In scope:
 - Template schema: `contributor:` accepting an ordered role list, plus a `merge:`
   configuration block (ordering, label modes, per-role overrides, same-person
   combination).
+- Reference schema: each contributor entry carries an explicit, non-empty
+  `roles:` list; legacy scalar `role:` input remains accepted.
 - Rendering semantics: entry ordering, individual/collective/none labeling,
-  same-person detection and combined-label resolution.
+  explicit multi-role combination and combined-label resolution.
 - Locale model for combined-role terms and the role-term connector.
 - An options-level same-person role-suppression rule for elision across
   components.
@@ -45,7 +48,7 @@ Out of scope:
 
 - Repositioning contributors into the author slot (e.g. MLA's editor-translator
   as primary entry) — that is substitution, covered by
-  [`ROLE_SUBSTITUTE_FALLBACK.md`](./ROLE_SUBSTITUTE_FALLBACK.md).
+  [`PRIMARY_CONTRIBUTOR_SUBSTITUTION.md`](./PRIMARY_CONTRIBUTOR_SUBSTITUTION.md).
 - `CitationCollapse` — the citation-cluster collapse mechanism is unrelated;
   this spec deliberately avoids the word "collapse" in schema keys.
 - New role-taxonomy values (e.g. a dedicated `executive-producer` sub-role) —
@@ -70,20 +73,22 @@ translations, film, television, and music:
 | **B** — individual vs. collective labels | APA labels each writer individually but producers collectively (`(Producers)`, pluralized) |
 | **C** — same person in multiple roles | `Whedon, J. (Writer & Director)`; `(J. Strachey, Ed. & Trans.)`; MLA `edited and translated by` |
 
-The design constraints: identity detection is per-person, not whole-list; the
+The design constraints: role membership is explicit per person in native data; the
 role-term connector is independent of the name-list conjunction; label placement
 (before/after) and individual/collective mode are style declarations, per role;
 collective labels pluralize; combined labels are declared locale terms, never
 mechanically composed when an authored term exists; and full elision of a
-secondary rendering (APA song: omit `[Recorded by …]` when songwriter and
-performer coincide) must be expressible.
+secondary rendering (APA classical/composer-first song: omit
+`[Recorded by …]` when songwriter and performer coincide) must be expressible.
+Modern-song references normally use the recording artist as author and emit
+`[Song]` directly, so they do not need this suppression rule.
 
 ### Schema surface
 
 `TemplateContributor.contributor` accepts a single role (unchanged) or an
-ordered list of roles. A `merge:` block configures the merged list and is valid
-**only** in list form; the singular `label:` field is valid **only** in
-single-role form (per-role labels move under `merge.roles`). Both misuses are
+ordered list of roles. A component `merge:` block is valid **only** in list
+form; the singular `label:` field is valid **only** in single-role form
+(per-role component exceptions move under `merge.roles`). Both misuses are
 schema-validation errors.
 
 ```yaml
@@ -95,11 +100,10 @@ schema-validation errors.
     roles:                     # optional per-role overrides
       writer:
         label:                 # full RoleLabel: term, form, placement,
-          term: writer         # text-case, prefix, suffix
+          term: writer         # text-case, wrap, prefix, suffix
           form: long
           text-case: capitalize-first
-          prefix: " ("
-          suffix: ")"
+          wrap: parentheses
       producer:
         labels: collective
     combine-same-person: true  # default: true
@@ -114,11 +118,45 @@ All existing whole-list options — `form`, `name-order`, `name-form`,
 `delimiter`, `sort-separator`, `shorten`, `and`, rendering affixes, `links`,
 `gender` — apply to the merged list exactly as they do to a single-role list.
 
+Reusable presentation belongs outside type templates. `options.contributors`
+provides style-wide merge defaults and role-label presentation; role terms are
+derived from the role-map keys rather than repeated in every type variant:
+
+```yaml
+options:
+  contributors:
+    role:
+      defaults: apa
+    merge:
+      order: document
+      labels: individual
+      roles:
+        director: {labels: collective}
+      combine-same-person: true
+```
+
+Component `merge` and label declarations remain explicit higher-precedence
+exceptions for generic migrated CSL structures whose primary-slot meaning
+cannot safely be inferred.
+
 ### Entry ordering (sub-problem A)
 
 The merged list is built from the reference's unified `contributors` vec
 (`ContributorEntry`, `crates/citum-schema-data/src/reference/contributor.rs`),
 filtered to the declared roles.
+
+Native data records role membership directly:
+
+```yaml
+contributors:
+  - roles: [writer, director]
+    contributor: {given: Joss, family: Whedon}
+```
+
+`roles:` must contain at least one distinct role. For compatibility, authored
+`role: writer` is accepted and normalized to `roles: [writer]` when serialized.
+Separate entries remain separate people even when their names happen to compare
+equal; the native renderer never infers identity from display data.
 
 - `order: document` (default) — entries keep the order of the reference's
   contributors vec. This reproduces source-credit order (APA episode: writers
@@ -161,27 +199,25 @@ collective for producers).
 
 ### Same-person combination (sub-problem C)
 
-When `combine-same-person: true` (default), entries in different declared roles
-that resolve to the same person render **once**, at the position of the
-person's first occurrence in the effective ordering, with a combined role
-label. Detection is per-person: contributors who appear in only one role are
-unaffected, fixing the whole-list-only limitation of CSL's `editortranslator`.
+When `combine-same-person: true` (default), a contributor entry carrying more
+than one declared role renders **once**, at that entry's position in the
+effective ordering, with a combined role label. Contributors carrying one role
+are unaffected. No name comparison occurs in this rendering step: explicit
+native role membership is authoritative.
 
-Two entries denote the same person when their names are equal after Unicode NFC
-normalization and whitespace trimming, comparing structured names field-wise
-(family, given, dropping particle, non-dropping particle, suffix — all must
-match exactly) and literal names as whole strings. A structured name and a
-literal name never denote the same person, even when their display forms
-coincide — no display-form normalization is attempted, since it invites false
-positives; mixed-form duplicates are an input-data defect to fix at the
-source. There is no fuzzy matching: `Smith, J.` and `Smith, John` are
-distinct. The data model has no person identifier, so literal equality is the
-deterministic contract (the same rule citeproc-js applies to
-`editortranslator`).
+`combine-same-person: false` expands a multi-role contributor entry once per
+declared role. Each occurrence follows the effective ordering and carries that
+role's label.
 
-`combine-same-person: false` renders the person once per declared role: each
-occurrence keeps its own position in the effective ordering and carries that
-role's label; no occurrence is dropped.
+Legacy CSL-JSON has independent name arrays rather than explicit role
+membership. Its conversion boundary therefore performs the compatibility
+inference once: names are split into individual contributors and equal
+cross-role occurrences are encoded as one `ContributorEntry.roles` list.
+Equality uses Unicode NFC normalization and whitespace trimming, compares
+structured names field-wise (family, given, particles, suffix), never equates
+structured and literal names, and performs no fuzzy matching. Same-role
+duplicates remain separate entries. The engine receives only the normalized
+native representation.
 
 ### Combined-label resolution
 
@@ -198,8 +234,9 @@ role-list order) resolves as:
 2. **Composed fallback** — when no authored term exists, the constituent role
    terms (each resolved at the label form in effect) are joined with a
    connector inserted verbatim: `merge.role-conjunction` when set on the
-   component, otherwise the locale's `role-conjunction` term. The term is a
-   new general locale term (en-US: `" & "`, spacing included), deliberately
+  component, otherwise the locale's MF2 `term.role-conjunction` message. The
+  legacy `terms.role-conjunction` entry remains its compatibility fallback.
+  The en-US value is `" & "` (spacing included), deliberately
    independent of the name-list conjunction — the `&` in `(Ed. & Trans.)`
    joins role terms, not names. Verbatim insertion keeps spacing explicit:
    styles that need `/`, `" and "`, or plain concatenation (`""`) declare
@@ -215,6 +252,11 @@ component and a post-title parenthetical component each carry their own label
 configuration, so the combined label's shape always follows the component
 being rendered, never a global per-role setting.
 
+Role-label wrapping is structural: `wrap: parentheses` wraps the resolved term
+before outer label affixes are applied. A wrapped suffix label uses a space as
+its default separator (`Name (Writer)`); labels without `wrap` retain the
+existing placement-derived affix defaults.
+
 Plural forms apply when two or more persons share the identical role
 combination. Authored combined-role terms are therefore a locale-content
 obligation: every pair term must ship the full form coverage of an ordinary
@@ -225,14 +267,15 @@ resolved identically to `editor-translator`.
 
 ### Same-person role suppression
 
-APA's music rule — omit the `[Recorded by …]` descriptor entirely when
-songwriter and performer are the same person — is a zero-output case that no
-label mechanism can express, because the affected text lives in a different
-template component. It is nevertheless not a template decision: which role is
-redundant when two roles coincide is a property of the style, not of any one
-template position. It is therefore declared in options, not in the template
-language (which this spec leaves untouched — in particular, `render-when`
-grows no new condition kinds):
+APA's classical/composer-first music rule — omit the `[Recorded by …]`
+descriptor entirely when songwriter and performer are the same person — is a
+zero-output case that no label mechanism can express, because the affected
+text lives in a different template component. Modern songs instead normally
+use the recording artist as author and render `[Song]` without this descriptor.
+For the composer-first case, which role is redundant when two roles coincide
+is a property of the style, not of any one template position. It is therefore
+declared in options, not in the template language (which this spec leaves
+untouched — in particular, `render-when` grows no new condition kinds):
 
 ```yaml
 contributors:
@@ -241,9 +284,11 @@ contributors:
       when-identical-to: composer
 ```
 
-A rule fires **if and only if** both roles resolve to non-empty person sets
-that are equal under the same-person rule above. While it fires, the
-suppressed role (`role:`) renders empty in every template component, citation
+A rule fires **if and only if** both roles resolve to the same non-empty set of
+explicit contributor entries. It does not compare names: equal-looking
+separate native entries remain distinct, while a single multi-role entry
+belongs to both sets. While it fires, the suppressed role (`role:`) renders
+empty in every template component, citation
 and bibliography alike; existing group empty-collapse then removes dependent
 descriptors such as the `[Recorded by …]` wrapper, whose group contains the
 performer component.
@@ -261,15 +306,17 @@ label instead of suppression uses `combine-same-person` and declares no
 
 ### Interactions
 
-- **Substitution** — a merged component whose declared roles are all empty
-  renders nothing; if `author` is among the declared roles, the author
-  substitute chain applies exactly as for an empty single-role author
-  component. Role-substitute suppression
+- **Primary substitution** — type-aware scalar or merged role membership is
+  selected by `options.substitute`; templates remain on `contributor: author`.
+  The effective primary is shared by rendering, sorting, and disambiguation as
+  specified by
+  [`PRIMARY_CONTRIBUTOR_SUBSTITUTION.md`](./PRIMARY_CONTRIBUTOR_SUBSTITUTION.md).
+  Role-substitute suppression
   ([`ROLE_SUBSTITUTE_FALLBACK.md`](./ROLE_SUBSTITUTE_FALLBACK.md)) applies
   per declared role: a role consumed by substitution elsewhere is excluded
   from the merged list.
-- **Suppress-author** — `options.suppress_author` suppresses a merged component
-  that declares `author`, mirroring single-role behavior.
+- **Suppress-author** — `options.suppress_author` removes the author role from
+  merged assembly while preserving any other declared roles.
 - **Sorting** — the component's sort key is the merged list in rendered order,
   after same-person combination, same as any name list.
 - **Disambiguation** — names in a merged list participate in name-based
@@ -283,22 +330,28 @@ label instead of suppression uses `combine-same-person` and declares no
 
 | CSL 1.0 | Citum |
 |---|---|
-| `<names variable="editor translator">` | `contributor: [editor, translator]` with `combine-same-person: true` (citeproc-js merges on identical lists; per-person detection is expected to match or improve on it for real-world data — an assumption, not a guarantee: output can differ when distinct same-family contributors lack given names in the data) |
+| `<names variable="editor translator">` | `contributor: [editor, translator]` with `combine-same-person: true`; legacy reference conversion supplies explicit multi-role contributor entries |
 | `editortranslator` term references | authored `editor-translator` locale term (the unhyphenated alias also resolves) |
 | Sequential multi-variable `<names>` with per-variable labels | `order: role` with per-role labels under `merge.roles` |
 
 ## Implementation Notes
 
-- The single-role path in `crates/citum-engine/src/values/contributor/mod.rs`
-  (`values()`) stays as-is; list form dispatches to a new merged-list renderer
-  that builds `(FlatName, role)` entries from the unified contributors vec and
+- Conventional non-primary single-role formatting stays on the established
+  path. The author component delegates to the effective-primary resolver, and
+  list form dispatches to a merged-list renderer
+  that builds `(FlatName, roles)` entries from the unified contributors vec and
   reuses the existing name formatting and `labels.rs::resolve_role_labels`
   per entry/run. `resolve_role_labels` needs the role as a parameter rather
   than reading it from the component.
 - Serde: `contributor:` becomes an untagged single-or-sequence; `merge:` is a
-  new optional struct on `TemplateContributor`. Validation (list ⇔ `merge`,
-  list ⇒ no singular `label:`) belongs in the existing style-validation layer,
-  not deserialization.
+  new optional struct on `TemplateContributor`. Validation (scalar ⇒ no
+  `merge`, list ⇒ at least two distinct roles and no singular `label:`) belongs
+  in the existing style-validation layer, not deserialization. List form
+  without `merge:` uses the documented defaults.
+- Reference serde canonicalizes contributors to explicit `roles:` arrays while
+  accepting scalar `role:` as a compatibility alias. CSL-JSON conversion owns
+  strict cross-role identity normalization; native rendering does not compare
+  names to infer identity.
 - The `contributors.suppress` check slots into the same engine path as
   substitute-driven role suppression
   (`substitute::is_role_suppressed_by_substitute`,
@@ -315,35 +368,43 @@ label instead of suppression uses `combine-same-person` and declares no
 
 ## Acceptance Criteria
 
-- [ ] `contributor:` accepts a single role or an ordered role list; `merge:` is
+- [x] `contributor:` accepts a single role or an ordered role list; `merge:` is
       rejected in single-role form and singular `label:` is rejected in list
       form; both forms round-trip through YAML serialization.
-- [ ] APA TV-episode fixture renders writers and director interleaved in
+- [x] Reference YAML accepts canonical `roles: [writer, director]`, rejects
+      empty or duplicate role lists, and accepts legacy `role: writer` input.
+- [x] APA TV-episode fixture renders writers and director interleaved in
       document order with individual labels and the name-list conjunction
       spanning all entries (sub-problems A + B).
-- [ ] Same-person fixture renders one entry with a combined label
+- [x] Same-person fixture renders one entry with a combined label
       (`(Writer & Director)`) resolved from an authored `writer-director` term,
       and falls back to `role-conjunction` composition when the term is
       absent, including a component-level `merge.role-conjunction` override.
-- [ ] Partial-identity fixture: with shared and unshared contributors across
+- [x] Equal-looking separate native contributor entries remain separate;
+      legacy conversion instead emits explicit multi-role entries using strict
+      NFC identity and preserves same-role duplicates.
+- [x] Partial-identity fixture: with shared and unshared contributors across
       two roles, only the shared person merges; others render per role.
-- [ ] Editor-translator fixture consumes the shipped en-US `editor-translator`
+- [x] Editor-translator fixture consumes the shipped en-US `editor-translator`
       term (`Ed. & Trans.` shape with explicit text-case).
-- [ ] MLA topology fixture renders `order: role` groups with collective
+- [x] MLA topology fixture renders `order: role` groups with collective
       verb-form labels preceding each group.
-- [ ] Collective pluralization fixture: a run of two or more same-role names
+- [x] Collective pluralization fixture: a run of two or more same-role names
       gets a pluralized collective label.
-- [ ] Et-al shortening counts entries after same-person combination: a fixture
+- [x] Et-al shortening counts entries after same-person combination: a fixture
       whose raw credit count exceeds the `shorten` threshold stays unshortened
       because combination brings the rendered entry count below it.
-- [ ] `contributors.suppress` fixtures cover the APA recorded-by case (rule
+- [x] `contributors.suppress` fixtures cover the APA recorded-by case (rule
       fires, descriptor group collapses), the absent-role case (rule does not
       fire), and the partial-overlap case (rule does not fire).
-- [ ] `citum-migrate` converts `<names variable="editor translator">` to a
+- [x] `citum-migrate` converts `<names variable="editor translator">` to a
       merged component and maps `editortranslator` term usage.
-- [ ] Sorting and disambiguation integration tests cover a merged list in the
+- [x] Sorting and disambiguation integration tests cover a merged list in the
       author position.
 
 ## Changelog
 
+- 2026-07-13: Activated version 1.0 after implementation and acceptance testing.
+- 2026-07-13: Made native contributor role membership explicit and moved
+  legacy name matching to the CSL-JSON conversion boundary.
 - 2026-07-13: Initial Draft for bean `csl26-7ip9`.

--- a/docs/specs/PRIMARY_CONTRIBUTOR_SUBSTITUTION.md
+++ b/docs/specs/PRIMARY_CONTRIBUTOR_SUBSTITUTION.md
@@ -1,0 +1,114 @@
+# Primary Contributor Substitution Specification
+
+**Status:** Active
+**Version:** 1.0
+**Date:** 2026-07-14
+**Supersedes:** None
+**Related:** PR #1052,
+[`CROSS_ROLE_CONTRIBUTOR_LISTS.md`](./CROSS_ROLE_CONTRIBUTOR_LISTS.md),
+[`ROLE_SUBSTITUTE_FALLBACK.md`](./ROLE_SUBSTITUTE_FALLBACK.md)
+
+## Purpose
+
+Define how a style promotes type-specific contributor roles into the primary
+contributor slot while retaining the ordinary missing-author substitution
+chain. Selection belongs in `options.substitute`; templates continue to render
+`contributor: author`, and contributor presentation remains style-wide under
+`options.contributors`.
+
+## Scope
+
+In scope: scalar and merged contributor substitution candidates, type-specific
+overrides, default fallback order, exact native type matching, validation, and
+the effective primary names used by rendering, sorting, and disambiguation.
+Out of scope: automatic membership of a secondary contributor block, new role
+taxonomy values, and media distinctions the reference schema cannot represent.
+
+## Design
+
+### Schema
+
+`options.substitute.template` and `options.substitute.overrides` use the same
+ordered candidate type. Existing scalar keys remain valid; contributor objects
+add arbitrary scalar or ordered multi-role candidates:
+
+```yaml
+options:
+  substitute:
+    template: [editor, title, translator]
+    overrides:
+      episode:
+        - contributor: [writer, director]
+      film:
+        - contributor: director
+
+  contributors:
+    role:
+      defaults: apa
+```
+
+The default `template` remains `editor`, `title`, then `translator`. It does not
+contain `author`: author resolution is the operation being supplemented, not a
+substitution candidate.
+
+### Resolution
+
+For a primary contributor component, resolve in this order:
+
+1. Select the first non-empty candidate from the first matching type override.
+2. If the override is absent or empty, resolve the established semantic author,
+   including an explicit native `author` and existing compatibility fallbacks.
+3. If no semantic author resolves, select the first non-empty candidate from
+   `template`.
+
+An override therefore expresses the style guide's authoritative primary credit
+for that type. A merged candidate is non-empty when at least one declared role
+has data; missing roles are omitted without invalidating the candidate. Exact
+native reference discriminators are tested before legacy aliases. Candidate
+lists are ordered and the first non-empty result wins.
+
+Contributor candidates reuse the normal scalar or merged name pipeline,
+including multilingual resolution, role suppression, same-person combination,
+et-al selection, and role-label presentation. A title candidate retains the
+existing title-substitution behavior.
+
+Native subtype keys such as `episode` and `film` are checked before their CSL
+compatibility aliases (`broadcast` and `motion-picture`). This permits an
+authored native override to coexist with a broader migrated compatibility rule.
+
+### Presentation boundary
+
+Substitution selects people; it does not specify how their roles appear.
+`options.contributors.role` supplies style-wide label presentation and
+`options.contributors.merge` supplies style-wide merged-list defaults.
+Component `label` and `merge` values remain higher-precedence exceptions.
+
+### Semantic consumers
+
+Rendering, bibliography sorting, citation sorting, and name-based
+disambiguation must ask one effective-primary resolver for the selected names.
+They must not independently inspect templates or repeat type-selection logic.
+
+## Implementation Notes
+
+- Keep legacy scalar `SubstituteKey` YAML source-compatible through an untagged
+  candidate representation.
+- Validate contributor role lists with the same distinct-role rules as merged
+  template components.
+- Reject invalid substitution candidates while loading the complete style,
+  even if the containing type override is not selected for the current item.
+
+## Acceptance Criteria
+
+- [x] Legacy scalar `template` and `overrides` values round-trip unchanged.
+- [x] Scalar and merged contributor candidates round-trip and appear in the
+      generated style schema.
+- [x] Exact-type overrides win when non-empty; semantic author and the default
+      template remain ordered fallbacks.
+- [x] Partially populated merged candidates render only available roles.
+- [x] Rendering, sorting, and disambiguation share effective-primary names.
+- [x] Invalid candidates fail style loading and CLI rendering before output.
+
+## Changelog
+
+- v1.0 (2026-07-14): Defined type-aware primary contributor substitution.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -85,7 +85,8 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | [`ARTICLE_JOURNAL_NO_PAGE_FALLBACK.md`](./ARTICLE_JOURNAL_NO_PAGE_FALLBACK.md) — external bibliography parameter for article-journal page fallback | Active | `bibliography.rs::article_journal_no_page_fallback` |
 | [`CITATION_BIBLIOGRAPHY_OPTION_SPLIT.md`](./CITATION_BIBLIOGRAPHY_OPTION_SPLIT.md) — strict schema split for citation and bibliography option scopes | Active | `bibliography.rs`, `citations.rs` |
 | [`INLINE_JOURNAL_DETAIL_GROUPING.md`](./INLINE_JOURNAL_DETAIL_GROUPING.md) — inline article-journal detail blocks with mixed delimiters | Active | `bibliography.rs` |
-| [`CROSS_ROLE_CONTRIBUTOR_LISTS.md`](./CROSS_ROLE_CONTRIBUTOR_LISTS.md) — merged multi-role name lists with per-name/collective labels and same-person combination | Draft | — |
+| [`CROSS_ROLE_CONTRIBUTOR_LISTS.md`](./CROSS_ROLE_CONTRIBUTOR_LISTS.md) — merged multi-role name lists with per-name/collective labels and same-person combination | Active | `cross_role_contributors.rs` |
+| [`PRIMARY_CONTRIBUTOR_SUBSTITUTION.md`](./PRIMARY_CONTRIBUTOR_SUBSTITUTION.md) — type-aware scalar and merged contributors promoted into the primary slot | Active | `cross_role_contributors.rs` |
 | [`ROLE_SUBSTITUTE_FALLBACK.md`](./ROLE_SUBSTITUTE_FALLBACK.md) — normative behavior for role-aware contributor fallback chains | Active | `bibliography.rs::substitution` |
 | [`SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md`](./SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md) — consistent rendering and verification for secondary contributor roles | Active | `bibliography.rs` |
 

--- a/docs/specs/ROLE_LABEL_DEFAULTS.md
+++ b/docs/specs/ROLE_LABEL_DEFAULTS.md
@@ -15,9 +15,10 @@ Style-guide research (PR #1017, divergence register div-012) established:
 1. Role labels are a **bibliography-only** convention in every examined
    style (APA, MLA, Chicago, Vancouver/NLM). No style carries a role label
    into the in-text citation.
-2. The role set and label form are **per-style**: APA labels editor only,
-   abbreviated; MLA labels a broader set in word form; Chicago prefers
-   post-title phrasing and labels none.
+2. The role set and label form are **per-style**: APA abbreviates editor but
+   uses long parenthetical labels for audiovisual writers and directors; MLA
+   labels a broader set in word form; Chicago prefers post-title phrasing and
+   labels none.
 
 ## Design
 
@@ -35,7 +36,7 @@ contributors:
 | Bundle | Roles labeled | Preset | Rendered shape |
 |---|---|---|---|
 | `none` (= unset) | — | — | no automatic label |
-| `apa` | editor | `short-suffix` | `" (ed.)"` (en-US short term; capitalization needs an explicit `text-case`) |
+| `apa` | editor; writer; director | per-role strategy | editor uses its abbreviated parenthetical; writer/director use title-cased long parentheticals |
 | `mla` | editor, translator, director, illustrator, interviewer | `long-suffix` | `", editor"` |
 
 Resolution order in `resolve_role_labels`
@@ -52,15 +53,19 @@ for the last step:
    context == RenderContext::Bibliography`), and never for verb/verb-short
    forms.
 
+Named bundles resolve a complete label presentation strategy rather than only
+a preset name. The strategy includes term form, placement, text case, wrapping,
+and affixes. Explicit component and per-role configuration still wins.
+
 ### Future extensibility
 
-The bundles currently map each role to a single suffix-shaped preset. MLA
+The bundles may map a role to a complete presentation strategy. MLA
 also uses labels as preceding descriptors in some Contributor-element
 positions; that case is already expressible today via per-role presets
 (`role.preset`, `role.roles.<role>.preset`, `role.form`) and verb/verb-short
 forms, which the bundle never overrides. If the `mla` bundle is later
 extended beyond simple long-suffixes, it should evolve into a per-role
-"default label strategy" (placement + form) rather than a suffix shape —
+"default label strategy" (placement, form, case, and wrapping) rather than a suffix shape —
 the schema surface (`defaults:` as an enum) leaves room for that without
 breaking existing styles.
 

--- a/docs/specs/ROLE_SUBSTITUTE_FALLBACK.md
+++ b/docs/specs/ROLE_SUBSTITUTE_FALLBACK.md
@@ -3,13 +3,14 @@
 **Status:** Active
 **Date:** 2026-04-10
 **Supersedes:** None
-**Related:** `docs/specs/SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md`, `csl26-5ap9`, `csl26-mwnt`
+**Related:** `docs/specs/SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md`,
+`docs/specs/PRIMARY_CONTRIBUTOR_SUBSTITUTION.md`, `csl26-5ap9`, `csl26-mwnt`
 
 ## Purpose
 Define the normative behavior of `options.substitute.role-substitute` so styles can declare role-aware contributor fallback chains without relying on engine-only assumptions or silently dropped custom roles.
 
 ## Scope
-In scope: parsing and normalization of role names, fallback contributor resolution, suppression behavior for explicit fallback roles, locale-driven label rendering for substitute contributors, and documentation of custom-role handling. Out of scope: new schema keys, substitute preset redesign, or year-suffix/disambiguation behavior.
+In scope: parsing and normalization of role names, fallback contributor resolution, suppression behavior for explicit fallback roles, locale-driven label rendering for substitute contributors, and documentation of custom-role handling. Out of scope: new schema keys, substitute preset redesign, primary author-slot substitution, or year-suffix/disambiguation behavior. Primary author-slot behavior is specified by `PRIMARY_CONTRIBUTOR_SUBSTITUTION.md`.
 
 ## Design
 `options.substitute.role-substitute` is a map from a primary contributor role to an ordered list of fallback roles.

--- a/docs/specs/SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md
+++ b/docs/specs/SECONDARY_CONTRIBUTOR_ROLE_FORMATTING.md
@@ -10,7 +10,7 @@
 Define a coherent configuration and verification model for secondary contributor roles so Citum can render editors, translators, interviewers, recipients, and related role-bearing contributors consistently across citation and bibliography contexts.
 
 ## Scope
-In scope: role-label presets, legacy `editor-label-format` compatibility, substitute-path parity, fixture coverage, and oracle diagnostics for secondary contributor rendering. Out of scope: new reference-data model fields for currently unsupported contributor relations and any redesign of the existing contributor or substitute preset systems.
+In scope: role-label presets, style-wide label presentation, substitute-path parity, fixture coverage, and oracle diagnostics for secondary contributor rendering. Out of scope: new reference-data model fields for currently unsupported contributor relations and automatic selection of which roles belong to a secondary contributor block.
 
 ## Design
 Secondary contributor role formatting is additive and non-breaking. Styles may configure a global role-label preset at `options.contributors.role.preset` and override it per role at `options.contributors.role.roles.<role>.preset`.
@@ -40,6 +40,11 @@ contributors:
 
 Repeating the same preset for every role in `roles` is redundant and must be collapsed to the global form.
 
+When a role needs presentation beyond a preset, use
+`role.roles.<role>.label`. This style-wide value carries form, placement,
+text-case, wrapping, and affixes while deriving the term from the map key; it
+must not be repeated in every type template.
+
 This wave defines the following presets:
 
 - `none`: suppress the configured role label.
@@ -50,11 +55,12 @@ This wave defines the following presets:
 
 Preset precedence is:
 
-1. Explicit `TemplateContributor.label`
-2. Per-role preset override
-3. Global role preset
-4. Legacy `editor-label-format` compatibility for editor and translator roles
-5. Existing form-based defaults
+1. Explicit component or merged-role `label`
+2. Style-wide `role.roles.<role>.label`
+3. Per-role preset override
+4. Global role preset
+5. Bibliography-only `role.defaults` strategy
+6. Existing form-based defaults
 
 Role-aware substitution must use the same locale-driven label resolution as normal contributor rendering. When `options.substitute.contributor-role-form` is present, it overrides the configured role-label preset for substitute labels only; otherwise substitute rendering falls back to the same role preset resolution path as ordinary role-bearing contributors.
 

--- a/examples/cross-role-contributors.yaml
+++ b/examples/cross-role-contributors.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/bib.json
+# Render with: citum render refs -b examples/cross-role-contributors.yaml -s apa-7th -m bib
+---
+info:
+  description: Native audiovisual contributor-role examples
+references:
+  - id: barris-lemons-2017
+    class: audio-visual
+    type: episode
+    title: Lemons
+    issued: "2017-01-11"
+    medium: TV series episode
+    contributors:
+      - roles: [writer, director]
+        contributor:
+          family: Barris
+          given: Kenya
+
+  - id: inside-out-2015
+    class: audio-visual
+    type: film
+    title: Inside out
+    issued: "2015"
+    medium: Film
+    publisher: Walt Disney Pictures; Pixar Animation Studios
+    contributors:
+      - role: director
+        contributor:
+          family: Docter
+          given: Pete
+      - role: director
+        contributor:
+          family: Del Carmen
+          given: Ronnie

--- a/tests/fixtures/audiovisual/apa-episode-cross-role.yaml
+++ b/tests/fixtures/audiovisual/apa-episode-cross-role.yaml
@@ -1,0 +1,9 @@
+- id: lemons
+  class: audio-visual
+  type: episode
+  title: Lemons
+  issued: "2017-01-11"
+  medium: TV series episode
+  contributors:
+    - roles: [writer, director]
+      contributor: {family: Barris, given: Kenya}

--- a/tests/fixtures/audiovisual/apa-film-directors.yaml
+++ b/tests/fixtures/audiovisual/apa-film-directors.yaml
@@ -1,0 +1,12 @@
+- id: inside-out
+  class: audio-visual
+  type: film
+  title: Inside out
+  issued: "2015"
+  medium: Film
+  publisher: Walt Disney Pictures; Pixar Animation Studios
+  contributors:
+    - role: director
+      contributor: {family: Docter, given: Pete}
+    - role: director
+      contributor: {family: Del Carmen, given: Ronnie}

--- a/tests/fixtures/coverage-manifest.json
+++ b/tests/fixtures/coverage-manifest.json
@@ -877,6 +877,45 @@
       "notes": "Legal grouping fixture used for Juris-M style hierarchy checks."
     },
     {
+      "fixture": "tests/fixtures/audiovisual/apa-episode-cross-role.yaml",
+      "domain": "core",
+      "kind": "references",
+      "reference_types": [
+        "episode"
+      ],
+      "citation_scenarios": [
+        "non-integral author-date citation"
+      ],
+      "rendering_risks": [
+        "type-aware primary contributor substitution",
+        "same-person writer-director combination",
+        "bibliography-only role labels"
+      ],
+      "used_by": [
+        "crates/citum-engine/tests/cross_role_contributors.rs"
+      ],
+      "ci_status": "required",
+      "notes": "Native APA episode fixture with one explicitly multi-role contributor."
+    },
+    {
+      "fixture": "tests/fixtures/audiovisual/apa-film-directors.yaml",
+      "domain": "core",
+      "kind": "references",
+      "reference_types": [
+        "film"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "type-aware primary contributor substitution",
+        "collective director label pluralization"
+      ],
+      "used_by": [
+        "crates/citum-engine/tests/cross_role_contributors.rs"
+      ],
+      "ci_status": "required",
+      "notes": "Native APA film fixture with a collective directors credit."
+    },
+    {
       "fixture": "tests/fixtures/grouping/multilingual-groups.json",
       "domain": "grouping",
       "kind": "references",


### PR DESCRIPTION
## Summary

- add explicit multi-role contributor data plus scalar/list style schema support, validation, locale terms, and generated schemas
- render ordered cross-role lists with individual or collective labels, authored/composed combined labels, post-combination et-al, and exact explicit-role suppression
- use merged contributors for sorting and disambiguation, preserve multi-variable CSL names during migration, and update APA multimedia behavior and fixtures

Native Citum YAML is authoritative: a contributor explicitly carries `roles: [...]`. The engine never infers identity from display names. Strict trimmed NFC identity matching exists only at the legacy CSL-JSON conversion boundary, where independent role arrays must be normalized into native contributor entries.

## Review hardening

A full spec/schema/engine/migration review pass folded the following fixes into this PR:

- merged lists now apply `role-substitute` suppression, so a role rendered as a primary-slot fallback is excluded from merged assembly (spec: Interactions)
- bibliography contributor matching (subsequent-author substitution) now uses the shared effective-primary resolver, honoring type overrides and merged candidates
- `role.omit` now also suppresses style-wide structural role labels (`role.roles.<role>.label`, `role.defaults` bundles) on both scalar and merged paths, with the existing verb-form exception
- empty-name substitute candidates (e.g. `editor: []`) no longer terminate the fallback chain; the next candidate is tried, restoring title fallback in rendering and disambiguation keys
- an empty merged primary component now sorts through the same substitute chain the render path uses instead of jumping to the title key
- grouped author-date citations recognize merged `[author, …]` leading components; migration gating and SQI compaction handle list-form components
- migration emits a per-role label override for every role in a multi-variable `<names>` block (previously only the first role was labeled, dropping e.g. the translator label when editor and translator differ)
- removed invented `writer`/`writer-director` short and verb-short locale abbreviations; short-form lookups fall back to the long forms
- spec: documented empty-merged-component fallback, component `merge:` wholesale replacement of style-wide defaults, and editor-translator combined-term order-insensitivity

Sort/disambiguation paths now resolve the effective primary once per reference instead of per comparison (single-pass resolver, precomputed sort keys, borrow-based merge config — `csl26-78ds`): rendering benchmarks improved 14–47% versus the prior baseline. Deferred to a bean: validation/label-type consolidation (`csl26-tsmg`).

## Validation

- `just pre-commit` — 1,986 tests passed; formatting and clippy clean
- `just schema-gen` — no drift against checked-in schemas
- APA oracle — citations 20/20; bibliography 45/46, with only the pre-existing standard-reference mismatch remaining
- new regression tests cover every review fix (each verified red-before/green-after)

## Tracking

- completes and archives bean `csl26-7ip9`; review tracked in `csl26-nnkf`; sort-path performance in `csl26-78ds`
- activates `docs/specs/CROSS_ROLE_CONTRIBUTOR_LISTS.md` (v1.0) and `docs/specs/PRIMARY_CONTRIBUTOR_SUBSTITUTION.md` (v1.0)
- follow-ups: `csl26-tsmg`, `csl26-h6b9`, `csl26-hyc4`, `csl26-ijvf`
