### PR TITLE
fix(engine): tailor case mapping by locale

### DIFF
--- a/.beans/archive/csl26-11wh--locale-tailored-case-mapping-turkish-dotted-i.md
+++ b/.beans/archive/csl26-11wh--locale-tailored-case-mapping-turkish-dotted-i.md
@@ -1,15 +1,19 @@
 ---
 # csl26-11wh
 title: Locale-tailored case mapping (Turkish dotted i)
-status: todo
+status: completed
 type: bug
 priority: normal
 tags:
     - multilingual
     - engine
 created_at: 2026-07-18T20:32:33Z
-updated_at: 2026-07-19T11:05:15Z
+updated_at: 2026-07-21T19:23:23Z
 parent: csl26-0ugp
 ---
 
 Case transforms in crates/citum-engine/src/values/text_case.rs use Rust's locale-blind to_uppercase()/to_lowercase(), so Turkish and Azerbaijani i/İ and ı/I map incorrectly under uppercase/lowercase/sentence transforms. The sting: Citum's own embedded tr-TR locale file is among the most complete in the tree (schema-v2, full MF2 coverage) — locale-data investment offers no protection against this engine-level casing gap. Adopt locale-tailored case mapping (ICU4X casemap) or explicitly gate the transforms with a diagnostic. See docs/architecture/audits/2026-07-18_MULTILINGUAL_ARCHITECTURE_AUDIT.md §2(e).
+
+## Summary of Changes
+
+Added ICU4X locale-tailored case mapping across plain, structured, and rich-text rendering; centralized underscore-aware language parsing with Citum-suffix fallback; isolated title overrides from non-title variables and free-text numbers; preserved root-locale compatibility APIs and Djot nocase spans; added Turkish/Azerbaijani unit and integration coverage; repaired restored `rusty_v8` artifacts in linking workflows; and verified small-wasm, the APA oracle baseline, benchmarks, workflow linting, Rust review-smell audit, and the full pre-commit gate.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,11 @@ jobs:
           shared-key: "citum-core-rust"
           cache-workspace-crates: true
 
+      # Restored target caches can contain v8 build metadata without the
+      # downloaded native archive; rebuild only this package's artifacts.
+      - name: Invalidate cached rusty_v8 build artifacts
+        run: cargo clean -p v8
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/compat-report.yml
+++ b/.github/workflows/compat-report.yml
@@ -60,6 +60,11 @@ jobs:
           cache-workspace-crates: true
           cache-directories: /home/runner/.cache/sccache
 
+      # Restored target caches can contain v8 build metadata without the
+      # downloaded native archive; rebuild only this package's artifacts.
+      - name: Invalidate cached rusty_v8 build artifacts
+        run: cargo clean -p v8
+
       - name: Configure environment
         run: |
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -85,6 +85,11 @@ jobs:
           cache-workspace-crates: true
           cache-directories: /home/runner/.cache/sccache
 
+      # Restored target caches can contain v8 build metadata without the
+      # downloaded native archive; rebuild only this package's artifacts.
+      - name: Invalidate cached rusty_v8 build artifacts
+        run: cargo clean -p v8
+
       - name: Configure environment
         run: |
           echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,7 @@ dependencies = [
  "citum-schema-data",
  "criterion",
  "csl-legacy",
+ "icu_casemap",
  "icu_collator",
  "icu_locale",
  "indexmap 2.14.0",
@@ -3363,6 +3364,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "118577bcf3a0fa7c6ac0a7d6e951814da84ee56b9b1f68fb4d8d10b08cefaf4d"
 
 [[package]]
+name = "icu_casemap"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "070f98b5b82798fcb93654bf96ed9f40064fc44c86f51a09ea711092cd5cc5be"
+dependencies = [
+ "icu_casemap_data",
+ "icu_collections 2.2.0",
+ "icu_locale_core",
+ "icu_properties 2.2.0",
+ "icu_provider 2.2.0",
+ "potential_utf",
+ "writeable 0.6.3",
+ "zerovec 0.11.6",
+]
+
+[[package]]
+name = "icu_casemap_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "846b0857ca091204be3c874bc93daaf89d4777e8d2d20b0d3ffe8f671d98014b"
+
+[[package]]
 name = "icu_collator"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3408,6 +3431,7 @@ checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "serde",
  "utf8_iter",
  "yoke 0.8.2",
  "zerofrom",

--- a/crates/citum-engine/Cargo.toml
+++ b/crates/citum-engine/Cargo.toml
@@ -28,6 +28,7 @@ jotdown = "0.10"
 pulldown-cmark = "0.13"
 orgize = "0.9"
 icu_collator = { version = "2.2.0", features = ["compiled_data"], optional = true }
+icu_casemap = { version = "2.2.0", features = ["compiled_data"] }
 icu_locale = "2.2.0"
 unicode-script = "0.5.8"
 schemars = { version = "1.2.1", features = ["derive"], optional = true }

--- a/crates/citum-engine/README.md
+++ b/crates/citum-engine/README.md
@@ -20,8 +20,9 @@ citum-engine = "0.73"
 citum-io = "0.73"
 ```
 
-Default features include `icu`, which enables ICU-backed collation and locale
-support used by sorting and rendering. Optional features:
+Locale-tailored text casing is available in every build through ICU4X. Default
+features also include `icu`, which enables ICU-backed collation for sorting.
+Optional features:
 
 | Feature | Purpose |
 |---|---|

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -784,7 +784,11 @@ impl Processor {
                 citum_schema::options::titles::TextCase::CapitalizeFirst,
                 Some(self.locale.locale.as_str()),
             );
-            crate::values::text_case::apply_text_case_markup_aware(&wrapped, case)
+            crate::values::text_case::apply_text_case_markup_aware_with_language(
+                &wrapped,
+                case,
+                Some(self.locale.locale.as_str()),
+            )
         } else {
             wrapped
         };

--- a/crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs
@@ -123,7 +123,9 @@ impl Renderer<'_> {
                     crate::values::text_case::resolve_text_case(TextCase::CapitalizeFirst, locale);
                 if let Some(prefix) = component.prefix.as_mut() {
                     // Explicit template prefix (e.g. ". Translated by ") — capitalize it.
-                    *prefix = crate::values::text_case::apply_text_case(prefix, case);
+                    *prefix = crate::values::text_case::apply_text_case_with_language(
+                        prefix, case, locale,
+                    );
                 } else if contributor.rendering.prefix.is_some() {
                     // A static YAML `prefix:` (e.g. "Narrated by ") already supplies
                     // the sentence-initial capital as authored. The contributor's own
@@ -134,12 +136,17 @@ impl Renderer<'_> {
                     // into the rendered value.  Capitalize the first word so that
                     // sentence-initial contributors read "Edited by …" not "edited by …".
                     component.value = if component.pre_formatted {
-                        crate::values::text_case::apply_text_case_markup_aware(
+                        crate::values::text_case::apply_text_case_markup_aware_with_language(
                             &component.value,
                             case,
+                            locale,
                         )
                     } else {
-                        crate::values::text_case::apply_text_case(&component.value, case)
+                        crate::values::text_case::apply_text_case_with_language(
+                            &component.value,
+                            case,
+                            locale,
+                        )
                     };
                 }
             }
@@ -152,15 +159,27 @@ impl Renderer<'_> {
                 // Groups are always pre-formatted (rendered markup); use the markup-aware
                 // variant so HTML tags and LaTeX/Typst command prefixes are not corrupted.
                 component.value =
-                    crate::values::text_case::apply_text_case_markup_aware(&component.value, case);
+                    crate::values::text_case::apply_text_case_markup_aware_with_language(
+                        &component.value,
+                        case,
+                        locale,
+                    );
             }
             TemplateComponent::Message(message) if !message.message.starts_with("term.") => {
                 let case =
                     crate::values::text_case::resolve_text_case(TextCase::CapitalizeFirst, locale);
                 component.value = if component.pre_formatted {
-                    crate::values::text_case::apply_text_case_markup_aware(&component.value, case)
+                    crate::values::text_case::apply_text_case_markup_aware_with_language(
+                        &component.value,
+                        case,
+                        locale,
+                    )
                 } else {
-                    crate::values::text_case::apply_text_case(&component.value, case)
+                    crate::values::text_case::apply_text_case_with_language(
+                        &component.value,
+                        case,
+                        locale,
+                    )
                 };
             }
             TemplateComponent::Term(_) | TemplateComponent::Message(_)

--- a/crates/citum-engine/src/values/contributor/labels.rs
+++ b/crates/citum-engine/src/values/contributor/labels.rs
@@ -194,7 +194,7 @@ pub(super) fn apply_label_case(
     match text_case {
         Some(case) => {
             let resolved = crate::values::text_case::resolve_text_case(case, Some(language));
-            crate::values::text_case::apply_text_case(&term, resolved)
+            crate::values::text_case::apply_text_case_with_language(&term, resolved, Some(language))
         }
         None => term,
     }

--- a/crates/citum-engine/src/values/contributor/mod.rs
+++ b/crates/citum-engine/src/values/contributor/mod.rs
@@ -147,7 +147,11 @@ fn normalized_role_term(
     // after a `". "` prefix) must opt in here explicitly.
     match effective_rendering.text_case {
         Some(citum_schema::options::titles::TextCase::CapitalizeFirst) => {
-            crate::values::text_case::capitalize_first_word(&term_str)
+            crate::values::text_case::apply_text_case_with_language(
+                &term_str,
+                citum_schema::options::titles::TextCase::CapitalizeFirst,
+                Some(options.locale.locale.as_str()),
+            )
         }
         _ => term_str,
     }

--- a/crates/citum-engine/src/values/contributor/substitute.rs
+++ b/crates/citum-engine/src/values/contributor/substitute.rs
@@ -11,7 +11,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use crate::processor::rendering::get_variable_key;
 use crate::reference::Reference;
 use crate::render::format::OutputFormat;
-use crate::values::text_case::apply_text_case;
+use crate::values::text_case::apply_text_case_with_language;
 use crate::values::title::resolve_substitute_text_case;
 use crate::values::{ProcHints, ProcValues, RenderContext, RenderOptions};
 use citum_schema::options::{
@@ -590,7 +590,10 @@ fn resolve_title_substitute<F: OutputFormat<Output = String>>(
     // config (keyed by reference type) applies here — see
     // `resolve_substitute_text_case`.
     let title_str = match resolve_substitute_text_case(title_type, reference, options) {
-        Some(case) => apply_text_case(&title_str, case),
+        Some(case) => {
+            let language = crate::values::title::effective_title_language(title_type, reference);
+            apply_text_case_with_language(&title_str, case, language.as_deref())
+        }
         None => title_str,
     };
     let value = if options.context == RenderContext::Citation && quote_in_citation {

--- a/crates/citum-engine/src/values/message.rs
+++ b/crates/citum-engine/src/values/message.rs
@@ -52,7 +52,11 @@ impl ComponentValues for TemplateMessage {
         }
 
         if let Some(tc) = self.rendering.text_case {
-            value = crate::values::text_case::apply_text_case(&value, tc);
+            value = crate::values::text_case::apply_text_case_with_language(
+                &value,
+                tc,
+                Some(options.locale.locale.as_str()),
+            );
         }
 
         if value.trim().is_empty() {

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -350,14 +350,14 @@ pub fn effective_component_language(
     }
 }
 
-/// Resolve a BCP 47 language tag to its effective ISO 15924 script code.
+/// Parse a language tag after applying Citum's accepted normalization and fallback rules.
 ///
-/// An explicit script subtag takes precedence. Otherwise, the tag's language
-/// and region are expanded with CLDR likely-subtags data. Missing, malformed,
-/// private-use-only, and unrecognized language evidence resolves to `None`;
-/// this function never supplies a default script.
-#[must_use]
-pub fn resolve_language_script(lang: Option<&str>) -> Option<String> {
+/// Underscores are normalized to BCP 47 separators, and unrecognized rightmost
+/// subtags are progressively removed so Citum-specific locale suffixes do not
+/// hide an otherwise valid language identifier.
+pub(crate) fn parse_language_identifier(
+    lang: Option<&str>,
+) -> Option<icu_locale::LanguageIdentifier> {
     use std::borrow::Cow;
 
     let lang = lang?.trim();
@@ -370,7 +370,26 @@ pub fn resolve_language_script(lang: Option<&str>) -> Option<String> {
     } else {
         Cow::Borrowed(lang)
     };
-    let mut langid = normalized.parse::<icu_locale::Locale>().ok()?.id;
+    let mut candidate = normalized.as_ref();
+    while !candidate.is_empty() {
+        if let Ok(locale) = candidate.parse::<icu_locale::Locale>() {
+            return Some(locale.id);
+        }
+        candidate = candidate.rsplit_once('-')?.0;
+    }
+
+    None
+}
+
+/// Resolve a BCP 47 language tag to its effective ISO 15924 script code.
+///
+/// An explicit script subtag takes precedence. Otherwise, the tag's language
+/// and region are expanded with CLDR likely-subtags data. Missing, malformed,
+/// private-use-only, and unrecognized language evidence resolves to `None`;
+/// this function never supplies a default script.
+#[must_use]
+pub fn resolve_language_script(lang: Option<&str>) -> Option<String> {
+    let mut langid = parse_language_identifier(lang)?;
 
     if let Some(script) = langid.script {
         return Some(script.to_string());

--- a/crates/citum-engine/src/values/number.rs
+++ b/crates/citum-engine/src/values/number.rs
@@ -238,7 +238,12 @@ impl ComponentValues for TemplateNumber {
             // Free-text number values (e.g. `edition`) honor an explicit
             // text-case override the same way string variables do.
             let value = if let Some(tc) = effective_rendering.text_case {
-                crate::values::text_case::apply_text_case(&value, tc)
+                let language = reference.language();
+                crate::values::text_case::apply_text_case_with_language(
+                    &value,
+                    tc,
+                    language.as_deref(),
+                )
             } else {
                 value
             };

--- a/crates/citum-engine/src/values/term.rs
+++ b/crates/citum-engine/src/values/term.rs
@@ -35,7 +35,11 @@ impl ComponentValues for TemplateTerm {
 
         // Apply text-case if configured
         if let Some(tc) = effective_rendering.text_case {
-            value = crate::values::text_case::apply_text_case(&value, tc);
+            value = crate::values::text_case::apply_text_case_with_language(
+                &value,
+                tc,
+                Some(options.locale.locale.as_str()),
+            );
         }
 
         if value.is_empty() {

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -53,10 +53,32 @@ fn language_script_resolution_prefers_explicit_script_evidence() {
 }
 
 #[test]
+fn language_identifier_parsing_normalizes_and_trims_shared_tag_forms() {
+    let underscore = super::parse_language_identifier(Some(" tr_TR ")).unwrap();
+    assert_eq!(underscore.language.as_str(), "tr");
+    assert_eq!(
+        underscore
+            .region
+            .map(|region| region.to_string())
+            .as_deref(),
+        Some("TR")
+    );
+
+    let suffixed = super::parse_language_identifier(Some("tr-TR-citum_override")).unwrap();
+    assert_eq!(suffixed.language, underscore.language);
+    assert_eq!(suffixed.region, underscore.region);
+
+    assert_eq!(super::parse_language_identifier(Some("_")), None);
+    assert_eq!(super::parse_language_identifier(Some("  ")), None);
+}
+
+#[test]
 fn language_script_resolution_uses_likely_subtags_for_recognized_languages() {
     for (language, expected) in [
         ("en", "Latn"),
         ("en_US", "Latn"),
+        ("sr_Latn_RS", "Latn"),
+        ("tr-TR-citum_override", "Latn"),
         ("en-u-ca-gregory", "Latn"),
         ("ru-RU", "Cyrl"),
         ("ar", "Arab"),

--- a/crates/citum-engine/src/values/text_case.rs
+++ b/crates/citum-engine/src/values/text_case.rs
@@ -11,6 +11,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 use citum_schema::NoteStartTextCase;
 use citum_schema::options::titles::TextCase;
+use icu_casemap::CaseMapper;
+use icu_locale::LanguageIdentifier;
 
 /// Apply a text-case transform to a single plain-text segment.
 ///
@@ -21,16 +23,54 @@ use citum_schema::options::titles::TextCase;
 /// not here — this function operates on already-resolved text segments.
 #[must_use]
 pub fn apply_text_case(text: &str, case: TextCase) -> String {
+    apply_text_case_with_language(text, case, None)
+}
+
+/// Apply a text-case transform using locale-tailored Unicode case mappings.
+///
+/// `language` accepts a BCP 47 language tag. Missing or malformed tags use
+/// the Unicode root locale, preserving deterministic default behavior.
+#[must_use]
+pub fn apply_text_case_with_language(text: &str, case: TextCase, language: Option<&str>) -> String {
+    let language = language_identifier_for_tag(language);
+    apply_text_case_with_language_id(text, case, &language)
+}
+
+pub(crate) fn apply_text_case_with_language_id(
+    text: &str,
+    case: TextCase,
+    language: &LanguageIdentifier,
+) -> String {
     match case {
         TextCase::AsIs => text.to_string(),
-        TextCase::Lowercase => text.to_lowercase(),
-        TextCase::Uppercase => text.to_uppercase(),
-        TextCase::CapitalizeFirst => capitalize_first_word(text),
+        TextCase::Lowercase => lowercase(text, language),
+        TextCase::Uppercase => uppercase(text, language),
+        TextCase::CapitalizeFirst => capitalize_first_word_with_language_id(text, language),
         TextCase::Sentence | TextCase::SentenceApa | TextCase::SentenceNlm => {
-            to_sentence_case(text)
+            to_sentence_case_with_language_id(text, language)
         }
-        TextCase::Title => to_title_case(text),
+        TextCase::Title => to_title_case_with_language_id(text, language),
     }
+}
+
+pub(crate) fn language_identifier_for_tag(language: Option<&str>) -> LanguageIdentifier {
+    super::parse_language_identifier(language).unwrap_or_else(root_language_identifier)
+}
+
+fn root_language_identifier() -> LanguageIdentifier {
+    icu_locale::langid!("und")
+}
+
+fn lowercase(text: &str, language: &LanguageIdentifier) -> String {
+    CaseMapper::new()
+        .lowercase_to_string(text, language)
+        .into_owned()
+}
+
+fn uppercase(text: &str, language: &LanguageIdentifier) -> String {
+    CaseMapper::new()
+        .uppercase_to_string(text, language)
+        .into_owned()
 }
 
 /// Apply text-case to a structured title (main + subtitles).
@@ -45,21 +85,39 @@ pub fn apply_to_structured_parts(
     subtitles: &[&str],
     case: TextCase,
 ) -> (String, Vec<String>) {
+    apply_to_structured_parts_with_language(main, subtitles, case, None)
+}
+
+/// Apply locale-tailored text casing to a structured title (main + subtitles).
+#[must_use]
+pub fn apply_to_structured_parts_with_language(
+    main: &str,
+    subtitles: &[&str],
+    case: TextCase,
+    language: Option<&str>,
+) -> (String, Vec<String>) {
+    let language = language_identifier_for_tag(language);
     match case {
         TextCase::SentenceApa => {
-            let main_cased = to_sentence_case(main);
-            let subs_cased = subtitles.iter().map(|s| to_sentence_case(s)).collect();
+            let main_cased = to_sentence_case_with_language_id(main, &language);
+            let subs_cased = subtitles
+                .iter()
+                .map(|s| to_sentence_case_with_language_id(s, &language))
+                .collect();
             (main_cased, subs_cased)
         }
         TextCase::SentenceNlm => {
-            let main_cased = to_sentence_case(main);
+            let main_cased = to_sentence_case_with_language_id(main, &language);
             // NLM: subtitles keep only explicit/protected capitals (lowercase the rest)
-            let subs_cased = subtitles.iter().map(|s| s.to_lowercase()).collect();
+            let subs_cased = subtitles.iter().map(|s| lowercase(s, &language)).collect();
             (main_cased, subs_cased)
         }
         _ => {
-            let main_cased = apply_text_case(main, case);
-            let subs_cased = subtitles.iter().map(|s| apply_text_case(s, case)).collect();
+            let main_cased = apply_text_case_with_language_id(main, case, &language);
+            let subs_cased = subtitles
+                .iter()
+                .map(|s| apply_text_case_with_language_id(s, case, &language))
+                .collect();
             (main_cased, subs_cased)
         }
     }
@@ -107,7 +165,7 @@ pub(crate) fn apply_note_start_text_case(
         NoteStartTextCase::CapitalizeFirst => TextCase::CapitalizeFirst,
         NoteStartTextCase::Lowercase => TextCase::Lowercase,
     };
-    apply_text_case(value, resolve_text_case(case, language))
+    apply_text_case_with_language(value, resolve_text_case(case, language), language)
 }
 
 /// Returns true if any character in `word` other than the first is uppercase.
@@ -153,7 +211,13 @@ fn rebuild_with_original_whitespace(text: &str, parts: &[String]) -> String {
 /// first, except words carrying internal capitalization (acronyms, mixed-case
 /// names), which are preserved exactly as written — including the first word,
 /// which is left unmodified rather than force-capitalized.
+#[cfg(test)]
 fn to_sentence_case(text: &str) -> String {
+    let language = root_language_identifier();
+    to_sentence_case_with_language_id(text, &language)
+}
+
+fn to_sentence_case_with_language_id(text: &str, language: &LanguageIdentifier) -> String {
     if text.is_empty() {
         return String::new();
     }
@@ -168,9 +232,12 @@ fn to_sentence_case(text: &str) -> String {
         if has_internal_uppercase(word) {
             parts.push((*word).to_string());
         } else if i == 0 {
-            parts.push(capitalize_first_word(&word.to_lowercase()));
+            parts.push(capitalize_first_word_with_language_id(
+                &lowercase(word, language),
+                language,
+            ));
         } else {
-            parts.push(word.to_lowercase());
+            parts.push(lowercase(word, language));
         }
     }
 
@@ -185,15 +252,19 @@ fn to_sentence_case(text: &str) -> String {
 /// first token is a numeral, not a word), so it is left as-is instead of
 /// capitalizing the first letter found later in the string (which would
 /// wrongly produce `"35 Mm film"`).
+#[cfg(test)]
 pub(crate) fn capitalize_first_word(text: &str) -> String {
+    let language = root_language_identifier();
+    capitalize_first_word_with_language_id(text, &language)
+}
+
+fn capitalize_first_word_with_language_id(text: &str, language: &LanguageIdentifier) -> String {
     let mut result = String::with_capacity(text.len());
     let mut found_first = false;
     let mut blocked_by_digit = false;
     for ch in text.chars() {
         if !found_first && !blocked_by_digit && ch.is_alphabetic() {
-            for upper in ch.to_uppercase() {
-                result.push(upper);
-            }
+            result.push_str(&uppercase(&ch.to_string(), language));
             found_first = true;
         } else {
             if !found_first && ch.is_ascii_digit() {
@@ -211,7 +282,16 @@ pub(crate) fn capitalize_first_word(text: &str) -> String {
 /// Use this variant when the input may already contain rendered markup from a
 /// pre-formatted component. For plain-text input, behaviour is identical to
 /// [`capitalize_first_word`].
+#[cfg(test)]
 pub(crate) fn capitalize_first_word_markup_aware(text: &str) -> String {
+    capitalize_first_word_markup_aware_with_language(text, None)
+}
+
+pub(crate) fn capitalize_first_word_markup_aware_with_language(
+    text: &str,
+    language: Option<&str>,
+) -> String {
+    let language = language_identifier_for_tag(language);
     let bytes = text.as_bytes();
     let len = bytes.len();
     let mut i = 0;
@@ -280,9 +360,7 @@ pub(crate) fn capitalize_first_word_markup_aware(text: &str) -> String {
             let ch_len = ch.len_utf8();
             let mut result = String::with_capacity(text.len());
             result.push_str(text.get(..i).unwrap_or_default());
-            for upper in ch.to_uppercase() {
-                result.push(upper);
-            }
+            result.push_str(&uppercase(&ch.to_string(), &language));
             result.push_str(text.get(i + ch_len..).unwrap_or_default());
             return result;
         }
@@ -296,12 +374,18 @@ pub(crate) fn capitalize_first_word_markup_aware(text: &str) -> String {
 /// Apply a text-case transform to a pre-formatted string that may contain
 /// rendered markup.
 ///
-/// Delegates to [`capitalize_first_word_markup_aware`] for `CapitalizeFirst`;
-/// all other cases fall back to [`apply_text_case`].
-pub(crate) fn apply_text_case_markup_aware(text: &str, case: TextCase) -> String {
+/// Delegates to locale-aware markup capitalization for `CapitalizeFirst` and
+/// applies the requested locale-aware transform for all other cases.
+pub(crate) fn apply_text_case_markup_aware_with_language(
+    text: &str,
+    case: TextCase,
+    language: Option<&str>,
+) -> String {
     match case {
-        TextCase::CapitalizeFirst => capitalize_first_word_markup_aware(text),
-        _ => apply_text_case(text, case),
+        TextCase::CapitalizeFirst => {
+            capitalize_first_word_markup_aware_with_language(text, language)
+        }
+        _ => apply_text_case_with_language(text, case, language),
     }
 }
 
@@ -329,29 +413,29 @@ fn contains_hyphen_like(text: &str) -> bool {
 /// is capitalized. Otherwise interior stop-word components stay lowercase.
 /// Splits on both the ASCII hyphen and the en dash (see [`HYPHEN_LIKE_CHARS`]),
 /// preserving whichever separator character was actually used.
-fn capitalize_hyphenated(word: &str, force_all: bool) -> String {
+fn capitalize_hyphenated(word: &str, force_all: bool, language: &LanguageIdentifier) -> String {
     let mut result = String::with_capacity(word.len());
     let mut last_end = 0;
     for (idx, sep) in word.match_indices(HYPHEN_LIKE_CHARS) {
         let part = word.get(last_end..idx).unwrap_or_default();
-        result.push_str(&capitalize_hyphen_part(part, force_all));
+        result.push_str(&capitalize_hyphen_part(part, force_all, language));
         result.push_str(sep);
         last_end = idx + sep.len();
     }
     let tail = word.get(last_end..).unwrap_or_default();
-    result.push_str(&capitalize_hyphen_part(tail, force_all));
+    result.push_str(&capitalize_hyphen_part(tail, force_all, language));
     result
 }
 
-fn capitalize_hyphen_part(part: &str, force_all: bool) -> String {
+fn capitalize_hyphen_part(part: &str, force_all: bool, language: &LanguageIdentifier) -> String {
     if force_all {
-        capitalize_first_word(part)
+        capitalize_first_word_with_language_id(part, language)
     } else {
         let alpha_core = part.trim_matches(|c: char| !c.is_alphanumeric());
         if TITLE_CASE_STOP_WORDS.contains(&alpha_core) {
             part.to_string()
         } else {
-            capitalize_first_word(part)
+            capitalize_first_word_with_language_id(part, language)
         }
     }
 }
@@ -366,7 +450,13 @@ fn trim_trailing_closing_punctuation(word: &str) -> &str {
 /// Interior stop words (articles, short prepositions, conjunctions) stay lowercase.
 /// The first word after `:`, `?`, or `!` is always capitalized.
 /// Hyphenated compounds capitalize each non-stop-word component.
+#[cfg(test)]
 fn to_title_case(text: &str) -> String {
+    let language = root_language_identifier();
+    to_title_case_with_language_id(text, &language)
+}
+
+fn to_title_case_with_language_id(text: &str, language: &LanguageIdentifier) -> String {
     if text.is_empty() {
         return String::new();
     }
@@ -386,12 +476,12 @@ fn to_title_case(text: &str) -> String {
             // preserve exactly as written, regardless of position.
             parts.push((*word).to_string());
         } else {
-            let lower = word.to_lowercase();
+            let lower = lowercase(word, language);
             if i == 0 || i == last_idx || capitalize_next {
                 if contains_hyphen_like(&lower) {
-                    parts.push(capitalize_hyphenated(&lower, true));
+                    parts.push(capitalize_hyphenated(&lower, true, language));
                 } else {
-                    parts.push(capitalize_first_word(&lower));
+                    parts.push(capitalize_first_word_with_language_id(&lower, language));
                 }
             } else {
                 // Strip leading/trailing punctuation when checking stop words so that
@@ -400,9 +490,9 @@ fn to_title_case(text: &str) -> String {
                 if TITLE_CASE_STOP_WORDS.contains(&alpha_core) {
                     parts.push(lower);
                 } else if contains_hyphen_like(&lower) {
-                    parts.push(capitalize_hyphenated(&lower, false));
+                    parts.push(capitalize_hyphenated(&lower, false, language));
                 } else {
-                    parts.push(capitalize_first_word(&lower));
+                    parts.push(capitalize_first_word_with_language_id(&lower, language));
                 }
             }
         }
@@ -466,6 +556,75 @@ mod tests {
         assert_eq!(capitalize_first_word("in Korean"), "In Korean");
     }
 
+    #[test]
+    fn turkish_case_mapping_handles_dotted_and_dotless_i() {
+        assert_eq!(
+            apply_text_case_with_language("istanbul ızmir", TextCase::Uppercase, Some("tr-TR"),),
+            "İSTANBUL IZMİR"
+        );
+        assert_eq!(
+            apply_text_case_with_language("İSTANBUL IĞDIR", TextCase::Lowercase, Some("tr-TR"),),
+            "istanbul ığdır"
+        );
+        assert_eq!(
+            apply_text_case_with_language("istanbul", TextCase::CapitalizeFirst, Some("tr")),
+            "İstanbul"
+        );
+        assert_eq!(
+            apply_text_case_with_language("istanbul ızmir", TextCase::Uppercase, Some("tr_TR")),
+            "İSTANBUL IZMİR"
+        );
+    }
+
+    #[test]
+    fn azerbaijani_case_mapping_uses_turkic_rules() {
+        assert_eq!(
+            apply_text_case_with_language("izmir ı", TextCase::Uppercase, Some("az-Latn-AZ")),
+            "İZMİR I"
+        );
+    }
+
+    #[test]
+    fn sentence_case_uses_the_supplied_language() {
+        assert_eq!(
+            apply_text_case_with_language("istanbul Izmir", TextCase::Sentence, Some("tr-TR"),),
+            "İstanbul ızmir"
+        );
+    }
+
+    #[test]
+    fn structured_subtitles_use_the_supplied_language() {
+        let (main, subtitles) = apply_to_structured_parts_with_language(
+            "istanbul tarihi",
+            &["izmir incelemesi"],
+            TextCase::SentenceApa,
+            Some("tr-TR"),
+        );
+
+        assert_eq!(main, "İstanbul tarihi");
+        assert_eq!(subtitles, ["İzmir incelemesi"]);
+    }
+
+    #[test]
+    fn malformed_language_tag_uses_root_case_mapping() {
+        assert_eq!(
+            apply_text_case_with_language("istanbul", TextCase::Uppercase, Some("not_a_language"),),
+            "ISTANBUL"
+        );
+    }
+
+    #[test]
+    fn locale_override_suffix_preserves_base_language_mapping() {
+        assert_eq!(
+            apply_text_case_with_language(
+                "istanbul",
+                TextCase::Uppercase,
+                Some("tr-TR-citum_override"),
+            ),
+            "İSTANBUL"
+        );
+    }
+
     // --- capitalize_first_word_markup_aware ---
 
     #[test]
@@ -481,6 +640,18 @@ mod tests {
         assert_eq!(
             capitalize_first_word_markup_aware("<em>the collected essays</em>"),
             "<em>The collected essays</em>"
+        );
+    }
+
+    #[test]
+    fn capitalize_markup_aware_uses_the_supplied_language() {
+        assert_eq!(
+            apply_text_case_markup_aware_with_language(
+                "<em>istanbul</em>",
+                TextCase::CapitalizeFirst,
+                Some("tr-TR"),
+            ),
+            "<em>İstanbul</em>"
         );
     }
 

--- a/crates/citum-engine/src/values/title.rs
+++ b/crates/citum-engine/src/values/title.rs
@@ -11,7 +11,7 @@ use crate::render::format::unicode_quote_marks;
 use crate::render::rich_text::{
     InlineRenderContext, render_djot_inline_with_transform_and_context,
 };
-use crate::values::text_case::{self, apply_text_case, capitalize_first_word};
+use crate::values::text_case::{self, apply_text_case_with_language};
 use crate::values::{
     ComponentValues, ProcHints, ProcValues, RenderOptions, effective_component_language,
 };
@@ -155,24 +155,37 @@ fn looks_like_djot_markup(value: &str) -> bool {
 ///
 /// The closure is used as the Djot text-leaf transform, so `.nocase` spans
 /// bypass it automatically via the rich-text renderer.
-fn make_case_transform(case: TextCase, quote_depth: usize) -> impl FnMut(&str) -> String {
+fn make_case_transform(
+    case: TextCase,
+    quote_depth: usize,
+    language: Option<&str>,
+) -> impl FnMut(&str) -> String {
     let mut seen_alpha = false;
+    let language = text_case::language_identifier_for_tag(language);
     move |text: &str| {
         let cased = match case {
             TextCase::Sentence | TextCase::SentenceApa | TextCase::SentenceNlm => {
-                let lowered = text.to_lowercase();
+                let lowered = text_case::apply_text_case_with_language_id(
+                    text,
+                    TextCase::Lowercase,
+                    &language,
+                );
                 if seen_alpha {
                     lowered
                 } else {
                     // Capitalize the first alphabetic character we encounter
-                    let result = capitalize_first_word(&lowered);
+                    let result = text_case::apply_text_case_with_language_id(
+                        &lowered,
+                        TextCase::CapitalizeFirst,
+                        &language,
+                    );
                     if result.chars().any(|c: char| c.is_alphabetic()) {
                         seen_alpha = true;
                     }
                     result
                 }
             }
-            _ => apply_text_case(text, case),
+            _ => text_case::apply_text_case_with_language_id(text, case, &language),
         };
         smarten_title_quotes_at_depth(&cased, quote_depth)
     }
@@ -185,6 +198,7 @@ fn render_part_with_case<F: crate::render::format::OutputFormat<Output = String>
     fmt: &F,
     case: Option<TextCase>,
     quote_depth: usize,
+    language: Option<&str>,
 ) -> (String, bool) {
     let context = InlineRenderContext { quote_depth };
     if looks_like_djot_markup(value) {
@@ -193,7 +207,7 @@ fn render_part_with_case<F: crate::render::format::OutputFormat<Output = String>
                 value,
                 fmt,
                 context,
-                make_case_transform(tc, quote_depth),
+                make_case_transform(tc, quote_depth, language),
             ),
             None => {
                 render_djot_inline_with_transform_and_context(value, fmt, context, move |text| {
@@ -203,7 +217,10 @@ fn render_part_with_case<F: crate::render::format::OutputFormat<Output = String>
         }
     } else {
         let result = match case {
-            Some(tc) => smarten_title_quotes_at_depth(&apply_text_case(value, tc), quote_depth),
+            Some(tc) => smarten_title_quotes_at_depth(
+                &apply_text_case_with_language(value, tc, language),
+                quote_depth,
+            ),
             None => smarten_title_quotes_at_depth(value, quote_depth),
         };
         (result, false)
@@ -220,10 +237,11 @@ fn render_structured_title<F: crate::render::format::OutputFormat<Output = Strin
     case: Option<TextCase>,
     short: bool,
     quote_depth: usize,
-    primary_delimiter: &str,
-    subtitle_delimiter: &str,
+    language: Option<&str>,
+    delimiters: (&str, &str),
 ) -> (String, bool) {
-    let (main_rendered, has_link) = render_part_with_case(&st.main, fmt, case, quote_depth);
+    let (main_rendered, has_link) =
+        render_part_with_case(&st.main, fmt, case, quote_depth, language);
     if short {
         return (main_rendered, has_link);
     }
@@ -245,10 +263,12 @@ fn render_structured_title<F: crate::render::format::OutputFormat<Output = Strin
 
     let mut rendered_subtitles = Vec::with_capacity(subs.len());
     for sub in subs {
-        let (sub_rendered, sub_link) = render_part_with_case(sub, fmt, subtitle_case, quote_depth);
+        let (sub_rendered, sub_link) =
+            render_part_with_case(sub, fmt, subtitle_case, quote_depth, language);
         has_link |= sub_link;
         rendered_subtitles.push(sub_rendered);
     }
+    let (primary_delimiter, subtitle_delimiter) = delimiters;
     let subtitle_group = rendered_subtitles.join(subtitle_delimiter);
 
     let mut rendered = main_rendered;
@@ -263,25 +283,24 @@ fn resolve_effective_text_case(
     template: &TemplateTitle,
     reference: &Reference,
     options: &RenderOptions<'_>,
+    language: Option<&str>,
 ) -> Option<TextCase> {
     // 1. Template-level override takes precedence
     if let Some(tc) = template.rendering.text_case {
-        return Some(apply_language_fallback(tc, reference));
+        return Some(apply_language_fallback(tc, language));
     }
 
     // 2. Global title-category config
     let ref_type = reference.ref_type();
-    let lang = reference.language();
-    let lang_str = lang.as_deref();
 
     if let Some(rendering) = crate::render::component::get_title_category_rendering(
         &template.title,
         Some(&ref_type),
-        lang_str,
+        language,
         &options.config,
     ) && let Some(tc) = rendering.text_case
     {
-        return Some(apply_language_fallback(tc, reference));
+        return Some(apply_language_fallback(tc, language));
     }
 
     None
@@ -300,15 +319,15 @@ pub(crate) fn resolve_substitute_text_case(
     options: &RenderOptions<'_>,
 ) -> Option<TextCase> {
     let ref_type = reference.ref_type();
-    let lang = reference.language();
+    let language = effective_title_language(title_type, reference);
     let rendering = crate::render::component::get_title_category_rendering(
         title_type,
         Some(&ref_type),
-        lang.as_deref(),
+        language.as_deref(),
         &options.config,
     )?;
     let tc = rendering.text_case?;
-    Some(apply_language_fallback(tc, reference))
+    Some(apply_language_fallback(tc, language.as_deref()))
 }
 
 fn resolve_effective_title_rendering(
@@ -359,9 +378,19 @@ fn effective_title_quote_depth(
 }
 
 /// Apply language-aware fallback: non-English → as-is for English-specific transforms.
-fn apply_language_fallback(case: TextCase, reference: &Reference) -> TextCase {
-    let lang = reference.language();
-    text_case::resolve_text_case(case, lang.as_deref())
+fn apply_language_fallback(case: TextCase, language: Option<&str>) -> TextCase {
+    text_case::resolve_text_case(case, language)
+}
+
+pub(crate) fn effective_title_language(
+    title_type: &TitleType,
+    reference: &Reference,
+) -> Option<String> {
+    let component = TemplateComponent::Title(TemplateTitle {
+        title: title_type.clone(),
+        ..Default::default()
+    });
+    effective_component_language(reference, &component)
 }
 
 impl ComponentValues for TemplateTitle {
@@ -414,7 +443,9 @@ impl ComponentValues for TemplateTitle {
         }
 
         let title = resolve_primary_title(reference, &self.title)?;
-        let effective_case = resolve_effective_text_case(self, reference, options);
+        let effective_language = effective_title_language(&self.title, reference);
+        let effective_case =
+            resolve_effective_text_case(self, reference, options, effective_language.as_deref());
         let effective_title_rendering = resolve_effective_title_rendering(self, reference, options);
         let (value, has_explicit_link, pre_formatted) = render_title_variant::<F>(
             &title,
@@ -423,6 +454,7 @@ impl ComponentValues for TemplateTitle {
             effective_title_rendering.as_ref(),
             options,
             quote_depth,
+            effective_language.as_deref(),
         );
 
         if value.is_empty() {
@@ -487,21 +519,21 @@ fn render_title_variant<F: crate::render::format::OutputFormat<Output = String>>
     effective_title_rendering: Option<&TitleRendering>,
     options: &RenderOptions<'_>,
     quote_depth: usize,
+    language: Option<&str>,
 ) -> (String, bool, bool) {
     let fmt = F::default();
     match title {
         Title::Structured(st) => {
             let short = matches!(form, Some(TitleForm::Short));
-            let (primary_delimiter, subtitle_delimiter) =
-                structured_title_delimiters(effective_title_rendering, options.locale);
+            let delimiters = structured_title_delimiters(effective_title_rendering, options.locale);
             let (value, has_link) = render_structured_title(
                 st,
                 &fmt,
                 effective_case,
                 short,
                 quote_depth,
-                primary_delimiter,
-                subtitle_delimiter,
+                language,
+                delimiters,
             );
             let pre_formatted = if short {
                 looks_like_djot_markup(&st.main)
@@ -522,14 +554,14 @@ fn render_title_variant<F: crate::render::format::OutputFormat<Output = String>>
                 options.locale.locale.as_str(),
             );
             let (rendered, has_link) =
-                render_part_with_case(&value, &fmt, effective_case, quote_depth);
+                render_part_with_case(&value, &fmt, effective_case, quote_depth, language);
             let pre_formatted = looks_like_djot_markup(&value);
             (rendered, has_link, pre_formatted)
         }
         _ => {
             let value = title_text(title, form);
             let (rendered, has_link) =
-                render_part_with_case(&value, &fmt, effective_case, quote_depth);
+                render_part_with_case(&value, &fmt, effective_case, quote_depth, language);
             let pre_formatted = looks_like_djot_markup(&value);
             (rendered, has_link, pre_formatted)
         }

--- a/crates/citum-engine/src/values/type_label.rs
+++ b/crates/citum-engine/src/values/type_label.rs
@@ -30,7 +30,11 @@ impl ComponentValues for TemplateTypeLabel {
         }
 
         if let Some(tc) = effective_rendering.text_case {
-            value = crate::values::text_case::apply_text_case(&value, tc);
+            value = crate::values::text_case::apply_text_case_with_language(
+                &value,
+                tc,
+                Some(options.locale.locale.as_str()),
+            );
         }
 
         if value.is_empty() {

--- a/crates/citum-engine/src/values/variable.rs
+++ b/crates/citum-engine/src/values/variable.rs
@@ -223,22 +223,34 @@ fn assemble_archive_hierarchy(
     }
 }
 
-fn make_rich_text_case_transform(case: TextCase) -> impl FnMut(&str) -> String {
+fn make_rich_text_case_transform(
+    case: TextCase,
+    language: Option<&str>,
+) -> impl FnMut(&str) -> String {
     let mut seen_alpha = false;
+    let language = crate::values::text_case::language_identifier_for_tag(language);
     move |text: &str| match case {
         TextCase::Sentence | TextCase::SentenceApa | TextCase::SentenceNlm => {
-            let lowered = text.to_lowercase();
+            let lowered = crate::values::text_case::apply_text_case_with_language_id(
+                text,
+                TextCase::Lowercase,
+                &language,
+            );
             if seen_alpha {
                 lowered
             } else {
-                let result = crate::values::text_case::capitalize_first_word(&lowered);
+                let result = crate::values::text_case::apply_text_case_with_language_id(
+                    &lowered,
+                    TextCase::CapitalizeFirst,
+                    &language,
+                );
                 if result.chars().any(char::is_alphabetic) {
                     seen_alpha = true;
                 }
                 result
             }
         }
-        _ => crate::values::text_case::apply_text_case(text, case),
+        _ => crate::values::text_case::apply_text_case_with_language_id(text, case, &language),
     }
 }
 
@@ -351,6 +363,7 @@ impl ComponentValues for TemplateVariable {
         _hints: &ProcHints,
         options: &RenderOptions<'_>,
     ) -> Option<ProcValues<F::Output>> {
+        let language = reference.language();
         // Rich-text variables carry format metadata — handle before the plain-string path.
         let rich_text: Option<RichText> = match self.variable {
             SimpleVariable::Note => reference.note(),
@@ -364,15 +377,20 @@ impl ComponentValues for TemplateVariable {
             }
             let fmt = F::default();
             let (value, pre_formatted) = match (rt, self.rendering.text_case) {
-                (RichText::Plain(s), Some(tc)) => {
-                    (crate::values::text_case::apply_text_case(&s, tc), false)
-                }
+                (RichText::Plain(s), Some(tc)) => (
+                    crate::values::text_case::apply_text_case_with_language(
+                        &s,
+                        tc,
+                        language.as_deref(),
+                    ),
+                    false,
+                ),
                 (RichText::Plain(s), None) => (s, false),
                 (RichText::Djot { djot }, Some(tc)) => (
                     crate::render::rich_text::render_djot_inline_with_transform(
                         &djot,
                         &fmt,
-                        make_rich_text_case_transform(tc),
+                        make_rich_text_case_transform(tc, language.as_deref()),
                     )
                     .0,
                     true,
@@ -396,7 +414,11 @@ impl ComponentValues for TemplateVariable {
 
         value.filter(|s: &String| !s.is_empty()).map(|value| {
             let value = if let Some(tc) = self.rendering.text_case {
-                crate::values::text_case::apply_text_case(&value, tc)
+                crate::values::text_case::apply_text_case_with_language(
+                    &value,
+                    tc,
+                    language.as_deref(),
+                )
             } else {
                 value
             };

--- a/crates/citum-engine/tests/i18n.rs
+++ b/crates/citum-engine/tests/i18n.rs
@@ -50,6 +50,162 @@ use citum_schema::{
 use rstest::rstest;
 use std::collections::HashMap;
 
+#[rstest]
+#[case(
+    "en-US",
+    Some("tr-TR"),
+    "istanbul ızmir",
+    "uppercase",
+    "İSTANBUL IZMİR"
+)]
+#[case("az-Latn-AZ", None, "İSTANBUL IĞDIR", "lowercase", "istanbul ığdır")]
+fn given_item_language_when_title_case_is_explicit_then_mapping_is_locale_tailored(
+    #[case] item_language: &str,
+    #[case] field_language: Option<&str>,
+    #[case] title: &str,
+    #[case] text_case: &str,
+    #[case] expected: &str,
+) {
+    let style: Style = serde_yaml::from_str(&format!(
+        r#"
+info:
+  title: Locale-tailored title casing
+bibliography:
+  template:
+    - title: primary
+      text-case: {text_case}
+"#,
+    ))
+    .unwrap();
+    let mut reference_json = serde_json::json!({
+        "class": "monograph",
+        "type": "book",
+        "id": "item",
+        "title": title,
+        "language": item_language
+    });
+    if let Some(field_language) = field_language {
+        reference_json["field-languages"] = serde_json::json!({ "title": field_language });
+    }
+    let reference: InputReference = serde_json::from_value(reference_json).unwrap();
+    let processor = Processor::new(
+        style,
+        indexmap::indexmap! { "item".to_string() => reference },
+    );
+
+    assert_eq!(processor.render_bibliography(), expected);
+}
+
+#[rstest]
+#[case("- variable: publisher-place", "en-US", "tr-TR", "ISTANBUL")]
+#[case("- variable: publisher-place", "tr_TR", "en-US", "İSTANBUL")]
+#[case("- number: edition", "en-US", "tr-TR", "ISTANBUL")]
+#[case("- number: edition", "tr_TR", "en-US", "İSTANBUL")]
+fn given_title_and_entry_languages_when_casing_non_title_fields_then_entry_language_wins(
+    #[case] component: &str,
+    #[case] item_language: &str,
+    #[case] title_language: &str,
+    #[case] expected: &str,
+) {
+    let style: Style = serde_yaml::from_str(&format!(
+        r#"
+info:
+  title: Field-scoped locale casing
+bibliography:
+  template:
+    {component}
+      text-case: uppercase
+"#,
+    ))
+    .unwrap();
+    let reference: InputReference = serde_json::from_value(serde_json::json!({
+        "class": "monograph",
+        "type": "book",
+        "id": "item",
+        "title": "istanbul",
+        "publisher": { "name": "publisher", "place": "istanbul" },
+        "edition": "istanbul",
+        "language": item_language,
+        "field-languages": { "title": title_language }
+    }))
+    .unwrap();
+    let processor = Processor::new(
+        style,
+        indexmap::indexmap! { "item".to_string() => reference },
+    );
+
+    assert_eq!(processor.render_bibliography(), expected);
+}
+
+#[test]
+fn turkish_title_case_preserves_djot_nocase_spans() {
+    let style: Style = serde_yaml::from_str(
+        r#"
+info:
+  title: Locale-tailored protected title casing
+bibliography:
+  template:
+    - title: primary
+      text-case: uppercase
+"#,
+    )
+    .unwrap();
+    let reference: InputReference = serde_json::from_value(serde_json::json!({
+        "class": "monograph",
+        "type": "book",
+        "id": "item",
+        "title": "istanbul [izmir]{.nocase}",
+        "language": "tr-TR"
+    }))
+    .unwrap();
+    let processor = Processor::new(
+        style,
+        indexmap::indexmap! { "item".to_string() => reference },
+    );
+
+    assert_eq!(processor.render_bibliography(), "İSTANBUL izmir");
+}
+
+#[rstest]
+#[case("- term: in\n      text-case: uppercase", "İÇİNDE")]
+#[case("- message: custom.case-test\n      text-case: uppercase", "İSTANBUL")]
+fn given_turkish_locale_when_locale_text_is_uppercased_then_mapping_is_locale_tailored(
+    #[case] component: &str,
+    #[case] expected: &str,
+) {
+    let style: Style = serde_yaml::from_str(&format!(
+        r#"
+info:
+  title: Locale-tailored locale casing
+options:
+  messages:
+    custom.case-test: istanbul
+bibliography:
+  template:
+    {component}
+"#,
+    ))
+    .unwrap();
+    let reference: InputReference = serde_json::from_value(serde_json::json!({
+        "class": "monograph",
+        "type": "book",
+        "id": "item",
+        "title": "unused"
+    }))
+    .unwrap();
+    let tr_yaml = std::str::from_utf8(
+        citum_schema::embedded::get_locale_bytes("tr-TR").expect("tr-TR must be embedded"),
+    )
+    .unwrap();
+    let processor = Processor::with_locale(
+        style,
+        indexmap::indexmap! { "item".to_string() => reference },
+        citum_schema::Locale::from_yaml_str(tr_yaml).unwrap(),
+    );
+
+    assert_eq!(processor.render_bibliography(), expected);
+}
+
 #[test]
 fn localized_citation_layouts_select_their_term_locale() {
     let style: Style = serde_yaml::from_str(


### PR DESCRIPTION
## Summary

- replace locale-blind text casing with ICU4X mappings across plain, structured, and rich-text rendering
- centralize underscore-aware language parsing with Citum locale-suffix fallback for script resolution and ICU casing
- keep title language overrides field-scoped while ordinary variables and free-text numbers use only entry language
- invalidate restored `v8` package artifacts in linking workflows so the missing `rusty_v8` native archive is regenerated

## Scope

- add unconditional `icu_casemap` compiled data, including `small-wasm`
- route title, variable, number, term, message, type-label, role-label, and sentence-initial casing through the shared implementation
- preserve the root-locale public API, English-only title/sentence gating, and `.nocase` protection
- repair Rust CI, Fidelity, and compatibility-report caches without disabling the broader Cargo cache
- complete/archive `csl26-11wh`; leave output-format small caps and sort normalization unchanged

## Validation

- `just pre-commit` — pass: formatting, all-target/all-feature Clippy, 2,126/2,126 tests
- `cargo nextest run -p citum-engine` — pass: 1,121/1,121 tests
- targeted locale/scoping regressions — pass: title override isolation for publisher place and free-text edition, plus underscore-form Turkish entry language
- `cargo check -p citum-bindings --no-default-features --features small-wasm` — pass
- `./scripts/workflow-test.sh styles-legacy/apa.csl` — unchanged documented baseline: citations 20/20, bibliography 45/46
- `python3 scripts/audit-rust-review-smells.py --changed` — no advisories
- workflow YAML lint and `git diff --check` — pass

## Benchmark

Before/after rendering benchmarks completed with no Criterion regressions reported. The final `critcmp` aggregation could not consume the repository script's human-readable `.txt` captures because it expects JSON; that harness serialization mismatch is pre-existing and is not changed here.

## Risk

- ICU compiled case-map data is now present in every build, including `small-wasm`, so binary size may increase as explicitly accepted for uniform correctness.
- malformed language tags fall back to ICU root casing; Citum-specific suffixes are tolerated by progressively trimming rightmost subtags.
- the workflow cache repair cleans only the `v8` package artifacts after restore, retaining the rest of the shared Cargo cache.

## Follow-ups

- repair `scripts/bench-check.sh` capture/`critcmp` serialization separately
