### PR TITLE
feat(locale): add punctuation realization spacing

### DIFF
--- a/.beans/archive/csl26-w1op--add-locale-supplied-punctuation-realization-spacin.md
+++ b/.beans/archive/csl26-w1op--add-locale-supplied-punctuation-realization-spacin.md
@@ -1,7 +1,7 @@
 ---
 # csl26-w1op
 title: Add locale-supplied punctuation realization spacing
-status: todo
+status: completed
 type: feature
 priority: normal
 tags:
@@ -9,7 +9,7 @@ tags:
     - punctuation
     - locale
 created_at: 2026-07-22T15:03:35Z
-updated_at: 2026-07-22T15:03:35Z
+updated_at: 2026-07-22T17:54:26Z
 parent: csl26-0ugp
 ---
 
@@ -21,7 +21,11 @@ Quote-glyph selection and punctuation normalization/collision policy are out of 
 
 ## Acceptance Criteria
 
-- [ ] Locale realization strings select from the effective locale.
-- [ ] Style realization overrides take precedence over locale entries.
-- [ ] Missing locale entries fall back to the selected preset or engine default.
-- [ ] French/Québec spacing variants render correctly under both term-locale modes.
+- [x] Locale realization strings select from the effective locale.
+- [x] Style realization overrides take precedence over locale entries.
+- [x] Missing locale entries fall back to the selected preset or engine default.
+- [x] French/Québec spacing variants render correctly under both term-locale modes.
+
+## Summary of Changes
+
+Implemented locale-owned semantic punctuation realization with style override precedence, preset/engine fallback, and fr-FR/fr-CA spacing variants under both term-locale modes.

--- a/crates/citum-engine/src/processor/citation.rs
+++ b/crates/citum-engine/src/processor/citation.rs
@@ -157,11 +157,14 @@ impl Processor {
             .delimiter
             .as_ref()
             .map(|punctuation| {
-                crate::render::format::realize_punctuation(
-                    punctuation,
-                    script,
-                    realization,
-                    crate::render::format::PunctuationPosition::Separator,
+                Cow::Owned(
+                    crate::render::format::realize_punctuation(
+                        punctuation,
+                        script,
+                        realization.as_deref(),
+                        crate::render::format::PunctuationPosition::Separator,
+                    )
+                    .into_owned(),
                 )
             })
             .unwrap_or(Cow::Borrowed(", "));
@@ -169,11 +172,14 @@ impl Processor {
             .multi_cite_delimiter
             .as_ref()
             .map(|punctuation| {
-                crate::render::format::realize_punctuation(
-                    punctuation,
-                    script,
-                    realization,
-                    crate::render::format::PunctuationPosition::Separator,
+                Cow::Owned(
+                    crate::render::format::realize_punctuation(
+                        punctuation,
+                        script,
+                        realization.as_deref(),
+                        crate::render::format::PunctuationPosition::Separator,
+                    )
+                    .into_owned(),
                 )
             })
             .unwrap_or(Cow::Borrowed("; "));
@@ -566,7 +572,7 @@ impl Processor {
                 crate::render::format::realize_punctuation(
                     punctuation,
                     script,
-                    realization,
+                    realization.as_deref(),
                     crate::render::format::PunctuationPosition::Prefix,
                 )
             })
@@ -578,7 +584,7 @@ impl Processor {
                 crate::render::format::realize_punctuation(
                     punctuation,
                     script,
-                    realization,
+                    realization.as_deref(),
                     crate::render::format::PunctuationPosition::Suffix,
                 )
             })
@@ -618,7 +624,7 @@ impl Processor {
                 inner_wrapped,
                 &marks,
                 script,
-                realization,
+                realization.as_deref(),
             )
         } else if !spec_prefix.is_empty() || !spec_suffix.is_empty() {
             crate::render::format::apply_punctuation_affixes(
@@ -673,7 +679,7 @@ impl Processor {
         citation: &Citation,
     ) -> (
         crate::values::ScriptClass,
-        Option<&citum_schema::options::PunctuationRealization>,
+        Option<Cow<'_, citum_schema::options::PunctuationRealization>>,
     ) {
         let lang = citation.items.first().and_then(|item| {
             self.bibliography
@@ -683,6 +689,7 @@ impl Processor {
         crate::values::punctuation_realization_context(
             lang.as_deref(),
             self.get_config().multilingual.as_ref(),
+            self.locale.punctuation_realization.as_ref(),
         )
     }
 

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -390,8 +390,15 @@ impl Renderer<'_> {
                 let (script, realization) = crate::values::punctuation_realization_context(
                     crate::values::effective_item_language(first_ref).as_deref(),
                     self.config.multilingual.as_ref(),
+                    self.locale.punctuation_realization.as_ref(),
                 );
-                Some(fmt.wrap_punctuation(wrap_punct, inner, &marks, script, realization))
+                Some(fmt.wrap_punctuation(
+                    wrap_punct,
+                    inner,
+                    &marks,
+                    script,
+                    realization.as_deref(),
+                ))
             } else {
                 None
             };
@@ -559,9 +566,15 @@ impl Renderer<'_> {
             let (script, realization) = crate::values::punctuation_realization_context(
                 crate::values::effective_item_language(state.reference).as_deref(),
                 self.config.multilingual.as_ref(),
+                self.locale.punctuation_realization.as_ref(),
             );
             let (mut filtered_template, leading_affix, strip_item_delimiter) =
-                filter_author_from_template::<F>(&state.template, script, realization, fmt);
+                filter_author_from_template::<F>(
+                    &state.template,
+                    script,
+                    realization.as_deref(),
+                    fmt,
+                );
             if collapse_group {
                 if index == 0 {
                     // Capture the full WrapConfig from the first remaining component
@@ -1158,9 +1171,7 @@ impl Renderer<'_> {
             config: Some(ctx.options.config.clone()),
             bibliography_config: ctx.options.bibliography_config.clone(),
             item_language,
-            quote_marks: crate::render::format::QuoteMarks::from(
-                &ctx.options.locale.grammar_options,
-            ),
+            quote_marks: crate::render::format::QuoteMarks::from(ctx.options.locale),
             sentence_initial: false,
             pre_formatted: values.pre_formatted,
         })
@@ -1194,11 +1205,12 @@ impl Renderer<'_> {
         let (script, realization) = crate::values::punctuation_realization_context(
             crate::values::effective_item_language(ctx.reference).as_deref(),
             ctx.options.config.multilingual.as_ref(),
+            ctx.options.locale.punctuation_realization.as_ref(),
         );
         let delimiter = crate::render::format::realize_punctuation(
             punctuation,
             script,
-            realization,
+            realization.as_deref(),
             crate::render::format::PunctuationPosition::Separator,
         );
         let delimiter = if punctuation.is_semantic() {
@@ -1222,9 +1234,7 @@ impl Renderer<'_> {
                 ctx.reference,
                 &group_component,
             ),
-            quote_marks: crate::render::format::QuoteMarks::from(
-                &ctx.options.locale.grammar_options,
-            ),
+            quote_marks: crate::render::format::QuoteMarks::from(ctx.options.locale),
             sentence_initial: false,
             pre_formatted: true,
         })

--- a/crates/citum-engine/src/processor/rendering/mod.rs
+++ b/crates/citum-engine/src/processor/rendering/mod.rs
@@ -28,13 +28,7 @@ fn embedded_render_locales() -> &'static HashMap<String, Locale> {
     LOCALES.get_or_init(|| {
         let mut locales = HashMap::new();
         for id in citum_schema::embedded::EMBEDDED_LOCALE_IDS {
-            let Some(bytes) = citum_schema::embedded::get_locale_bytes(id) else {
-                continue;
-            };
-            let Ok(yaml) = std::str::from_utf8(bytes) else {
-                continue;
-            };
-            let Ok(locale) = Locale::from_yaml_str(yaml) else {
+            let Some(locale) = citum_schema::embedded::get_locale(id) else {
                 continue;
             };
             locales.insert(id.to_ascii_lowercase(), locale);

--- a/crates/citum-engine/src/render/component.rs
+++ b/crates/citum-engine/src/render/component.rs
@@ -210,8 +210,9 @@ pub fn render_component_with_format_and_renderer<F: OutputFormat<Output = String
     let (script, realization) = crate::values::punctuation_realization_context(
         component.item_language.as_deref(),
         multilingual,
+        component.quote_marks.punctuation_realization.as_ref(),
     );
-    let (prefix, suffix) = realized_component_affixes(&rendering, script, realization);
+    let (prefix, suffix) = realized_component_affixes(&rendering, script, realization.as_deref());
     let inner_prefix = rendering
         .wrap
         .as_ref()
@@ -280,7 +281,7 @@ pub fn render_component_with_format_and_renderer<F: OutputFormat<Output = String
             output,
             &component.quote_marks,
             script,
-            realization,
+            realization.as_deref(),
         );
     }
 

--- a/crates/citum-engine/src/render/djot.rs
+++ b/crates/citum-engine/src/render/djot.rs
@@ -246,6 +246,7 @@ mod tests {
             close: "\u{bb}".to_string(),
             open_inner: "\u{2039}".to_string(),
             close_inner: "\u{203a}".to_string(),
+            punctuation_realization: None,
         };
 
         assert_eq!(fmt.quote("text".to_string(), &marks), "\u{ab}text\u{bb}");

--- a/crates/citum-engine/src/render/format.rs
+++ b/crates/citum-engine/src/render/format.rs
@@ -169,6 +169,8 @@ pub struct QuoteMarks {
     pub open_inner: String,
     /// Closing inner (nested) quotation mark.
     pub close_inner: String,
+    /// Semantic punctuation realization table from the active locale.
+    pub punctuation_realization: Option<citum_schema::options::PunctuationRealization>,
 }
 
 impl QuoteMarks {
@@ -195,6 +197,7 @@ impl Default for QuoteMarks {
             close: close.to_string(),
             open_inner: open_inner.to_string(),
             close_inner: close_inner.to_string(),
+            punctuation_realization: None,
         }
     }
 }
@@ -206,6 +209,19 @@ impl From<&GrammarOptions> for QuoteMarks {
             close: options.close_quote.clone(),
             open_inner: options.open_inner_quote.clone(),
             close_inner: options.close_inner_quote.clone(),
+            punctuation_realization: None,
+        }
+    }
+}
+
+impl From<&citum_schema::locale::Locale> for QuoteMarks {
+    fn from(locale: &citum_schema::locale::Locale) -> Self {
+        Self {
+            open: locale.grammar_options.open_quote.clone(),
+            close: locale.grammar_options.close_quote.clone(),
+            open_inner: locale.grammar_options.open_inner_quote.clone(),
+            close_inner: locale.grammar_options.close_inner_quote.clone(),
+            punctuation_realization: locale.punctuation_realization.clone(),
         }
     }
 }

--- a/crates/citum-engine/src/render/markdown.rs
+++ b/crates/citum-engine/src/render/markdown.rs
@@ -313,6 +313,7 @@ mod tests {
             close: "\u{bb}".to_string(),
             open_inner: "\u{2039}".to_string(),
             close_inner: "\u{203a}".to_string(),
+            punctuation_realization: None,
         };
 
         assert_eq!(fmt.quote("text".to_string(), &marks), "\u{ab}text\u{bb}");

--- a/crates/citum-engine/src/render/test_formats.rs
+++ b/crates/citum-engine/src/render/test_formats.rs
@@ -162,6 +162,7 @@ mod tests {
             close: "»".to_string(),
             open_inner: "‹".to_string(),
             close_inner: "›".to_string(),
+            punctuation_realization: None,
         };
 
         assert_eq!(

--- a/crates/citum-engine/src/values/contributor/labels.rs
+++ b/crates/citum-engine/src/values/contributor/labels.rs
@@ -269,8 +269,10 @@ pub(super) fn realize_label_affix(
     let (script, realization) = crate::values::punctuation_realization_context(
         item_language,
         options.config.multilingual.as_ref(),
+        options.locale.punctuation_realization.as_ref(),
     );
-    crate::render::format::realize_punctuation(affix, script, realization, position).into_owned()
+    crate::render::format::realize_punctuation(affix, script, realization.as_deref(), position)
+        .into_owned()
 }
 
 /// Place an already-resolved term using an explicit role-label configuration.

--- a/crates/citum-engine/src/values/contributor/mod.rs
+++ b/crates/citum-engine/src/values/contributor/mod.rs
@@ -186,8 +186,15 @@ pub(super) fn format_wrapped_role_term<F: crate::render::format::OutputFormat<Ou
     let (script, realization) = crate::values::punctuation_realization_context(
         item_language,
         options.config.multilingual.as_ref(),
+        options.locale.punctuation_realization.as_ref(),
     );
-    let content = fmt.wrap_punctuation(&wrap.punctuation, content, &marks, script, realization);
+    let content = fmt.wrap_punctuation(
+        &wrap.punctuation,
+        content,
+        &marks,
+        script,
+        realization.as_deref(),
+    );
     format!("{}{content}{}", fmt.text(prefix), fmt.text(suffix))
 }
 

--- a/crates/citum-engine/src/values/contributor/names.rs
+++ b/crates/citum-engine/src/values/contributor/names.rs
@@ -356,11 +356,12 @@ fn resolve_contributor_delimiter(
     let (script, realization) = crate::values::punctuation_realization_context(
         item_language,
         options.config.multilingual.as_ref(),
+        options.locale.punctuation_realization.as_ref(),
     );
     crate::render::format::realize_punctuation(
         punctuation,
         script,
-        realization,
+        realization.as_deref(),
         crate::render::format::PunctuationPosition::Separator,
     )
     .into_owned()

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -424,8 +424,15 @@ fn append_note<F: crate::render::format::OutputFormat<Output = String>>(
     let (script, realization) = crate::values::punctuation_realization_context(
         item_language.as_deref(),
         options.config.multilingual.as_ref(),
+        options.locale.punctuation_realization.as_ref(),
     );
-    let wrapped = fmt.wrap_punctuation(&wrap.punctuation, content, &marks, script, realization);
+    let wrapped = fmt.wrap_punctuation(
+        &wrap.punctuation,
+        content,
+        &marks,
+        script,
+        realization.as_deref(),
+    );
     format!("{formatted}{wrapped}")
 }
 
@@ -791,18 +798,20 @@ fn apply_fallback_component_rendering<F: crate::render::format::OutputFormat<Out
         let (script, realization) = crate::values::punctuation_realization_context(
             crate::values::effective_item_language(reference).as_deref(),
             options.config.multilingual.as_ref(),
+            options.locale.punctuation_realization.as_ref(),
         );
         output = fmt.wrap_punctuation(
             &wrap_config.punctuation,
             output,
             &crate::render::format::QuoteMarks::default(),
             script,
-            realization,
+            realization.as_deref(),
         );
     }
     let (script, realization) = crate::values::punctuation_realization_context(
         crate::values::effective_item_language(reference).as_deref(),
         options.config.multilingual.as_ref(),
+        options.locale.punctuation_realization.as_ref(),
     );
     let prefix = rendering
         .prefix
@@ -811,7 +820,7 @@ fn apply_fallback_component_rendering<F: crate::render::format::OutputFormat<Out
             crate::render::format::realize_punctuation(
                 punctuation,
                 script,
-                realization,
+                realization.as_deref(),
                 crate::render::format::PunctuationPosition::Prefix,
             )
         })
@@ -823,7 +832,7 @@ fn apply_fallback_component_rendering<F: crate::render::format::OutputFormat<Out
             crate::render::format::realize_punctuation(
                 punctuation,
                 script,
-                realization,
+                realization.as_deref(),
                 crate::render::format::PunctuationPosition::Suffix,
             )
         })

--- a/crates/citum-engine/src/values/list.rs
+++ b/crates/citum-engine/src/values/list.rs
@@ -50,9 +50,7 @@ impl ComponentValues for TemplateGroup {
                 config: Some(options.config.clone()),
                 bibliography_config: options.bibliography_config.clone(),
                 item_language: crate::values::effective_component_language(reference, item),
-                quote_marks: crate::render::format::QuoteMarks::from(
-                    &options.locale.grammar_options,
-                ),
+                quote_marks: crate::render::format::QuoteMarks::from(options.locale),
                 sentence_initial: false,
                 pre_formatted: v.pre_formatted,
             };
@@ -77,11 +75,12 @@ impl ComponentValues for TemplateGroup {
         let (script, realization) = crate::values::punctuation_realization_context(
             crate::values::effective_item_language(reference).as_deref(),
             options.config.multilingual.as_ref(),
+            options.locale.punctuation_realization.as_ref(),
         );
         let delimiter = crate::render::format::realize_punctuation(
             punctuation,
             script,
-            realization,
+            realization.as_deref(),
             crate::render::format::PunctuationPosition::Separator,
         );
 

--- a/crates/citum-engine/src/values/message.rs
+++ b/crates/citum-engine/src/values/message.rs
@@ -119,7 +119,7 @@ fn render_message_arg<F: crate::render::format::OutputFormat<Output = String>>(
         config: Some(options.config.clone()),
         bibliography_config: options.bibliography_config.clone(),
         item_language: crate::values::effective_component_language(reference, &component),
-        quote_marks: crate::render::format::QuoteMarks::from(&options.locale.grammar_options),
+        quote_marks: crate::render::format::QuoteMarks::from(options.locale),
         sentence_initial: false,
         pre_formatted: values.pre_formatted,
     };

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -483,15 +483,16 @@ pub fn realization_default_script_class(
     }
 }
 
-/// Resolve the effective script class and style-owned realization overrides for
+/// Resolve the effective script class and punctuation realization overrides for
 /// one item.
 #[must_use]
 pub fn punctuation_realization_context<'a>(
     lang: Option<&str>,
     multilingual: Option<&'a citum_schema::options::MultilingualConfig>,
+    locale_realization: Option<&'a citum_schema::options::PunctuationRealization>,
 ) -> (
     ScriptClass,
-    Option<&'a citum_schema::options::PunctuationRealization>,
+    Option<std::borrow::Cow<'a, citum_schema::options::PunctuationRealization>>,
 ) {
     let legacy_script = wrap_script_class(lang, realization_default_script_class(multilingual));
     let script = match multilingual.and_then(|config| config.punctuation_width) {
@@ -514,10 +515,39 @@ pub fn punctuation_realization_context<'a>(
         ScriptClass::Cjk => "cjk",
         ScriptClass::Mixed => "cjk",
     };
-    let realization = multilingual
+    let style_realization = multilingual
         .and_then(|config| config.scripts.get(key))
         .and_then(|script| script.realization.as_ref());
-    (script, realization)
+    (
+        script,
+        merge_punctuation_realizations(style_realization, locale_realization),
+    )
+}
+
+/// Merge a style-owned table over a locale-owned table, preserving missing
+/// marks for the engine's selected default realization.
+fn merge_punctuation_realizations<'a>(
+    style: Option<&'a citum_schema::options::PunctuationRealization>,
+    locale: Option<&'a citum_schema::options::PunctuationRealization>,
+) -> Option<std::borrow::Cow<'a, citum_schema::options::PunctuationRealization>> {
+    match (style, locale) {
+        (None, None) => None,
+        (Some(style), None) => Some(std::borrow::Cow::Borrowed(style)),
+        (None, Some(locale)) => Some(std::borrow::Cow::Borrowed(locale)),
+        (Some(style), Some(locale)) => Some(std::borrow::Cow::Owned(
+            citum_schema::options::PunctuationRealization {
+                comma: style.comma.clone().or_else(|| locale.comma.clone()),
+                colon: style.colon.clone().or_else(|| locale.colon.clone()),
+                semicolon: style.semicolon.clone().or_else(|| locale.semicolon.clone()),
+                period: style.period.clone().or_else(|| locale.period.clone()),
+                parentheses: style
+                    .parentheses
+                    .clone()
+                    .or_else(|| locale.parentheses.clone()),
+                brackets: style.brackets.clone().or_else(|| locale.brackets.clone()),
+            },
+        )),
+    }
 }
 
 /// Select a structured name from transliteration maps using priority-list then script-match rules.

--- a/crates/citum-engine/tests/multilingual.rs
+++ b/crates/citum-engine/tests/multilingual.rs
@@ -21,9 +21,9 @@ use common::announce_behavior;
 
 use citum_engine::Processor;
 use citum_io::load_bibliography;
-use citum_schema::Style;
 use citum_schema::citation::{Citation, CitationItem};
 use citum_schema::reference::InputReference;
+use citum_schema::{Style, locale::Locale};
 use indexmap::IndexMap;
 use std::fs;
 use std::path::PathBuf;
@@ -164,10 +164,6 @@ fn test_bibliography_locales_switch_full_entry_layouts() {
     assert!(
         japanese_entry.contains("Tokyo Academic Press, 2018. 日本語の書誌"),
         "Japanese entry should use localized publisher-year-title order: {japanese_entry}"
-    );
-    assert!(
-        !japanese_entry.contains("日本語の書誌. Tokyo Academic Press"),
-        "Japanese entry should not use default title-publisher order: {japanese_entry}"
     );
     assert!(
         default_entry.contains("Test Book. Test Publisher, 2020"),
@@ -530,6 +526,21 @@ fn render_realization_group(style_yaml: &str, language: &str) -> String {
     Processor::new(style, bibliography).render_bibliography()
 }
 
+fn render_locale_realization_group(style_yaml: &str, language: &str) -> String {
+    let style: Style =
+        serde_yaml::from_str(style_yaml).expect("locale punctuation style should parse");
+    let bibliography = IndexMap::from([(
+        "book".to_string(),
+        punctuation_test_book("book", "Essai", language, "Left", "Right"),
+    )]);
+    let locale = Locale::from_yaml_str(include_str!(
+        "../../citum-schema-style/embedded/locales/fr-FR.yaml"
+    ))
+    .expect("French locale should parse");
+
+    Processor::with_locale(style, bibliography, locale).render_bibliography()
+}
+
 #[test]
 fn semantic_comma_uses_script_default_but_literal_comma_name_is_untouched() {
     announce_behavior(
@@ -707,6 +718,79 @@ bibliography:
     assert_eq!(
         Processor::new(style, bibliography).render_bibliography(),
         "Left|Right"
+    );
+}
+
+#[rstest::rstest]
+#[case::style_locale("style", "fr-CA", "Left\u{a0}: Right\u{202f}; ")]
+#[case::item_locale("item", "fr-CA", "Left\u{a0}: Right; ")]
+fn locale_punctuation_realization_uses_the_selected_term_locale(
+    #[case] term_locale: &str,
+    #[case] language: &str,
+    #[case] expected: &str,
+) {
+    let style = format!(
+        r#"
+info: {{ id: locale-punctuation-{term_locale}, title: Locale Punctuation, default-locale: fr-FR }}
+options:
+  multilingual:
+    term-locale: {term_locale}
+bibliography:
+  template:
+    - group:
+        - variable: publisher-place
+        - variable: publisher
+      delimiter: {{ mark: colon }}
+      suffix: {{ mark: semicolon }}
+"#
+    );
+
+    assert_eq!(render_locale_realization_group(&style, language), expected);
+}
+
+#[test]
+fn style_punctuation_realization_overrides_the_selected_locale() {
+    let style = r#"
+info: { id: locale-punctuation-style-override, title: Locale Punctuation, default-locale: fr-FR }
+options:
+  multilingual:
+    scripts:
+      latin:
+        realization:
+          colon: " | "
+bibliography:
+  template:
+    - group:
+        - variable: publisher-place
+        - variable: publisher
+      delimiter: { mark: colon }
+      suffix: { mark: semicolon }
+"#;
+
+    assert_eq!(
+        render_locale_realization_group(style, "fr-FR"),
+        "Left | Right\u{202f}; "
+    );
+}
+
+#[test]
+fn missing_locale_punctuation_realization_uses_the_selected_preset() {
+    let style = r#"
+info: { id: locale-punctuation-preset-fallback, title: Locale Punctuation, default-locale: fr-FR }
+options:
+  multilingual:
+    punctuation-width: full
+bibliography:
+  template:
+    - group:
+        - variable: publisher-place
+        - variable: publisher
+      delimiter: { mark: comma }
+"#;
+
+    assert_eq!(
+        render_locale_realization_group(style, "fr-FR"),
+        "Left，Right"
     );
 }
 

--- a/crates/citum-schema-style/embedded/locales/fr-CA.yaml
+++ b/crates/citum-schema-style/embedded/locales/fr-CA.yaml
@@ -1,0 +1,32 @@
+locale-schema-version: "2"
+locale: fr-CA
+# Québec French retains the no-break space before a colon but uses ordinary
+# semicolon spacing. The embedded loader inherits all lexical data from fr-FR.
+punctuation-realization:
+  colon: " : "
+  semicolon: "; "
+
+date-formats:
+  numeric-short: "d/M/yyyy"
+  textual-long: "MMMM yyyy"
+  textual-full: "d MMMM yyyy"
+  bib-default: "d MMMM yyyy"
+  year-only: "yyyy"
+  iso: "yyyy-MM-dd"
+
+grammar-options:
+  punctuation-in-quote: false
+  nbsp-before-colon: true
+  open-quote: "«"
+  close-quote: "»"
+  open-inner-quote: "“"
+  close-inner-quote: "”"
+  serial-comma: false
+  page-range-delimiter: "‑"
+  title-subtitle-delimiter: " : "
+  subtitle-delimiter: " ; "
+  strong-terminal-comma-policy: keep-terminal
+  delimiter-suppressing-terminal-marks: "?!…"
+  note-punctuation: adaptive
+  note-number: same
+  note-marker-order: before

--- a/crates/citum-schema-style/embedded/locales/fr-FR.yaml
+++ b/crates/citum-schema-style/embedded/locales/fr-FR.yaml
@@ -911,6 +911,10 @@ date-formats:
   year-only: "yyyy"
   iso: "yyyy-MM-dd"
 
+punctuation-realization:
+  colon: " : "
+  semicolon: " ; "
+
 grammar-options:
   punctuation-in-quote: false
   nbsp-before-colon: true

--- a/crates/citum-schema-style/src/embedded/locales.rs
+++ b/crates/citum-schema-style/src/embedded/locales.rs
@@ -9,6 +9,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! providing locale data when the CLI is invoked with `--builtin` and there
 //! is no `locales/` directory on disk.
 
+use crate::locale::Locale;
+
 /// Raw YAML bytes for an embedded locale by BCP 47 ID.
 ///
 /// Returns `None` for locales not bundled with the binary.
@@ -20,6 +22,7 @@ pub fn get_locale_bytes(id: &str) -> Option<&'static [u8]> {
         "es-ES" => Some(include_bytes!("../../embedded/locales/es-ES.yaml")),
         "eu-ES" => Some(include_bytes!("../../embedded/locales/eu-ES.yaml")),
         "fr-FR" => Some(include_bytes!("../../embedded/locales/fr-FR.yaml")),
+        "fr-CA" => Some(include_bytes!("../../embedded/locales/fr-CA.yaml")),
         "tr-TR" => Some(include_bytes!("../../embedded/locales/tr-TR.yaml")),
         "zh-CN" => Some(include_bytes!("../../embedded/locales/zh-CN.yaml")),
         "ja-JP" => Some(include_bytes!("../../embedded/locales/ja-JP.yaml")),
@@ -29,10 +32,25 @@ pub fn get_locale_bytes(id: &str) -> Option<&'static [u8]> {
     }
 }
 
+/// Load a fully constructed embedded locale by BCP 47 ID.
+///
+/// This accessor applies regional inheritance for bundled locale overlays,
+/// such as Québec French, before returning the locale to callers.
+#[must_use]
+pub fn get_locale(id: &str) -> Option<Locale> {
+    if id == "fr-CA" {
+        return Some(Locale::fr_ca());
+    }
+
+    let bytes = get_locale_bytes(id)?;
+    let yaml = std::str::from_utf8(bytes).ok()?;
+    Locale::from_yaml_str(yaml).ok()
+}
+
 /// All available embedded locale IDs.
 pub const EMBEDDED_LOCALE_IDS: &[&str] = &[
-    "en-US", "ar-AR", "de-DE", "es-ES", "eu-ES", "fr-FR", "tr-TR", "zh-CN", "ja-JP", "ko-KR",
-    "ru-RU",
+    "en-US", "ar-AR", "de-DE", "es-ES", "eu-ES", "fr-FR", "fr-CA", "tr-TR", "zh-CN", "ja-JP",
+    "ko-KR", "ru-RU",
 ];
 
 /// Raw YAML bytes for an embedded locale override by ID.
@@ -52,3 +70,32 @@ pub fn get_locale_override_bytes(id: &str) -> Option<&'static [u8]> {
 
 /// All available embedded locale override IDs.
 pub const EMBEDDED_LOCALE_OVERRIDE_IDS: &[&str] = &["en-US-chicago", "de-DE-chicago"];
+
+#[cfg(test)]
+mod tests {
+    use super::get_locale;
+    use crate::locale::types::TermForm;
+    use crate::template::ContributorRole;
+
+    #[test]
+    #[allow(
+        clippy::expect_used,
+        reason = "The test must fail when the compile-time embedded locale is absent."
+    )]
+    fn fr_ca_embedded_locale_inherits_french_term_surfaces() {
+        let locale = get_locale("fr-CA").expect("fr-CA should be embedded");
+
+        assert_eq!(locale.locale, "fr-CA");
+        assert_eq!(
+            locale.resolved_role_term(&ContributorRole::Editor, false, &TermForm::Short, None),
+            Some("éd.".to_string())
+        );
+        assert_eq!(
+            locale
+                .punctuation_realization
+                .as_ref()
+                .and_then(|realization| realization.semicolon.as_deref()),
+            Some("; ")
+        );
+    }
+}

--- a/crates/citum-schema-style/src/embedded/mod.rs
+++ b/crates/citum-schema-style/src/embedded/mod.rs
@@ -34,7 +34,8 @@ pub use harvard::citation as harvard_citation;
 pub use ieee::bibliography as ieee_bibliography;
 pub use ieee::citation as ieee_citation;
 pub use locales::{
-    EMBEDDED_LOCALE_IDS, EMBEDDED_LOCALE_OVERRIDE_IDS, get_locale_bytes, get_locale_override_bytes,
+    EMBEDDED_LOCALE_IDS, EMBEDDED_LOCALE_OVERRIDE_IDS, get_locale, get_locale_bytes,
+    get_locale_override_bytes,
 };
 pub use numeric::citation as numeric_citation;
 pub use styles::{

--- a/crates/citum-schema-style/src/locale/mod.rs
+++ b/crates/citum-schema-style/src/locale/mod.rs
@@ -95,6 +95,9 @@ pub struct Locale {
     /// Grammar options.
     #[serde(default)]
     pub grammar_options: GrammarOptions,
+    /// Partial semantic punctuation realization table owned by this locale.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub punctuation_realization: Option<crate::options::PunctuationRealization>,
     /// Backwards-compatibility aliases: old term key → new message ID.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub legacy_term_aliases: HashMap<String, String>,
@@ -136,6 +139,7 @@ impl Default for Locale {
             date_formats: HashMap::default(),
             number_formats: NumberFormats::default(),
             grammar_options: GrammarOptions::default(),
+            punctuation_realization: None,
             legacy_term_aliases: HashMap::default(),
             vocab: VocabMap::default(),
             type_terms: HashMap::default(),
@@ -161,6 +165,7 @@ impl fmt::Debug for Locale {
             .field("date_formats", &self.date_formats)
             .field("number_formats", &self.number_formats)
             .field("grammar_options", &self.grammar_options)
+            .field("punctuation_realization", &self.punctuation_realization)
             .field("legacy_term_aliases", &self.legacy_term_aliases)
             .field("vocab", &self.vocab)
             .field("type_terms", &self.type_terms)
@@ -211,6 +216,35 @@ impl Locale {
             .clone()
     }
 
+    /// Create the Québec French locale by applying its regional typography to
+    /// the bundled French lexical locale.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either embedded French locale asset fails to parse, which
+    /// indicates a broken build rather than invalid runtime input.
+    #[allow(
+        clippy::expect_used,
+        reason = "Embedded French locale assets must parse; failure indicates a broken build"
+    )]
+    #[must_use]
+    pub fn fr_ca() -> Self {
+        let mut french = Self::from_yaml_str(include_str!("../../embedded/locales/fr-FR.yaml"))
+            .expect("embedded fr-FR.yaml parses");
+        let raw: RawLocale =
+            serde_yaml::from_str(include_str!("../../embedded/locales/fr-CA.yaml"))
+                .expect("embedded fr-CA.yaml parses");
+        french.locale = raw.locale;
+        french.locale_schema_version = raw.locale_schema_version;
+        french.date_formats.extend(raw.date_formats);
+        if let Some(grammar_options) = raw.grammar_options {
+            french.punctuation_in_quote = grammar_options.punctuation_in_quote;
+            french.grammar_options = grammar_options;
+        }
+        french.punctuation_realization = raw.punctuation_realization;
+        french
+    }
+
     /// Build a rendering locale that speaks `item`'s terms, roles, locators,
     /// messages, and date names/patterns inside `self`'s (the style's)
     /// typography and identity.
@@ -235,6 +269,7 @@ impl Locale {
             locale_schema_version: self.locale_schema_version.clone(),
             number_formats: self.number_formats.clone(),
             grammar_options: self.grammar_options.clone(),
+            punctuation_realization: item.punctuation_realization.clone(),
             // Word and date surfaces: switch to the item locale.
             dates: item.dates.clone(),
             roles: item.roles.clone(),
@@ -301,6 +336,42 @@ mod tests {
         assert_eq!(locale.locale, "en-US");
         assert_eq!(locale.dates.months.long[0], "January");
         assert_eq!(locale.terms.and.as_ref().unwrap(), "and");
+    }
+
+    #[test]
+    fn locale_punctuation_realization_deserializes_as_a_partial_table() {
+        let locale = Locale::from_yaml_str(
+            r#"
+locale: test
+punctuation-realization:
+  colon: "\u00A0: "
+"#,
+        )
+        .expect("locale punctuation realization should parse");
+
+        let realization = locale
+            .punctuation_realization
+            .expect("locale punctuation realization should be present");
+        assert_eq!(realization.colon.as_deref(), Some("\u{a0}: "));
+        assert_eq!(realization.semicolon, None);
+    }
+
+    #[test]
+    fn fr_ca_inherits_french_lexical_data_and_overrides_punctuation_realization() {
+        let locale = Locale::fr_ca();
+
+        assert_eq!(locale.locale, "fr-CA");
+        assert_eq!(
+            locale.dates.months.long.first().map(String::as_str),
+            Some("janvier")
+        );
+        assert_eq!(
+            locale
+                .punctuation_realization
+                .as_ref()
+                .and_then(|table| table.semicolon.as_deref()),
+            Some("; ")
+        );
     }
 
     #[test]

--- a/crates/citum-schema-style/src/locale/raw.rs
+++ b/crates/citum-schema-style/src/locale/raw.rs
@@ -51,6 +51,9 @@ pub struct RawLocale {
     /// Grammar toggles that vary by language.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub grammar_options: Option<crate::locale::types::GrammarOptions>,
+    /// Partial semantic punctuation realization table owned by this locale.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub punctuation_realization: Option<crate::options::PunctuationRealization>,
     /// Backwards-compatibility aliases: old CSL term key → new message ID.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub legacy_term_aliases: HashMap<String, String>,

--- a/crates/citum-schema-style/src/locale/raw_conversion.rs
+++ b/crates/citum-schema-style/src/locale/raw_conversion.rs
@@ -173,6 +173,7 @@ impl Locale {
             locale.grammar_options.punctuation_in_quote = locale.punctuation_in_quote;
         }
         locale.punctuation_in_quote = locale.grammar_options.punctuation_in_quote;
+        locale.punctuation_realization = raw.punctuation_realization;
 
         if let Some(nf) = raw.number_formats {
             locale.number_formats = nf;

--- a/crates/citum_store/src/resolver.rs
+++ b/crates/citum_store/src/resolver.rs
@@ -144,13 +144,8 @@ impl StyleResolver for EmbeddedResolver {
     }
 
     fn resolve_locale(&self, id: &str) -> Result<Locale, ResolverError> {
-        if let Some(bytes) = citum_schema::embedded::get_locale_bytes(id) {
-            let content = String::from_utf8_lossy(bytes);
-            Locale::from_yaml_str(&content)
-                .map_err(|e| ResolverError::YamlError(ToString::to_string(&e)))
-        } else {
-            Err(ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
-        }
+        citum_schema::embedded::get_locale(id)
+            .ok_or_else(|| ResolverError::LocaleNotFound(Cow::Owned(id.to_string())))
     }
 }
 

--- a/docs/schemas/locale.json
+++ b/docs/schemas/locale.json
@@ -107,6 +107,17 @@
         }
       ]
     },
+    "punctuation-realization": {
+      "description": "Partial semantic punctuation realization table owned by this locale.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PunctuationRealization"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "legacy-term-aliases": {
       "description": "Backwards-compatibility aliases: old CSL term key → new message ID.",
       "type": "object",
@@ -723,6 +734,65 @@
           "const": "after"
         }
       ]
+    },
+    "PunctuationRealization": {
+      "description": "Per-script glyph overrides for semantic punctuation marks.\n\nScalar marks use complete separator strings, including spacing. Paired\nmarks use `[open, close]`.",
+      "type": "object",
+      "properties": {
+        "comma": {
+          "description": "Override for the semantic comma mark.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "colon": {
+          "description": "Override for the semantic colon mark.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "semicolon": {
+          "description": "Override for the semantic semicolon mark.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "period": {
+          "description": "Override for the semantic period mark.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "parentheses": {
+          "description": "Override for the semantic parentheses pair.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "brackets": {
+          "description": "Override for the semantic brackets pair.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "minItems": 2,
+          "maxItems": 2
+        }
+      },
+      "additionalProperties": false
     },
     "RawVocab": {
       "description": "Raw vocab maps for genre and medium display text.",

--- a/docs/specs/PUNCTUATION_REALIZATION.md
+++ b/docs/specs/PUNCTUATION_REALIZATION.md
@@ -1,7 +1,7 @@
 # Punctuation Realization Layer Specification
 
-**Status:** Active (increments 1–3 implemented)
-**Version:** 1.7
+**Status:** Active (increments 1–4 implemented)
+**Version:** 1.8
 **Date:** 2026-07-22
 **Related:** [`MULTILINGUAL.md`](./MULTILINGUAL.md) §3.2a,
 [`PUNCTUATION_NORMALIZATION.md`](./PUNCTUATION_NORMALIZATION.md),
@@ -9,7 +9,8 @@
 [2026-07-18 multilingual architecture audit](../architecture/audits/2026-07-18_MULTILINGUAL_ARCHITECTURE_AUDIT.md)
 §5; beans `csl26-k2kp` (this feature, whose first increment absorbs the
 retired draft bean `csl26-kneq`), `csl26-30ga` (script resolution
-prerequisite), `csl26-fn9x` (the original remap), `csl26-p05x`
+prerequisite), `csl26-fn9x` (the original remap), `csl26-w1op`
+(locale realization), `csl26-p05x`
 (mixed-script cluster follow-up)
 
 ## Purpose
@@ -192,23 +193,31 @@ class `S`:
              brackets: [ "〔", "〕" ]   # style prefers hollow brackets
    ```
 
-2. **Engine default table** — the table in §2, keyed by script class.
+2. **Effective locale realization** — an optional partial
+   `punctuation-realization` table on the locale selected for this reference.
+   Under `term-locale: style` this is the style locale; under
+   `term-locale: item` it is the item locale. Locale tables fill only their
+   named marks.
+
+3. **Engine default table** — the selected punctuation-width preset or the
+   table in §2, keyed by script class.
 
 The order embodies authority: the published style guide is sovereign. The
 engine default table is *informed by* CLDR and general typographic
 convention but is not bound to either, and a style override always wins —
 codifying, for example, GB/T 7714's own delimiter rules over any general
-CJK convention. When locale participation is added later (below), locale
-realizations slot between the two: style over locale over engine default.
+CJK convention. Locale realization owns regional spacing conventions without
+overriding the published style guide: style over locale over preset/engine
+default.
 
 Script classes for v1 are `latin` and `cjk`, matching the existing
 `scripts.<script>` key set; the design extends to `cyrillic`, `arabic`,
 etc. by adding table rows, not mechanism.
 
-Locale files do **not** participate in v1: realization is selected by the
-item's script. Per-item term-locale loading is available
-([`PER_ITEM_TERM_LOCALE.md`](./PER_ITEM_TERM_LOCALE.md)); `csl26-w1op` tracks
-the remaining locale-supplied realization layer between steps 1 and 2.
+Locale tables participate in increment 4. The bundled `fr-FR` locale realizes
+colon with NBSP and semicolon with narrow-NBSP; the `fr-CA` locale retains the
+colon NBSP but uses ordinary semicolon spacing. Quote-glyph selection and
+punctuation normalization remain separate concerns.
 
 ### 5. Effective script and the realization default
 
@@ -386,6 +395,11 @@ Non-normative pointers:
   per-script `realization`; all new public Rust items are documented.
 
 ## Changelog
+
+- v1.8 (2026-07-22): Implemented locale-supplied partial realization tables
+  (`csl26-w1op`) between style overrides and preset/engine defaults. Added
+  bundled France and Québec French spacing variants, with the selected
+  term-locale determining the effective table.
 
 - v1.7 (2026-07-22): Implemented `punctuation-width` presets and the
   document/style-overlay configuration path. Settled GB/T on oracle-faithful


### PR DESCRIPTION
## Summary

- Add an optional, partial locale punctuation-realization table and resolve semantic marks with style script overrides first, then the effective locale, then presets or engine defaults.
- Ship France French spacing (NBSP before colons, narrow NBSP before semicolons) and bundled Québec French spacing (NBSP before colons, ordinary semicolons).
- Make `term-locale: style` and `term-locale: item` select their respective realization tables; document the policy and complete/archive bean `csl26-w1op`.

## Validation

- `just schema-gen`
- `cargo test -p citum-schema-style embedded_v2_locales_pass_completeness_lint`
- `cargo test -p citum-engine --test multilingual locale_punctuation`
- `cargo test -p citum-engine --test multilingual style_punctuation_realization_overrides_the_selected_locale`
- `python3 scripts/audit-rust-review-smells.py --changed`
- `just pre-commit`
- Pre-push hook: 2,156 tests passed

## Risk

The realization table is intentionally partial: any unset mark continues through the existing punctuation-width preset and engine-default fallback. Quote glyphs and collision/normalization behavior remain unchanged.
