### PR TITLE
fix(engine): disamb grouping and anon term

### DIFF
--- a/.beans/csl26-6eak--tune-gb-t-7714-2025-author-date-to-full-fidelity.md
+++ b/.beans/csl26-6eak--tune-gb-t-7714-2025-author-date-to-full-fidelity.md
@@ -1,7 +1,7 @@
 ---
 # csl26-6eak
 title: Tune gb-t-7714-2025-author-date to full fidelity
-status: todo
+status: in-progress
 type: task
 priority: normal
 tags:
@@ -9,7 +9,7 @@ tags:
     - fidelity
     - multilingual
 created_at: 2026-07-16T10:56:59Z
-updated_at: 2026-07-23T15:05:20Z
+updated_at: 2026-07-23T17:05:29Z
 blocking:
     - csl26-dxuo
 blocked_by:
@@ -393,3 +393,129 @@ anonymous term) is smaller (10 entries) and more contained (one new
 `MessageArgSource` variant or a routing fix, no shared-path risk). Findings
 2 and 3 are narrower, independent, and can be picked up in either order or
 split into their own beans.
+
+## Session progress (2026-07-23, later session): three engine gaps found and fixed, 125/203 → 141/203 raw (69.5%), 152/203 → 162/203 adjusted (79.8%)
+
+Picked up from the prior 2026-07-23 session's 125/203 raw / 152/203 adjusted
+baseline. Fresh triage of the 51 adjusted failures showed the dominant
+pattern was missing year-suffix disambiguation on anonymous/no-date
+fallback entries (oracle: `无日期-a … 无日期-v`, `2011a`/`2011b`; citum: bare
+`无日期`/`2011`). Root-caused to **three independent, precisely-located
+engine gaps**, not one — each confirmed via direct instrumentation
+(`ProcHints` dumps, CLI render diffs) before fixing, per repeated
+empirical checkpoints rather than assumption:
+
+1. **Disambiguation grouping used the citation-scoped substitute, not the
+   bibliography-scoped one** — `build_reference_cache`
+   (`crates/citum-engine/src/processor/disambiguation.rs`) resolved the
+   anonymous-fallback collision key from `self.config.substitute`
+   (citation-scoped: includes `title`) instead of `self.sort_config`
+   (already documented as the effective bibliography config). A style
+   overriding only the bibliography-scope substitute (GB/T author-date's
+   `[editor, translator]`, no `title`) therefore saw every anonymous
+   reference resolve a *distinct* substituted-title key at the grouping
+   layer, even though the bibliography itself renders the same constant
+   `佚名` fallback for all of them — singleton groups, no suffix. Fixed by
+   reading `sort_config.substitute`; all current call sites already pass
+   the bibliography config as `sort_config`, so this is a no-op everywhere
+   else (confirmed: 157-style `check-core-quality` clean).
+
+2. **`TemplateDate`'s explicit `fallback:` branch never computed or
+   attached a disambiguation suffix at all** — regardless of which
+   fallback candidate resolved. The suffix mechanism
+   (`compute_disamb_suffix_label` / `append_no_date_disamb_suffix` /
+   `inline_disamb_suffix`, `crates/citum-engine/src/values/date.rs`) only
+   existed in the implicit (no explicit `fallback:`) no-date branch and
+   the real-date branch. GB/T author-date's date components always carry
+   an explicit `fallback:` chain (front-loaded `date: issued` with
+   `copyright → printing → accessed → message: term.no-date`), so even
+   after fix (1) correctly grouped references, *nothing* ever attached a
+   letter. Fixed by applying the same append-suffix convention when the
+   winning fallback candidate is a `message:` component — by construction
+   the terminal "no data available" case in a date's fallback chain —
+   respecting `suppress-disamb-suffix` like the other two branches. This
+   alone, with (1), still moved **zero** oracle numbers (verified) — see
+   (3).
+
+3. **The anonymous term was a locale-independent style constant, and
+   grouping didn't scope by language either** — `佚名` was pinned via a
+   style-owned `options.messages: term.anonymous: 佚名` override, which
+   `TemplateMessage::values` checks *before* consulting the active
+   locale, so it applied unconditionally regardless of item language.
+   Oracle actually keeps **two independent** year-suffix letter sequences
+   — `佚名，无日期-a…w` (Chinese) and `Anon，n.d.-a…j` (English) — because the
+   rendered term differs by language, so CSL treats them as different
+   "authors." Root cause for why `term.anonymous` couldn't just move to a
+   locale file directly: `general_message_id()`
+   (`crates/citum-schema-style/src/locale/message_ids.rs`), which decides
+   which `GeneralTerm`s get MF2-message-first treatment ahead of the
+   legacy structured `terms:` catalog, had `NoDate`/`Circa` but not
+   `Anonymous` — so a locale's `messages.term-anonymous` entry was never
+   even consulted; resolution always fell straight to the hardcoded
+   legacy default (en-US: `"anon."`). Fixed in three parts: (a) add
+   `Anonymous` to `general_message_id`'s allowlist, mirroring `NoDate`
+   exactly; (b) drop the style-owned override, add
+   `term.anonymous`/`term.anonymous-long` to `zh-CN.yaml` (`佚名`) and
+   `en-US.yaml` (`Anon`); (c) scope the `ANONYMOUS_FALLBACK_KEY` sentinel
+   in `build_author_slot_key` by `effective_item_language(reference)` —
+   the same driver `process_bibliography_entry_with_format` already uses
+   to pick a `bibliography: locales:` branch — so Chinese and English
+   anonymous items collide into separate sequences instead of one merged,
+   scrambled one.
+
+Three previously-passing pinned tests
+(`crates/citum-engine/tests/date_annotations.rs`) regressed once (3)
+landed: they construct a bare `Processor::new` (seeds `Locale::en_us()`)
+directly rather than resolving the style's `info.default-locale` the way
+the real `citum render` CLI does (`create_processor`,
+`citum-cli/src/style_resolver.rs`) — they only passed before because the
+old override was locale-independent. Fixed the harness (constructed with
+the embedded zh-CN locale, mirroring the existing
+`localized_author_date_grouping_uses_the_selected_term_locale` precedent
+in `crates/citum-engine/tests/i18n.rs`), not the assertions — the expected
+`佚名` strings are unchanged and correct.
+
+`just pre-commit` green (2161/2161, fmt, clippy). `just check-core-quality`
+clean (157 styles, fidelity=1.0, 0 warnings) — the shared `en-US.yaml`
+term.anonymous default change (`"anon." → "Anon"` for styles that
+reference `message: term.anonymous`/`GeneralTerm::Anonymous`) does not
+regress any other embedded style (verified no other embedded style uses
+`message: term.anonymous` or `term: anonymous` as a component).
+
+### Residual findings (41 adjusted failures), precisely characterized
+
+1. **NEW, dominant — suffix *order within* the anonymous collision group
+   doesn't match oracle's render order** (~28 of 41: the entire 无日期
+   bucket plus `2011a/b`, `2012a/b`, `2023a/b/c`, `2024a/b` swapped
+   pairs). Confirmed via direct evidence, not assumption: citum's own
+   *render* position for the 佚名+无日期 bucket (0, 1, 2, 3…) does not
+   correlate at all with its own assigned *letters* (k, w, x, a…) —
+   `sort_group_for_year_suffix`'s no-`group_sort` branch
+   (`disambiguation.rs`) hardcodes a title-alphabetical tiebreak
+   (`a_title.cmp(b_title)`) as the *default* ordering whenever no
+   explicit `bibliography.sort:`/`group_sort` is configured — which GB/T
+   author-date doesn't set. That assumption doesn't match this style's
+   actual (apparently insertion-order) bibliography arrangement. This is
+   an **internal inconsistency** (citum's own suffix order disagrees with
+   citum's own render order), not a deeper bibliography-sort divergence
+   from oracle — the fix is in the same shared no-`group_sort` fallback
+   used by *every* style without an explicit `group_sort`, so it needs
+   its own dedicated pass with full `check-core-quality` verification.
+   Single highest-leverage remaining item.
+2. **Finding 2 — org-as-author for `standard` type** (3 entries,
+   `gbt7714.8.9.2:1-3`, unchanged from prior triage): oracle promotes the
+   issuing committee into the author slot; Citum's `standard`
+   type-variant has no path to promote an org/publisher field into the
+   author position. Needs a `substitute.template` extension (new
+   `SubstituteField` variant or a publisher-as-contributor path).
+3. **Date-parsing singles** (`gbt7714.8.11.2.2:1`, `8.11.3.2:1/5`):
+   approximate/bracketed year (`[2025]`) falls through to the no-date term
+   instead of the approximate-year value — the front `date: issued`
+   component's `fallback:` chain doesn't reach `accessed` the way the
+   rendered oracle text implies it should for these types.
+4. **2 unclassified singles**: `gbt7714.8.5.1.1:7` (body date silently
+   dropped), `gbt7714.7.2.1:4` (oracle shows a bare disambiguation letter
+   `b` with no `无日期-`/`b` prefix pattern — an outlier, not understood).
+
+`verification-policy.yaml` left untouched (`count_toward_fidelity: false`)
+— 141/203 raw is nowhere near the 1.0 bar it requires. Not flipped.

--- a/.beans/csl26-m8la--align-year-suffix-ordering-with-bibliography-rende.md
+++ b/.beans/csl26-m8la--align-year-suffix-ordering-with-bibliography-rende.md
@@ -1,0 +1,31 @@
+---
+# csl26-m8la
+title: Align year-suffix ordering with bibliography render order for constant-fallback collision groups
+status: todo
+type: bug
+priority: high
+tags:
+    - style
+    - fidelity
+    - engine
+created_at: 2026-07-23T17:05:46Z
+updated_at: 2026-07-23T17:06:50Z
+---
+
+Disambiguator::sort_group_for_year_suffix (crates/citum-engine/src/processor/disambiguation.rs) has a no-group_sort fallback that hardcodes a title-alphabetical tiebreak (a_title.cmp(b_title)) as the DEFAULT year-suffix ordering whenever a style doesn't configure an explicit bibliography.sort:/group_sort. This is wrong for styles (confirmed: gb-t-7714-2025-author-date) whose actual bibliography render order is NOT title-alphabetical.
+
+## Evidence (csl26-6eak, 2026-07-23 session)
+
+Confirmed via direct evidence, not assumption: citum's own bibliography RENDER position for a large anonymous-author collision group (the 佚名+无日期 bucket, ~25 items) does not correlate at all with the LETTERS it assigns them — e.g. render position 0 gets letter 'k', position 1 gets 'w', position 3 gets 'a'. Oracle (citeproc-js), by contrast, assigns a/b/c... in exact bibliography render order.
+
+This means citum's own suffix order disagrees with citum's own render order — an internal inconsistency, not (necessarily) a deeper bibliography-sort divergence from the oracle. Fixing sort_group_for_year_suffix's no-group_sort fallback to follow the ACTUAL resolved bibliography order (rather than a hardcoded title-alphabetical assumption) should fix this bucket AND the smaller `2011a/2011b`, `2012a/2012b`, `2023a/b/c`, `2024a/b`, `2000b/c` swapped-pair cases seen elsewhere in the same corpus (all traceable to the same root cause).
+
+## Scope / risk
+
+This is a SHARED code path: the no-group_sort branch is the DEFAULT ordering for every style that doesn't set an explicit group_sort — likely the common case across the embedded corpus, not rare. Any fix needs a full `just check-core-quality` (157 styles) pass to confirm no regression, in addition to the GB/T author-date oracle corpus (tests/fixtures/test-items-library/gb-t-7714-2025.json, --scope bibliography).
+
+## Recommended approach
+
+Investigate what the CORRECT default ordering should be when no explicit group_sort is configured — likely "the order references actually appear in the rendered bibliography" (which may already be available via some existing render-order/index the Disambiguator doesn't currently have access to at hint-calculation time), rather than a fresh title-alphabetical computation. Do not assume; verify against the oracle for at least gb-t-7714-2025-author-date plus a broader spot-check of other author-date styles with real (non-anonymous) same-author-year collisions.
+
+Part of csl26-6eak (Tune gb-t-7714-2025-author-date to full fidelity) — the single highest-leverage remaining item, ~28 of 41 residual adjusted failures trace to this.

--- a/.beans/csl26-o333--fix-gbt-author-date-date-parsing-edge-cases-approx.md
+++ b/.beans/csl26-o333--fix-gbt-author-date-date-parsing-edge-cases-approx.md
@@ -1,0 +1,22 @@
+---
+# csl26-o333
+title: Fix GB/T author-date date-parsing edge cases (approximate year, dropped body date)
+status: todo
+type: bug
+priority: low
+tags:
+    - style
+    - fidelity
+created_at: 2026-07-23T17:06:18Z
+updated_at: 2026-07-23T17:06:50Z
+---
+
+Small cluster of unresolved GB/T 7714-2025 author-date rendering gaps against the upstream corpus (tests/fixtures/test-items-library/gb-t-7714-2025.json, --scope bibliography), triaged in csl26-6eak's 2026-07-23 session but not attempted (low item count, distinct root causes from the main disambiguation work):
+
+1. **Approximate/bracketed year falls to no-date term instead of the approximate value** — `gbt7714.8.11.2.2:1` (oracle: `佚名，[2025a]. 中国国家博物馆...`, citum: `佚名，无日期-p. ...`), `gbt7714.8.11.3.2:1` (oracle: `高等教育文献保障系统，[2025]. ...`, citum: `...无日期`), `gbt7714.8.11.3.2:5` (oracle: `Zotero，[2024]. ...`, citum: `Zotero，n.d. ...`). These items have no `issued` but do have `accessed`; the front `date: issued, form: year` component's `fallback:` chain apparently doesn't reach `accessed` the way the oracle's rendering implies it should for these carrier types (GB/T §7.5.4.3 uncertain-date convention — bracketed year).
+
+2. **Body date silently dropped** — `gbt7714.8.5.1.1:7`: oracle shows `佚名，2024b. [J]. 2024-05-09` (a full-precision body date after the bracket), citum shows `佚名，2024b. [J]` with the body date missing entirely.
+
+3. **Unexplained bare disambiguation letter** — `gbt7714.7.2.1:4`: oracle shows `佚名，b. [J]. ...` (a bare letter `b` with no `无日期-`/`n.d.-` prefix at all, unlike every other item in the same no-date collision group). Not understood; may be an oracle/citeproc-js quirk rather than a citum gap — verify against citeproc-js behavior directly before assuming citum is wrong.
+
+Part of csl26-6eak (Tune gb-t-7714-2025-author-date to full fidelity). Low priority — 5 entries total, none block the higher-leverage csl26-m8la (suffix ordering) or csl26-yyrs (org-as-author) follow-ups.

--- a/.beans/csl26-yyrs--promote-issuing-org-as-author-fallback-for-gbt-sta.md
+++ b/.beans/csl26-yyrs--promote-issuing-org-as-author-fallback-for-gbt-sta.md
@@ -1,0 +1,24 @@
+---
+# csl26-yyrs
+title: Promote issuing-org as author fallback for GB/T standard type
+status: todo
+type: task
+priority: normal
+tags:
+    - fidelity
+    - style
+created_at: 2026-07-23T17:06:02Z
+updated_at: 2026-07-23T17:06:50Z
+---
+
+GB/T 7714-2025 author-date's `standard` reference type: oracle promotes the issuing committee/organization into the author slot (e.g. `全国信息与文献标准化技术委员会，2021. GB/T 3792—2021 ...`) when no personal author exists. Citum's `standard` type-variant has no path to promote an org/publisher-shaped field into the author position, so it falls through to the `佚名` anonymous fallback instead, dropping the org name entirely.
+
+## Evidence
+
+3 corpus entries fail on this (tests/fixtures/test-items-library/gb-t-7714-2025.json, gbt7714.8.9.2:1-3), unchanged since the original 2026-07-22 triage in csl26-6eak.
+
+## Likely approach
+
+Needs a `substitute.template` extension — either a new `SubstituteField` variant for publisher/issuing-org, or a `TemplateContributor`-shaped publisher-as-contributor path (crates/citum-schema-style/src/options/substitute.rs, crates/citum-schema-style/src/template.rs). Scope carefully: if this needs to generalize beyond GB/T's one type-variant, consider whether it should be a broader `substitute` schema feature rather than a GB/T-specific hack.
+
+Part of csl26-6eak (Tune gb-t-7714-2025-author-date to full fidelity).

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -290,8 +290,18 @@ impl<'a> Disambiguator<'a> {
         refs: &[&'b Reference],
         needs_title_key: bool,
     ) -> ReferenceCache<'b> {
+        // Grouping must resolve the substitute chain from `sort_config` (the
+        // effective bibliography config, per its doc comment), not `config`
+        // (which may be citation-scoped). A style can override the
+        // bibliography-scope substitute independently of the citation-scope
+        // one (e.g. GB/T 7714 author-date's constant `佚名` anonymous-author
+        // fallback, csl26-6eak) — if grouping used the citation substitute
+        // instead, it would see a per-reference substituted title where the
+        // bibliography renders the same constant text for every such
+        // reference, so those references would each form a singleton group
+        // instead of colliding on year like a real shared author.
         let substitute = citum_schema::options::SubstituteConfig::resolve_or_default(
-            self.config.substitute.as_ref(),
+            self.sort_config.substitute.as_ref(),
         );
         refs.iter()
             .enumerate()
@@ -381,12 +391,22 @@ impl<'a> Disambiguator<'a> {
             // to promote. Unlike a substituted title (which already varies
             // per reference and so needs no further disambiguation), a
             // component-level `TemplateContributor.fallback` (e.g. GB/T
-            // 7714's `佚名` anonymous-author term, csl26-6eak) renders the
-            // *same* constant text for every such reference — so, like a
-            // real shared author name, these entries must collide on year
-            // for suffix assignment rather than each forming its own
-            // singleton group.
-            None => Self::ANONYMOUS_FALLBACK_KEY.to_string(),
+            // 7714's `佚名`/`Anon` anonymous-author term, csl26-6eak) renders
+            // the *same* constant text for every such reference sharing a
+            // language — so, like a real shared author name, these entries
+            // must collide on year for suffix assignment rather than each
+            // forming its own singleton group. Scoped by the reference's own
+            // effective language (the same driver the bibliography renderer
+            // uses to pick a `locales:` branch, `core.rs`'s
+            // `effective_item_language`) because the rendered term itself
+            // varies by language (`佚名` vs `Anon`) — a Chinese and an
+            // English anonymous item must not share one year-suffix letter
+            // sequence when their rendered author text actually differs.
+            None => format!(
+                "{}{}",
+                Self::ANONYMOUS_FALLBACK_KEY,
+                crate::values::effective_item_language(reference).unwrap_or_default()
+            ),
             Some(_) => String::new(),
         }
     }

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -15,7 +15,9 @@ use citum_schema::locale::{GeneralTerm, TermForm};
 use citum_schema::options::dates::TimeFormat;
 use citum_schema::reference::types::RefDate;
 use citum_schema::reference::{ClassExtension, WorkRelation};
-use citum_schema::template::{DateForm, DateVariable as TemplateDateVar, TemplateDate};
+use citum_schema::template::{
+    DateForm, DateVariable as TemplateDateVar, TemplateComponent, TemplateDate,
+};
 
 fn month_to_string(month: u32, months: &[String]) -> String {
     if month > 0 {
@@ -883,7 +885,7 @@ impl ComponentValues for TemplateDate {
             if let Some(fallbacks) = &self.fallback {
                 for component in fallbacks {
                     if let Some(values) = component.values::<F>(reference, hints, options) {
-                        let output = apply_fallback_component_rendering(
+                        let mut output = apply_fallback_component_rendering(
                             &fmt,
                             &values.value,
                             values.pre_formatted,
@@ -891,6 +893,25 @@ impl ComponentValues for TemplateDate {
                             reference,
                             options,
                         );
+                        // A `message:` fallback candidate is, by construction,
+                        // the terminal "no data available" case in a date's
+                        // fallback chain (e.g. GB/T 7714's `无日期`/`n.d.`
+                        // term via `message: term.no-date`) — apply the same
+                        // year-suffix-append convention the implicit (no
+                        // explicit `fallback:`) no-date path below already
+                        // uses, so explicit and implicit no-date fallbacks
+                        // disambiguate identically. Without this, a style
+                        // whose date components always carry an explicit
+                        // `fallback:` chain (as GB/T author-date's do) never
+                        // reaches the implicit branch and never gets a
+                        // suffix at all. See csl26-6eak.
+                        if matches!(self.date, TemplateDateVar::Issued)
+                            && self.suppress_disamb_suffix != Some(true)
+                            && matches!(component, TemplateComponent::Message(_))
+                            && let Some(suffix) = compute_disamb_suffix_label(hints, options, &fmt)
+                        {
+                            append_no_date_disamb_suffix(&mut output, &suffix, options);
+                        }
                         return Some(ProcValues {
                             value: output,
                             prefix: None,

--- a/crates/citum-engine/tests/date_annotations.rs
+++ b/crates/citum-engine/tests/date_annotations.rs
@@ -35,6 +35,21 @@ use indexmap::IndexMap;
 use rstest::rstest;
 use std::path::PathBuf;
 
+/// Load the embedded zh-CN locale for GB/T fixtures.
+///
+/// `Processor::new` seeds a plain `Locale::en_us()` base locale; the real
+/// `citum render` CLI resolves a style's `info.default-locale` (zh-CN for
+/// the GB/T family) into an explicit locale via `create_processor`
+/// (`citum-cli/src/style_resolver.rs`). Tests that construct a `Processor`
+/// directly must do the same or a language-sensitive term (e.g. GB/T's
+/// `佚名`/`Anon` anonymous-author term, csl26-6eak) resolves against the
+/// wrong locale's default.
+fn zh_cn_locale() -> citum_schema::Locale {
+    let bytes = citum_schema::embedded::get_locale_bytes("zh-CN").expect("zh-CN must be embedded");
+    citum_schema::Locale::from_yaml_str(std::str::from_utf8(bytes).expect("valid UTF-8"))
+        .expect("zh-CN locale should parse")
+}
+
 /// Project root path resolver.
 fn project_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
@@ -60,7 +75,7 @@ fn render_pinned_gbt_entry(style_name: &str, ref_id: &str) -> String {
         .unwrap_or_else(|_| panic!("{style_name} should parse"))
         .into_resolved();
 
-    Processor::new(style, bibliography).render_bibliography()
+    Processor::with_locale(style, bibliography, zh_cn_locale()).render_bibliography()
 }
 
 /// Build a minimal book reference with an annotated `issued` date.
@@ -195,7 +210,7 @@ fn given_gb_t_author_date_style_when_rendering_bibliography_then_calendar_note_i
         annotated_book("minguo-1947", "戰後臺灣史", "1947", "民国三十六年"),
     )]);
 
-    let processor = Processor::new(style, bibliography);
+    let processor = Processor::with_locale(style, bibliography, zh_cn_locale());
     let rendered = processor.render_bibliography();
 
     assert_eq!(rendered, "佚名，1947（民国三十六年）. 戰後臺灣史[M]. ");

--- a/crates/citum-schema-style/embedded/locales/en-US.yaml
+++ b/crates/citum-schema-style/embedded/locales/en-US.yaml
@@ -933,6 +933,10 @@ messages:
   term.retrieved: "retrieved"
   term.no-date: "n.d."
   term.no-date-long: "no date"
+  # GB/T 7714's own anonymous-author convention (not the CSL legacy
+  # `terms.anonymous` "anon." catalog entry) — see csl26-6eak.
+  term.anonymous: "Anon"
+  term.anonymous-long: "Anonymous"
   term.forthcoming: "forthcoming"
   # CSL reference locale (scripts/locales-en-US.xml): CMOS 10.48 allows
   # "ca." but CSL has historically used "c." — match the CSL reference.

--- a/crates/citum-schema-style/embedded/locales/zh-CN.yaml
+++ b/crates/citum-schema-style/embedded/locales/zh-CN.yaml
@@ -145,6 +145,8 @@ messages:
   term.et-al: "等"
   term.no-date: "无日期"
   term.no-date-long: "无日期"
+  term.anonymous: "佚名"
+  term.anonymous-long: "佚名"
   term.page-label: "页"
   term.page-label-long: "页"
   term.chapter-label: "章"

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-author-date.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-author-date.yaml
@@ -20,14 +20,13 @@ info:
     - href: https://std.samr.gov.cn/gb/search/gbDetailed?id=4507EFE13D37CB6AE06397BE0A0A601F
       rel: documentation
 options:
-  # Style-owned so it resolves independent of which Locale object backs a
-  # given render (`Processor::new` seeds a plain en-US base locale; only a
-  # scoped `locales:` branch or a per-item `language` swaps in the real
-  # zh-CN locale — csl26-6eak). GB/T 7714's `佚名` (anonymous-author)
-  # placeholder, used by `contributor: author`'s `fallback:` on every
-  # bibliography type-variant below.
-  messages:
-    term.anonymous: 佚名
+  # GB/T 7714's anonymous-author placeholder (`佚名`/`Anon`), used by
+  # `contributor: author`'s `fallback:` on every bibliography type-variant
+  # below, is sourced from each locale file's `messages.term.anonymous`
+  # (zh-CN.yaml/en-US.yaml) — not a style-owned override — so the same
+  # `bibliography: locales:` per-item branch selection that already picks
+  # `term.no-date`'s locale (`n.d.` vs `无日期`) also picks the correct
+  # anonymous term. csl26-6eak.
   substitute: standard
   processing: author-date-givenname
   contributors:

--- a/crates/citum-schema-style/src/locale/message_ids.rs
+++ b/crates/citum-schema-style/src/locale/message_ids.rs
@@ -149,6 +149,8 @@ impl Locale {
             (GeneralTerm::Retrieved, _) => Some("term.retrieved"),
             (GeneralTerm::NoDate, TermForm::Long) => Some("term.no-date-long"),
             (GeneralTerm::NoDate, _) => Some("term.no-date"),
+            (GeneralTerm::Anonymous, TermForm::Long) => Some("term.anonymous-long"),
+            (GeneralTerm::Anonymous, _) => Some("term.anonymous"),
             (GeneralTerm::Forthcoming, _) => Some("term.forthcoming"),
             (GeneralTerm::Circa, TermForm::Long) => Some("term.circa-long"),
             (GeneralTerm::Circa, _) => Some("term.circa"),


### PR DESCRIPTION
## Summary

Continues csl26-6eak (Tune `gb-t-7714-2025-author-date` to full fidelity). Root-causes and fixes three independent engine gaps blocking year-suffix disambiguation for GB/T's anonymous-author entries — found via direct instrumentation (`ProcHints` dumps, CLI render diffs) at each step rather than assumption:

1. **Disambiguation grouping used the citation-scoped substitute, not the bibliography-scoped one** (`disambiguation.rs`) — a style overriding only the bibliography-scope substitute never collided same-year anonymous entries for suffix assignment.
2. **`TemplateDate`'s explicit `fallback:` branch never computed or attached a disambiguation suffix** (`date.rs`) — the suffix mechanism only existed in the implicit no-date and real-date branches; GB/T author-date's date components always use an explicit `fallback:` chain.
3. **The anonymous term (`佚名`/`Anon`) was a locale-independent style constant**, and grouping wasn't scoped by item language either — `general_message_id`'s allowlist omitted `Anonymous` (unlike `NoDate`), so a locale's own message catalog was never consulted; fixed to mirror `no-date`'s existing per-locale mechanism exactly, and scoped the grouping sentinel by item language so Chinese/English anonymous entries get independent letter sequences (matching oracle).

Three previously-passing pinned tests regressed once (3) landed — fixed the test harness (construct with the embedded zh-CN locale, matching how the real `citum render` CLI resolves a style's `default-locale`), not the assertions.

**Fidelity**: raw 125/203 → 141/203 (69.5%), adjusted 152/203 → 162/203 (79.8%) against the upstream GB/T corpus. Not yet at the 100% bar `verification-policy.yaml` requires, so it's left untouched.

Residue is precisely characterized and split into follow-up beans:
- csl26-m8la (highest leverage, ~28 of 41 remaining failures): `sort_group_for_year_suffix`'s no-`group_sort` fallback hardcodes a title-alphabetical tiebreak that doesn't match this style's actual render order — a shared path needing its own dedicated corpus-verified pass.
- csl26-yyrs: org-as-author promotion for the `standard` type (3 entries).
- csl26-o333: approximate-year/dropped-body-date edge cases (5 entries).

## Test plan

- [x] `just pre-commit` (fmt, clippy, 2161/2161 nextest) — green
- [x] `just check-core-quality` (157 embedded styles, fidelity=1.0, 0 warnings) — green, no regression from the shared `en-US.yaml` term.anonymous default change
- [x] GB/T author-date oracle corpus (bibliography scope, `tests/fixtures/test-items-library/gb-t-7714-2025.json`) — 141/203 raw, 162/203 adjusted, up from 125/152
- [x] `date_annotations.rs` (13/13) — including the 3 harness-fixed pinned era-annotation cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
