### PR TITLE
build(schema): add unicode normalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "specta",
+ "unicode-normalization",
  "url",
 ]
 

--- a/crates/citum-schema-data/Cargo.toml
+++ b/crates/citum-schema-data/Cargo.toml
@@ -16,6 +16,7 @@ citum-edtf = { workspace = true, features = ["serde"] }
 url = { version = "2.5", features = ["serde"] }
 csl-legacy = { workspace = true, optional = true }
 indexmap = { version = "2", features = ["serde"] }
+unicode-normalization = "0.1.25"
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

- add `unicode-normalization` as an explicit workspace dependency of `citum-schema-data`
- record the direct package dependency in `Cargo.lock`

This isolates the dependency/security review from PR #1052, which uses NFC normalization for cross-role contributor identity matching.

## Validation

- `just pre-commit` (1,927 tests passed)

## Follow-up

PR #1052 will rebase onto this change after it lands. This PR intentionally contains no bean or feature implementation.
