### PR TITLE
fix(styles): gb/t 7714 entry terminal period

### DIFF
--- a/crates/citum-engine/tests/date_annotations.rs
+++ b/crates/citum-engine/tests/date_annotations.rs
@@ -213,7 +213,7 @@ fn given_gb_t_author_date_style_when_rendering_bibliography_then_calendar_note_i
     let processor = Processor::with_locale(style, bibliography, zh_cn_locale());
     let rendered = processor.render_bibliography();
 
-    assert_eq!(rendered, "佚名，1947（民国三十六年）. 戰後臺灣史[M]. ");
+    assert_eq!(rendered, "佚名，1947（民国三十六年）. 戰後臺灣史[M].");
 }
 
 #[test]
@@ -269,8 +269,8 @@ fn given_two_refs_same_author_year_different_note_when_disambiguating_then_still
 
     assert_eq!(
         rendered,
-        "Kang，1947a（民国三十六年）. First Work[M]. \n\n\
-         Kang，1947b（不同的注释）. Second Work[M]. "
+        "Kang，1947a（民国三十六年）. First Work[M].\n\n\
+         Kang，1947b（不同的注释）. Second Work[M]."
     );
 }
 
@@ -286,47 +286,47 @@ fn given_two_refs_same_author_year_different_note_when_disambiguating_then_still
 #[case::gb_t_7714_2025_author_date_minguo(
     "gb-t-7714-2025-author-date",
     "gbt7714.7.5.4.1:1",
-    "佚名，1947（民国三十六年）. [M]. "
+    "佚名，1947（民国三十六年）. [M]."
 )]
 #[case::gb_t_7714_2025_author_date_kangxi(
     "gb-t-7714-2025-author-date",
     "gbt7714.7.5.4.1:2",
-    "佚名，1705（康熙四十四年）. [M]. "
+    "佚名，1705（康熙四十四年）. [M]."
 )]
 #[case::gb_t_7714_2025_numeric_minguo(
     "gb-t-7714-2025-numeric",
     "gbt7714.7.5.4.1:1",
-    "[1][M]. 1947（民国三十六年）"
+    "[1][M]. 1947（民国三十六年）."
 )]
 #[case::gb_t_7714_2025_numeric_kangxi(
     "gb-t-7714-2025-numeric",
     "gbt7714.7.5.4.1:2",
-    "[1][M]. 1705（康熙四十四年）"
+    "[1][M]. 1705（康熙四十四年）."
 )]
 #[case::gb_t_7714_2025_note_minguo(
     "gb-t-7714-2025-note",
     "gbt7714.7.5.4.1:1",
-    "[1][M]. 1947（民国三十六年）"
+    "[1][M]. 1947（民国三十六年）."
 )]
 #[case::gb_t_7714_2025_note_kangxi(
     "gb-t-7714-2025-note",
     "gbt7714.7.5.4.1:2",
-    "[1][M]. 1705（康熙四十四年）"
+    "[1][M]. 1705（康熙四十四年）."
 )]
 #[case::gb_t_7714_2025_author_date_qing_dynasty(
     "gb-t-7714-2025-author-date",
     "gbt7714.8.2.2:2",
-    "王夫之，1865（清同治四年）. 宋论[M]. 刻本. 金陵：湘乡曾国荃"
+    "王夫之，1865（清同治四年）. 宋论[M]. 刻本. 金陵：湘乡曾国荃."
 )]
 #[case::gb_t_7714_2025_author_date_guangxu_era(
     "gb-t-7714-2025-author-date",
     "gbt7714.8.12.3:1",
-    "李鸿章，1887. 奏请上海道库洋务外销要款无款可筹仍拨药厘接济事：04-01-35-0399-039[A]. 北京：中国第一历史档案馆，1887（光绪十三年三月十三日）"
+    "李鸿章，1887. 奏请上海道库洋务外销要款无款可筹仍拨药厘接济事：04-01-35-0399-039[A]. 北京：中国第一历史档案馆，1887（光绪十三年三月十三日）."
 )]
 #[case::gb_t_7714_2025_author_date_republic_era(
     "gb-t-7714-2025-author-date",
     "gbt7714.8.12.3:3",
-    "佚名，1949. 中国人民解放军武汉市军事管制委员会接管国立武汉大学的文告[A/OL]. 武汉：武汉大学档案馆，1949（中华民国三十八年八月）. https://archive.whu.edu.cn/index/forwardView/20/51"
+    "佚名，1949. 中国人民解放军武汉市军事管制委员会接管国立武汉大学的文告[A/OL]. 武汉：武汉大学档案馆，1949（中华民国三十八年八月）. https://archive.whu.edu.cn/index/forwardView/20/51."
 )]
 fn given_pinned_gbt_record_when_rendering_bibliography_then_note_is_wrapped(
     #[case] style_name: &str,

--- a/crates/citum-engine/tests/multilingual.rs
+++ b/crates/citum-engine/tests/multilingual.rs
@@ -22,7 +22,10 @@ use common::announce_behavior;
 use citum_engine::Processor;
 use citum_io::load_bibliography;
 use citum_schema::citation::{Citation, CitationItem};
-use citum_schema::reference::InputReference;
+use citum_schema::reference::{
+    Contributor, DateValue, InputReference, LangID, Monograph, MonographType, MultilingualString,
+    Place, Publisher, StructuredName, Title,
+};
 use citum_schema::{Style, locale::Locale};
 use indexmap::IndexMap;
 use std::fs;
@@ -302,7 +305,7 @@ fn given_gb_t_numeric_style_when_rendering_latin_script_book_then_delimiters_fol
 
     assert_eq!(
         rendered,
-        "[1]AI and the future of banking[M]. New York：Wiley，1988"
+        "[1]AI and the future of banking[M]. New York：Wiley，1988."
     );
 }
 
@@ -332,7 +335,7 @@ fn given_gb_t_numeric_style_when_rendering_cjk_script_book_then_delimiters_stay_
 
     assert_eq!(
         rendered,
-        "[1]银行业的未来与人工智能[M]. 北京：清华大学出版社，1988"
+        "[1]银行业的未来与人工智能[M]. 北京：清华大学出版社，1988."
     );
 }
 
@@ -369,7 +372,86 @@ fn english_article_journal_falls_back_to_section_type_variant() {
 
     assert_eq!(
         rendered,
-        "[1]Coffee drinking and cancer of the pancreas[J]. Br Med J，1981，283（6292）：628"
+        "[1]Coffee drinking and cancer of the pancreas[J]. Br Med J，1981，283（6292）：628."
+    );
+}
+
+#[test]
+fn given_gb_t_numeric_style_when_bare_entry_has_no_trailing_field_then_terminal_period_is_appended()
+{
+    announce_behavior(
+        "GB/T 7714—2025's own worked examples (data/GB-T_7714-2025.original.toml) and \
+         real Zotero output always end a bibliography entry in a period, even after a \
+         bare page-locator with no dimensions/url/cstr/doi field to otherwise trigger \
+         one. `bibliography.options.entry-suffix: '.'` (unset before this fix) closes \
+         that gap — csl26-iqxu.",
+    );
+    let style = citum_schema::embedded::get_embedded_style("gb-t-7714-2025-numeric")
+        .expect("gb-t-7714-2025-numeric should be embedded")
+        .expect("gb-t-7714-2025-numeric should parse")
+        .into_resolved();
+    let bare_book = InputReference::Monograph(Box::new(Monograph {
+        id: Some("hawking".into()),
+        r#type: MonographType::Book,
+        title: Some(Title::Single("A Brief History of Time".to_string())),
+        author: Some(Contributor::StructuredName(StructuredName {
+            family: MultilingualString::Simple("Hawking".to_string()),
+            given: MultilingualString::Simple("Stephen".to_string()),
+            suffix: None,
+            dropping_particle: None,
+            non_dropping_particle: None,
+        })),
+        publisher: Some(Publisher {
+            name: MultilingualString::Simple("Bantam Dell Publishing Group".to_string()),
+            place: Some(Place("New York".to_string())),
+        }),
+        language: Some(LangID("en".to_string())),
+        issued: DateValue::new("1988".to_string()),
+        ..Default::default()
+    }));
+    let bibliography = IndexMap::from([("hawking".to_string(), bare_book)]);
+
+    let processor = Processor::new(style, bibliography);
+    let rendered = processor.render_bibliography();
+
+    assert_eq!(
+        rendered,
+        "[1]Hawking S. A Brief History of Time[M]. New York：Bantam Dell Publishing Group，1988."
+    );
+}
+
+#[test]
+fn given_gb_t_numeric_style_when_entry_already_ends_in_url_then_period_is_not_doubled() {
+    announce_behavior(
+        "`entry-suffix-after-url: true` forces the terminal period after a URL-ending \
+         entry (per GB/T convention — real Zotero output always has it), but the \
+         engine's `TerminalLink` guard must not double-punctuate an entry the URL \
+         field already terminated correctly — csl26-iqxu.",
+    );
+    let style = citum_schema::embedded::get_embedded_style("gb-t-7714-2025-numeric")
+        .expect("gb-t-7714-2025-numeric should be embedded")
+        .expect("gb-t-7714-2025-numeric should parse")
+        .into_resolved();
+    let corpus_path = project_root().join("tests/fixtures/test-items-library/gb-t-7714-2025.json");
+    let corpus = load_bibliography(&corpus_path).expect("pinned GB/T corpus should load");
+    let ref_id = "gbt7714.7.5.2.3:3";
+    let reference = corpus
+        .get(ref_id)
+        .unwrap_or_else(|| panic!("pinned GB/T corpus should contain {ref_id}"))
+        .clone();
+    let bibliography = IndexMap::from([(ref_id.to_string(), reference)]);
+
+    let processor = Processor::new(style, bibliography);
+    let rendered = processor.render_bibliography();
+
+    assert_eq!(
+        rendered,
+        "[1][M/OL]. Open University Press，2025. \
+         https://www.mheducation.co.uk/economics-13e-9781526850232-emea-group."
+    );
+    assert!(
+        !rendered.ends_with(".."),
+        "URL-terminated entry must not be double-punctuated: {rendered}"
     );
 }
 

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-base.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-base.yaml
@@ -111,6 +111,9 @@ bibliography:
         delimiter-precedes-last: contextual
       delimiter: { mark: comma }
     separator: ''
+    entry-suffix: '.'
+    entry-suffix-after-url: true
+    entry-suffix-after-doi: true
   template:
   - number: citation-number
     wrap:


### PR DESCRIPTION
## Summary
- `gb-t-7714-2025-base.yaml` never set `bibliography.options.entry-suffix`, so entries with no trailing `dimensions`/`url`/`cstr`/`doi` field (the common case) rendered without the terminal period GB/T 7714-2025's own worked examples and real Zotero output both require. Found while quantifying citum's showing on the external [gb7714-bench](https://github.com/YDX-2147483647/gb7714-bench) benchmark — see [docs/architecture/audits/2026-07-23_GB7714_BENCH_COMPARISON.md](../blob/main/docs/architecture/audits/2026-07-23_GB7714_BENCH_COMPARISON.md).
- Fix: `entry-suffix: '.'` + `entry-suffix-after-url: true` + `entry-suffix-after-doi: true` on the base style, inherited by numeric/author-date/note. The mechanism already existed in the engine (used by MLA/IEEE) — GB/T just never configured it.
- Confirmed no double-punctuation on entries that already end correctly (via the existing `TerminalLink` guard).

## Scope
`crates/citum-schema-style/embedded/styles/gb-t-7714-2025-base.yaml` (2 lines) + updated 11 pre-existing test assertions in `date_annotations.rs`/`multilingual.rs` that hardcoded the old (wrong) no-period output + 2 new dedicated regression tests (bare-entry-gets-period, url-entry-not-double-punctuated), natively-constructed `InputReference` per repo test conventions.

## Validation
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo nextest run` — all clean (2163/2163 tests pass, pre-push gate).
- Manually verified via CLI on the Hawking fixture (`tests/fixtures/references-expanded.json` `ITEM-2`) and a pinned-corpus URL-ending entry (`gbt7714.7.5.2.3:3`) — matches the audit doc's findings exactly.
- Note: `report-core.js`'s fidelity score for this style is unchanged post-fix — confirmed this is expected, tracked separately as `csl26-7jib` (our local CSL-M oracle fixture independently shares the same missing-period defect, so it can't see this fix land; verified directly via the CLI instead, not via the oracle).

## Follow-ups
Bean `csl26-iqxu` (this fix). Related, not done here: `csl26-7jib` (oracle fixture staleness), `csl26-zaqk` (nocase HTML leak), `csl26-2mse` (BibLaTeX conversion gap), and cutting a release + asking gb7714-bench PR #25 to bump its `CITUM_VERSION` pin once this lands.
