### PR TITLE
docs(beans): track realization increments 2-3

### DIFF
--- a/.beans/archive/csl26-k2kp--punctuation-realization-layer-semantic-delimiters.md
+++ b/.beans/archive/csl26-k2kp--punctuation-realization-layer-semantic-delimiters.md
@@ -9,8 +9,10 @@ tags:
     - punctuation
     - architecture
 created_at: 2026-07-18T20:31:58Z
-updated_at: 2026-07-19T14:18:51Z
+updated_at: 2026-07-19T16:30:21Z
 parent: csl26-0ugp
+blocking:
+    - csl26-0kqf
 ---
 
 Introduce a realization layer that maps semantic punctuation roles (list separator, field separator, subfield delimiter, wrap open/close, sort separator) to glyphs per (role, effective script, locale), so styles author intent once and each item's script selects half-width or full-width forms. Subsumes the one-directional remap_to_latin_punctuation pass and its three insertion points; csl26-kneq (script-aware wrap rendering) is the first implementation increment. See docs/architecture/audits/2026-07-18_MULTILINGUAL_ARCHITECTURE_AUDIT.md §5.

--- a/.beans/csl26-5y6k--punctuation-realization-migrate-gbt-to-semantic-ma.md
+++ b/.beans/csl26-5y6k--punctuation-realization-migrate-gbt-to-semantic-ma.md
@@ -1,0 +1,41 @@
+---
+# csl26-5y6k
+title: 'Punctuation realization: migrate GB/T to semantic marks, demote remap to shim'
+status: todo
+type: feature
+priority: normal
+tags:
+    - multilingual
+    - punctuation
+    - style
+created_at: 2026-07-19T16:30:10Z
+updated_at: 2026-07-19T16:30:16Z
+parent: csl26-0ugp
+blocked_by:
+    - csl26-w6wf
+---
+
+Increment 3 (final) of the punctuation realization layer (spec §8). Requires
+the `{ mark: ... }` token form and per-script `realization` override from
+increment 2 (`csl26-w6wf`) — GB/T's literal full-width punctuation can't move
+to semantic marks until that schema surface exists.
+
+- Migrate embedded bilingual styles (GB/T 7714 first) from literal full-width
+  punctuation (`prefix: （`, `delimiter: ，`, etc.) to semantic marks +
+  `options.multilingual.realization-default: cjk` (already available from
+  increment 1, `csl26-k2kp`).
+- Demote `remap_to_latin_punctuation`
+  (`crates/citum-engine/src/render/component.rs`) to documented
+  compatibility-shim status: kept functional for external literal-authored
+  bilingual styles, no longer extended to new scripts or marks (spec §7).
+- Update `MULTILINGUAL.md` §3.2a to reflect the shim's demoted status.
+
+## Acceptance criteria (from spec)
+
+- [ ] The GB/T embedded style migrated to semantic marks matches its
+      standard-derived expectations, with citeproc-js divergences registered
+      where the standard and the oracle disagree.
+- [ ] `remap_to_latin_punctuation` documented as a compatibility shim in
+      `MULTILINGUAL.md` §3.2a; no new scripts/marks added to it going forward.
+
+Spec: `docs/specs/PUNCTUATION_REALIZATION.md` §8 (increment 3).

--- a/.beans/csl26-w6wf--punctuation-realization-mark-token-form-per-script.md
+++ b/.beans/csl26-w6wf--punctuation-realization-mark-token-form-per-script.md
@@ -1,0 +1,48 @@
+---
+# csl26-w6wf
+title: 'Punctuation realization: mark token form + per-script overrides'
+status: todo
+type: feature
+priority: normal
+tags:
+    - multilingual
+    - punctuation
+    - architecture
+created_at: 2026-07-19T16:29:49Z
+updated_at: 2026-07-19T16:29:59Z
+parent: csl26-0ugp
+---
+
+Increment 2 of the punctuation realization layer (spec §8), building on the
+script-aware `WrapPunctuation` realization landed in increment 1 (`csl26-k2kp`,
+merged). Adds:
+
+- The `{ mark: <name> }` token form for `delimiter`/`prefix`/`suffix` fields
+  (mapping form only — `delimiter: comma` must stay the literal text "comma",
+  not be misread as a token; see spec §3).
+- The engine default realization table (`comma`, `colon`, `semicolon`,
+  `period`, `parentheses`, `brackets` — spec §2), keyed on (mark, script class).
+- The per-script `realization` override:
+  `options.multilingual.scripts.<S>.realization`, living alongside the
+  existing `delimiter`/`sort-separator`/`use-native-ordering`/`punctuation`
+  block in `ScriptConfig` (spec §4). Resolution order: style override → engine
+  default table.
+- Schema regeneration (`just schema-gen`) for the new token form and override
+  field.
+
+## Acceptance criteria (from spec)
+
+- [ ] `delimiter: { mark: comma }` renders `，` for CJK items and `, ` for
+      Latin items; `delimiter: "comma"` renders the literal text "comma".
+- [ ] A per-script `realization` override replaces the engine default for
+      exactly the overridden marks.
+- [ ] Literal punctuation in `prefix`/`suffix`/`delimiter` is never rewritten
+      by the realization layer.
+- [ ] Realization output passes through output-format escaping (HTML, LaTeX,
+      Typst, plain, Djot) unchanged in meaning.
+- [ ] Generated schemas include the token form and per-script `realization`;
+      all new public Rust items documented.
+
+Spec: `docs/specs/PUNCTUATION_REALIZATION.md` §8 (increment 2).
+Prerequisite `ScriptClass`/`realize_wrap` infrastructure already landed in
+`crates/citum-engine/src/values/mod.rs` and `render/format.rs` via `csl26-k2kp`.


### PR DESCRIPTION
## Summary
- Increment 1 of the punctuation realization layer (`csl26-k2kp`, spec `docs/specs/PUNCTUATION_REALIZATION.md`) merged in #1071. Its bean body promised follow-up beans for increments 2 and 3, plus a formal blocking link once increment 1 landed on `main`. This PR adds them.
- `csl26-w6wf` — Increment 2: `{ mark: ... }` token form for `delimiter`/`prefix`/`suffix`, engine default realization table, per-script `realization` override map.
- `csl26-5y6k` — Increment 3: migrate embedded GB/T styles to semantic marks + `realization-default: cjk`, demote `remap_to_latin_punctuation` to a documented compatibility shim. Set `blocked-by csl26-w6wf` (can't migrate to semantic marks before the mark token form exists).
- Added `csl26-k2kp --blocking csl26-0kqf` (calendar-note wraps), per `csl26-k2kp`'s own noted follow-up now that increment 1 is on `main`.

## Scope
- `.beans/csl26-w6wf--*.md` (new)
- `.beans/csl26-5y6k--*.md` (new)
- `.beans/archive/csl26-k2kp--*.md` (relationship update only)

No code changes — doc/tracking only.

## Validation
- Bean hygiene check passes (pre-commit/pre-push hooks); only pre-existing advisory notices for unrelated beans, not blocking.
- No `.rs` files touched — cargo gate correctly skipped by the pre-push hook.

## Risk
None — bean tracking files only, no runtime behavior change.
