### PR TITLE
feat(locale): add localized digit systems

### DIFF
--- a/.beans/archive/csl26-5q59--digit-system-localization-in-number-formats.md
+++ b/.beans/archive/csl26-5q59--digit-system-localization-in-number-formats.md
@@ -1,14 +1,21 @@
 ---
 # csl26-5q59
 title: Digit-system localization in number-formats
-status: todo
+status: completed
 type: feature
+priority: normal
 tags:
     - multilingual
     - locale
 created_at: 2026-07-18T20:32:33Z
-updated_at: 2026-07-18T20:32:33Z
+updated_at: 2026-07-22T13:32:58Z
 parent: csl26-0ugp
 ---
 
 Locale number-formats covers separators but not digit systems: Arabic-Indic (٠١٢), Persian, and Devanagari digits are unrepresentable in rendered output. Add an optional digit-system field to locale number-formats with a conversion pass at number rendering, defaulting to Western digits so existing locales are unaffected. See docs/architecture/audits/2026-07-18_MULTILINGUAL_ARCHITECTURE_AUDIT.md §2(f).
+
+## Summary of Changes
+
+- Added locale-configured Western, Arabic-Indic, extended Arabic-Indic, and Devanagari digit rendering for number template components.
+- Enabled Arabic-Indic digits for ar-AR and documented the public locale schema contract.
+- Added schema, renderer, and regression coverage; regenerated locale schema.

--- a/crates/citum-engine/src/values/number.rs
+++ b/crates/citum-engine/src/values/number.rs
@@ -10,7 +10,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 use crate::reference::Reference;
 use crate::values::{ComponentValues, ProcHints, ProcValues, RenderOptions};
-use citum_schema::locale::{GeneralTerm, GrammaticalGender, MessageArgs, TermForm};
+use citum_schema::locale::{DigitSystem, GeneralTerm, GrammaticalGender, MessageArgs, TermForm};
 use citum_schema::reference::ClassExtension;
 use citum_schema::template::{LabelForm, NumberForm, NumberVariable, TemplateNumber};
 
@@ -214,6 +214,30 @@ fn render_ordinal(value: String, options: &RenderOptions<'_>) -> String {
         .unwrap_or(value)
 }
 
+/// Replace ASCII digits in a rendered numeric value with the locale's configured glyphs.
+///
+/// Non-digit characters remain unchanged, so ranges and mixed identifiers preserve their
+/// punctuation and letters while their numeric portions follow locale conventions.
+fn localize_digits(value: String, digit_system: &DigitSystem) -> String {
+    let digits = match digit_system {
+        DigitSystem::Western => return value,
+        DigitSystem::ArabicIndic => ['٠', '١', '٢', '٣', '٤', '٥', '٦', '٧', '٨', '٩'],
+        DigitSystem::ExtendedArabicIndic => ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'],
+        DigitSystem::Devanagari => ['०', '१', '२', '३', '४', '५', '६', '७', '८', '९'],
+        _ => return value,
+    };
+
+    value
+        .chars()
+        .map(|ch| {
+            ch.to_digit(10)
+                .filter(|_| ch.is_ascii_digit())
+                .and_then(|digit| digits.get(digit as usize).copied())
+                .unwrap_or(ch)
+        })
+        .collect()
+}
+
 impl ComponentValues for TemplateNumber {
     fn values<F: crate::render::format::OutputFormat<Output = String>>(
         &self,
@@ -296,6 +320,7 @@ impl ComponentValues for TemplateNumber {
                 (None, None) => None,
             };
             let suffix = numeric_suffix;
+            let value = localize_digits(value, &options.locale.number_formats.digit_system);
 
             ProcValues {
                 value,
@@ -374,6 +399,38 @@ mod is_numeric_tests {
     fn given_empty_value_when_checked_then_not_numeric() {
         assert!(!is_numeric(""));
         assert!(!is_numeric("   "));
+    }
+}
+
+#[cfg(test)]
+mod digit_system_tests {
+    use super::localize_digits;
+    use citum_schema::locale::DigitSystem;
+
+    #[test]
+    fn localizes_ascii_digits_for_supported_digit_systems() {
+        for (digit_system, expected) in [
+            (DigitSystem::Western, "AB-12, 34"),
+            (DigitSystem::ArabicIndic, "AB-١٢, ٣٤"),
+            (DigitSystem::ExtendedArabicIndic, "AB-۱۲, ۳۴"),
+            (DigitSystem::Devanagari, "AB-१२, ३४"),
+        ] {
+            assert_eq!(
+                localize_digits("AB-12, 34".to_string(), &digit_system),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn preserves_western_digits_for_unknown_digit_system() {
+        assert_eq!(
+            localize_digits(
+                "12".to_string(),
+                &DigitSystem::Unknown("future".to_string())
+            ),
+            "12"
+        );
     }
 }
 

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -3147,6 +3147,112 @@ fn template_number_ordinal_form_uses_the_active_locale_message() {
 }
 
 #[test]
+fn template_number_localizes_digits_for_the_active_locale() {
+    let config = make_config();
+    let locale = make_arabic_gendered_locale();
+    let options = RenderOptions {
+        config: Arc::new(config),
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Citation,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+        abbreviation_map: None,
+    };
+    let reference = Reference::from(LegacyReference {
+        id: "localized-number".to_string(),
+        ref_type: "report".to_string(),
+        page: Some("12-34".to_string()),
+        number: Some("TR-7".to_string()),
+        ..Default::default()
+    });
+
+    let citation_number = TemplateNumber {
+        number: NumberVariable::CitationNumber,
+        ..Default::default()
+    };
+    let pages = TemplateNumber {
+        number: NumberVariable::Pages,
+        ..Default::default()
+    };
+    let report_number = TemplateNumber {
+        number: NumberVariable::ReportNumber,
+        ..Default::default()
+    };
+
+    assert_eq!(
+        citation_number
+            .values::<PlainText>(
+                &reference,
+                &ProcHints {
+                    citation_number: Some(12),
+                    ..Default::default()
+                },
+                &options,
+            )
+            .expect("citation number should render")
+            .value,
+        "١٢"
+    );
+    assert_eq!(
+        pages
+            .values::<PlainText>(&reference, &ProcHints::default(), &options)
+            .expect("page range should render")
+            .value,
+        "١٢–٣٤"
+    );
+    assert_eq!(
+        report_number
+            .values::<PlainText>(&reference, &ProcHints::default(), &options)
+            .expect("report number should render")
+            .value,
+        "TR-٧"
+    );
+}
+
+#[test]
+fn template_number_without_digit_system_preserves_western_digits() {
+    let config = make_config();
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: Arc::new(config),
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Citation,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+        abbreviation_map: None,
+    };
+    let citation_number = TemplateNumber {
+        number: NumberVariable::CitationNumber,
+        ..Default::default()
+    };
+
+    assert_eq!(
+        citation_number
+            .values::<PlainText>(
+                &make_reference(),
+                &ProcHints {
+                    citation_number: Some(12),
+                    ..Default::default()
+                },
+                &options,
+            )
+            .expect("citation number should render")
+            .value,
+        "12"
+    );
+}
+
+#[test]
 fn monograph_metadata_variables_render_their_accessors() {
     let config = make_config();
     let locale = make_locale();

--- a/crates/citum-schema-style/embedded/locales/ar-AR.yaml
+++ b/crates/citum-schema-style/embedded/locales/ar-AR.yaml
@@ -118,6 +118,9 @@ date-formats:
   year-only: "yyyy"
   iso: "yyyy-MM-dd"
 
+number-formats:
+  digit-system: arabic-indic
+
 grammar-options:
   punctuation-in-quote: false
   nbsp-before-colon: false

--- a/crates/citum-schema-style/src/locale/mod.rs
+++ b/crates/citum-schema-style/src/locale/mod.rs
@@ -630,8 +630,26 @@ legacy-term-aliases:
         assert_eq!(locale.number_formats.decimal_separator, ".");
         assert_eq!(locale.number_formats.thousands_separator, ",");
         assert_eq!(locale.number_formats.minimum_digits, 1);
+        assert_eq!(locale.number_formats.digit_system, DigitSystem::Western);
 
         // Sort articles.
         assert_eq!(locale.sort_articles, ["the", "a", "an"]);
+    }
+
+    #[test]
+    fn locale_number_formats_accept_each_supported_digit_system() {
+        for (digit_system, expected) in [
+            ("western", DigitSystem::Western),
+            ("arabic-indic", DigitSystem::ArabicIndic),
+            ("extended-arabic-indic", DigitSystem::ExtendedArabicIndic),
+            ("devanagari", DigitSystem::Devanagari),
+        ] {
+            let locale = Locale::from_yaml_str(&format!(
+                "locale: test\nnumber-formats:\n  digit-system: {digit_system}\n"
+            ))
+            .expect("locale should parse");
+
+            assert_eq!(locale.number_formats.digit_system, expected);
+        }
     }
 }

--- a/crates/citum-schema-style/src/locale/types.rs
+++ b/crates/citum-schema-style/src/locale/types.rs
@@ -420,6 +420,9 @@ pub struct MonthNames {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub struct NumberFormats {
+    /// Digit glyph system used when rendering number template components.
+    #[serde(default)]
+    pub digit_system: DigitSystem,
     /// Decimal separator (e.g., "." for en-US, "," for de-DE).
     #[serde(default = "default_decimal_separator")]
     pub decimal_separator: String,
@@ -429,6 +432,22 @@ pub struct NumberFormats {
     /// Minimum digits to display.
     #[serde(default = "default_minimum_digits")]
     pub minimum_digits: u8,
+}
+
+crate::str_enum! {
+    /// Digit glyph system used by a locale when rendering numeric values.
+    #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+    pub enum DigitSystem {
+        /// ASCII Western digits (`0` through `9`).
+        #[default]
+        Western = "western",
+        /// Arabic-Indic digits (`٠` through `٩`).
+        ArabicIndic = "arabic-indic",
+        /// Extended Arabic-Indic digits (`۰` through `۹`).
+        ExtendedArabicIndic = "extended-arabic-indic",
+        /// Devanagari digits (`०` through `९`).
+        Devanagari = "devanagari"
+    }
 }
 
 fn default_decimal_separator() -> String {

--- a/docs/schemas/locale.json
+++ b/docs/schemas/locale.json
@@ -523,6 +523,11 @@
       "description": "Number formatting options for a locale.",
       "type": "object",
       "properties": {
+        "digit-system": {
+          "description": "Digit glyph system used when rendering number template components.",
+          "$ref": "#/$defs/DigitSystem",
+          "default": "western"
+        },
         "decimal-separator": {
           "description": "Decimal separator (e.g., \".\" for en-US, \",\" for de-DE).",
           "type": "string",
@@ -542,6 +547,31 @@
           "default": 1
         }
       }
+    },
+    "DigitSystem": {
+      "description": "Digit glyph system used by a locale when rendering numeric values.",
+      "oneOf": [
+        {
+          "description": "ASCII Western digits (`0` through `9`).",
+          "type": "string",
+          "const": "western"
+        },
+        {
+          "description": "Arabic-Indic digits (`٠` through `٩`).",
+          "type": "string",
+          "const": "arabic-indic"
+        },
+        {
+          "description": "Extended Arabic-Indic digits (`۰` through `۹`).",
+          "type": "string",
+          "const": "extended-arabic-indic"
+        },
+        {
+          "description": "Devanagari digits (`०` through `९`).",
+          "type": "string",
+          "const": "devanagari"
+        }
+      ]
     },
     "GrammarOptions": {
       "description": "Grammar options that vary by language or regional convention.",

--- a/docs/specs/LOCALE_MESSAGES.md
+++ b/docs/specs/LOCALE_MESSAGES.md
@@ -442,9 +442,16 @@ flat term file but carries the same terms in the `messages` block, plus
 | `evaluation` | `object` | no | Runtime evaluation options. See §3.4. |
 | `messages` | `map<string, string>` | yes | Message ID → message body (static or MF2 syntax). |
 | `date-formats` | `map<string, string>` | yes | Symbolic name → CLDR date pattern. |
-| `number-formats` | `object` | yes | `decimal-separator`, `thousands-separator`, `minimum-digits`. |
+| `number-formats` | `object` | yes | `digit-system`, `decimal-separator`, `thousands-separator`, `minimum-digits`. |
 | `grammar-options` | `object` | yes | See §3.3. |
 | `legacy-term-aliases` | `map<string, string>` | yes | Old key → new message ID. |
+
+`number-formats.digit-system` controls digit glyphs for every rendered
+`number` template component. Its values are `western` (the default),
+`arabic-indic`, `extended-arabic-indic`, and `devanagari`. Rendering replaces
+only ASCII digits after ordinal and label resolution; letters, punctuation,
+ranges, and other text are preserved. Decimal and thousands separators remain
+separate locale conventions and are not changed by this field.
 
 #### 3.4 `evaluation` Block
 
@@ -558,6 +565,7 @@ date-formats:
   iso:            "yyyy-MM-dd"
 
 number-formats:
+  digit-system:        western
   decimal-separator:   "."
   thousands-separator: ","
   minimum-digits:      1
@@ -639,6 +647,7 @@ date-formats:
   iso:            "yyyy-MM-dd"
 
 number-formats:
+  digit-system:        western
   decimal-separator:   ","
   thousands-separator: "."
   minimum-digits:      1


### PR DESCRIPTION
## Summary

Adds locale-configured digit rendering for `number` template components, with Arabic-Indic digits enabled for the embedded `ar-AR` locale.

## Scope

- Adds the public `number-formats.digit-system` schema enum and regenerated locale schema.
- Localizes ASCII digits after ordinal and label resolution while preserving letters and punctuation.
- Documents the locale contract and completes bean `csl26-5q59`.

## Validation

- `just schema-gen`
- `python3 scripts/audit-rust-review-smells.py --changed`
- `just pre-commit`
- Pre-push hook: `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo nextest run`

## Risk

Existing locales default to Western digits. Coverage includes the default, Arabic-Indic, extended Arabic-Indic, Devanagari, ranges, and mixed identifiers.
