### PR TITLE
fix(ci): enforce squash merge commit policy

### DIFF
--- a/.beans/csl26-xg1o--close-commit-policy-enforcement-gap.md
+++ b/.beans/csl26-xg1o--close-commit-policy-enforcement-gap.md
@@ -1,0 +1,23 @@
+---
+# csl26-xg1o
+title: Close commit-policy enforcement gap
+status: in-progress
+type: bug
+priority: high
+tags:
+    - ci
+    - hooks
+created_at: 2026-07-21T20:21:42Z
+updated_at: 2026-07-21T20:24:43Z
+---
+
+## Checklist
+
+- [ ] Add an always-on commit-policy workflow.
+- [ ] Validate squash-merge PR titles from the alint policy.
+- [x] Add regression coverage and validate the workflow.
+- [ ] Audit and synchronize the Tangled mirror once.
+
+## Context
+
+GitHub squash merge created 41ce890a with a 69-character PR title, bypassing local hooks. The docs-gated alint CI job did not run for the Rust/beans change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,8 @@ jobs:
           python3 -m unittest \
             scripts/test_infer_release_bump.py \
             scripts/test_coverage_analysis.py \
-            scripts/test_release_workflow.py
+            scripts/test_release_workflow.py \
+            scripts/test_validate_pr_title.py
 
   release-dry-runs:
     name: Release Dry Runs

--- a/.github/workflows/commit-policy.yml
+++ b/.github/workflows/commit-policy.yml
@@ -1,0 +1,31 @@
+name: Commit Policy
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  commit-policy:
+    name: Commit Policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate squash-merge title
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: python3 scripts/validate-pr-title.py "$PR_TITLE"
+
+      - name: Validate accepted commit messages
+        uses: asamarts/alint@9a341559646a0a128957a0f70671e0835fb38dcb  # v0.13.0
+        env:
+          ALINT_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}

--- a/.github/workflows/commit-policy.yml
+++ b/.github/workflows/commit-policy.yml
@@ -14,7 +14,7 @@ jobs:
     name: Commit Policy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803  # v6
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/scripts/test_validate_pr_title.py
+++ b/scripts/test_validate_pr_title.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Regression tests for squash-merge pull request title validation."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parent / "validate-pr-title.py"
+SPEC = importlib.util.spec_from_file_location("validate_pr_title", SCRIPT_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Could not load pull request title validator from {SCRIPT_PATH}")
+validator = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = validator
+SPEC.loader.exec_module(validator)
+
+
+class PullRequestTitleTests(unittest.TestCase):
+    """Verify GitHub squash-merge titles obey the commit subject policy."""
+
+    def test_rejects_the_historical_sixty_nine_character_title(self) -> None:
+        title = "fix(engine): restore locale type-variant fallback in bilingual styles"
+
+        self.assertEqual(
+            validator.validate_title(title),
+            "pull request title is 69 chars; max allowed is 50",
+        )
+
+    def test_accepts_a_fifty_character_title(self) -> None:
+        title = "fix(engine): " + "a" * 37
+
+        self.assertEqual(len(title), 50)
+        self.assertIsNone(validator.validate_title(title))
+
+    def test_rejects_a_fifty_one_character_title(self) -> None:
+        title = "fix(engine): " + "a" * 38
+
+        self.assertEqual(len(title), 51)
+        self.assertEqual(
+            validator.validate_title(title),
+            "pull request title is 51 chars; max allowed is 50",
+        )
+
+    def test_rejects_a_scope_outside_the_alint_policy(self) -> None:
+        title = "fix(unknown): retain compatibility"
+
+        self.assertEqual(
+            validator.validate_title(title),
+            "pull request title does not match the conventional-commit policy",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-pr-title.py
+++ b/scripts/validate-pr-title.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Validate a squash-merge pull request title against the alint commit policy."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ALINT_CONFIG = REPO_ROOT / ".alint.yml"
+
+
+def commit_subject_policy(config_path: Path = ALINT_CONFIG) -> tuple[re.Pattern[str], int]:
+    """Return the conventional-commit pattern and subject limit from alint."""
+    config = config_path.read_text(encoding="utf-8")
+    rule = re.search(
+        r"(?ms)^  - id: conventional-commits\n(?P<body>.*?)(?=^  - id:|\Z)",
+        config,
+    )
+    if rule is None:
+        raise ValueError(".alint.yml does not define the conventional-commits rule")
+
+    pattern = re.search(r"(?m)^    pattern: '(.+)'$", rule["body"])
+    limit = re.search(r"(?m)^    subject_max_length: (\d+)$", rule["body"])
+    if pattern is None or limit is None:
+        raise ValueError("conventional-commits is missing pattern or subject_max_length")
+
+    return re.compile(pattern[1]), int(limit[1])
+
+
+def validate_title(title: str) -> str | None:
+    """Return a validation error when a pull request title cannot be a commit subject."""
+    pattern, maximum_length = commit_subject_policy()
+    if "\n" in title or "\r" in title:
+        return "pull request title must be a single line"
+    if len(title) > maximum_length:
+        return f"pull request title is {len(title)} chars; max allowed is {maximum_length}"
+    if pattern.fullmatch(title) is None:
+        return "pull request title does not match the conventional-commit policy"
+    return None
+
+
+def main() -> int:
+    """Validate the title supplied by GitHub Actions."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("title", help="pull request title to validate")
+    args = parser.parse_args()
+
+    error = validate_title(args.title)
+    if error is None:
+        return 0
+
+    print(f"[ERROR] {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add an always-on commit-policy workflow for pull requests and pushes to main
- validate squash-merge PR titles from the existing alint commit policy
- validate the actual accepted commit range using the event base SHA
- add regressions for the historical 69-character title and subject limits

## Root cause

GitHub squash merge generated commit 41ce890a from a 69-character PR title.
Local hooks did not run, and alint was restricted to a docs-gated CI job while
the change only affected Rust and Beans files.

## Validation

- `python3 -m unittest scripts/test_validate_pr_title.py scripts/test_infer_release_bump.py scripts/test_coverage_analysis.py scripts/test_release_workflow.py`
- `actionlint -color .github/workflows/commit-policy.yml .github/workflows/ci.yml`
- `ALINT_BASE_SHA=main alint check --base main .`
