### PR TITLE
fix(styles): add missing gb-t-7714 type-variants

### DIFF
--- a/.beans/archive/csl26-h3yr--author-gbt-7714-numeric-type-variants-for-governme.md
+++ b/.beans/archive/csl26-h3yr--author-gbt-7714-numeric-type-variants-for-governme.md
@@ -1,7 +1,7 @@
 ---
 # csl26-h3yr
 title: Author GB/T 7714 numeric type-variants for government/legal/media reference classes
-status: todo
+status: completed
 type: task
 priority: normal
 tags:
@@ -10,7 +10,7 @@ tags:
     - fidelity
     - rendering
 created_at: 2026-07-24T14:25:51Z
-updated_at: 2026-07-24T14:27:10Z
+updated_at: 2026-07-24T15:37:48Z
 ---
 
 gb-t-7714-2025-numeric (and the shared gb-t-7714-2025-base bibliography grammar it inherits) has no bibliography.type-variants entry for several ref_type() strings that legitimately occur in the broader test corpus: motion-picture, broadcast, legal-case, treaty, hearing, regulation, statute, and interview (monograph). Reference.ref_type() and the CSL-JSON->Citum conversion were verified correct for all of these via the conversion-layer pre-flight (cargo run --bin citum -- convert refs ... --from csl-json); the defect is entirely on the style-authoring side.
@@ -35,3 +35,13 @@ Scope: author type-variants for these ref_type() strings (grouping compatible on
 Also worth checking as a smaller side finding: the software/graphic/article,dataset,preprint/webpage,post,post-weblog type-variants share a 'date: accessed (suffix period) then variable: url (no prefix)' pattern that silently drops the joining period when accessed is absent (fixed for 'software' specifically in csl26-gc43; article,dataset,preprint/graphic/webpage,post,post-weblog are unverified for this same latent gap since no failing fixture currently exercises an accessed-less item there).
 
 Confirmed via the full report-core.js run (all styles, fresh cache): `gb-t-7714-2025-author-date.yaml` has its own separate, non-shared `software` type-variant (line ~729) with the identical accessed-suffix/url-no-prefix bug fixed in `csl26-gc43` for the numeric style's copy. Still shows `（2015）http://...` (missing period) for TLIB-SEL-SOFTWARE-1. Not touched by csl26-gc43 (out of scope — that PR only covers gb-t-7714-2025-numeric, and author-date is diagnostic-only per verification-policy.yaml, not gated). Confirmed this is pre-existing, not a regression from csl26-gc43's changes.
+
+## Summary of Changes
+
+Authored the 8 missing `bibliography.type-variants` entries in `gb-t-7714-2025-base.yaml`: `legal-case`, `treaty`, `regulation,statute` (shared shape), `hearing` (also covers `bill`, which the conversion layer canonicalizes to `hearing`), `motion-picture`, `broadcast`, `interview`. All 9 previously-garbled oracle entries ([20],[22],[23],[24],[40],[43],[44],[46],[47]) now match byte-for-byte.
+
+While verifying `regulation`, found and fixed a real engine bug (not a style gap): `Reference::container_title()` in `crates/citum-schema-data/src/reference/accessors.rs` had match arms for `LegalCase`, `Statute`, and `Treaty` but was missing `Regulation`, so `regulation`-type references silently dropped their `code` field (e.g. "C.F.R.") from `container_title()`. Added the missing arm — same shape of bug as the `medium()`/`Software` gap fixed in `csl26-gc43`.
+
+Result: `gb-t-7714-2025-numeric` bibliography 249/250 (was 240/250); only the CSTR duplicate-identifier item `[178]` remains, deferred to `csl26-ia43` (blocked on external reviewer confirmation, out of scope here). Gated 203-item native corpus unaffected (unchanged raw 193/203, i.e. adjusted 202/203 — same as before this change). `docs/compat.html` regenerated to reflect current numbers. Full suite: 2181/2181 passing, clippy clean.
+
+The side-finding about accessed-suffix/url-no-prefix punctuation in `article,dataset,preprint`/`graphic`/`webpage,post,post-weblog` was not touched — none of the new type-variants exercised that pattern, so it remains a separate, not-yet-filed follow-up if anyone hits it.

--- a/crates/citum-schema-data/src/reference/accessors.rs
+++ b/crates/citum-schema-data/src/reference/accessors.rs
@@ -1125,6 +1125,7 @@ impl InputReference {
             }),
             ClassExtension::LegalCase(r) => r.reporter.clone().map(Title::Single),
             ClassExtension::Statute(r) => r.code.clone().map(Title::Single),
+            ClassExtension::Regulation(r) => r.code.clone().map(Title::Single),
             ClassExtension::Treaty(r) => r.reporter.clone().map(Title::Single),
             ClassExtension::Event(r) => r.container.as_ref().and_then(|c| match c {
                 WorkRelation::Embedded(p) => p.title().or_else(|| p.container_title()),

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-base.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-base.yaml
@@ -1110,4 +1110,202 @@ bibliography:
       prefix: '. CSTR:'
     - variable: doi
       prefix: '. DOI:'
+    legal-case:
+    - number: citation-number
+      wrap:
+        punctuation: brackets
+    - group:
+      - title: primary
+      - message: gb-t-7714-type-code
+        args:
+          type: { reference-type: key }
+          carrier: { carrier: { online: OL, absent: '-' } }
+        wrap:
+          punctuation: brackets
+      delimiter: ''
+      suffix: //
+    - group:
+      - title: container-title
+      - number: volume
+        when-numeric: short
+      delimiter: { mark: colon }
+      suffix: '. '
+    - group:
+      - date: issued
+        form: year
+        fallback: []
+      - number: pages
+      delimiter: { mark: colon }
+    treaty:
+    - number: citation-number
+      wrap:
+        punctuation: brackets
+    - contributor: author
+      form: long
+      name-order: family-first
+      delimiter: { mark: comma }
+      sort-separator: ' '
+      suffix: '. '
+    - group:
+      - title: primary
+      - message: gb-t-7714-type-code
+        args:
+          type: { reference-type: key }
+          carrier: { carrier: { online: OL, absent: '-' } }
+        wrap:
+          punctuation: brackets
+      delimiter: ''
+      suffix: //
+    - group:
+      - title: container-title
+      - variable: volume
+        prefix: 'v.'
+      delimiter: { mark: colon }
+      suffix: '. '
+    - group:
+      - date: issued
+        form: year
+        fallback: []
+      - number: pages
+      delimiter: { mark: colon }
+    regulation,statute:
+    - number: citation-number
+      wrap:
+        punctuation: brackets
+    - group:
+      - title: primary
+      - message: gb-t-7714-type-code
+        args:
+          type: { reference-type: key }
+          carrier: { carrier: { online: OL, absent: '-' } }
+        wrap:
+          punctuation: brackets
+      delimiter: ''
+      suffix: //
+    - group:
+      - title: container-title
+      - variable: volume
+        prefix: 'v.'
+      delimiter: { mark: colon }
+      suffix: '. '
+    - variable: url
+      prefix: '. '
+    - identifier: cstr
+      prefix: '. CSTR:'
+    - variable: doi
+      prefix: '. DOI:'
+    hearing:
+    - number: citation-number
+      wrap:
+        punctuation: brackets
+    - group:
+      - title: primary
+      - number: number
+      delimiter: { mark: colon }
+    - message: gb-t-7714-type-code
+      args:
+        type: { reference-type: key }
+        carrier: { carrier: { online: OL, absent: '-' } }
+      wrap:
+        punctuation: brackets
+      suffix: '. '
+    - date: issued
+      form: year
+      fallback: []
+      wrap: parentheses
+      suffix: '. '
+    - variable: url
+    - identifier: cstr
+      prefix: '. CSTR:'
+    - variable: doi
+      prefix: '. DOI:'
+    motion-picture:
+    - number: citation-number
+      wrap:
+        punctuation: brackets
+    - contributor: author
+      form: long
+      name-order: family-first
+      delimiter: { mark: comma }
+      sort-separator: ' '
+      suffix: '. '
+    - title: primary
+    - message: gb-t-7714-type-code
+      args:
+        type: { reference-type: key }
+        carrier: { carrier: { online: OL, absent: '-' } }
+      wrap:
+        punctuation: brackets
+      suffix: '. '
+    - date: issued
+      form: year
+      fallback: []
+    - variable: url
+      prefix: '. '
+    - identifier: cstr
+      prefix: '. CSTR:'
+    - variable: doi
+      prefix: '. DOI:'
+    broadcast:
+    - number: citation-number
+      wrap:
+        punctuation: brackets
+    - contributor: author
+      form: long
+      name-order: family-first
+      delimiter: { mark: comma }
+      sort-separator: ' '
+      suffix: '. '
+    - group:
+      - group:
+        - title: primary
+        - number: number
+        delimiter: { mark: colon }
+      - message: gb-t-7714-type-code
+        args:
+          type: { reference-type: key }
+          carrier: { carrier: { online: OL, absent: '-' } }
+        wrap:
+          punctuation: brackets
+      delimiter: ''
+      suffix: //
+    - title: container-title
+      suffix: '. '
+    - date: issued
+      form: year
+      fallback: []
+    - variable: url
+      prefix: '. '
+    - identifier: cstr
+      prefix: '. CSTR:'
+    - variable: doi
+      prefix: '. DOI:'
+    interview:
+    - number: citation-number
+      wrap:
+        punctuation: brackets
+    - contributor: author
+      form: long
+      name-order: family-first
+      delimiter: { mark: comma }
+      sort-separator: ' '
+      suffix: '. '
+    - title: primary
+    - message: gb-t-7714-type-code
+      args:
+        type: { reference-type: key }
+        carrier: { carrier: { online: OL, absent: '-' } }
+      wrap:
+        punctuation: brackets
+      suffix: '. '
+    - date: issued
+      form: year-month-day
+      fallback: []
+      wrap: parentheses
+      suffix: '. '
+    - variable: url
+    - identifier: cstr
+      prefix: '. CSTR:'
+    - variable: doi
+      prefix: '. DOI:'
   groups-enabled: true


### PR DESCRIPTION
## Summary

Investigated why `docs.citum.org/compat.html` showed 96.3% for `gb-t-7714-2025-numeric` after a prior session claimed 100% fidelity. Two separate things were going on:

- `docs/compat.html` was stale — it predated two harness-bug fixes (`csl26-7jib`, `csl26-gc43`) that corrected an oracle comparator masking real defects. The live number (96.3%, 240/250 bibliography) was already correct; the committed HTML just hadn't been regenerated.
- The earlier "100% fidelity" claim (`csl26-d3hs`) was real but scoped to the gated 203-item native corpus with registered oracle-divergence adjustments applied — never a claim about the full 250-item diagnostic corpus, where a real 10-item gap was already tracked in bean `csl26-h3yr`.

This PR fixes the real gap and regenerates the dashboard:

- Authors 7 missing `bibliography.type-variants` keys in `gb-t-7714-2025-base.yaml`: `legal-case`, `treaty`, `regulation,statute`, `hearing` (also covers `bill`), `motion-picture`, `broadcast`, `interview`. These types previously fell through to the bare unkeyed default template with no punctuation.
- Fixes a real engine bug found while verifying `regulation`: `Reference::container_title()` had match arms for `LegalCase`/`Statute`/`Treaty` but was missing `Regulation`, silently dropping the `code` field (e.g. "C.F.R."). Same shape as the `medium()`/`Software` gap fixed in `csl26-gc43`.
- Regenerates `docs/compat.html`.

`gb-t-7714-2025-numeric` bibliography: 240/250 → **249/250**. The one remaining item (`[178]`, a CSTR duplicate-identifier question) is tracked separately by `csl26-ia43`, blocked on external reviewer confirmation (PR #1064) — intentionally out of scope here. Gated 203-item native corpus unaffected (unchanged).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run` — 2181/2181 passing
- [x] `node scripts/report-core.js --style gb-t-7714-2025-numeric --json` — 249/250 bibliography, 21/21 citations
- [x] `docs/compat.html` regenerated and committed
