### PR TITLE
feat(schema): preserve GB/T monograph metadata

### DIFF
--- a/.beans/csl26-ra71--gbt-numeric-wave-3-remaining-structural-gaps-after.md
+++ b/.beans/csl26-ra71--gbt-numeric-wave-3-remaining-structural-gaps-after.md
@@ -1,7 +1,7 @@
 ---
 # csl26-ra71
 title: 'GB/T numeric wave-3: remaining structural gaps after zmod+49sj'
-status: todo
+status: in-progress
 type: task
 priority: normal
 tags:
@@ -10,7 +10,7 @@ tags:
     - multilingual
     - dates
 created_at: 2026-07-17T10:22:18Z
-updated_at: 2026-07-17T11:01:24Z
+updated_at: 2026-07-17T12:13:48Z
 ---
 
 Remaining ~9 genuine gaps in gb-t-7714-2025-numeric after csl26-zmod (structural long tail) and csl26-49sj (conditional number labels) both landed, bringing the upstream corpus to 190/203. Not counting the 4 ordinal-form entries (tracked separately, see csl26-g49a).
@@ -31,3 +31,10 @@ All style fixes below go in the shared hidden base, `crates/citum-schema-style/e
 6. **CSTR tail dedupe, not a suppression bug — a divergence candidate** (gbt7714.8.14.3:1). Raw fixture: `note: "tex.cstr: 16666.11.nbsdc.tfpbwtqf"` (Zotero's alias spelling) plus a `URL` that happens to contain the same string as part of its path. Citum's csl-legacy parser correctly normalizes `tex.cstr` → canonical `CSTR` (per its own documented design) and the style's `identifier: cstr` component renders it — this is *correct* per Citum's data model. The CSL-M source's own macro (`<if variable="CSTR">...<else>...DOI...</else></if>`) only recognizes the literal `CSTR` variable, not the Zotero `tex.cstr` alias, so citeproc-js's oracle rendering never sees a CSTR value and renders no tail at all. This is a real citeproc-vs-citum divergence (citum arguably more correct), not "citum over-rendering" as previously framed — a registered-divergence candidate for `scripts/report-data/verification-policy.yaml`, not a style fix.
 
 7. **Preprint version prefix** (gbt7714.8.15.2:3, `type: article` with a `version` field). Oracle wants `V2.` rendered before the `arXiv（date）` segment; citum drops it. The `article,dataset,preprint:` variant in base.yaml needs a `variable: version` (or `number: version`) component with a `V` prefix and `.` suffix, positioned before the creation-date group. Check the existing `variable: version, strip-periods: true` component already used elsewhere in base.yaml (flat default template, ~line 152) for the right shape to copy.
+
+
+## Wave A — monograph metadata fidelity
+
+- [ ] Preserve monograph `volume-title`, map scale/dimensions, and preprint version through conversion and rendering.
+- [ ] Tune shared GB/T base templates for container volumes, volume titles, map metadata, and preprint versions.
+- [x] Regenerate schemas and verify the GB/T fidelity, quality, and Rust gates.

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -2937,6 +2937,52 @@ fn test_report_number_variable_uses_report_number_accessor() {
 }
 
 #[test]
+fn monograph_metadata_variables_render_their_accessors() {
+    let config = make_config();
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: Arc::new(config),
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+        abbreviation_map: None,
+    };
+    let hints = ProcHints::default();
+    let reference = InputReference::Monograph(Box::new(Monograph {
+        r#type: MonographType::Document,
+        genre: Some("map".to_string()),
+        volume_title: Some("History of Science".to_string()),
+        scale: Some("1:25000".to_string()),
+        version: Some("2".to_string()),
+        ..Default::default()
+    }));
+
+    for (variable, expected) in [
+        (SimpleVariable::VolumeTitle, "History of Science"),
+        (SimpleVariable::Scale, "1:25000"),
+        (SimpleVariable::Version, "2"),
+    ] {
+        let component = TemplateVariable {
+            variable,
+            ..Default::default()
+        };
+        assert_eq!(
+            component
+                .values::<PlainText>(&reference, &hints, &options)
+                .expect("monograph metadata should render")
+                .value,
+            expected
+        );
+    }
+}
+
+#[test]
 fn test_number_variable_excludes_report_number_accessor() {
     let config = make_config();
     let locale = make_locale();

--- a/crates/citum-engine/src/values/variable.rs
+++ b/crates/citum-engine/src/values/variable.rs
@@ -265,6 +265,7 @@ fn resolve_variable_value(
         SimpleVariable::EventPlace => event_place(reference),
         SimpleVariable::Dimensions => dimensions(reference),
         SimpleVariable::References => references(reference),
+        SimpleVariable::Scale => reference.scale(),
         // A genre that merely restates the reference's own type (e.g. an
         // entry-encyclopedia carrying genre "entry-encyclopedia") is the data
         // model's internal type-carrier, round-tripped through `ref_type()` for
@@ -317,6 +318,7 @@ fn resolve_variable_value(
         SimpleVariable::AdsBibcode => reference.ads_bibcode(),
         SimpleVariable::ReportNumber => reference.report_number(),
         SimpleVariable::Version => reference.version(),
+        SimpleVariable::VolumeTitle => reference.volume_title(),
         SimpleVariable::ContainerTitleShort => container_title_short(reference),
         SimpleVariable::Locator => options.locator_raw.map(|loc| {
             // When no explicit locators config is set, derive a default from the

--- a/crates/citum-schema-data/src/reference/accessors.rs
+++ b/crates/citum-schema-data/src/reference/accessors.rs
@@ -534,6 +534,14 @@ impl InputReference {
         }
     }
 
+    /// Return the title of an individual volume.
+    pub fn volume_title(&self) -> Option<String> {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.volume_title.clone(),
+            _ => None,
+        }
+    }
+
     fn non_empty_date(date: EdtfString) -> Option<EdtfString> {
         if date.is_empty() { None } else { Some(date) }
     }
@@ -1025,8 +1033,17 @@ impl InputReference {
     /// Return the version.
     pub fn version(&self) -> Option<String> {
         match &self.extension {
+            ClassExtension::Monograph(r) => r.version.clone(),
             ClassExtension::Dataset(r) => r.version.clone(),
             ClassExtension::Software(r) => r.version.clone(),
+            _ => None,
+        }
+    }
+
+    /// Return the cartographic scale.
+    pub fn scale(&self) -> Option<String> {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.scale.clone(),
             _ => None,
         }
     }
@@ -1122,6 +1139,14 @@ impl InputReference {
                 .volume
                 .clone()
                 .or_else(|| self.find_numbering(NumberingType::Volume))
+                .or_else(|| {
+                    r.container.as_ref().and_then(|container| match container {
+                        WorkRelation::Embedded(parent) => {
+                            parent.volume().map(|volume| volume.to_string())
+                        }
+                        WorkRelation::Id(_) => None,
+                    })
+                })
                 .map(NumOrStr::Str),
             ClassExtension::SerialComponent(r) => r
                 .volume

--- a/crates/citum-schema-data/src/reference/conversion/contract_tests.rs
+++ b/crates/citum-schema-data/src/reference/conversion/contract_tests.rs
@@ -21,6 +21,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 use super::*;
 use csl_legacy::csl_json::CSL_TYPES;
+use serde_json::json;
 
 /// Build the minimal legacy reference the contract test converts for a
 /// given CSL type: an id, the type under test, a title, and an issued
@@ -205,4 +206,53 @@ fn manuscript_with_recognized_collection_note_override_converts_to_collection() 
         Some("University of Georgia Library"),
         "archival fields must survive the collection conversion"
     );
+}
+
+#[test]
+fn book_volume_title_note_field_survives_as_monograph_metadata() {
+    let mut legacy = minimal_reference("book");
+    legacy.note = Some("volume-title: History of Science".to_string());
+    legacy.parse_note_field_hacks();
+
+    let converted = InputReference::from(legacy);
+    let crate::reference::ClassExtension::Monograph(monograph) = converted.extension() else {
+        panic!("book must convert to a Monograph");
+    };
+
+    assert_eq!(
+        monograph.volume_title.as_deref(),
+        Some("History of Science")
+    );
+    assert!(monograph.container.is_none());
+}
+
+#[test]
+fn map_scale_and_dimensions_survive_as_monograph_metadata() {
+    let mut legacy = minimal_reference("map");
+    legacy.note = Some("dimensions: 128cm×84cm".to_string());
+    legacy.extra.insert("scale".to_string(), json!("1:25000"));
+    legacy.parse_note_field_hacks();
+
+    let converted = InputReference::from(legacy);
+    let crate::reference::ClassExtension::Monograph(monograph) = converted.extension() else {
+        panic!("map must convert to a Monograph");
+    };
+
+    assert_eq!(monograph.scale.as_deref(), Some("1:25000"));
+    assert_eq!(monograph.size.as_deref(), Some("128cm×84cm"));
+}
+
+#[test]
+fn standalone_article_version_note_field_survives_on_preprint() {
+    let mut legacy = minimal_reference("article");
+    legacy.note = Some("version: 2".to_string());
+    legacy.parse_note_field_hacks();
+
+    let converted = InputReference::from(legacy);
+    assert_eq!(converted.ref_type(), "preprint");
+    let crate::reference::ClassExtension::Monograph(monograph) = converted.extension() else {
+        panic!("standalone article must convert to a preprint Monograph");
+    };
+
+    assert_eq!(monograph.version.as_deref(), Some("2"));
 }

--- a/crates/citum-schema-data/src/reference/conversion/scholarly.rs
+++ b/crates/citum-schema-data/src/reference/conversion/scholarly.rs
@@ -197,12 +197,11 @@ pub(super) fn from_monograph_ref(
         part_title.or(ctx.title)
     };
 
-    // Batch 1: volume-title enriches container; part-number adds a Part numbering entry.
+    // Batch 1: part-number adds a Part numbering entry.
     let container = {
         let base_title = legacy.container_title.clone().map(Title::Single);
-        let effective_title = volume_title.map(Title::Single).or(base_title);
         let collection = relation_collection_title(collection_title);
-        if let Some(t) = effective_title {
+        if let Some(t) = base_title {
             Some(WorkRelation::Embedded(Box::new(InputReference::Monograph(
                 Box::new(Monograph {
                     title: Some(t),
@@ -301,6 +300,7 @@ pub(super) fn from_monograph_ref(
         r#type,
         title: build_title(title, ctx.short_title.clone()),
         short_title: None,
+        volume_title,
         container,
         author,
         editor,
@@ -318,6 +318,7 @@ pub(super) fn from_monograph_ref(
         isbn: ctx.isbn,
         doi: ctx.doi,
         ads_bibcode: None,
+        version: None,
         volume,
         issue: None,
         edition,
@@ -874,8 +875,10 @@ pub(super) fn from_document_ref(
     };
     let original = legacy_original_relation(&legacy);
 
-    let volume = legacy.volume.map(|v| v.to_string());
+    let volume = legacy.volume.as_ref().map(ToString::to_string);
     let number = legacy.number.clone();
+    let scale = legacy_extra_str(&legacy, "scale");
+    let dimensions = legacy_extra_str(&legacy, "dimensions");
     // Seed genre from ref_type for CSL types whose round trip through
     // `ref_type()` depends on genre (see `monograph_ref_type`'s Document
     // arm in accessors.rs); never overwrites a user-supplied genre.
@@ -932,6 +935,8 @@ pub(super) fn from_document_ref(
         isbn: ctx.isbn,
         doi: ctx.doi,
         ads_bibcode: None,
+        scale,
+        size: dimensions,
         volume,
         number,
         genre,
@@ -989,6 +994,7 @@ pub(super) fn from_preprint_ref(
             }]
         })
         .unwrap_or_default();
+    let version = legacy_extra_str(&legacy, "version");
 
     InputReference::Monograph(Box::new(Monograph {
         id: ctx.id,
@@ -1010,6 +1016,7 @@ pub(super) fn from_preprint_ref(
         note: ctx.note.map(RichText::Plain),
         doi: ctx.doi,
         isbn: ctx.isbn,
+        version,
         numbering,
         genre: legacy.genre,
         medium: legacy.medium,

--- a/crates/citum-schema-data/src/reference/types/structural.rs
+++ b/crates/citum-schema-data/src/reference/types/structural.rs
@@ -118,6 +118,9 @@ pub struct Monograph {
     /// Optional short form of the title for style-directed rendering.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub short_title: Option<String>,
+    /// Title of an individual volume within the monographic work.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volume_title: Option<String>,
     /// The primary container for this work (e.g., a multivolume set or series).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container: Option<WorkRelation>,
@@ -172,6 +175,9 @@ pub struct Monograph {
     /// ADS bibcode identifier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ads_bibcode: Option<String>,
+    /// Version or revision identifier for the work.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
     /// Volume number (shorthand for numbering).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub volume: Option<String>,
@@ -271,6 +277,7 @@ struct MonographDeser {
     r#type: MonographType,
     title: Option<Title>,
     short_title: Option<String>,
+    volume_title: Option<String>,
     container: Option<WorkRelation>,
     author: Option<Contributor>,
     editor: Option<Contributor>,
@@ -298,6 +305,7 @@ struct MonographDeser {
     #[serde(alias = "DOI")]
     doi: Option<String>,
     ads_bibcode: Option<String>,
+    version: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     volume: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -346,6 +354,7 @@ impl From<MonographDeser> for Monograph {
             r#type: raw.r#type,
             title: raw.title,
             short_title: raw.short_title,
+            volume_title: raw.volume_title,
             container: raw.container,
             author: views.author,
             editor: views.editor,
@@ -363,6 +372,7 @@ impl From<MonographDeser> for Monograph {
             isbn: raw.isbn,
             doi: raw.doi,
             ads_bibcode: raw.ads_bibcode,
+            version: raw.version,
             volume: raw.volume,
             issue: raw.issue,
             edition: raw.edition,

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-base.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-base.yaml
@@ -535,7 +535,11 @@ bibliography:
       sort-separator: ' '
       strip-periods: true
       suffix: '. '
-    - title: container-title
+    - group:
+      - title: container-title
+      - number: volume
+        when-numeric: short
+      delimiter: ：
       suffix: '. '
     - group:
       - number: edition
@@ -646,9 +650,14 @@ bibliography:
       suffix: '. '
     - group:
       - title: primary
-      - number: volume
-        when-numeric: short
+      - group:
+        - number: volume
+          when-numeric: short
+        - variable: volume-title
+        delimiter: ' '
       delimiter: ：
+    - variable: scale
+      prefix: '. '
     - message: gb-t-7714-type-code
       args:
         type: { reference-type: key }
@@ -693,6 +702,8 @@ bibliography:
         - number: pages
         delimiter: ：
       delimiter: '. '
+    - variable: dimensions
+      prefix: '. '
     - variable: url
       prefix: '. '
     - identifier: cstr

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -1501,6 +1501,7 @@ pub enum SimpleVariable {
     References,
     Scale,
     Version,
+    VolumeTitle,
     Locator,
     ContainerTitleShort,
     Authority,

--- a/crates/csl-legacy/src/csl_json.rs
+++ b/crates/csl-legacy/src/csl_json.rs
@@ -939,6 +939,7 @@ fn is_string_variable(key: &str) -> bool {
             | "genre"
             | "medium"
             | "dimensions"
+            | "version"
             | "section"
             | "volume"
             | "issue"
@@ -1085,7 +1086,7 @@ fn handle_string_variable(ref_obj: &mut Reference, key: &str, value: &str) {
         | "archive-collection" | "archive_collection" | "dimensions" | "part-number"
         | "supplement-number" | "references" | "source" | "status" | "reviewed-title"
         | "reviewed-genre" | "call-number" | "jurisdiction" | "citation-number"
-        | "citation-label" | "annote" | "keyword" | "title-short" => {
+        | "citation-label" | "annote" | "keyword" | "title-short" | "version" => {
             let key_to_store = match key {
                 "archive_collection" => "archive-collection",
                 "event-location" => "event-place",

--- a/docs/schemas/bib.json
+++ b/docs/schemas/bib.json
@@ -110,6 +110,12 @@
                 "null"
               ]
             },
+            "volume-title": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "container": {
               "anyOf": [
                 {
@@ -240,6 +246,12 @@
               ]
             },
             "ads-bibcode": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "version": {
               "type": [
                 "string",
                 "null"

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -2474,6 +2474,7 @@
         "references",
         "scale",
         "version",
+        "volume-title",
         "locator",
         "container-title-short",
         "authority",

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -2151,6 +2151,7 @@
         "references",
         "scale",
         "version",
+        "volume-title",
         "locator",
         "container-title-short",
         "authority",


### PR DESCRIPTION
## Summary

- Preserve CSL-M `volume-title`, map scale/dimensions, and preprint `version` through Citum conversion and rendering.
- Extend monograph metadata and template variables so the shared GB/T 7714 base renders those fields without overloading `container-title`.
- Add conversion-contract and variable-rendering regressions; update the Wave A checklist in `csl26-ra71`.

## Fidelity

- GB/T numeric: 21/21 citations; 239/250 bibliography entries (0.959 fidelity, up from 234/250).
- The remaining mismatch for `gbt7714.8.3.2:2` has its container-volume fixed; its unrelated extra-editor divergence remains outside this slice.

## Validation

- `just schema-gen`
- `just pre-commit` (2,044 tests)
- `just check-core-quality`
- `node scripts/report-core.js --style gb-t-7714-2025-numeric`
- Bean hygiene and changed-Rust review
