### PR TITLE
fix(release): use bash for tag recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,6 +350,7 @@ jobs:
 
       - name: Validate recovery tag
         if: github.event_name == 'workflow_dispatch' && inputs.command == 'publish-crates'
+        shell: bash
         env:
           RELEASE_REF: ${{ inputs.release_ref }}
         run: |

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -128,6 +128,11 @@ class ReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("publish-crates requires release_ref", build.group("block"))
         self.assertIn("ref: ${{ inputs.release_ref || github.ref }}", build.group("block"))
         self.assertIn("ref: ${{ inputs.release_ref || github.ref }}", publish.group("block"))
+        self.assertRegex(
+            build.group("block"),
+            r"- name: Validate recovery tag[\s\S]*?shell: bash",
+            "Tag validation must use Bash on the Windows build matrix entry.",
+        )
 
     def test_release_binary_matrix_drops_intel_macos_but_keeps_windows(self) -> None:
         self.assertNotIn("target: x86_64-apple-darwin", self.workflow)


### PR DESCRIPTION
## Summary

Run the manual release-tag validation step with Bash on every release matrix platform.

## Root cause

The v0.75.0 crates.io recovery dispatch checked out and validated the requested tag successfully on Unix runners, but its Windows matrix entry used the default PowerShell shell. The validation body uses Bash syntax, so PowerShell rejected it before the build matrix completed and `publish-crates` was skipped.

## Validation

- `python3 scripts/test_release_workflow.py`
- `sh -n scripts/install.sh`
- `git diff --check`
- YAML parse validation
