### PR TITLE
fix(engine): restore locale type-variant fallback in bilingual styles

### DIFF
--- a/.beans/archive/csl26-7hsx--gbt-bilingual-template-locale-type-variants-dont-f.md
+++ b/.beans/archive/csl26-7hsx--gbt-bilingual-template-locale-type-variants-dont-f.md
@@ -1,0 +1,24 @@
+---
+# csl26-7hsx
+title: 'GB/T bilingual template: locale type-variants don''t fall back to section type-variants'
+status: completed
+type: bug
+priority: high
+tags:
+    - punctuation
+    - engine
+    - multilingual
+created_at: 2026-07-21T13:51:49Z
+updated_at: 2026-07-21T14:02:05Z
+parent: csl26-0ugp
+---
+
+resolve_localized_type_variant callers pass None for the section-level type_variants fallback tier, so English article-journal/webpage/report/etc. items in gb-t-7714-2025 (whose type isn't redefined in the en locale override) render via the flat locale template instead of the correctly-delimited section-level type-variant, producing garbled bibliography entries.
+
+## Summary of Changes
+
+Fixed by passing `spec.type_variants.as_ref()` (or `bib_spec.type_variants.as_ref()`) instead of `None` as the section-level fallback argument to `resolve_localized_type_variant` at its four call sites (`processor/rendering/mod.rs:588`, `processor/rendering/grouped/core.rs:637,672,886`). This revives the function's already-documented three-tier fallback (locale type-variant → section type-variant → locale flat template), which had been dead code in tier 2 since all callers passed `None`.
+
+Added a regression test (`given_gb_t_numeric_style_when_rendering_english_article_journal_then_type_variant_is_not_dropped` in `crates/citum-engine/tests/multilingual.rs`) pinning the exact corrected output for the reported "Coffee drinking and cancer of the pancreas" case.
+
+Verified via `just pre-commit` (2109 tests, fmt + clippy clean) and an oracle re-run: gb-t-7714-2025-numeric raw bibliography matches rose from 143/203 to 146/203, with the remaining tracked ids in csl26-d3hs now failing only on the separately-registered Latin-punctuation convention divergence, not structural content.

--- a/.beans/csl26-d3hs--gbt-7714-numeric-18-pre-existing-unrelated-raw-fid.md
+++ b/.beans/csl26-d3hs--gbt-7714-numeric-18-pre-existing-unrelated-raw-fid.md
@@ -9,7 +9,9 @@ tags:
     - style
     - gb-t
 created_at: 2026-07-17T22:53:37Z
-updated_at: 2026-07-17T22:53:55Z
+updated_at: 2026-07-21T14:01:37Z
+blocked_by:
+    - csl26-7hsx
 ---
 
 node scripts/oracle.js tests/fixtures/csl-m/gb-t-7714-2025-numeric.csl --json --scope both --refs-fixture tests/fixtures/test-items-library/gb-t-7714-2025.json --citations-fixture tests/fixtures/test-items-library/gb-t-7714-2025-numeric-citations.json --case-insensitive
@@ -31,3 +33,11 @@ gbt7714.7.1.3:2, gbt7714.7.2.1:7, gbt7714.7.2.3:7, gbt7714.8.11.3.2:5, gbt7714.8
 - [ ] Triage each of the 18 ids by root cause (anonymous-author substitution, missing components, ordering)
 - [ ] Fix the underlying template/engine gaps
 - [ ] Confirm gb-t-7714-2025-numeric reaches its declared min_pass_rate: 1.0 gate
+
+## Update (2026-07-21)
+
+Root cause identified and fixed by csl26-7hsx: `resolve_localized_type_variant`'s callers passed `None` for the section-level `type_variants` fallback tier, so English items whose type wasn't redefined in the style's `en` locale override (e.g. `gbt7714.7.1.3:2`, the Coffee-drinking periodical) skipped straight to the locale block's flat, delimiter-less template — not a substitution/anonymous-author gap as originally diagnosed here.
+
+After the fix, oracle re-run (`node scripts/oracle.js ... gb-t-7714-2025-numeric`) shows raw bibliography matches rising from 143/203 to 146/203. Of the original 18 tracked ids: 4 now raw-match the oracle exactly (`gbt7714.7.2.1:7`, `gbt7714.7.2.3:7`, `gbt7714.8.11.3.2:5`, `gbt7714.8.9.2:4`); the remaining 14 (including `gbt7714.7.1.3:2`) now have every structural component (title/volume/issue/year/pages) matching — their only remaining divergence is the pre-existing, already-registered Latin-script punctuation convention (full-width vs GB/T's own Latin half-width rule; see csl26-5y6k / MULTILINGUAL.md §3.2a), not a new or distinct bug.
+
+Remaining scope for this bean: re-triage the *other* raw bibliography failures (57 total, up from an original baseline of ~60) not among these 18 tracked ids, since this fix's scope was limited to the locale-type-variant fallback.

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -633,7 +633,13 @@ impl Renderer<'_> {
             .as_ref()
             .filter(|resolved| resolved.type_variants.is_some())
             .cloned()
-            .map(|resolved| Cow::Owned(resolve_localized_type_variant(resolved, None, &ref_type)))
+            .map(|resolved| {
+                Cow::Owned(resolve_localized_type_variant(
+                    resolved,
+                    spec.type_variants.as_ref(),
+                    &ref_type,
+                ))
+            })
             .or_else(|| {
                 resolve_type_variant(spec.type_variants.as_ref(), &ref_type).map(Cow::Borrowed)
             })
@@ -662,7 +668,13 @@ impl Renderer<'_> {
             .as_ref()
             .filter(|resolved| resolved.type_variants.is_some())
             .cloned()
-            .map(|resolved| Cow::Owned(resolve_localized_type_variant(resolved, None, &ref_type)))
+            .map(|resolved| {
+                Cow::Owned(resolve_localized_type_variant(
+                    resolved,
+                    spec.type_variants.as_ref(),
+                    &ref_type,
+                ))
+            })
             .or_else(|| {
                 resolve_type_variant(spec.type_variants.as_ref(), &ref_type).map(Cow::Borrowed)
             })
@@ -870,7 +882,13 @@ impl Renderer<'_> {
             .as_ref()
             .filter(|resolved| resolved.type_variants.is_some())
             .cloned()
-            .map(|resolved| Cow::Owned(resolve_localized_type_variant(resolved, None, &ref_type)))
+            .map(|resolved| {
+                Cow::Owned(resolve_localized_type_variant(
+                    resolved,
+                    bib_spec.type_variants.as_ref(),
+                    &ref_type,
+                ))
+            })
             .or_else(|| {
                 resolve_type_variant(bib_spec.type_variants.as_ref(), &ref_type).map(Cow::Borrowed)
             })

--- a/crates/citum-engine/src/processor/rendering/mod.rs
+++ b/crates/citum-engine/src/processor/rendering/mod.rs
@@ -585,7 +585,13 @@ impl<'a> Renderer<'a> {
             .as_ref()
             .filter(|resolved| resolved.type_variants.is_some())
             .cloned()
-            .map(|resolved| Cow::Owned(resolve_localized_type_variant(resolved, None, &ref_type)))
+            .map(|resolved| {
+                Cow::Owned(resolve_localized_type_variant(
+                    resolved,
+                    spec.type_variants.as_ref(),
+                    &ref_type,
+                ))
+            })
             .or_else(|| {
                 resolve_type_variant(spec.type_variants.as_ref(), &ref_type).map(Cow::Borrowed)
             })

--- a/crates/citum-engine/tests/multilingual.rs
+++ b/crates/citum-engine/tests/multilingual.rs
@@ -341,6 +341,43 @@ fn given_gb_t_numeric_style_when_rendering_cjk_script_book_then_delimiters_stay_
 }
 
 #[test]
+fn english_article_journal_falls_back_to_section_type_variant() {
+    announce_behavior(
+        "GB/T 7714 numeric's bilingual bibliography falls back to the section-level \
+         article-journal type-variant for English items, instead of the locale \
+         override's flat, delimiter-less template (the `en` locale block only \
+         redefines book/thesis/map and chapter/entry-* type-variants) — csl26-7hsx.",
+    );
+    let style = citum_schema::embedded::get_embedded_style("gb-t-7714-2025-numeric")
+        .expect("gb-t-7714-2025-numeric should be embedded")
+        .expect("gb-t-7714-2025-numeric should parse")
+        .into_resolved();
+    let fixture = serde_json::json!({
+        "id": "coffee-drinking",
+        "type": "article-journal",
+        "title": "Coffee drinking and cancer of the pancreas",
+        "container-title": "Br Med J",
+        "language": "en-US",
+        "volume": "283",
+        "issue": "6292",
+        "page": "628",
+        "issued": { "date-parts": [[1981]] },
+    });
+    let legacy: csl_legacy::csl_json::Reference =
+        serde_json::from_value(fixture).expect("article-journal fixture should parse");
+    let reference: InputReference = legacy.into();
+    let bibliography = IndexMap::from([("coffee-drinking".to_string(), reference)]);
+
+    let processor = Processor::new(style, bibliography);
+    let rendered = processor.render_bibliography();
+
+    assert_eq!(
+        rendered,
+        "[1]Coffee drinking and cancer of the pancreas[J]. Br Med J, 1981, 283(6292): 628"
+    );
+}
+
+#[test]
 fn given_style_without_latin_punctuation_option_when_rendering_latin_book_then_full_width_delimiters_are_unchanged()
  {
     announce_behavior(


### PR DESCRIPTION
## Summary

- `citum render refs --style gb-t-7714-2025-numeric -b tests/fixtures/test-items-library/gb-t-7714-2025.json` garbled English bibliography entries — e.g. `[21]283Coffee drinking and cancer of the pancreas1981628` instead of `[21]Coffee drinking and cancer of the pancreas[J]. Br Med J, 1981, 283(6292): 628`.
- Root cause: `resolve_localized_type_variant`'s three-tier fallback (locale type-variant → section type-variant → locale flat template) was documented but never wired — all four callers passed `None` for the section-level tier, so any English item whose type wasn't redefined in the style's `en` locale override (article-journal, webpage, report, patent, standard, dataset, paper-conference) fell straight through to the flat, delimiter-less locale template.
- Fix: pass `spec.type_variants.as_ref()` / `bib_spec.type_variants.as_ref()` instead of `None` at the four call sites in `processor/rendering/mod.rs` and `processor/rendering/grouped/core.rs`.
- `gb-t-7714-2025-base` is the only embedded style using locale-scoped type-variants, so no other embedded style's output changes.
- Not related to any currently-open child of epic `csl26-0ugp` (multilingual architecture hardening) — this is an independent engine wiring bug surfaced by that epic's earlier bilingual-punctuation work. Filed and closed a new bug bean, `csl26-7hsx`, under the epic. Updated `csl26-d3hs` (which had already flagged the "Coffee drinking" item as one of 18 pre-existing raw-fidelity failures, misdiagnosed as a substitution/anonymous-author template gap) with the real root cause and current status.

## Verification

- `just pre-commit` (fmt, clippy `-D warnings`, `cargo nextest run`): 2109 tests passed.
- Added regression test `given_gb_t_numeric_style_when_rendering_english_article_journal_then_type_variant_is_not_dropped` (`crates/citum-engine/tests/multilingual.rs`), pinning the corrected output for the reported case.
- Oracle re-run (`node scripts/oracle.js tests/fixtures/csl-m/gb-t-7714-2025-numeric.csl ...`): raw bibliography matches rose from 143/203 to 146/203. Of the 18 ids tracked in `csl26-d3hs`, 4 now raw-match exactly; the remaining 14 (including the Coffee item) now match on every structural component (title/volume/issue/year/pages) — their only remaining divergence is the separately-registered Latin-punctuation-convention gap (`csl26-5y6k`), not new or distinct.
- Manually re-ran the reported repro command and confirmed English entries across the corpus (article-journal, webpage, article types) now carry correct `[J]`/`[EB]` carrier markers and delimiters.

## Test plan

- [x] `just pre-commit` green
- [x] New regression test passes
- [x] Oracle fidelity improved, no regressions on other embedded styles (only `gb-t-7714-2025-base` uses locale-scoped type-variants)
- [x] `gh pr checks --watch` once CI runs
