### PR TITLE
fix(gb-t): model copyright/printing/estimated dates natively

### DIFF
--- a/.beans/archive/csl26-5nl2--fix-gbt-c1988-misinterpretation-add-native-copyrig.md
+++ b/.beans/archive/csl26-5nl2--fix-gbt-c1988-misinterpretation-add-native-copyrig.md
@@ -1,0 +1,74 @@
+---
+# csl26-5nl2
+title: 'Fix GB/T c1988 misinterpretation: add native copyright/printing dates'
+status: completed
+type: bug
+priority: high
+tags:
+    - style
+    - fidelity
+    - multilingual
+    - dates
+    - migrate
+created_at: 2026-07-18T10:41:08Z
+updated_at: 2026-07-18T11:52:56Z
+parent: csl26-8uxa
+---
+
+PR #1064 modeled GB/T 7714 c1988 as EDTF circa/approximate, but the c means copyright, not circa (reviewer comment on PR #1064). Revert the circa hack, add native copyright and printing date variables, fix estimated-date bracket rendering, revert range-bracket wrapping, and revisit the div-009 tex.cstr divergence.
+
+## Checklist
+
+- [x] Commit 1: revert circa misinterpretation (`normalize_csl_circa_literal`, contract test, GB/T approximation-marker)
+- [x] Commit 2: revert range bracket wrapping (`format_closed_range`, `range_end_prefix/suffix`, GB/T YAMLs); keep note-field range parsing
+- [x] Commit 3: native `copyright` date variable (enum, resolver, accessor, migration, GB/T fallback chain)
+- [x] Commit 4: estimated-date brackets (`approximation_marker_suffix`) + native `printing` date variable
+- [x] Commit 5: revisit `div-009` tex.cstr divergence (documented reviewer's §7.9.1/§7.9.2 alternate reading in verification-policy.yaml; omission fix split to follow-up bean csl26-ia43, blocked on reviewer confirmation)
+- [x] Update `docs/specs/DATE_MODEL.md` with copyright/printing date variables and the §7.5.4.3 four-case mapping
+- [x] `just schema-gen` if citum-schema* changed
+- [x] `just pre-commit` green
+- [x] GB/T oracle confirms all four fixtures render correctly (copyright/printing/estimated/range), with documented pending-reviewer divergence for 3 of 4 vs the pinned oracle
+- [x] Push branch, `gh pr checks --watch` green (do not merge)
+
+## Oracle divergence note (pending reviewer sign-off)
+
+The pinned CSL-M oracle (`tests/fixtures/csl-m/gb-t-7714-2025-numeric.csl` +
+`tests/fixtures/test-items-library/gb-t-7714-2025.json`) does NOT match the
+GB/T 7714 §7.5.4.3 standard-conformant rendering the reviewer described for
+three of the four cases:
+
+- Copyright (`c1988`): oracle wants `c1988` — matches; Commit 3 fixes this correctly.
+- Printing (`1995印刷`): oracle currently matches plain `1995` (no 印刷 suffix).
+- Estimated (`1936~` → `[1936]`): oracle currently matches plain `1936` (no brackets).
+- Range (`1957/1990`): oracle wants the bracketed `1957—[1990]`, not the
+  reviewer-suspected first-run artifact `1957—1990`.
+
+Per Bruce (2026-07-18): defer to the reviewer over the pinned oracle here —
+CSL has no native concept for these GB/T substitute-year forms, so some
+hackery is expected either way. Proceeding to implement printing suffix +
+estimated brackets per the reviewer's described standard behavior, and kept
+the range-bracket revert (Commit 2) as-is. This means the branch will show a
+raw fidelity regression against `gb-t-7714-2025-numeric.csl` for rows
+2/3/4 vs `main` — expected and to be called out explicitly in the PR
+description for reviewer confirmation before merge.
+
+## Summary of Changes
+
+Reverted the c1988 circa misread from PR #1064 (commit d56ac1a1) and its
+paired range-bracket wrapping. Added native `copyright` and `printing`
+date variables end to end (schema enum, engine resolution, Monograph
+fields, migration routing) and estimated-date bracket rendering via a new
+`approximation-marker-suffix` style option. All 6 commits pass
+`just pre-commit` (2054 tests). Rebuilt commit history once after the
+pre-push hook rejected `gb-t`/`specs` as invalid conventional-commit
+scopes (not in the allowed list) — corrected to `schema`/`spec`/`migrate`.
+
+Known, deliberate divergence from the pinned `gb-t-7714-2025-numeric.csl`
+oracle for 3 of 4 target cases (printing suffix, estimated brackets, range
+un-bracketing) — documented in the PR description and this bean for
+reviewer confirmation before merge, per Bruce's explicit direction to
+defer to the reviewer over the pinned oracle here.
+
+Deferred: URL-containment-based CSTR identifier omission (div-009,
+§7.9.1/§7.9.2) — split to draft bean csl26-ia43, blocked on reviewer
+confirmation of the interpretation.

--- a/.beans/csl26-0kqf--support-gbt-7714-7541-regnalera-year-annotations.md
+++ b/.beans/csl26-0kqf--support-gbt-7714-7541-regnalera-year-annotations.md
@@ -1,0 +1,24 @@
+---
+# csl26-0kqf
+title: Support GB/T 7714 §7.5.4.1 regnal/era-year annotations
+status: draft
+type: feature
+priority: normal
+tags:
+    - multilingual
+    - migrate
+    - style
+    - dates
+created_at: 2026-07-18T14:15:31Z
+updated_at: 2026-07-18T14:15:55Z
+---
+
+GB/T 7714—2025 §7.5.4.1 requires historical citations to show the Gregorian year annotated with the original calendar's year in parens, e.g. 1705（康熙四十四年） (Kangxi reign year 44) or 1947（民国三十六年） (Minguo year 36). Raised by reviewer @YDX-2147483647 on PR #1067 as more common than the copyright/printing/estimated cases fixed there. Existing EraLabels/EDTF-historical-era support (docs/specs/EDTF_HISTORICAL_ERA_RENDERING.md, EDTF_ERA_LABEL_PROFILES.md) is a fixed BC/AD/BCE/CE suffix on negative years only and does not cover this — it is a genuinely different, larger feature requiring calendar-conversion lookup tables.
+
+## Scope notes
+
+- **Minguo (Republic-era) case** — cheap: `year_name = Gregorian - 1911`, no lookup table. Could be a low-cost first slice if ever prioritized.
+- **Imperial reign-era case** (e.g. 康熙/Kangxi) — expensive: needs a dynasty/era-name → Gregorian-span lookup table (irregular per-emperor/per-era boundaries, not a formula), Han-numeral ordinal-year formatting, and a new parenthetical dual-year render shape (`format_display_year` in `crates/citum-engine/src/values/date.rs` currently only appends a single trailing suffix string, not a bracketed secondary annotation).
+- Needs a data-model decision too: where does the original-calendar year come from on input? Not present in current `InputReference`/EDTF model at all.
+- Reference: https://en.wikipedia.org/wiki/Regnal_year#Sinosphere_era_names
+- Not attempted in PR #1067 — see `docs/reference/GBT_7714_CITATION_CONVENTIONS.md`.

--- a/.beans/csl26-1j3v--rebase-pr-1067-and-address-reviewers-new-gbt-date.md
+++ b/.beans/csl26-1j3v--rebase-pr-1067-and-address-reviewers-new-gbt-date.md
@@ -1,0 +1,31 @@
+---
+# csl26-1j3v
+title: 'Rebase PR #1067 and address reviewer''s new GB/T date feedback'
+status: in-progress
+type: task
+priority: high
+tags:
+    - style
+    - fidelity
+    - multilingual
+    - dates
+    - migrate
+created_at: 2026-07-18T13:20:11Z
+updated_at: 2026-07-18T14:16:43Z
+parent: csl26-8uxa
+---
+
+PR #1067 needs rebase onto main (unrelated CJK-punctuation work landed). Reviewer confirmed the divergence table and raised two new GB/T 7714 date cases: ancient/regnal years (§7.5.4.1) and sequel/serial-continuation citations (§8.5.1.3). Rebase, document the sequel convention, and file follow-up beans for both new cases.
+
+## Checklist
+
+- [x] Rebase `fix/gb-t-copyright-date` onto `origin/main`, resolve the single `verification-policy.yaml` conflict (div-009/div-010 adjacency)
+- [x] Regenerate `docs/schemas/style.json` via `just schema-gen` (no diff vs rebase auto-merge)
+- [x] `just pre-commit` green post-rebase (2058 tests)
+- [x] Oracle spot-check unchanged for the four target fixtures (copyright matches; printing/estimated/range diverge as intended, no new regressions vs main baseline of 146/203)
+- [x] Confirm with user, then force-push-with-lease
+- [ ] `gh pr checks 1067 --watch` green again
+- [x] Document the §8.5.1.3 sequel convention (zero code) — docs/reference/GBT_7714_CITATION_CONVENTIONS.md
+- [x] File ancient/regnal-years bean (§7.5.4.1) — csl26-0kqf
+- [x] File sequel-extension-options bean (§8.5.1.3) — csl26-to3s
+- [ ] Confirm reply wording with user, post PR comment (do not merge)

--- a/.beans/csl26-ia43--implement-url-containment-omission-for-gbt-cstr-id.md
+++ b/.beans/csl26-ia43--implement-url-containment-omission-for-gbt-cstr-id.md
@@ -1,0 +1,16 @@
+---
+# csl26-ia43
+title: Implement URL-containment omission for GB/T CSTR identifier tail
+status: draft
+type: task
+priority: normal
+tags:
+    - style
+    - migrate
+    - fidelity
+created_at: 2026-07-18T11:41:22Z
+updated_at: 2026-07-18T11:41:30Z
+parent: csl26-8uxa
+---
+
+GB/T 7714 §7.9.1/§7.9.2 may require omitting the identifier: cstr rendering tail when the reference URL already contains the same identifier, regardless of the tex.cstr/CSTR alias question that div-009 currently documents. Raised by reviewer @YDX-2147483647 on PR #1064. Blocked on reviewer confirmation of the interpretation before implementing.

--- a/.beans/csl26-to3s--consider-extending-workrelation-for-gbt-8513-seque.md
+++ b/.beans/csl26-to3s--consider-extending-workrelation-for-gbt-8513-seque.md
@@ -1,0 +1,47 @@
+---
+# csl26-to3s
+title: Consider extending WorkRelation for GB/T §8.5.1.3 sequel citations
+status: draft
+type: task
+priority: low
+tags:
+    - style
+    - migrate
+created_at: 2026-07-18T14:16:03Z
+updated_at: 2026-07-18T14:16:15Z
+parent: csl26-8uxa
+---
+
+GB/T 7714—2025 §8.5.1.3 sequel citations (serially-published parts appended after the first) are currently handled by a documented convention only (cram into SerialComponent.pages, see docs/reference/GBT_7714_CITATION_CONVENTIONS.md) per reviewer @YDX-2147483647's explicit recommendation not to overfit this rare case on PR #1067. This bean captures the extension options if demand for structured rendering ever appears.
+
+## Options
+
+**Option 1 (current, zero code):** document the convention using existing
+`SerialComponent.pages`/`note` fields, matching what gbt7714-bibtex-style
+and biblatex-gb7714-2025 already do. See
+`docs/reference/GBT_7714_CITATION_CONVENTIONS.md`. Opaque text — no
+per-part sorting/localization/delimiter styling.
+
+**Option 2 (middle ground, ~5-7 files):** add `sequels: Vec<WorkRelation>`
+on `SerialComponent`, reusing the existing `original`/embedded-relation
+pattern (an accessor that walks embedded parts pulling
+`issued`/`volume`/`issue`/`pages`, a value resolver, a template variable
+joining with `; `). Matches the `original`/`container` idiom Citum already
+uses for related-work fields
+(`crates/citum-schema-data/src/reference/accessors.rs` `original_embedded`,
+`original_date`, `original_title` etc.). No new relation variant or public
+type.
+
+**Option 3 (most complete, ~8-12 files):** a dedicated
+`SequelPart { year, volume, issue, pages }` struct in
+`crates/citum-schema-data/src/reference/types/common.rs` alongside
+`Numbering`, with its own accessor, value resolver, template variable,
+JSON-schema/specta derives, and conversion support. Structured/sortable/
+localizable, but the most net-new schema surface for a case the reviewer
+called "quite rare."
+
+**Recommendation if ever revisited:** Option 2 is the closest fit to
+Citum's existing idiom, but Option 1 already reaches parity with the
+reference LaTeX implementations at zero cost — only pursue Option 2/3 if
+concrete demand (a real corpus item needing structured rendering)
+materializes.

--- a/crates/citum-engine/src/render/component.rs
+++ b/crates/citum-engine/src/render/component.rs
@@ -89,6 +89,8 @@ fn resolve_semantic_class(component: &ProcTemplateComponent) -> Option<String> {
                 DateVariable::OriginalPublished => "original-published",
                 DateVariable::Submitted => "submitted",
                 DateVariable::EventDate => "event-date",
+                DateVariable::Copyright => "copyright",
+                DateVariable::Printing => "printing",
             }
         )),
         TemplateComponent::Number(n) => Some(format!("citum-{}", n.number.as_key())),

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -349,15 +349,7 @@ fn format_closed_range(
     );
 
     match (start, end) {
-        (Some(s), Some(e)) => {
-            let prefix = date_config
-                .and_then(|config| config.range_end_prefix.as_deref())
-                .unwrap_or("");
-            let suffix = date_config
-                .and_then(|config| config.range_end_suffix.as_deref())
-                .unwrap_or("");
-            Some(format!("{s}{delimiter}{prefix}{e}{suffix}"))
-        }
+        (Some(s), Some(e)) => Some(format!("{s}{delimiter}{e}")),
         (Some(s), None) => Some(s),
         (None, Some(e)) => Some(e),
         (None, None) => None,
@@ -405,7 +397,10 @@ fn apply_date_markers(
     if date.is_approximate()
         && let Some(marker) = date_config.and_then(|c| c.approximation_marker.as_ref())
     {
-        result = format!("{marker}{result}");
+        let suffix = date_config
+            .and_then(|c| c.approximation_marker_suffix.as_deref())
+            .unwrap_or("");
+        result = format!("{marker}{result}{suffix}");
     }
     if date.is_uncertain()
         && let Some(marker) = date_config.and_then(|c| c.uncertainty_marker.as_ref())
@@ -742,6 +737,8 @@ impl ComponentValues for TemplateDate {
             TemplateDateVar::Accessed => reference.accessed(),
             TemplateDateVar::OriginalPublished => reference.original_date(),
             TemplateDateVar::EventDate => event_date(reference),
+            TemplateDateVar::Copyright => reference.copyright(),
+            TemplateDateVar::Printing => reference.printing(),
             _ => None,
         };
 

--- a/crates/citum-schema-data/src/reference/accessors.rs
+++ b/crates/citum-schema-data/src/reference/accessors.rs
@@ -625,6 +625,24 @@ impl InputReference {
         self.issued().or_else(|| self.created())
     }
 
+    /// Return the copyright year, a publication-year substitute used when
+    /// the true issue date is unknown (GB/T 7714 §7.5.4.3's `c1988`).
+    pub fn copyright(&self) -> Option<EdtfString> {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.copyright.clone().and_then(Self::non_empty_date),
+            _ => None,
+        }
+    }
+
+    /// Return the printing/impression year, another publication-year
+    /// substitute (GB/T 7714 §7.5.4.3's `1995印刷`).
+    pub fn printing(&self) -> Option<EdtfString> {
+        match &self.extension {
+            ClassExtension::Monograph(r) => r.printing.clone().and_then(Self::non_empty_date),
+            _ => None,
+        }
+    }
+
     /// Return the DOI.
     pub fn doi(&self) -> Option<String> {
         match &self.extension {

--- a/crates/citum-schema-data/src/reference/conversion/contract_tests.rs
+++ b/crates/citum-schema-data/src/reference/conversion/contract_tests.rs
@@ -24,12 +24,11 @@ use csl_legacy::csl_json::CSL_TYPES;
 use serde_json::json;
 
 #[test]
-fn circa_csl_dates_convert_to_approximate_edtf() {
-    let literal: EdtfString = csl_legacy::csl_json::DateVariable {
-        literal: Some("c1988".to_string()),
-        ..Default::default()
-    }
-    .into();
+fn structured_circa_csl_dates_convert_to_approximate_edtf() {
+    // A `c1988`-shaped *literal* is CSL's copyright-year convention (GB/T
+    // 7714 §7.5.4.3), not circa — see `copyright_year_from_legacy` and
+    // `docs/specs/DATE_MODEL.md`. Only the structured `circa: true` flag
+    // maps to EDTF approximate (`~`).
     let structured: EdtfString = csl_legacy::csl_json::DateVariable {
         date_parts: Some(vec![vec![1988]]),
         circa: Some(true),
@@ -37,7 +36,6 @@ fn circa_csl_dates_convert_to_approximate_edtf() {
     }
     .into();
 
-    assert_eq!(literal.0, "1988~");
     assert_eq!(structured.0, "1988~");
 }
 

--- a/crates/citum-schema-data/src/reference/conversion/mod.rs
+++ b/crates/citum-schema-data/src/reference/conversion/mod.rs
@@ -465,6 +465,46 @@ struct RefContext {
     edition: Option<String>,
     container_title_short: Option<String>,
     journal_abbreviation: Option<String>,
+    /// Copyright year, a publication-year substitute used when the true
+    /// issue date is unknown. See `copyright_year_from_legacy`.
+    copyright: Option<EdtfString>,
+    /// Printing/impression year, another publication-year substitute. See
+    /// `docs/specs/DATE_MODEL.md`.
+    printing: Option<EdtfString>,
+}
+
+/// Extract a GB/T-style copyright year from a CSL `c<year>` literal issued
+/// date (e.g. `"c1988"`). GB/T 7714 §7.5.4.3 uses this as a
+/// publication-year substitute when the true issue date is unknown; an
+/// earlier revision misread the `c` as EDTF circa (`~`) instead of
+/// copyright — see `docs/specs/DATE_MODEL.md`.
+fn copyright_year_from_legacy(legacy: &csl_legacy::csl_json::Reference) -> Option<EdtfString> {
+    let literal = legacy.issued.as_ref()?.literal.as_deref()?;
+    let year = literal.strip_prefix('c')?.trim();
+    (year.len() == 4 && year.bytes().all(|byte| byte.is_ascii_digit()))
+        .then(|| EdtfString(year.to_string()))
+}
+
+/// Interpret a raw `issued:` note-field override that didn't reduce to a
+/// structured date (see csl-legacy's `issued-note-literal` extra, set when
+/// the override coexists with an already-structured `issued`). GB/T 7714
+/// §7.5.4.3 defines two more publication-year substitutes alongside
+/// copyright: a printing/impression year (Chinese suffix `印刷`) and an
+/// estimated year (EDTF approximate, trailing `~`).
+fn printing_year_from_legacy(legacy: &csl_legacy::csl_json::Reference) -> Option<EdtfString> {
+    let literal = legacy_extra_str(legacy, "issued-note-literal")?;
+    let year = literal.strip_suffix("印刷")?.trim();
+    (year.len() == 4 && year.bytes().all(|byte| byte.is_ascii_digit()))
+        .then(|| EdtfString(year.to_string()))
+}
+
+/// Interpret an estimated-year note-field override (trailing `~`) as an
+/// EDTF approximate `issued` date. See `printing_year_from_legacy`.
+fn estimated_issued_from_legacy(legacy: &csl_legacy::csl_json::Reference) -> Option<EdtfString> {
+    let literal = legacy_extra_str(legacy, "issued-note-literal")?;
+    let year = literal.strip_suffix('~')?.trim();
+    (year.len() == 4 && year.bytes().all(|byte| byte.is_ascii_digit()))
+        .then(|| EdtfString(format!("{year}~")))
 }
 
 fn legacy_type_uses_created(ref_type: &str) -> bool {
@@ -480,9 +520,24 @@ fn legacy_type_uses_created(ref_type: &str) -> bool {
 }
 
 impl From<csl_legacy::csl_json::Reference> for InputReference {
+    #[allow(
+        clippy::too_many_lines,
+        reason = "Legacy CSL mapping requires extensive branching"
+    )]
     fn from(mut legacy: csl_legacy::csl_json::Reference) -> Self {
         legacy.parse_note_field_hacks();
         let cstr = legacy_extra_str(&legacy, "CSTR");
+        // GB/T 7714 §7.5.4.3 publication-year substitutes, used when the
+        // true issue date is unknown. Copyright is a top-level `c<year>`
+        // issued literal; printing and estimated are note-field overrides
+        // that didn't reduce to a structured date (see
+        // `copyright_year_from_legacy` and friends). Copyright and printing
+        // route to their own fields, leaving `issued` empty so a style's
+        // fallback chain renders them; estimated folds into `issued` itself
+        // as an EDTF approximate date.
+        let copyright = copyright_year_from_legacy(&legacy);
+        let printing = printing_year_from_legacy(&legacy);
+        let estimated_issued = estimated_issued_from_legacy(&legacy);
         let ctx = RefContext {
             id: Some(legacy.id.clone().into()),
             title: legacy.title.clone(),
@@ -497,11 +552,17 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
             } else {
                 EdtfString(String::new())
             },
-            issued: legacy
-                .issued
-                .clone()
-                .map(EdtfString::from)
-                .unwrap_or(EdtfString(String::new())),
+            issued: if copyright.is_some() || printing.is_some() {
+                EdtfString(String::new())
+            } else if let Some(estimated) = estimated_issued.clone() {
+                estimated
+            } else {
+                legacy
+                    .issued
+                    .clone()
+                    .map(EdtfString::from)
+                    .unwrap_or(EdtfString(String::new()))
+            },
             url: legacy.url.as_ref().and_then(|u| Url::parse(u).ok()),
             accessed: legacy.accessed.clone().map(EdtfString::from),
             language: legacy.language.clone().map(Into::into),
@@ -511,6 +572,8 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
             edition: legacy.edition.as_ref().map(|e| e.to_string()),
             container_title_short: short_title_from_legacy(&legacy, "container-title-short"),
             journal_abbreviation: short_title_from_legacy(&legacy, "journalAbbreviation"),
+            copyright,
+            printing,
         };
 
         let mut reference = match legacy.ref_type.as_str() {
@@ -601,7 +664,7 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
 impl From<csl_legacy::csl_json::DateVariable> for EdtfString {
     fn from(date: csl_legacy::csl_json::DateVariable) -> Self {
         if let Some(literal) = date.literal {
-            return EdtfString(normalize_csl_circa_literal(&literal).unwrap_or(literal));
+            return EdtfString(literal);
         }
         if let Some(parts) = date.date_parts {
             let mut rendered = parts.iter().map(|part| render_date_part(part));
@@ -616,16 +679,10 @@ impl From<csl_legacy::csl_json::DateVariable> for EdtfString {
             }
         }
         if let Some(raw) = date.raw {
-            return EdtfString(normalize_csl_circa_literal(&raw).unwrap_or(raw));
+            return EdtfString(raw);
         }
         EdtfString(String::new())
     }
-}
-
-/// Convert CSL's common circa spellings into their equivalent EDTF form.
-fn normalize_csl_circa_literal(value: &str) -> Option<String> {
-    let year = value.strip_prefix('c')?.trim();
-    (year.len() == 4 && year.bytes().all(|byte| byte.is_ascii_digit())).then(|| format!("{year}~"))
 }
 
 /// Apply CSL's structured circa flag to an EDTF date that lacks a qualifier.
@@ -810,6 +867,80 @@ mod tests {
         );
         assert_eq!(original_monograph.issued, EdtfString("1925".to_string()));
         assert!(original_monograph.author.is_some());
+    }
+
+    #[test]
+    fn legacy_copyright_year_literal_routes_to_copyright_not_issued() {
+        // GB/T 7714 §7.5.4.3: a `c<year>` issued literal is a copyright
+        // year, a publication-year substitute — not EDTF circa. It must
+        // land on `copyright`, leaving `issued` empty so a style's
+        // issued->copyright fallback chain renders it.
+        let legacy = csl_legacy::csl_json::Reference {
+            id: "book-3".to_string(),
+            ref_type: "book".to_string(),
+            title: Some("A Brief History of Time".to_string()),
+            issued: Some(csl_legacy::csl_json::DateVariable {
+                literal: Some("c1988".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let converted = InputReference::from(legacy);
+
+        let ClassExtension::Monograph(monograph) = converted.extension() else {
+            panic!("expected monograph");
+        };
+        assert_eq!(monograph.copyright, Some(EdtfString("1988".to_string())));
+        assert_eq!(monograph.issued, EdtfString(String::new()));
+    }
+
+    #[test]
+    fn legacy_printing_year_note_override_routes_to_printing_not_issued() {
+        // GB/T 7714 §7.5.4.3: a note-field "issued: <year>印刷" override is
+        // a printing/impression year, another publication-year substitute.
+        // It must land on `printing`, leaving `issued` empty.
+        let legacy = csl_legacy::csl_json::Reference {
+            id: "book-4".to_string(),
+            ref_type: "book".to_string(),
+            title: Some("Printed Book".to_string()),
+            issued: Some(legacy_year(1995)),
+            note: Some("issued: 1995印刷".to_string()),
+            ..Default::default()
+        };
+
+        let converted = InputReference::from(legacy);
+
+        let ClassExtension::Monograph(monograph) = converted.extension() else {
+            panic!("expected monograph");
+        };
+        assert_eq!(monograph.printing, Some(EdtfString("1995".to_string())));
+        assert_eq!(monograph.issued, EdtfString(String::new()));
+    }
+
+    #[test]
+    fn legacy_estimated_year_note_override_folds_into_approximate_issued() {
+        // GB/T 7714 §7.5.4.3: a note-field "issued: <year>~" override is an
+        // estimated year — the same publication date, marked inferred. It
+        // folds into `issued` itself as an EDTF approximate date, not a
+        // separate field.
+        let legacy = csl_legacy::csl_json::Reference {
+            id: "book-5".to_string(),
+            ref_type: "book".to_string(),
+            title: Some("Estimated-Date Book".to_string()),
+            issued: Some(legacy_year(1936)),
+            note: Some("issued: 1936~".to_string()),
+            ..Default::default()
+        };
+
+        let converted = InputReference::from(legacy);
+
+        let ClassExtension::Monograph(monograph) = converted.extension() else {
+            panic!("expected monograph");
+        };
+        assert_eq!(monograph.issued, EdtfString("1936~".to_string()));
+        assert_eq!(monograph.copyright, None);
+        assert_eq!(monograph.printing, None);
     }
 
     #[test]

--- a/crates/citum-schema-data/src/reference/conversion/scholarly.rs
+++ b/crates/citum-schema-data/src/reference/conversion/scholarly.rs
@@ -338,6 +338,8 @@ pub(super) fn from_monograph_ref(
         event,
         status,
         available_date,
+        copyright: ctx.copyright,
+        printing: ctx.printing,
         size,
         duration,
         references,

--- a/crates/citum-schema-data/src/reference/types/structural.rs
+++ b/crates/citum-schema-data/src/reference/types/structural.rs
@@ -240,6 +240,16 @@ pub struct Monograph {
     #[cfg_attr(feature = "bindings", specta(type = Option<String>))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub available_date: Option<EdtfString>,
+    /// Copyright year, a publication-year substitute used when the true
+    /// issue date is unknown (GB/T 7714 §7.5.4.3's `c1988`).
+    #[cfg_attr(feature = "bindings", specta(type = Option<String>))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub copyright: Option<EdtfString>,
+    /// Printing/impression year, another publication-year substitute
+    /// (GB/T 7714 §7.5.4.3's `1995印刷`).
+    #[cfg_attr(feature = "bindings", specta(type = Option<String>))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub printing: Option<EdtfString>,
     /// Physical dimensions or format (e.g., `"24 x 30 cm"`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<String>,
@@ -335,6 +345,10 @@ struct MonographDeser {
     status: Option<String>,
     #[cfg_attr(feature = "bindings", specta(type = Option<String>))]
     available_date: Option<EdtfString>,
+    #[cfg_attr(feature = "bindings", specta(type = Option<String>))]
+    copyright: Option<EdtfString>,
+    #[cfg_attr(feature = "bindings", specta(type = Option<String>))]
+    printing: Option<EdtfString>,
     size: Option<String>,
     duration: Option<String>,
     references: Option<String>,
@@ -392,6 +406,8 @@ impl From<MonographDeser> for Monograph {
             event: raw.event,
             status: raw.status,
             available_date: raw.available_date,
+            copyright: raw.copyright,
+            printing: raw.printing,
             size: raw.size,
             duration: raw.duration,
             references: raw.references,

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-author-date.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-author-date.yaml
@@ -35,10 +35,9 @@ options:
   dates:
     month: numeric
     uncertainty-marker: '?'
-    approximation-marker: c
+    approximation-marker: '['
+    approximation-marker-suffix: ']'
     range-delimiter: —
-    range-end-prefix: '['
-    range-end-suffix: ']'
     no-date-year-suffix-delimiter: '-'
     show-seconds: false
     show-timezone: false

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-base.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-base.yaml
@@ -92,10 +92,9 @@ options:
   dates:
     month: numeric
     uncertainty-marker: '?'
-    approximation-marker: c
+    approximation-marker: '['
+    approximation-marker-suffix: ']'
     range-delimiter: —
-    range-end-prefix: '['
-    range-end-suffix: ']'
     no-date-year-suffix-delimiter: '-'
     show-seconds: false
     show-timezone: false
@@ -831,12 +830,30 @@ bibliography:
           # `book`/`thesis`/`map` route through this imprint position even
           # without a publisher (unlike `software`, which has no matching
           # branch at all and falls to the generic online-resource shape
-          # below instead) — an absent issued date falls back to the
-          # ACCESSED YEAR ONLY here (not a full date), matching the pinned
-          # CSL-M source's shared `date` macro, not `creation-accessed-date`.
+          # below instead) — an absent issued date falls back through GB/T
+          # 7714 §7.5.4.3's publication-year substitutes (copyright, then
+          # printing year), and finally to the ACCESSED YEAR ONLY (not a
+          # full date), matching the pinned CSL-M source's shared `date`
+          # macro, not `creation-accessed-date`.
+          #
+          # KNOWN DIVERGENCE (pending reviewer sign-off, PR discussion): the
+          # printing-year suffix here and the estimated-year bracket wrap
+          # (`approximation-marker`/`-suffix` above) diverge from the
+          # currently pinned CSL-M oracle source, which renders these two
+          # cases as plain years with no substitute-year marker at all. This
+          # implements the GB/T standard's own §7.5.4.3 convention per
+          # reviewer @YDX-2147483647's comment on PR #1064; CSL has no
+          # native concept for these forms, so some divergence from the
+          # pinned source is expected either way.
           - date: issued
             form: year
             fallback:
+            - date: copyright
+              form: year
+              prefix: c
+            - date: printing
+              form: year
+              suffix: 印刷
             - date: accessed
               form: year
               wrap:

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-note.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-note.yaml
@@ -34,10 +34,9 @@ options:
   dates:
     month: numeric
     uncertainty-marker: '?'
-    approximation-marker: c
+    approximation-marker: '['
+    approximation-marker-suffix: ']'
     range-delimiter: —
-    range-end-prefix: '['
-    range-end-suffix: ']'
     no-date-year-suffix-delimiter: '-'
     show-seconds: false
     show-timezone: false

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-numeric.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-numeric.yaml
@@ -34,10 +34,9 @@ options:
   dates:
     month: numeric
     uncertainty-marker: '?'
-    approximation-marker: c
+    approximation-marker: '['
+    approximation-marker-suffix: ']'
     range-delimiter: —
-    range-end-prefix: '['
-    range-end-suffix: ']'
     no-date-year-suffix-delimiter: '-'
     show-seconds: false
     show-timezone: false

--- a/crates/citum-schema-style/src/options/dates.rs
+++ b/crates/citum-schema-style/src/options/dates.rs
@@ -104,15 +104,14 @@ pub struct DateConfig {
     /// Marker for approximate dates (e.g., "ca. " or "~"). None suppresses display.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub approximation_marker: Option<String>,
+    /// Optional closing marker paired with `approximation_marker`, for
+    /// bracket-style approximate-date notation (e.g. GB/T 7714's `[1936]`
+    /// estimated year, where the marker is `[` and this is `]`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approximation_marker_suffix: Option<String>,
     /// Delimiter for date ranges (default: en-dash "–").
     #[serde(default = "default_range_delimiter")]
     pub range_delimiter: String,
-    /// Optional prefix applied to the end of a closed date range.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub range_end_prefix: Option<String>,
-    /// Optional suffix applied to the end of a closed date range.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub range_end_suffix: Option<String>,
     /// Marker for open-ended ranges (e.g., "–present"). None uses locale default.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub open_range_marker: Option<String>,
@@ -168,9 +167,8 @@ impl Default for DateConfig {
             month: MonthFormat::Long,
             uncertainty_marker: Some("?".to_string()),
             approximation_marker: Some("ca. ".to_string()),
+            approximation_marker_suffix: None,
             range_delimiter: default_range_delimiter(),
-            range_end_prefix: None,
-            range_end_suffix: None,
             open_range_marker: None,
             no_date_form: None,
             no_date_year_suffix_delimiter: default_no_date_year_suffix_delimiter(),

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -1014,6 +1014,12 @@ pub enum DateVariable {
     OriginalPublished,
     Submitted,
     EventDate,
+    /// Copyright year, used as a publication-year substitute when the true
+    /// issue date is unknown (e.g. GB/T 7714 §7.5.4.3's `c1988`).
+    Copyright,
+    /// Printing/impression year, another publication-year substitute (e.g.
+    /// GB/T 7714 §7.5.4.3's `1995印刷`).
+    Printing,
 }
 
 crate::str_enum! {

--- a/crates/csl-legacy/src/csl_json.rs
+++ b/crates/csl-legacy/src/csl_json.rs
@@ -747,6 +747,21 @@ fn handle_date_variable(ref_obj: &mut Reference, key: &str, value: &str) {
         "issued" if ref_obj.issued.is_none() || is_date_range(&date) => {
             ref_obj.issued = Some(date);
         }
+        // A raw (unparsed) override coexisting with an already-structured
+        // issued date is a GB/T-style publication-year substitute
+        // annotation layered on top of the structured date CSL already
+        // exports (e.g. a printing year "1995印刷" or an estimated year
+        // "1936~", GB/T 7714 §7.5.4.3). Preserve the raw text so downstream
+        // conversion can interpret the substitute form; the structured
+        // `issued` value is left untouched.
+        "issued" if date.raw.is_some() => {
+            if let Some(raw) = date.raw {
+                ref_obj.extra.insert(
+                    "issued-note-literal".to_string(),
+                    serde_json::Value::String(raw),
+                );
+            }
+        }
         "accessed" if ref_obj.accessed.is_none() => {
             ref_obj.accessed = Some(date);
         }
@@ -1177,6 +1192,32 @@ mod tests {
         assert_eq!(
             ref_obj.issued.and_then(|date| date.date_parts),
             Some(vec![vec![1957], vec![1990]])
+        );
+    }
+
+    #[test]
+    fn note_field_issued_literal_preserved_alongside_structured_date() {
+        // GB/T 7714 §7.5.4.3 publication-year substitute annotations
+        // ("1995印刷" printing year, "1936~" estimated year) don't parse as
+        // structured dates and shouldn't overwrite an already-structured
+        // `issued`; preserve the raw text for downstream interpretation.
+        let mut ref_obj = Reference {
+            id: "printing-year".to_string(),
+            ref_type: "book".to_string(),
+            issued: Some(DateVariable::year(1995)),
+            note: Some("issued: 1995印刷".to_string()),
+            ..Default::default()
+        };
+
+        ref_obj.parse_note_field_hacks();
+
+        assert_eq!(
+            ref_obj.issued.and_then(|date| date.date_parts),
+            Some(vec![vec![1995]])
+        );
+        assert_eq!(
+            ref_obj.extra.get("issued-note-literal"),
+            Some(&serde_json::Value::String("1995印刷".to_string()))
         );
     }
 

--- a/docs/reference/GBT_7714_CITATION_CONVENTIONS.md
+++ b/docs/reference/GBT_7714_CITATION_CONVENTIONS.md
@@ -1,0 +1,68 @@
+# GB/T 7714—2025 Citation Conventions
+
+**Version:** 1.0
+**Date:** 2026-07-18
+**Related:** [DATE_MODEL.md](../specs/DATE_MODEL.md)
+
+Some GB/T 7714—2025 citation forms don't have first-class Citum schema
+support: either a documented convention using existing fields, or a
+tracked gap.
+
+## Sequel citations (§8.5.1.3)
+
+GB/T 7714—2025 allows a work published serially across multiple issues of
+the same journal to append the later parts' `year, volume(issue): pages`
+after the first part instead of citing each part separately:
+
+```
+2011, 33(2): 20-25; 2011, 33(3): 26-30
+```
+
+Citum has no dedicated schema for this — there is no `sequels`/`continued_in`
+relation on `SerialComponent`
+([structural.rs](../../crates/citum-schema-data/src/reference/types/structural.rs)).
+This is deliberate: per reviewer feedback on
+[PR #1067](https://github.com/citum/citum-core/pull/1067#issuecomment-5011352331),
+the case is rare, Zotero users typically import each part separately, and
+the reference LaTeX implementations
+([gbt7714-bibtex-style](https://github.com/zepinglee/gbt7714-bibtex-style/blob/5aaf4c5064db6b876e52a6c4a6a59c3f735f6e60/gbt7714-examples.bib#L967-L970),
+[biblatex-gb7714-2025](https://github.com/hushidong/biblatex-gb7714-2025/blob/7e43909a3ccee6201009983dec8530c6bad8e83b/example2025.bib#L1209))
+don't implement it as structured data either — they cram the extra parts
+into an existing field as a literal string.
+
+**Convention:** append the subsequent parts onto `SerialComponent.pages`
+(`structural.rs:988`), semicolon-delimited, matching the shape GB/T 7714
+itself shows and the reference LaTeX implementations already use:
+
+```yaml
+pages: "20-25; 2011, 33(3): 26-30"
+```
+
+The engine renders this as an opaque string — no per-part sorting,
+localization, or delimiter styling. If structured rendering is ever
+needed, see the extension options recorded in the follow-up bean
+(csl26-to3s, "Consider extending WorkRelation for GB/T §8.5.1.3 sequel
+citations") for the tradeoffs between reusing `WorkRelation::Embedded` and
+adding a dedicated structured type.
+
+## Ancient/regnal years (§7.5.4.1)
+
+GB/T 7714—2025 requires a Gregorian publication year to be annotated with
+the original calendar's year in parentheses when the source uses a
+non-Gregorian calendar, e.g. `1705（康熙四十四年）` (the 44th year of the
+Kangxi reign) or `1947（民国三十六年）` (Minguo year 36). See the reviewer's
+[explanation](https://github.com/citum/citum-core/pull/1067#issuecomment-5011352331)
+and the [Sinosphere era names background](https://en.wikipedia.org/wiki/Regnal_year#Sinosphere_era_names).
+
+This is a genuine gap, not something already covered by Citum's existing
+"ancient date" support. [EDTF_HISTORICAL_ERA_RENDERING.md](../specs/EDTF_HISTORICAL_ERA_RENDERING.md)
+and [EDTF_ERA_LABEL_PROFILES.md](../specs/EDTF_ERA_LABEL_PROFILES.md) cover
+only a fixed BC/AD/BCE/CE suffix on *negative* EDTF years (astronomical→
+historical `1 - year` conversion, implemented in `format_display_year`,
+[date.rs](../../crates/citum-engine/src/values/date.rs)) — explicitly
+scoped to exclude "automatic AD/CE rendering for positive years." Chinese
+regnal-year annotation needs a different, larger capability: era-name/dynasty→
+Gregorian-span lookup tables, ordinal-year formatting, and a new
+parenthetical dual-year render shape. Tracked in a follow-up bean
+(csl26-0kqf, "Support GB/T 7714 §7.5.4.1 regnal/era-year annotations");
+not attempted in PR #1067.

--- a/docs/schemas/bib.json
+++ b/docs/schemas/bib.json
@@ -394,6 +394,26 @@
                 }
               ]
             },
+            "copyright": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "printing": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/EdtfString"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "size": {
               "type": [
                 "string",

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -1715,13 +1715,27 @@
     },
     "DateVariable": {
       "description": "Date variables.",
-      "type": "string",
-      "enum": [
-        "issued",
-        "accessed",
-        "original-published",
-        "submitted",
-        "event-date"
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "issued",
+            "accessed",
+            "original-published",
+            "submitted",
+            "event-date"
+          ]
+        },
+        {
+          "description": "Copyright year, used as a publication-year substitute when the true\nissue date is unknown (e.g. GB/T 7714 §7.5.4.3's `c1988`).",
+          "type": "string",
+          "const": "copyright"
+        },
+        {
+          "description": "Printing/impression year, another publication-year substitute (e.g.\nGB/T 7714 §7.5.4.3's `1995印刷`).",
+          "type": "string",
+          "const": "printing"
+        }
       ]
     },
     "DateForm": {

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -1392,13 +1392,27 @@
     },
     "DateVariable": {
       "description": "Date variables.",
-      "type": "string",
-      "enum": [
-        "issued",
-        "accessed",
-        "original-published",
-        "submitted",
-        "event-date"
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "issued",
+            "accessed",
+            "original-published",
+            "submitted",
+            "event-date"
+          ]
+        },
+        {
+          "description": "Copyright year, used as a publication-year substitute when the true\nissue date is unknown (e.g. GB/T 7714 §7.5.4.3's `c1988`).",
+          "type": "string",
+          "const": "copyright"
+        },
+        {
+          "description": "Printing/impression year, another publication-year substitute (e.g.\nGB/T 7714 §7.5.4.3's `1995印刷`).",
+          "type": "string",
+          "const": "printing"
+        }
       ]
     },
     "DateForm": {
@@ -4945,24 +4959,17 @@
             "null"
           ]
         },
+        "approximation-marker-suffix": {
+          "description": "Optional closing marker paired with `approximation_marker`, for\nbracket-style approximate-date notation (e.g. GB/T 7714's `[1936]`\nestimated year, where the marker is `[` and this is `]`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "range-delimiter": {
           "description": "Delimiter for date ranges (default: en-dash \"–\").",
           "type": "string",
           "default": "–"
-        },
-        "range-end-prefix": {
-          "description": "Optional prefix applied to the end of a closed date range.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "range-end-suffix": {
-          "description": "Optional suffix applied to the end of a closed date range.",
-          "type": [
-            "string",
-            "null"
-          ]
         },
         "open-range-marker": {
           "description": "Marker for open-ended ranges (e.g., \"–present\"). None uses locale default.",

--- a/docs/specs/DATE_MODEL.md
+++ b/docs/specs/DATE_MODEL.md
@@ -24,8 +24,39 @@ In many descriptive standards (including archival standards like DACS), the prim
 - `recorded`: For audio-visual works, oral histories, or performances.
 - `filed`: For patents, legal filings, or bureaucratic records.
 - `revised`: For updated editions or versioned documents.
+- `copyright`: A copyright year, used as a publication-year substitute when
+  the true issue date is unknown (e.g. a CSL `c1988` literal). This is a
+  distinct date event, not an approximate/circa qualifier on `issued`.
+- `printing`: A printing/impression year, another publication-year
+  substitute distinct from `copyright` (e.g. a Chinese-suffixed literal like
+  `1995印刷`).
 
 These role-specific dates supplement `created` and `issued`; they do not replace `created` as the canonical creation date.
+
+### Publication-Year Substitutes (GB/T 7714 §7.5.4.3)
+
+When the true publication year is unknown, GB/T 7714 §7.5.4.3 defines three
+substitute forms, which Citum models two different ways:
+
+| Substitute | Citum model | Example |
+|---|---|---|
+| Copyright year | `copyright` field | `c1988` |
+| Printing/impression year | `printing` field | `1995印刷` |
+| Estimated year | `issued` marked EDTF approximate (`~`) | `1936~` → `[1936]` |
+
+Copyright and printing are distinct *date events* standing in for an
+unknown publication year, so each gets its own field; a style can chain them
+into an `issued` fallback (see `gb-t-7714-2025-base.yaml`). An estimated
+year is the *same* publication date, only marked inferred — it stays on
+`issued` as an EDTF approximate date, and a style renders that qualifier
+however it chooses (GB/T wraps it in brackets via
+`approximation-marker`/`approximation-marker-suffix`).
+
+An earlier revision (PR #1064) misread a copyright-year literal like
+`c1988` as EDTF circa and normalized it to `1988~`, conflating copyright
+with genuine approximation. The two are unrelated: circa marks uncertainty
+about an otherwise-known date, while copyright substitutes an entirely
+different date for an unknown one.
 
 ## Mapping & Downstream Compatibility
 

--- a/scripts/report-data/verification-policy.yaml
+++ b/scripts/report-data/verification-policy.yaml
@@ -44,9 +44,18 @@ divergences:
     tags:
       - normalized-tex-cstr
       - duplicate-url-identifier-tail
+      - pending-reviewer-confirmation
     note: Citum normalizes Zotero's tex.cstr alias to canonical CSTR. When the
       same identifier is already embedded in the URL, citeproc-js omits the
-      canonical tail because it does not recognize the alias.
+      canonical tail because it does not recognize the alias. The pull
+      request review raised GB/T 7714 §7.9.1 and §7.9.2 as a possible
+      alternate reading — when the URL already contains the persistent
+      identifier, the identifier tail can be omitted regardless of the
+      tex.cstr/CSTR alias question, meaning Citum's own rendering, not just
+      citeproc-js's alias gap, might need to omit the tail here. Left
+      registered as-is pending reviewer confirmation; if confirmed,
+      implement URL-containment-based omission in the CSTR identifier
+      component and retire this divergence rather than only documenting it.
   div-010:
     scopes:
       - citation


### PR DESCRIPTION
## Summary

PR #1064 (commit `d56ac1a1`) modeled GB/T 7714's `c1988` publication-year
substitute as EDTF circa (`1988~`), per reviewer comment on that PR — the
`c` in `c1988` marks a **copyright year** (GB/T 7714 §7.5.4.3), not circa.
This PR:

- Reverts the circa misread and its paired closed-range bracket wrapping
  (`YYYY—[YYYY]`), the latter possibly a citeproc-js first-run artifact
  (Juris-M/citeproc-js#280).
- Adds native `copyright` and `printing` date variables end to end (schema
  enum, engine value resolution, `Monograph` fields, migration routing from
  CSL `c<year>` literals and `<year>印刷` note-field overrides).
- Renders GB/T's estimated-year substitute (`1936~` → `[1936]`) via a new
  `approximation-marker-suffix` style option, reusing the bracket-wrapping
  infrastructure removed from ranges.
- Documents the reviewer's alternate reading of the `div-009` tex.cstr
  divergence (GB/T 7714 §7.9.1/§7.9.2) without implementing it yet; split
  to draft bean for later, pending confirmation.
- Updates `docs/specs/DATE_MODEL.md` with the new date fields and the
  §7.5.4.3 substitute-year mapping.

## Divergence from the pinned oracle — needs your review

The pinned `gb-t-7714-2025-numeric.csl` oracle currently renders 3 of the
4 target cases as **plain years / an unbracketed range**, not the GB/T
standard forms this PR implements:

| Case | Oracle (pinned CSL-M) | This branch |
|---|---|---|
| Copyright `c1988` | `c1988` | `c1988` ✓ matches |
| Printing `1995印刷` | `1995` | `1995印刷` — diverges |
| Estimated `1936~` | `1936` | `[1936]` — diverges |
| Range `1957/1990` | `1957—[1990]` | `1957—1990` — diverges |

CSL has no native concept for copyright/printing/estimated-year
substitutes, so some divergence from the pinned CSL-M source was expected
either way. This branch follows the GB/T standard's own §7.5.4.3
convention (as described in review) over the pinned oracle for
printing/estimated, and keeps the range-bracket revert as-is rather than
chasing the possible citeproc-js first-run artifact. **Please confirm
this is the right call before merge** — happy to register these as
tracked divergences instead if you'd rather match the pinned oracle for
now.

## Test plan

- [x] `just pre-commit` green (fmt, clippy, 2054 tests) — also re-verified
      by the pre-push hook.
- [x] Oracle spot-checked on all four target fixtures
      (`gbt7714.7.5.4.3:1/2/3`, `gbt7714.8.4.2:2`) via
      `node scripts/oracle.js tests/fixtures/csl-m/gb-t-7714-2025-numeric.csl`.
- [x] `just schema-gen` run; `docs/schemas/` regenerated.
