### PR TITLE
Scope the spin Yank Exception

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,8 @@ jobs:
           tool: cargo-audit,cargo-deny,cargo-fuzz
 
       - name: Check RustSec advisories
-        run: cargo audit --deny warnings
+        # cargo-deny below enforces yanks and supports exact package exceptions.
+        run: cargo audit --deny warnings --no-yanked
 
       - name: Check dependency policy
         run: cargo deny check advisories licenses bans sources

--- a/deny.toml
+++ b/deny.toml
@@ -2,9 +2,10 @@
 version = 2
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-# NOTE: cargo-audit does not read this file. Its ignore list is maintained
-# separately in .cargo/audit.toml and must be kept in sync with this block.
+# NOTE: Advisory IDs must stay in sync with .cargo/audit.toml. Yank exceptions
+# live only here because cargo-audit cannot ignore an exact yanked package.
 ignore = [
+    { crate = "spin@0.9.8", reason = "Yanked upstream; transitive through Typst and wasmi, whose latest stable releases still require spin 0.9. Remove when wasmi upgrades." },
     { id = "RUSTSEC-2024-0320", reason = "Transitive through syntect in the current Typst stack; no direct dependency or safe local replacement in this PR." },
     { id = "RUSTSEC-2024-0436", reason = "Transitive through V8, hayagriva, and biblatex; no direct dependency or safe local replacement in this PR." },
     { id = "RUSTSEC-2025-0141", reason = "Transitive through deno_core and syntect; no direct dependency or safe local replacement in this PR." },


### PR DESCRIPTION
## Summary

- keep yank enforcement fail-closed in cargo-deny
- allow only the transitive `spin@0.9.8` version required by the current Typst/wasmi dependency chain
- run cargo-audit with `--no-yanked`, since cargo-audit cannot express an exact-package yank exception and cargo-deny immediately follows it

## Rationale

Updating Typst does not resolve this issue: Typst 0.15 still reaches `spin 0.9.8` through wasmi. This PR therefore scopes the temporary exception to the exact package version without changing the dependency graph or weakening advisory checks.

## Validation

- `cargo audit --deny warnings --no-yanked` — passed (752 dependencies, 1160 advisories)
- `cargo deny check advisories licenses bans sources` — passed
- negative control with only the `spin@0.9.8` exception removed — failed specifically on the yanked `spin 0.9.8` dependency path
- pre-push hooks — passed; no Rust files changed, so the Cargo gate was correctly skipped

## Follow-up

Remove the exact exception once wasmi no longer resolves `spin 0.9.8`.
