### PR TITLE
fix(hooks): honor primary history for mirrors

### DIFF
--- a/.beans/archive/csl26-xg1o--close-commit-policy-enforcement-gap.md
+++ b/.beans/archive/csl26-xg1o--close-commit-policy-enforcement-gap.md
@@ -1,14 +1,14 @@
 ---
 # csl26-xg1o
 title: Close commit-policy enforcement gap
-status: in-progress
+status: completed
 type: bug
 priority: high
 tags:
     - ci
     - hooks
 created_at: 2026-07-21T20:21:42Z
-updated_at: 2026-07-21T20:42:03Z
+updated_at: 2026-07-21T20:48:41Z
 ---
 
 ## Checklist
@@ -16,8 +16,12 @@ updated_at: 2026-07-21T20:42:03Z
 - [x] Add an always-on commit-policy workflow.
 - [x] Validate squash-merge PR titles from the alint policy.
 - [x] Add regression coverage and validate the workflow.
-- [ ] Audit and synchronize the Tangled mirror once.
+- [x] Transfer Tangled synchronization to csl26-pn7r.
 
 ## Context
 
 GitHub squash merge created 41ce890a with a 69-character PR title, bypassing local hooks. The docs-gated alint CI job did not run for the Rust/beans change.
+
+## Summary of Changes
+
+Implemented and merged the always-on commit-policy workflow, PR-title validation, and event-range alint checks in PR #1080. Tangled synchronization is tracked separately in csl26-pn7r because it depends on PR #1081.

--- a/.beans/csl26-xg1o--close-commit-policy-enforcement-gap.md
+++ b/.beans/csl26-xg1o--close-commit-policy-enforcement-gap.md
@@ -8,13 +8,13 @@ tags:
     - ci
     - hooks
 created_at: 2026-07-21T20:21:42Z
-updated_at: 2026-07-21T20:24:43Z
+updated_at: 2026-07-21T20:42:03Z
 ---
 
 ## Checklist
 
-- [ ] Add an always-on commit-policy workflow.
-- [ ] Validate squash-merge PR titles from the alint policy.
+- [x] Add an always-on commit-policy workflow.
+- [x] Validate squash-merge PR titles from the alint policy.
 - [x] Add regression coverage and validate the workflow.
 - [ ] Audit and synchronize the Tangled mirror once.
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+source "$ROOT_DIR/scripts/pre-push-policy-base.sh"
 
 # Check for Co-Authored-By commits in the push range
 printf '[PRE-PUSH] Checking for Co-Authored-By commits...\n'
@@ -16,15 +16,14 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     continue
   fi
 
-  if [[ "$remote_sha" =~ ^0+$ ]]; then
-    # New branch: only validate commits not already reachable from origin/main,
-    # so the scope allowlist doesn't retroactively fail pre-allowlist history.
-    remote_sha="$(git -C "$ROOT_DIR" merge-base "$local_sha" "refs/remotes/origin/main" 2>/dev/null || echo "$EMPTY_TREE")"
-  fi
+  # Commits already accepted on origin/main are CI-governed history. When a
+  # secondary mirror lags behind it, validate only the commits new to origin;
+  # otherwise an old fixed history violation would block mirror catch-up.
+  policy_base="$(pre_push_policy_base "$ROOT_DIR" "$local_sha" "$remote_sha")"
 
   # Check commit trailers for Co-Authored-By (match line-start to avoid false
   # positives when commit bodies mention the string as documentation/code).
-  if git -C "$ROOT_DIR" log --format=%B "$remote_sha..$local_sha" \
+  if git -C "$ROOT_DIR" log --format=%B "$policy_base..$local_sha" \
       | grep -qE '^Co-Authored-By:'; then
     printf '[ERROR] Commit contains Co-Authored-By footer.\n'
     printf '[ERROR] Direct commits must not have Co-Authored-By footers.\n'
@@ -36,7 +35,7 @@ while read -r local_ref local_sha remote_ref remote_sha; do
   # Validate conventional commits (scope allowlist, format, body) via alint.
   # The authoritative scope list lives in .alint.yml — no duplication here.
   if command -v alint &>/dev/null; then
-    if ! ALINT_BASE_SHA="$remote_sha" alint check --base "$remote_sha" \
+    if ! ALINT_BASE_SHA="$policy_base" alint check --base "$policy_base" \
         "$ROOT_DIR" 2>&1; then
       printf '[ERROR] alint check failed.\n' >&2
       exit 1
@@ -60,7 +59,7 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     if [[ "$path" =~ \.(rs)$ ]] || [[ "$path" == "Cargo.toml" ]] || [[ "$path" == "Cargo.lock" ]]; then
       changed_rs_or_cargo+=("$path")
     fi
-  done < <(git -C "$ROOT_DIR" diff --name-only --diff-filter=ACMR "$remote_sha" "$local_sha")
+  done < <(git -C "$ROOT_DIR" diff --name-only --diff-filter=ACMR "$policy_base" "$local_sha")
 
   # If Rust files changed, run the gate
   if (( ${#changed_rs_or_cargo[@]} > 0 )); then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,9 @@ jobs:
             scripts/test_release_workflow.py \
             scripts/test_validate_pr_title.py
 
+      - name: Run hook regression tests
+        run: ./scripts/test_pre_push_policy_base.sh
+
   release-dry-runs:
     name: Release Dry Runs
     needs: changes

--- a/scripts/pre-push-policy-base.sh
+++ b/scripts/pre-push-policy-base.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+pre_push_policy_base() {
+  local root_dir="${1:?missing repository root}"
+  local local_sha="${2:?missing local SHA}"
+  local remote_sha="${3:?missing remote SHA}"
+  local primary_main="refs/remotes/origin/main"
+  local empty_tree="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+  if [[ "$remote_sha" =~ ^0+$ ]]; then
+    git -C "$root_dir" merge-base "$local_sha" "$primary_main" 2>/dev/null \
+      || printf '%s\n' "$empty_tree"
+  elif git -C "$root_dir" show-ref --verify --quiet "$primary_main" \
+    && git -C "$root_dir" merge-base --is-ancestor "$remote_sha" "$primary_main"; then
+    printf '%s\n' "$primary_main"
+  else
+    printf '%s\n' "$remote_sha"
+  fi
+}

--- a/scripts/test_pre_push_policy_base.sh
+++ b/scripts/test_pre_push_policy_base.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/scripts/pre-push-policy-base.sh"
+
+repo_dir="$(mktemp -d)"
+trap 'rm -rf "$repo_dir"' EXIT
+
+git -C "$repo_dir" init --quiet
+git -C "$repo_dir" config user.name "Test User"
+git -C "$repo_dir" config user.email "test@example.com"
+git -C "$repo_dir" config commit.gpgsign false
+
+printf 'base\n' > "$repo_dir/history"
+git -C "$repo_dir" add history
+git -C "$repo_dir" commit --quiet -m 'chore: establish test history' -m 'Create a baseline for hook tests.'
+base_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+
+printf 'primary\n' >> "$repo_dir/history"
+git -C "$repo_dir" commit --quiet -am 'fix(ci): establish primary history' -m 'Advance the trusted primary branch.'
+primary_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+git -C "$repo_dir" update-ref refs/remotes/origin/main "$primary_sha"
+
+lagging_base="$(pre_push_policy_base "$repo_dir" "$primary_sha" "$base_sha")"
+[[ "$lagging_base" == "refs/remotes/origin/main" ]]
+
+git -C "$repo_dir" checkout --quiet -b divergent "$base_sha"
+printf 'divergent\n' >> "$repo_dir/history"
+git -C "$repo_dir" commit --quiet -am 'fix(ci): establish divergent history' -m 'Create an independent mirror branch.'
+divergent_sha="$(git -C "$repo_dir" rev-parse HEAD)"
+
+divergent_base="$(pre_push_policy_base "$repo_dir" "$primary_sha" "$divergent_sha")"
+[[ "$divergent_base" == "$divergent_sha" ]]
+
+new_branch_base="$(pre_push_policy_base "$repo_dir" "$primary_sha" "0000000000000000000000000000000000000000")"
+[[ "$new_branch_base" == "$primary_sha" ]]


### PR DESCRIPTION
## Summary

- treat commits already accepted on `origin/main` as CI-governed history when a secondary mirror lags behind
- continue validating locally new commits and divergent remote histories
- add a regression harness covering lagging, divergent, and new-branch baselines

## Why

Tangled remains behind `origin/main` at a historical commit whose subject fails
today's commit policy. The old hook relinted that already-accepted history on
every mirror catch-up, requiring `--no-verify` indefinitely.

## Validation

- `bash scripts/test_pre_push_policy_base.sh`
- `git push --dry-run tangled main`
- `ALINT_BASE_SHA=refs/remotes/origin/main alint check --base refs/remotes/origin/main .`
