### PR TITLE
fix(release): recover crate publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,12 @@ on:
         type: choice
         options:
           - release-pr
+          - publish-crates
           - publish-jsr
+      release_ref:
+        description: "Release tag to recover (required for publish-crates, e.g. v0.75.0)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -303,13 +308,15 @@ jobs:
             fi
           fi
 
-  # ── Step 4: Build cross-platform binaries on tag push ─────────────
-  # Triggered only by `push: tags: ["v*"]` — orthogonal to the
-  # pull_request-gated steps above. Each matrix job builds citum +
-  # citum-server for its target and uploads the tarball + SHA256 as
-  # job artifacts. The `release` job aggregates them in the next step.
+  # ── Step 4: Build cross-platform binaries for a tag or recovery ───
+  # Tag pushes and manual crates.io recovery both run the full build matrix
+  # before publishing. Each matrix job builds citum + citum-server for its
+  # target and uploads the tarball + SHA256 as job artifacts. The `release`
+  # job aggregates them only for tag-push releases.
   build:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.command == 'publish-crates')
     strategy:
       fail-fast: false
       matrix:
@@ -322,15 +329,11 @@ jobs:
             use_cross: "1"
           # glibc Linux targets: rusty_v8 (citum-migrate's V8 dependency)
           # only publishes prebuilt static libs for gnu/glibc, not musl.
-          # These targets exist so citum-migrate has a prebuilt on Linux at
-          # all — install.sh falls back to them for that one binary while
-          # citum/citum-server keep shipping from the musl targets above.
+          # This target carries the x86_64 Linux citum-migrate prebuilt while
+          # citum/citum-server keep shipping from the musl target above.
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             use_cross: "0"
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            use_cross: "1"
           - target: aarch64-apple-darwin
             os: macos-latest
             use_cross: "0"
@@ -343,6 +346,25 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           persist-credentials: false
+          ref: ${{ inputs.release_ref || github.ref }}
+
+      - name: Validate recovery tag
+        if: github.event_name == 'workflow_dispatch' && inputs.command == 'publish-crates'
+        env:
+          RELEASE_REF: ${{ inputs.release_ref }}
+        run: |
+          case "$RELEASE_REF" in
+            v[0-9]*) ;;
+            *) echo "publish-crates requires release_ref to be a v* tag" >&2; exit 1 ;;
+          esac
+          if ! git rev-parse -q --verify "refs/tags/${RELEASE_REF}" >/dev/null; then
+            echo "release_ref ${RELEASE_REF} is not a tag in this checkout" >&2
+            exit 1
+          fi
+          if [ "$(git describe --exact-match --tags HEAD)" != "$RELEASE_REF" ]; then
+            echo "checkout does not resolve to ${RELEASE_REF}" >&2
+            exit 1
+          fi
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
@@ -367,7 +389,7 @@ jobs:
         env:
           USE_CROSS: ${{ matrix.use_cross }}
           TARGET: ${{ matrix.target }}
-          REF_NAME: ${{ github.ref_name }}
+          REF_NAME: ${{ inputs.release_ref || github.ref_name }}
         run: bash scripts/release-binary.sh "$TARGET" "$REF_NAME"
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
@@ -431,13 +453,16 @@ jobs:
   # The script is idempotent — re-running after partial failure
   # skips already-published versions.
   publish-crates:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.command == 'publish-crates')
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           persist-credentials: false
+          ref: ${{ inputs.release_ref || github.ref }}
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -83,13 +83,12 @@ resolve_version() {
 }
 
 # citum-migrate has no musl prebuilt (rusty_v8 doesn't publish musl static
-# libs) but does have a gnu/glibc one — see scripts/release-binary.sh. Maps
-# a musl Linux target to its gnu counterpart so install.sh can fetch
-# citum-migrate from there instead of skipping it.
+# libs) but does have an x86_64 gnu/glibc one — see scripts/release-binary.sh.
+# This maps the x86_64 musl target to that counterpart so install.sh can fetch
+# citum-migrate instead of skipping it.
 migrate_fallback_target() {
   case "$1" in
     x86_64-unknown-linux-musl)  echo "x86_64-unknown-linux-gnu" ;;
-    aarch64-unknown-linux-musl) echo "aarch64-unknown-linux-gnu" ;;
   esac
 }
 
@@ -205,15 +204,17 @@ tar -xzf "${TMP}/${TARBALL}" -C "$TMP"
 STAGE="${TMP}/citum-${VER_BARE}-${TARGET}"
 
 # citum-migrate has no musl prebuilt (see fetch_tarball's doc comment); fetch
-# it from the gnu counterpart tarball so it isn't silently skipped on Linux.
+# it from the x86_64 gnu counterpart tarball when one is available.
 MIGRATE_STAGE=""
 case "$TARGET" in
   *-linux-musl)
     case " $SELECTED " in
       *' citum-migrate '*)
         MIGRATE_TARGET="$(migrate_fallback_target "$TARGET")"
-        say "citum-migrate has no musl prebuilt; fetching it from ${MIGRATE_TARGET} instead"
-        MIGRATE_STAGE="$(fetch_tarball "$MIGRATE_TARGET" || true)"
+        if [ -n "$MIGRATE_TARGET" ]; then
+          say "citum-migrate has no musl prebuilt; fetching it from ${MIGRATE_TARGET} instead"
+          MIGRATE_STAGE="$(fetch_tarball "$MIGRATE_TARGET" || true)"
+        fi
         ;;
     esac
     ;;

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -101,33 +101,58 @@ class ReleaseWorkflowTests(unittest.TestCase):
             "publish-jsr must include a real publish step after dry-run",
         )
 
-    def test_release_workflow_has_fast_manual_jsr_publish_recovery(self) -> None:
+    def test_release_workflow_has_manual_publish_recovery_commands(self) -> None:
         self.assertIn("- publish-jsr", self.workflow)
-        self.assertNotIn("- publish-crates", self.workflow)
+        self.assertIn("- publish-crates", self.workflow)
+
+    def test_manual_crates_publish_recovery_runs_the_build_gate(self) -> None:
+        """Manual crates.io recovery must retain the release build gate."""
+        build = re.search(
+            r"\n  build:\n(?P<block>.*?)(?=\n  [a-zA-Z0-9_-]+:|\Z)",
+            self.workflow,
+            flags=re.DOTALL,
+        )
+        publish = re.search(
+            r"\n  publish-crates:\n(?P<block>.*?)(?=\n  [a-zA-Z0-9_-]+:|\Z)",
+            self.workflow,
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(build)
+        self.assertIsNotNone(publish)
+        assert build is not None
+        assert publish is not None
+        self.assertIn("inputs.command == 'publish-crates'", build.group("block"))
+        self.assertIn("inputs.command == 'publish-crates'", publish.group("block"))
+        self.assertIn("needs: build", publish.group("block"))
+        self.assertIn("release_ref", self.workflow)
+        self.assertIn("publish-crates requires release_ref", build.group("block"))
+        self.assertIn("ref: ${{ inputs.release_ref || github.ref }}", build.group("block"))
+        self.assertIn("ref: ${{ inputs.release_ref || github.ref }}", publish.group("block"))
 
     def test_release_binary_matrix_drops_intel_macos_but_keeps_windows(self) -> None:
         self.assertNotIn("target: x86_64-apple-darwin", self.workflow)
         self.assertIn("target: aarch64-apple-darwin", self.workflow)
         self.assertIn("target: x86_64-pc-windows-msvc", self.workflow)
 
-    def test_release_binary_matrix_adds_gnu_linux_targets_for_migrate(self) -> None:
+    def test_release_binary_matrix_keeps_only_x86_64_gnu_migrate_target(self) -> None:
         """rusty_v8 (citum-migrate's V8 dep) has no musl prebuilt but does
-        have a gnu one — see issue #1054. The matrix must build gnu Linux
-        targets so install.sh has somewhere to fetch citum-migrate from."""
+        have an x86_64 gnu one — see issue #1054. The matrix must retain that
+        target without requiring the unsupported ARM GNU V8 link."""
         self.assertIn("target: x86_64-unknown-linux-gnu", self.workflow)
-        self.assertIn("target: aarch64-unknown-linux-gnu", self.workflow)
+        self.assertNotIn("target: aarch64-unknown-linux-gnu", self.workflow)
         # musl targets must still be present — they remain the default for
         # citum/citum-server.
         self.assertIn("target: x86_64-unknown-linux-musl", self.workflow)
         self.assertIn("target: aarch64-unknown-linux-musl", self.workflow)
 
-    def test_installer_fetches_migrate_from_gnu_fallback_on_musl(self) -> None:
+    def test_installer_fetches_migrate_from_x86_64_gnu_fallback_on_musl(self) -> None:
         """install.sh must not silently drop citum-migrate on Linux; it
         should fetch the binary from the gnu tarball instead (issue #1054)."""
         self.assertIn("migrate_fallback_target", self.install_script)
         self.assertIn("x86_64-unknown-linux-gnu", self.install_script)
-        self.assertIn("aarch64-unknown-linux-gnu", self.install_script)
+        self.assertNotIn("aarch64-unknown-linux-gnu", self.install_script)
         self.assertIn("fetch_tarball", self.install_script)
+        self.assertIn('if [ -n "$MIGRATE_TARGET" ]; then', self.install_script)
         # The graceful degrade path (gnu fetch itself unavailable) must
         # remain, so a stale/offline mirror doesn't hard-fail the install.
         self.assertIn("cargo install citum-migrate --locked", self.install_script)


### PR DESCRIPTION
## Summary

- remove the unsupported `aarch64-unknown-linux-gnu` `citum-migrate` release build that blocked v0.75.0
- retain the x86_64 GNU fallback for Linux `citum-migrate`
- add guarded `publish-crates` recovery dispatch that rebuilds a supplied release tag before invoking the idempotent crates.io publisher

## Root cause

The v0.75.0 release matrix failed while linking `citum-migrate` for `aarch64-unknown-linux-gnu`: the `cross` image lacked `memfd_create` required by V8. `publish-crates` depends on the full build matrix, so it was skipped and no 0.75.0 crates were published.

## Recovery

After merge, dispatch **Release** from `main` with command `publish-crates` and `release_ref` set to `v0.75.0`. The workflow validates and checks out that tag, runs the full build gate, then publishes only versions not already present.

## Validation

- `python3 scripts/test_release_workflow.py`
- `sh -n scripts/install.sh`
- `git diff --check`
- YAML parse validation (actionlint unavailable locally)
