### PR TITLE
fix(cli): add installer component flag

### DIFF
--- a/.beans/archive/csl26-08s9--add-installer-component-cli-selection.md
+++ b/.beans/archive/csl26-08s9--add-installer-component-cli-selection.md
@@ -1,14 +1,14 @@
 ---
 # csl26-08s9
 title: Add installer component CLI selection
-status: in-progress
+status: completed
 type: bug
 priority: normal
 tags:
     - cli
     - release
 created_at: 2026-07-14T23:17:04Z
-updated_at: 2026-07-15T10:30:34Z
+updated_at: 2026-07-15T10:39:24Z
 ---
 
 Implement --components support in the POSIX installer while preserving CITUM_COMPONENTS compatibility.
@@ -16,7 +16,7 @@ Implement --components support in the POSIX installer while preserving CITUM_COM
 - [x] Add argument parsing and help text
 - [x] Add isolated installer regression coverage
 - [x] Update installation documentation
-- [ ] Merge PR #1060 and archive bean
+
 
 ## Summary of Changes
 

--- a/.beans/csl26-08s9--add-installer-component-cli-selection.md
+++ b/.beans/csl26-08s9--add-installer-component-cli-selection.md
@@ -8,15 +8,15 @@ tags:
     - cli
     - release
 created_at: 2026-07-14T23:17:04Z
-updated_at: 2026-07-14T23:22:34Z
+updated_at: 2026-07-15T10:30:34Z
 ---
 
 Implement --components support in the POSIX installer while preserving CITUM_COMPONENTS compatibility.
 
-- [ ] Add argument parsing and help text
-- [ ] Add isolated installer regression coverage
+- [x] Add argument parsing and help text
+- [x] Add isolated installer regression coverage
 - [x] Update installation documentation
-- [x] Validate, open PR, and record results
+- [ ] Merge PR #1060 and archive bean
 
 ## Summary of Changes
 

--- a/.beans/csl26-08s9--add-installer-component-cli-selection.md
+++ b/.beans/csl26-08s9--add-installer-component-cli-selection.md
@@ -8,7 +8,7 @@ tags:
     - cli
     - release
 created_at: 2026-07-14T23:17:04Z
-updated_at: 2026-07-14T23:20:27Z
+updated_at: 2026-07-14T23:22:34Z
 ---
 
 Implement --components support in the POSIX installer while preserving CITUM_COMPONENTS compatibility.
@@ -16,4 +16,8 @@ Implement --components support in the POSIX installer while preserving CITUM_COM
 - [ ] Add argument parsing and help text
 - [ ] Add isolated installer regression coverage
 - [x] Update installation documentation
-- [ ] Validate, open PR, and record results
+- [x] Validate, open PR, and record results
+
+## Summary of Changes
+
+Added --components installer selection, preserved CITUM_COMPONENTS compatibility, documented the new command, and opened PR #1060 after 22 targeted regression tests passed.

--- a/.beans/csl26-08s9--add-installer-component-cli-selection.md
+++ b/.beans/csl26-08s9--add-installer-component-cli-selection.md
@@ -1,0 +1,19 @@
+---
+# csl26-08s9
+title: Add installer component CLI selection
+status: in-progress
+type: bug
+priority: normal
+tags:
+    - cli
+    - release
+created_at: 2026-07-14T23:17:04Z
+updated_at: 2026-07-14T23:20:27Z
+---
+
+Implement --components support in the POSIX installer while preserving CITUM_COMPONENTS compatibility.
+
+- [ ] Add argument parsing and help text
+- [ ] Add isolated installer regression coverage
+- [x] Update installation documentation
+- [ ] Validate, open PR, and record results

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ Prebuilt binaries (Linux, macOS arm64, Windows via Git Bash):
 curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | sh
 ```
 
-The installer verifies SHA-256 checksums and installs to `~/.local/bin`. Select components with `CITUM_COMPONENTS` (`citum`, `citum-server`, `citum-migrate`, or `all`):
+The installer verifies SHA-256 checksums and installs to `~/.local/bin`. It installs `citum` by default. Select components (`citum`, `citum-server`, `citum-migrate`, or `all`) without an environment variable:
 
 ```bash
-curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | CITUM_COMPONENTS=all sh
+curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | sh -s -- --components all
 ```
+
+`CITUM_COMPONENTS` remains supported for non-interactive automation; the command-line option takes precedence.
 
 From source: `cargo install citum --locked` (also: `citum-server`, `citum-migrate`).
 

--- a/docs/developer.html
+++ b/docs/developer.html
@@ -69,8 +69,9 @@
                 <pre><code>curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | sh</code></pre>
             </div>
             <p style="margin-top: 1rem; color: var(--citum-muted); font-size: 0.92rem;">
-                Select components with <code>CITUM_COMPONENTS</code> (<code>citum</code>, <code>citum-server</code>,
-                <code>citum-migrate</code>, or <code>all</code>). From source:
+                Select components with <code>--components</code> (<code>citum</code>, <code>citum-server</code>,
+                <code>citum-migrate</code>, or <code>all</code>). <code>CITUM_COMPONENTS</code> remains available
+                for automation. From source:
                 <code>cargo install citum --locked</code> (also: <code>citum-server</code>, <code>citum-migrate</code>).
                 JavaScript/TypeScript (WASM): <code>npx jsr add @citum/engine</code>.
                 See the <a href="#cli">CLI section</a> for component examples and common commands.
@@ -155,16 +156,16 @@
                 <div class="workshop-label">Install (pre-built binary)</div>
                 <pre><code>curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | sh</code></pre>
                 <p style="margin-top: 0.75rem; color: var(--citum-muted); font-size: 0.92rem;">
-                    Installs <code>citum</code> by default. To pick a different subset, set
-                    <code>CITUM_COMPONENTS</code> to a comma-separated list of
+                    Installs <code>citum</code> by default. To pick a different subset, pass
+                    <code>--components</code> with a comma-separated list of
                     <code>citum</code>, <code>citum-server</code>, <code>citum-migrate</code>,
-                    or <code>all</code>:
+                    or <code>all</code>. <code>CITUM_COMPONENTS</code> remains available for automation:
                 </p>
                 <pre><code># everything
-curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | CITUM_COMPONENTS=all sh
+curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | sh -s -- --components all
 
 # citum + citum-migrate, no server
-curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | CITUM_COMPONENTS=citum,citum-migrate sh</code></pre>
+curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | sh -s -- --components citum,citum-migrate</code></pre>
             </div>
             <div class="workshop-block" style="margin-top: 1rem;">
                 <div class="workshop-label">Install (from source)</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,7 +67,8 @@
                 </div>
                 <p class="install-block-note">
                     Installs the <code>citum</code> CLI to <code>~/.local/bin</code> (SHA-256 verified).
-                    More options &mdash; components, Cargo, WASM &mdash; in <a href="developer.html#install">Integrate</a>.
+                    Install every CLI with <code>sh -s -- --components all</code>. More options &mdash; components,
+                    Cargo, WASM &mdash; in <a href="developer.html#install">Integrate</a>.
                 </p>
             </div>
             <aside class="workshop-block">

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,11 @@
 # same release, and installs the selected Citum binaries to
 # $CITUM_INSTALL_DIR (default $HOME/.local/bin).
 #
+# Options:
+#   --components <list> — comma-separated subset of {citum, citum-server,
+#                         citum-migrate}, or the alias `all`
+#   --help              — show usage
+#
 # Environment overrides:
 #   CITUM_VERSION       — release tag (default: latest)
 #   CITUM_INSTALL_DIR   — install destination (default: $HOME/.local/bin)
@@ -17,20 +22,71 @@
 #
 # Examples:
 #   curl -fsSL .../install.sh | sh                                  # citum only
-#   curl -fsSL .../install.sh | CITUM_COMPONENTS=all sh             # everything
-#   curl -fsSL .../install.sh | CITUM_COMPONENTS=citum,citum-migrate sh
+#   curl -fsSL .../install.sh | sh -s -- --components all           # everything
+#   curl -fsSL .../install.sh | sh -s -- --components citum,citum-migrate
 
 set -eu
 
 REPO="${CITUM_REPO:-citum/citum-core}"
 VERSION="${CITUM_VERSION:-latest}"
 INSTALL_DIR="${CITUM_INSTALL_DIR:-$HOME/.local/bin}"
-COMPONENTS_RAW="${CITUM_COMPONENTS:-citum}"
 
 # ---------- helpers ---------------------------------------------------
 
 say()    { printf '%s\n'    "citum-installer: $*"; }
 err()    { printf '%s\n' >&2 "citum-installer: error: $*"; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: install.sh [--components <list>]
+
+Install selected Citum binaries. Components are a comma-separated subset of
+citum, citum-server, and citum-migrate; use `all` to install every component.
+
+Examples:
+  curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | sh
+  curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | sh -s -- --components all
+  curl -fsSL https://github.com/citum/citum-core/releases/latest/download/install.sh | sh -s -- --components citum,citum-migrate
+
+CITUM_COMPONENTS remains available for non-interactive automation. When both
+are set, --components takes precedence.
+EOF
+}
+
+COMPONENTS_ARG=""
+COMPONENTS_ARG_SET=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --components)
+      [ "$#" -ge 2 ] || err "--components requires a value"
+      COMPONENTS_ARG="$2"
+      COMPONENTS_ARG_SET=1
+      shift 2
+      ;;
+    --components=*)
+      COMPONENTS_ARG="${1#--components=}"
+      COMPONENTS_ARG_SET=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      [ "$#" -eq 0 ] || err "unexpected positional argument: $1"
+      ;;
+    *) err "unknown option: $1 (try --help)" ;;
+  esac
+done
+
+if [ "$COMPONENTS_ARG_SET" -eq 1 ]; then
+  COMPONENTS_RAW="$COMPONENTS_ARG"
+  COMPONENTS_SOURCE="--components"
+else
+  COMPONENTS_RAW="${CITUM_COMPONENTS:-citum}"
+  COMPONENTS_SOURCE="CITUM_COMPONENTS"
+fi
 
 need_cmd() {
   command -v "$1" >/dev/null 2>&1 || err "required command not found: $1"
@@ -151,7 +207,7 @@ esac
 # carry) to single spaces and trim both ends — `tr` handles the squeeze,
 # `awk` handles trim portably without bashisms.
 SELECTED=$(printf '%s' "$SELECTED" | tr -s '[:space:]' ' ' | awk '{$1=$1; print}')
-[ -z "$SELECTED" ] && err "CITUM_COMPONENTS is empty (valid: citum, citum-server, citum-migrate, all)"
+[ -z "$SELECTED" ] && err "${COMPONENTS_SOURCE} is empty (valid: citum, citum-server, citum-migrate, all)"
 for c in $SELECTED; do
   case "$c" in
     citum|citum-server|citum-migrate) ;;

--- a/scripts/test_release_workflow.py
+++ b/scripts/test_release_workflow.py
@@ -3,8 +3,13 @@
 
 from __future__ import annotations
 
+import hashlib
+import io
+import os
 import re
 import subprocess
+import tarfile
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -221,6 +226,139 @@ class ReleaseWorkflowTests(unittest.TestCase):
             r"^\d+\.\d+\.\d+$",
             f"sed did not extract a valid semver from {SCHEMA_LIB}; got: {version!r}",
         )
+
+
+class InstallerTests(unittest.TestCase):
+    """Exercise installer component selection against a local fake release."""
+
+    version = "9.9.9"
+    musl_target = "x86_64-unknown-linux-musl"
+    gnu_target = "x86_64-unknown-linux-gnu"
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.release_dir = self.root / "release"
+        self.release_dir.mkdir()
+        self.bin_dir = self.root / "bin"
+        self.bin_dir.mkdir()
+        self.curl_log = self.root / "curl.log"
+        self._write_tarball(self.musl_target, ("citum", "citum-server"))
+        self._write_tarball(self.gnu_target, ("citum-migrate",))
+        self._write_checksum_manifest()
+        self._write_fake_curl()
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _tarball_name(self, target: str) -> str:
+        return f"citum-{self.version}-{target}.tar.gz"
+
+    def _write_tarball(self, target: str, components: tuple[str, ...]) -> None:
+        archive = self.release_dir / self._tarball_name(target)
+        stage = f"citum-{self.version}-{target}"
+        with tarfile.open(archive, "w:gz") as tar:
+            for component in components:
+                contents = f"fixture {component}\n".encode()
+                info = tarfile.TarInfo(f"{stage}/{component}")
+                info.mode = 0o755
+                info.size = len(contents)
+                tar.addfile(info, fileobj=io.BytesIO(contents))
+
+    def _write_checksum_manifest(self) -> None:
+        lines = []
+        for archive in sorted(self.release_dir.glob("*.tar.gz")):
+            digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+            lines.append(f"{digest}  {archive.name}\n")
+        (self.release_dir / "SHA256SUMS").write_text("".join(lines), encoding="utf-8")
+
+    def _write_fake_curl(self) -> None:
+        curl = self.bin_dir / "curl"
+        curl.write_text(
+            "#!/usr/bin/env sh\n"
+            "set -eu\n"
+            "output=\n"
+            "url=\n"
+            "while [ \"$#\" -gt 0 ]; do\n"
+            "  case \"$1\" in\n"
+            "    --output) output=\"$2\"; shift 2 ;;\n"
+            "    *) url=\"$1\"; shift ;;\n"
+            "  esac\n"
+            "done\n"
+            "name=${url##*/}\n"
+            "printf '%s\\n' \"$name\" >> \"$CURL_LOG\"\n"
+            "cp \"$FAKE_RELEASE/$name\" \"$output\"\n",
+            encoding="utf-8",
+        )
+        curl.chmod(0o755)
+
+    def _run_installer(
+        self, *args: str, components: str | None = None
+    ) -> tuple[subprocess.CompletedProcess[str], Path]:
+        install_dir = self.root / f"install-{'-'.join(args) or components or 'default'}"
+        environment = os.environ | {
+            "CITUM_VERSION": self.version,
+            "CITUM_INSTALL_DIR": str(install_dir),
+            "FAKE_RELEASE": str(self.release_dir),
+            "CURL_LOG": str(self.curl_log),
+            "PATH": f"{self.bin_dir}:{os.environ['PATH']}",
+        }
+        if components is not None:
+            environment["CITUM_COMPONENTS"] = components
+        result = subprocess.run(
+            ["sh", str(INSTALL_SCRIPT), *args],
+            cwd=REPO_ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+        return result, install_dir
+
+    def test_components_option_installs_all_with_gnu_migrate_fallback(self) -> None:
+        result, install_dir = self._run_installer("--components", "all")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            sorted(path.name for path in install_dir.iterdir()),
+            ["citum", "citum-migrate", "citum-server"],
+        )
+        self.assertIn(self._tarball_name(self.gnu_target), self.curl_log.read_text())
+
+    def test_components_option_overrides_environment_selection(self) -> None:
+        result, install_dir = self._run_installer(
+            "--components=citum-server", components="citum"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual([path.name for path in install_dir.iterdir()], ["citum-server"])
+
+    def test_environment_component_selection_remains_supported(self) -> None:
+        result, install_dir = self._run_installer(components="citum,citum-migrate")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            sorted(path.name for path in install_dir.iterdir()),
+            ["citum", "citum-migrate"],
+        )
+
+    def test_malformed_options_fail_without_downloading(self) -> None:
+        for args, message in (
+            (("--components",), "--components requires a value"),
+            (("--unknown",), "unknown option: --unknown"),
+        ):
+            with self.subTest(args=args):
+                result, _ = self._run_installer(*args)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(message, result.stderr)
+                self.assertFalse(self.curl_log.exists())
+
+    def test_help_explains_cli_component_selection_without_downloading(self) -> None:
+        result, _ = self._run_installer("--help")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--components <list>", result.stdout)
+        self.assertIn("sh -s -- --components all", result.stdout)
+        self.assertFalse(self.curl_log.exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add `--components <list>` and `--components=<list>` to the POSIX installer
- retain `CITUM_COMPONENTS` for automation, with command-line selection taking precedence
- document copy-pasteable all-components installation and test the Linux GNU fallback without network access

## Root cause

The earlier missing `citum-migrate` warning came from the stale `v0.74.0` latest-release asset. `v0.75.0` now resolves correctly and its GNU fallback works; this PR improves the normal component-selection UX for future releases.

## Validation

- `python3 scripts/test_release_workflow.py` (22 tests)
- `sh -n scripts/install.sh`
- `shellcheck -S warning scripts/install.sh`
- `git diff --check`

## Rollout

The immutable `v0.75.0` release asset remains unchanged. The new option ships in the next normal patch release.
