### PR TITLE
feat(tooling): wasm bench build + jsr/session opts

### DIFF
--- a/.beans/archive/csl26-8gb2--add-local-wasm-build-recipe-and-optional-jsr-downl.md
+++ b/.beans/archive/csl26-8gb2--add-local-wasm-build-recipe-and-optional-jsr-downl.md
@@ -1,0 +1,30 @@
+---
+# csl26-8gb2
+title: Add local WASM build recipe and optional JSR download to benchmark-wasm-workflow.js
+status: completed
+type: task
+priority: normal
+tags:
+    - tooling
+    - wasm
+created_at: 2026-07-20T21:25:26Z
+updated_at: 2026-07-20T21:36:37Z
+---
+
+scripts/benchmark-wasm-workflow.js requires a manually-built nodejs-target WASM artifact with no just recipe to build it, and can't fall back to the prebuilt @citum/engine package already published on JSR. Add: (1) just build-wasm-nodejs recipe wrapping wasm-pack build --target nodejs --features full-wasm, matching what the script already expects at crates/citum-bindings/pkg/. (2) An opt-in --source=jsr flag on the benchmark script that downloads @citum/engine from JSR's npm-compatible registry into a scratch dir and runs the benchmark against it (web-target init() called with the wasm bytes directly, bypassing fetch). Default --source=local behavior (and its error message) stays offline; --source=jsr is the only path that touches the network.
+
+## Todo
+- [x] Add build-wasm-nodejs recipe to justfile
+- [x] Update missing-artifact error message in benchmark-wasm-workflow.js
+- [x] Add --source arg parsing (local default / jsr)
+- [x] Implement JSR download + web-target init path
+- [x] Verify: just build-wasm-nodejs works
+- [x] Verify: default (local) missing-artifact path stays offline
+- [x] Verify: --source jsr path runs end to end
+
+## Summary of Changes
+
+- Added `just build-wasm-nodejs` recipe (wraps `wasm-pack build crates/citum-bindings --target nodejs --features full-wasm`).
+- Added `--source local|jsr` to benchmark-wasm-workflow.js. `jsr` downloads `@jsr/citum__engine` from npm.jsr.io into a disposable tmp prefix (no repo package.json/lockfile touched) and loads the web-target ESM build via dynamic import, initializing wasm-bindgen with the raw bytes (bypassing fetch). Default stays fully offline with a clearer error pointing at both options.
+- Extra (raised mid-task, not in original scope): added `--mode stateless|session`. `session` drives the script through the stateful `DocumentSession` API (parse style/refs once, `insert_citation` incrementally) instead of re-parsing style+refs JSON on every call — a more realistic word-processor simulation. Note: `DocumentSession.insert_citation` always re-renders the bibliography internally (no incremental re-render support yet), so in session mode `get_bibliography()` timings reflect a cached read, not a fresh render.
+- Verified all four source/mode combinations locally (local/jsr x stateless/session) plus the offline missing-artifact error path.

--- a/justfile
+++ b/justfile
@@ -23,6 +23,10 @@ schema-gen:
 bootstrap setup="minimal":
     ./scripts/bootstrap.sh {{setup}}
 
+# Build nodejs-target WASM bindings for local tooling (e.g. scripts/benchmark-wasm-workflow.js)
+build-wasm-nodejs:
+    wasm-pack build crates/citum-bindings --target nodejs --features full-wasm
+
 # Regenerate docs/demo.html from docs/demo.djot (optionally override style)
 demo style="styles/embedded/chicago-author-date-18th.yaml":
     ./scripts/build-demo.sh {{style}}

--- a/scripts/benchmark-wasm-workflow.js
+++ b/scripts/benchmark-wasm-workflow.js
@@ -7,11 +7,16 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus
  * @file benchmark-wasm-workflow.js
  * @description Simulates a word processor workflow using Citum WASM bindings.
  * Measures performance metrics for citation and bibliography rendering.
+ * --mode=stateless (default) uses the one-shot renderCitation/renderBibliography
+ * API; --mode=session uses the stateful DocumentSession API.
  */
 
 const { performance } = require('node:perf_hooks');
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { execFileSync } = require('node:child_process');
 
 // --- Configuration ---
 const args = process.argv.slice(2);
@@ -25,20 +30,59 @@ const REFS_COUNT = parseInt(getArg('--refs', CI_MODE ? '50' : '500'), 10);
 const CITATIONS_COUNT = parseInt(getArg('--cites', CI_MODE ? '20' : '100'), 10);
 const REFRESH_INTERVAL = parseInt(getArg('--interval', CI_MODE ? '5' : '20'), 10);
 const STYLE_PATH = getArg('--style', 'styles/embedded/apa-7th.yaml');
+const SOURCE = getArg('--source', 'local');
+const MODE = getArg('--mode', 'stateless');
 
-function runBenchmark() {
-  // Lazy-load WASM so a missing artifact gives a clear, actionable error.
-  let renderCitation, renderBibliography, validateStyle;
+// Downloads the published @citum/engine package from JSR's npm-compatible
+// registry and loads it. This is a web-target (ESM) build, so it's loaded via
+// dynamic import and initialized with the wasm bytes directly (bypassing the
+// browser fetch() its generated init() normally uses).
+async function loadFromJsr() {
+  const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), 'citum-jsr-'));
+  console.log(`[Status] Downloading @citum/engine from JSR into ${scratchDir}...`);
+  execFileSync(
+    'npm',
+    ['install', '@jsr/citum__engine', '--no-save', '--prefix', scratchDir, '--registry', 'https://npm.jsr.io'],
+    { stdio: 'inherit' }
+  );
+
+  const pkgDir = path.join(scratchDir, 'node_modules', '@jsr', 'citum__engine');
+  const jsFile = path.join(pkgDir, 'citum_bindings.js');
+  const wasmFile = path.join(pkgDir, 'citum_bindings_bg.wasm');
+
+  const mod = await import(pathToFileURL(jsFile).href);
+  await mod.default({ module_or_path: fs.readFileSync(wasmFile) });
+  return {
+    renderCitation: mod.renderCitation,
+    renderBibliography: mod.renderBibliography,
+    validateStyle: mod.validateStyle,
+    DocumentSession: mod.DocumentSession,
+  };
+}
+
+// Loads the locally-built nodejs-target WASM bindings, erroring with
+// actionable next steps if they haven't been built yet.
+function loadFromLocal() {
   const wasmJs = path.resolve(__dirname, '../crates/citum-bindings/pkg/citum_bindings.js');
   const wasmBin = path.resolve(__dirname, '../crates/citum-bindings/pkg/citum_bindings_bg.wasm');
   if (!fs.existsSync(wasmJs) || !fs.existsSync(wasmBin)) {
     console.error(
-      'WASM not built. Run: wasm-pack build --target nodejs --features full-wasm  (in crates/citum-bindings/)'
+      'WASM not built. Either:\n' +
+        '  - Build it locally: just build-wasm-nodejs\n' +
+        '    (or: wasm-pack build crates/citum-bindings --target nodejs --features full-wasm)\n' +
+        '  - Download the published build instead: node scripts/benchmark-wasm-workflow.js --source jsr'
     );
     process.exit(1);
   }
+  const { renderCitation, renderBibliography, validateStyle, DocumentSession } = require(wasmJs);
+  return { renderCitation, renderBibliography, validateStyle, DocumentSession };
+}
+
+async function runBenchmark() {
+  let renderCitation, renderBibliography, validateStyle, DocumentSession;
   try {
-    ({ renderCitation, renderBibliography, validateStyle } = require(wasmJs));
+    ({ renderCitation, renderBibliography, validateStyle, DocumentSession } =
+      SOURCE === 'jsr' ? await loadFromJsr() : loadFromLocal());
   } catch (e) {
     console.error('Failed to load WASM bindings:', e.message);
     process.exit(1);
@@ -51,10 +95,12 @@ function runBenchmark() {
   const styleYaml = fs.readFileSync(path.resolve(__dirname, '..', STYLE_PATH), 'utf8');
 
   console.log(`[Config] Style:      ${STYLE_PATH}`);
+  console.log(`[Config] Source:     ${SOURCE}`);
+  console.log(`[Config] Mode:       ${MODE}`);
   console.log(`[Config] References: ${REFS_COUNT}`);
   console.log(`[Config] Citations:  ${CITATIONS_COUNT}`);
   console.log(`[Config] Refresh:    Every ${REFRESH_INTERVAL} citations`);
-  if (CI_MODE) console.log('[Config] Mode:       CI (reduced params)');
+  if (CI_MODE) console.log('[Config] CI:         reduced params');
   console.log('----------------------------------------------------');
 
   // 1. Warmup / Validation
@@ -80,45 +126,12 @@ function runBenchmark() {
   }
   const refsJson = JSON.stringify(refs);
 
-  const citationTimes = [];
-  const bibTimes = [];
-
   console.log('Simulating authoring workflow...');
 
-  for (let i = 0; i < CITATIONS_COUNT; i++) {
-    // Simulate inserting a citation
-    const citation = {
-      id: `cite-${i}`,
-      items: [{ id: `item-${i % REFS_COUNT}` }]
-    };
-    const citationJson = JSON.stringify(citation);
-
-    const start = performance.now();
-    try {
-      renderCitation(styleYaml, refsJson, citationJson, null);
-      const end = performance.now();
-      citationTimes.push(end - start);
-    } catch (e) {
-      console.error(`\nError rendering citation ${i}:`, e);
-      break;
-    }
-
-    // Periodically update the bibliography
-    if ((i + 1) % REFRESH_INTERVAL === 0) {
-      const bStart = performance.now();
-      try {
-        renderBibliography(styleYaml, refsJson);
-        const bEnd = performance.now();
-        bibTimes.push(bEnd - bStart);
-        console.log(`[Progress] Citation ${String(i + 1).padStart(3)}/${CITATIONS_COUNT} | Bibliography refreshed (${(bEnd - bStart).toFixed(2)}ms)`);
-      } catch (e) {
-        console.error(`\nError rendering bibliography at index ${i}:`, e);
-        break;
-      }
-    } else if ((i + 1) % 10 === 0 || i === 0) {
-      console.log(`[Progress] Citation ${String(i + 1).padStart(3)}/${CITATIONS_COUNT}...`);
-    }
-  }
+  const { citationTimes, bibTimes } =
+    MODE === 'session'
+      ? runSessionWorkflow({ DocumentSession, styleYaml, refsJson })
+      : runStatelessWorkflow({ renderCitation, renderBibliography, styleYaml, refsJson });
 
   console.log('\n\nSimulation complete.');
 
@@ -135,12 +148,107 @@ function runBenchmark() {
   console.log('----------------------------------------------------');
   console.log('             Performance Statistics (WASM)');
   console.log('----------------------------------------------------');
-  console.log(`render_citation:     ${stats(citationTimes)}`);
-  console.log(`render_bibliography: ${stats(bibTimes)}`);
+  if (MODE === 'session') {
+    console.log(`insert_citation (incl. bibliography re-render): ${stats(citationTimes)}`);
+    console.log(`get_bibliography (cached read):                 ${stats(bibTimes)}`);
+  } else {
+    console.log(`render_citation:     ${stats(citationTimes)}`);
+    console.log(`render_bibliography: ${stats(bibTimes)}`);
+  }
   console.log('----------------------------------------------------');
 }
 
-try { runBenchmark(); } catch (err) {
+// Stateless mode: re-parses style + refs JSON on every call, matching the
+// engine's one-shot render_citation/render_bibliography WASM API. Only
+// re-renders the bibliography every REFRESH_INTERVAL citations.
+function runStatelessWorkflow({ renderCitation, renderBibliography, styleYaml, refsJson }) {
+  const citationTimes = [];
+  const bibTimes = [];
+
+  for (let i = 0; i < CITATIONS_COUNT; i++) {
+    const citation = {
+      id: `cite-${i}`,
+      items: [{ id: `item-${i % REFS_COUNT}` }]
+    };
+    const citationJson = JSON.stringify(citation);
+
+    const start = performance.now();
+    try {
+      renderCitation(styleYaml, refsJson, citationJson, null);
+      citationTimes.push(performance.now() - start);
+    } catch (e) {
+      console.error(`\nError rendering citation ${i}:`, e);
+      break;
+    }
+
+    if ((i + 1) % REFRESH_INTERVAL === 0) {
+      const bStart = performance.now();
+      try {
+        renderBibliography(styleYaml, refsJson);
+        const bTime = performance.now() - bStart;
+        bibTimes.push(bTime);
+        console.log(`[Progress] Citation ${String(i + 1).padStart(3)}/${CITATIONS_COUNT} | Bibliography refreshed (${bTime.toFixed(2)}ms)`);
+      } catch (e) {
+        console.error(`\nError rendering bibliography at index ${i}:`, e);
+        break;
+      }
+    } else if ((i + 1) % 10 === 0 || i === 0) {
+      console.log(`[Progress] Citation ${String(i + 1).padStart(3)}/${CITATIONS_COUNT}...`);
+    }
+  }
+
+  return { citationTimes, bibTimes };
+}
+
+// Session mode: parses the style + refs once into a DocumentSession, then
+// mutates incrementally — closer to a real word processor. Each
+// insert_citation re-renders the bibliography internally (the session API
+// doesn't yet support incremental re-rendering), so its timing already
+// includes that cost. get_bibliography() timings, taken every
+// REFRESH_INTERVAL citations, measure a cached read of the last render
+// rather than a fresh one.
+function runSessionWorkflow({ DocumentSession, styleYaml, refsJson }) {
+  const citationTimes = [];
+  const bibTimes = [];
+  const session = new DocumentSession(styleYaml, refsJson);
+
+  for (let i = 0; i < CITATIONS_COUNT; i++) {
+    const citation = {
+      id: `cite-${i}`,
+      items: [{ id: `item-${i % REFS_COUNT}` }]
+    };
+    const citationJson = JSON.stringify(citation);
+
+    const start = performance.now();
+    try {
+      session.insert_citation(citationJson, null);
+      citationTimes.push(performance.now() - start);
+    } catch (e) {
+      console.error(`\nError inserting citation ${i}:`, e);
+      break;
+    }
+
+    if ((i + 1) % REFRESH_INTERVAL === 0) {
+      const bStart = performance.now();
+      try {
+        session.get_bibliography();
+        const bTime = performance.now() - bStart;
+        bibTimes.push(bTime);
+        console.log(`[Progress] Citation ${String(i + 1).padStart(3)}/${CITATIONS_COUNT} | Bibliography read (${bTime.toFixed(2)}ms)`);
+      } catch (e) {
+        console.error(`\nError reading bibliography at index ${i}:`, e);
+        break;
+      }
+    } else if ((i + 1) % 10 === 0 || i === 0) {
+      console.log(`[Progress] Citation ${String(i + 1).padStart(3)}/${CITATIONS_COUNT}...`);
+    }
+  }
+
+  session.dispose();
+  return { citationTimes, bibTimes };
+}
+
+runBenchmark().catch(err => {
   console.error('\nFatal error:', err);
   process.exit(1);
-}
+});


### PR DESCRIPTION
## Summary
- Add `just build-wasm-nodejs` recipe wrapping `wasm-pack build crates/citum-bindings --target nodejs --features full-wasm`, matching what `scripts/benchmark-wasm-workflow.js` already expects — previously the only guidance was a one-line error message telling you to type the wasm-pack command by hand.
- Add `--source local|jsr` to the benchmark script. `jsr` downloads the published `@citum/engine` package from JSR's npm-compatible registry (`npm.jsr.io`) into a disposable scratch dir — no Rust toolchain needed to run the benchmark. It's a web-target (ESM) build, loaded via dynamic `import()` and initialized directly with the wasm bytes (bypassing the browser `fetch()` its generated `init()` normally uses). Default (`local`) behavior is unchanged and stays fully offline; its error message now also points at both options.
- Add `--mode stateless|session` (raised mid-review, folded into the same small PR). `stateless` is the existing behavior (re-parses style + refs JSON on every `renderCitation`/`renderBibliography` call). `session` drives the stateful `DocumentSession` API instead — parses style + refs once, then mutates incrementally via `insert_citation` — closer to how a real word processor would use this. Note: `DocumentSession.insert_citation` currently re-renders the bibliography internally on every call (no incremental re-render yet), so in session mode `get_bibliography()` timings measure a cached read, not a fresh render — called out explicitly in the script's output labels.

## Test plan
- [x] `just build-wasm-nodejs` builds `crates/citum-bindings/pkg/citum_bindings.js` + `.wasm`
- [x] `node scripts/benchmark-wasm-workflow.js --ci` (default `--source local --mode stateless`) runs against the local build
- [x] `rm -rf crates/citum-bindings/pkg && node scripts/benchmark-wasm-workflow.js --ci` prints the updated build/download guidance and exits non-zero without any network access
- [x] `node scripts/benchmark-wasm-workflow.js --ci --source jsr` downloads `@citum/engine` from JSR and completes a full run
- [x] `node scripts/benchmark-wasm-workflow.js --ci --mode session` and `--source jsr --mode session` both complete, with `get_bibliography` timings visibly near-zero (cached read) versus `insert_citation`'s full render cost
