### PR TITLE
feat(engine): resolve ISO 15924 scripts

### DIFF
--- a/.beans/archive/csl26-30ga--unify-effective-script-resolution-iso-15924.md
+++ b/.beans/archive/csl26-30ga--unify-effective-script-resolution-iso-15924.md
@@ -1,14 +1,22 @@
 ---
 # csl26-30ga
 title: Unify effective-script resolution (ISO 15924)
-status: todo
+status: completed
 type: task
+priority: normal
 tags:
     - multilingual
     - engine
 created_at: 2026-07-18T20:31:57Z
-updated_at: 2026-07-18T20:31:57Z
+updated_at: 2026-07-19T12:28:51Z
 parent: csl26-0ugp
 ---
 
 Replace the boolean is_latin_script_language classifier (crates/citum-engine/src/values/mod.rs) with a single resolver that returns an ISO 15924 script code for an item/field's effective language, preserving the positive-evidence rule (absent or unrecognized evidence resolves to no script, never a default). Keep a thin bool adapter so existing call sites are unchanged. This unblocks script-keyed punctuation realization and any future per-script behavior beyond the current latin/not-latin split. See docs/architecture/audits/2026-07-18_MULTILINGUAL_ARCHITECTURE_AUDIT.md §2(b).
+
+## Summary of Changes
+
+Replaced the Latin/non-Latin classifier with an ICU4X likely-subtags resolver
+that returns canonical ISO 15924 codes only from positive BCP 47 evidence. Kept
+the existing Latin boolean adapter, added explicit/inferred/unknown-language
+coverage, and verified no-default-feature and punctuation compatibility.

--- a/.beans/archive/csl26-30ga--unify-effective-script-resolution-iso-15924.md
+++ b/.beans/archive/csl26-30ga--unify-effective-script-resolution-iso-15924.md
@@ -8,7 +8,7 @@ tags:
     - multilingual
     - engine
 created_at: 2026-07-18T20:31:57Z
-updated_at: 2026-07-19T12:28:51Z
+updated_at: 2026-07-19T12:57:11Z
 parent: csl26-0ugp
 ---
 
@@ -20,3 +20,7 @@ Replaced the Latin/non-Latin classifier with an ICU4X likely-subtags resolver
 that returns canonical ISO 15924 codes only from positive BCP 47 evidence. Kept
 the existing Latin boolean adapter, added explicit/inferred/unknown-language
 coverage, and verified no-default-feature and punctuation compatibility.
+
+## Review Follow-up
+
+Cached ICU4X extended locale expansion per thread because LocaleExpander is neither Send nor Sync; this removes repeated construction without introducing synchronization or changing resolution behavior.

--- a/crates/citum-engine/Cargo.toml
+++ b/crates/citum-engine/Cargo.toml
@@ -28,14 +28,14 @@ jotdown = "0.10"
 pulldown-cmark = "0.13"
 orgize = "0.9"
 icu_collator = { version = "2.2.0", features = ["compiled_data"], optional = true }
-icu_locale = { version = "2.2.0", optional = true }
+icu_locale = "2.2.0"
 unicode-script = "0.5.8"
 schemars = { version = "1.2.1", features = ["derive"], optional = true }
 rayon = { version = "1", optional = true }
 
 [features]
 default = ["icu"]
-icu = ["dep:icu_collator", "dep:icu_locale"]
+icu = ["dep:icu_collator"]
 ffi = []
 schema = ["dep:schemars", "citum-schema/schema", "citum-schema-data/schema"]
 # Opt-in: renders bibliography entries across threads with rayon once a

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -345,59 +345,46 @@ pub fn effective_component_language(
     }
 }
 
-/// Whether a BCP 47 language tag's script is Latin, for `options.multilingual.scripts.latin`
-/// punctuation mapping.
+/// Resolve a BCP 47 language tag to its effective ISO 15924 script code.
 ///
-/// Prefers an explicit script subtag (e.g. `zh-Latn`, `ja-Hani`) when present; otherwise falls
-/// back to a lookup of primary language subtags for scripts commonly found in bilingual
-/// bibliographic corpora (CJK, Cyrillic, Arabic, Hebrew, Greek, Devanagari). Returns `false` for
-/// an absent or unrecognized tag so punctuation is only remapped on positive evidence of a
-/// Latin-script item.
+/// An explicit script subtag takes precedence. Otherwise, the tag's language
+/// and region are expanded with CLDR likely-subtags data. Missing, malformed,
+/// private-use-only, and unrecognized language evidence resolves to `None`;
+/// this function never supplies a default script.
 #[must_use]
-pub fn is_latin_script_language(lang: Option<&str>) -> bool {
-    const NON_LATIN_SCRIPT_SUBTAGS: &[&str] = &[
-        "hans", "hant", "hani", "jpan", "kore", "hang", "cyrl", "arab", "hebr", "grek", "deva",
-    ];
-    const NON_LATIN_PRIMARY_LANGUAGES: &[&str] = &[
-        // CJK
-        "zh", "ja", "ko", "yue", "wuu", "nan", "hak", "cjy", "cmn", "hsn", // Cyrillic
-        "ru", "be", "bg", "mk", "sr", "uk", // Arabic
-        "ar", "fa", "ur", // Hebrew / Yiddish
-        "he", "yi", // Greek
-        "el", // Devanagari
-        "hi", "mr", "ne",
-    ];
+pub fn resolve_language_script(lang: Option<&str>) -> Option<String> {
+    use std::borrow::Cow;
 
-    let Some(lang) = lang else {
-        return false;
-    };
-    let mut subtags = lang.split(['-', '_']).map(str::to_ascii_lowercase);
-    let Some(primary) = subtags.next().filter(|tag| !tag.is_empty()) else {
-        return false;
-    };
-    if !is_meaningful_language_primary(&primary) {
-        return false;
+    let lang = lang?.trim();
+    if lang.is_empty() {
+        return None;
     }
 
-    for subtag in subtags {
-        if subtag == "latn" {
-            return true;
-        }
-        if NON_LATIN_SCRIPT_SUBTAGS.contains(&subtag.as_str()) {
-            return false;
-        }
+    let normalized = if lang.contains('_') {
+        Cow::Owned(lang.replace('_', "-"))
+    } else {
+        Cow::Borrowed(lang)
+    };
+    let mut langid = normalized.parse::<icu_locale::Locale>().ok()?.id;
+
+    if let Some(script) = langid.script {
+        return Some(script.to_string());
+    }
+    if langid.language.is_unknown() || matches!(langid.language.as_str(), "mul" | "zxx") {
+        return None;
     }
 
-    !NON_LATIN_PRIMARY_LANGUAGES.contains(&primary.as_str())
+    icu_locale::LocaleExpander::new_extended().maximize(&mut langid);
+    langid.script.map(|script| script.to_string())
 }
 
-/// Whether a primary BCP 47 language subtag can provide script evidence.
-fn is_meaningful_language_primary(primary: &str) -> bool {
-    !matches!(primary, "und" | "mul" | "zxx")
-        && (2..=8).contains(&primary.len())
-        && primary
-            .chars()
-            .all(|character| character.is_ascii_alphabetic())
+/// Whether a BCP 47 language tag resolves to the Latin script.
+///
+/// This compatibility adapter preserves the positive-evidence behavior used
+/// by the Latin punctuation remapping call sites.
+#[must_use]
+pub fn is_latin_script_language(lang: Option<&str>) -> bool {
+    resolve_language_script(lang).as_deref() == Some("Latn")
 }
 
 /// Select a structured name from transliteration maps using priority-list then script-match rules.

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -60,6 +60,11 @@ use citum_schema::reference::types::Title;
 use citum_schema::template::{TemplateComponent, TitleType};
 use std::sync::Arc;
 
+thread_local! {
+    static EXTENDED_LOCALE_EXPANDER: icu_locale::LocaleExpander =
+        const { icu_locale::LocaleExpander::new_extended() };
+}
+
 pub use contributor::format_contributors_short;
 pub use date::int_to_letter;
 
@@ -374,7 +379,7 @@ pub fn resolve_language_script(lang: Option<&str>) -> Option<String> {
         return None;
     }
 
-    icu_locale::LocaleExpander::new_extended().maximize(&mut langid);
+    EXTENDED_LOCALE_EXPANDER.with(|expander| expander.maximize(&mut langid));
     langid.script.map(|script| script.to_string())
 }
 

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -36,18 +36,51 @@ fn make_config() -> Config {
 }
 
 #[test]
-fn latin_script_language_detection_requires_meaningful_language_evidence() {
-    for language in ["en", "en-US", "zh-Latn", "ja-Latn"] {
-        assert!(
-            super::is_latin_script_language(Some(language)),
+fn language_script_resolution_prefers_explicit_script_evidence() {
+    for (language, expected) in [
+        ("zh-Latn", "Latn"),
+        ("ja-Hani", "Hani"),
+        ("sr-Latn-RS", "Latn"),
+        ("en-Cyrl", "Cyrl"),
+        ("und-Arab", "Arab"),
+    ] {
+        assert_eq!(
+            super::resolve_language_script(Some(language)).as_deref(),
+            Some(expected),
             "{language}"
         );
     }
+}
 
+#[test]
+fn language_script_resolution_uses_likely_subtags_for_recognized_languages() {
+    for (language, expected) in [
+        ("en", "Latn"),
+        ("en_US", "Latn"),
+        ("en-u-ca-gregory", "Latn"),
+        ("ru-RU", "Cyrl"),
+        ("ar", "Arab"),
+        ("he", "Hebr"),
+        ("el", "Grek"),
+        ("hi", "Deva"),
+        ("zh", "Hans"),
+        ("zh-TW", "Hant"),
+        ("ja", "Jpan"),
+        ("ko", "Kore"),
+    ] {
+        assert_eq!(
+            super::resolve_language_script(Some(language)).as_deref(),
+            Some(expected),
+            "{language}"
+        );
+    }
+}
+
+#[test]
+fn language_script_resolution_requires_positive_language_evidence() {
     for language in [
-        "zh",
-        "zh-Hans",
-        "ru-RU",
+        "",
+        " ",
         "und",
         "mul",
         "zxx",
@@ -56,7 +89,26 @@ fn latin_script_language_detection_requires_meaningful_language_evidence() {
         "e",
         "1en",
         "123",
+        "zz",
     ] {
+        assert_eq!(
+            super::resolve_language_script(Some(language)),
+            None,
+            "{language} must not resolve to a default script"
+        );
+    }
+    assert_eq!(super::resolve_language_script(None), None);
+}
+
+#[test]
+fn latin_script_adapter_matches_only_resolved_latin_script() {
+    for language in ["en", "en-US", "zh-Latn", "ja-Latn"] {
+        assert!(
+            super::is_latin_script_language(Some(language)),
+            "{language}"
+        );
+    }
+    for language in ["zh", "zh-Hans", "ru-RU", "und", "zz"] {
         assert!(
             !super::is_latin_script_language(Some(language)),
             "{language} must not trigger Latin punctuation remapping"


### PR DESCRIPTION
## Summary

- add `resolve_language_script`, returning canonical ISO 15924 codes from explicit BCP 47 script subtags or ICU4X extended likely-subtags data
- preserve positive-evidence behavior: absent, malformed, private-use-only, and unrecognized languages resolve to no script
- retain `is_latin_script_language` as a thin compatibility adapter for existing punctuation call sites
- make the existing `icu_locale` dependency available without the optional collation feature and complete/archive bean `csl26-30ga`

## Validation

- `just pre-commit` — formatting, all-target/all-feature Clippy with warnings denied, and 2,061 tests passed
- `cargo check -p citum-engine --no-default-features`
- `cargo check -p citum-bindings`
- targeted GB/T Latin/CJK punctuation integration tests
- `python3 scripts/audit-rust-review-smells.py --changed` — no advisory findings
- bean hygiene passed with the documented unrelated soft-stale advisories ignored

## Risk

Known language tags that were previously guessed as Latin unless present in a
small negative list now resolve only when ICU4X has positive likely-subtags
evidence. This is the intended behavior and is covered by explicit, inferred,
malformed, and unknown-language tests.

## Follow-ups

The new resolver is ready for script-keyed punctuation realization and
directionality work; those remain separate beans.
