### PR TITLE
fix(migrate): convert citeproc html markup outside titles

### DIFF
--- a/.beans/archive/csl26-6eoi--convert-citeproc-html-markup-outside-titles-contai.md
+++ b/.beans/archive/csl26-6eoi--convert-citeproc-html-markup-outside-titles-contai.md
@@ -1,0 +1,93 @@
+---
+# csl26-6eoi
+title: Convert citeproc HTML markup outside titles (container-title, biblatex fields)
+status: completed
+type: bug
+priority: high
+tags:
+    - nocase
+    - csl-json
+    - biblatex
+    - rendering
+    - engine
+created_at: 2026-07-25T11:36:00Z
+updated_at: 2026-07-25T12:18:34Z
+---
+
+Fix raw citeproc-js HTML (<span class=\"nocase\">, <i>, <b>, <sc>, <sup>, <sub>) leaking
+into rendered bibliography output. Surfaced by gb7714-bench:
+https://gb7714.zhtyp.art/entry/gbt7714.8.6.1-5/
+
+Bean csl26-zaqk fixed this for `title`/`short_title` only (via html_markup_to_djot in
+crates/citum-schema-data/src/reference/conversion/mod.rs), explicitly deferring
+container-title/publisher/note/etc. This bean is that deferred scope, plus a second,
+independently-discovered leak on the biblatex ingestion path (crates/citum-refs/src/biblatex.rs),
+which has no HTML->Djot conversion at all.
+
+Baseline (gb-t-7714-2025-numeric, 344-entry corpus from typst-doc-cn/bib-csl-dev-data):
+- builtin.json: 2 entries leak raw HTML (container-title)
+- better.json: 2 entries leak raw HTML (container-title)
+- builtin.bib: 9 entries leak raw HTML (title AND container-title -- biblatex path has zero conversion)
+- better.bib: 0 (uses {{...}} brace protection already handled)
+
+Target: 0/0/0/0.
+
+## Plan
+- [x] Move html_markup_to_djot + DjotTag + classify_open_tag out of the legacy-convert-gated
+      conversion/mod.rs into a new ungated crates/citum-schema-data/src/reference/citeproc_markup.rs
+- [x] CSL-JSON path: apply html_markup_to_djot over an explicit allowlist of rich-text fields
+      (title, container_title, collection_title, original_title, publisher, publisher_place,
+      event, genre, medium, section, authority, abstract_text, archive, archive_location,
+      dimensions) in InputReference::from(LegacyReference), after parse_note_field_hacks().
+      NOTE: `number` was dropped from the allowlist after verification -- see below.
+- [x] Keep the existing html_markup_to_djot calls in build_title (idempotent; needed for
+      part-title which comes from the extra map, skipped by the central pass) -- add comment
+- [x] Biblatex path: add rich_field_str closure + BibRefContext field in citum-refs/src/biblatex.rs;
+      route title/subtitle/publisher/institution/organization/school/location/booktitle/series/
+      journaltitle/journal through it
+- [x] Tests: moved unit tests for citeproc_markup.rs; conversion-boundary rstest for
+      container-title/collection-title; biblatex rstest for escaped-HTML booktitle/title;
+      end-to-end regression test for the benchmark's exact gbt7714.8.6.1:5 entry
+- [x] Verify: full 344-entry corpus (builtin.json/better.json/builtin.bib/better.bib) renders
+      zero raw HTML through gb-t-7714-2025-numeric
+- [x] Verify: report-core.js --style gb-t-7714-2025-numeric fidelity unchanged pre/post fix (see Summary -- baseline is actually 0.996/193-203, not zaqk's stale 0.989)
+- [x] just pre-commit green (fmt, clippy -D warnings, nextest)
+- [x] just schema-gen (citum-schema-data matches citum-schema*) -- expect no diff
+- [ ] PR via gh pr create, --body-file, citing benchmark URL and leak-count table
+
+## Deferred (follow-up beans, not in this PR)
+- Biblatex path diverges from CSL-JSON path on 301/344 entries (drops authors, page ranges
+  wholesale) -- much larger benchmark gap than the nocase leak, needs its own investigation
+- Name.literal (institutional authors) as a likely next HTML carrier -- none in this corpus
+- RIS ingestion path (citum-refs/src/formats/ris.rs) has the same exposure, unexercised by
+  this benchmark
+- StringOrNumber fields (volume, issue, edition) could carry the same ordinal markup as
+  `number` but no fixture exercises it
+
+## Summary of Changes
+
+Root cause: bean csl26-zaqk converted citeproc-js's literal HTML rich-text convention (`<span class="nocase">`, `<i>`, `<b>`, `<sc>`, `<sup>`, `<sub>`) to Djot at ingestion, but wired the conversion in only at `build_title` -- `title`/`short_title`. Every other free-text CSL-JSON field, and the entire biblatex ingestion path, still leaked raw HTML verbatim into rendered output.
+
+### Changes
+- Promoted `html_markup_to_djot` (+ `DjotTag`/`classify_open_tag`) out of the `legacy-convert`-gated `conversion/` submodule into a new ungated `crates/citum-schema-data/src/reference/citeproc_markup.rs`, since the biblatex path needs it too and has nothing to do with CSL-legacy.
+- CSL-JSON path: new `normalize_rich_text_markup` runs once in `InputReference::from(LegacyReference)`, right after `parse_note_field_hacks()`, converting an explicit allowlist of 15 fields (title, container_title, collection_title, original_title, publisher, publisher_place, event, genre, medium, section, authority, abstract_text, archive, archive_location, dimensions).
+- Biblatex path (`citum-refs/src/biblatex.rs`): added a `rich_field_str` closure alongside the existing `field_str`, routed through `title`/`subtitle`, `publisher`/`institution`/`organization`/`school`/`location`, `booktitle`, `journaltitle`/`journal`, `abstract`, and `type` (genre).
+- 11 new/moved tests across `citeproc_markup.rs`, `conversion/mod.rs` (conversion-boundary tests for container-title and collection-title, plus a direct test of `normalize_rich_text_markup` confirming `note` stays untouched), `citum-refs/src/biblatex.rs` (escaped-HTML `title`/`booktitle` cases), and a new end-to-end regression test `crates/citum-engine/tests/gb7714_bench_regression.rs` rendering the exact benchmark entry through the embedded `gb-t-7714-2025-numeric` style.
+
+### `number` field: added then reverted
+Initially added `number` to the CSL-JSON allowlist, citing `tests/csl-test-suite/processor-tests/machines/flipflop_NumericField.json` (`"number": "1<sup>er</sup>"`) as evidence. Running that exact fixture through the real `citeproc` npm package (not just eyeballing citum's own render) showed this was backwards: real citeproc-js does NOT flip-flop the `number` variable -- it renders the tag literally, HTML-escaped (`1&#60;sup&#62;er&#60;/sup&#62;`). `number` is a CSL number-type variable, exempt from flip-flop, unlike ordinary text variables. Removed it from the allowlist before committing. Separately verified via the same method (real `citeproc` engine, hyphenated CSL-JSON keys) that every field actually kept in the allowlist -- including `container-title`, `collection-title`, and `publisher-place`, which don't render standalone in citeproc-js's default variable wrapping and needed a slightly different harness to confirm -- DOES flip-flop correctly.
+
+### Verification
+- Full 344-entry corpus from all four benchmark sources (typst-doc-cn/bib-csl-dev-data's builtin.json/better.json/builtin.bib/better.bib) rendered through `gb-t-7714-2025-numeric`: 0 entries with raw HTML in any of the four, down from the pre-fix baseline of 2/2/9/0.
+- `just pre-commit` green: fmt, clippy -D warnings, 2187 nextest tests.
+- `just schema-gen`: no diff (as expected -- no schema-visible type changes).
+- report-core.js --style gb-t-7714-2025-numeric: fidelityScore 0.996, GB/T upstream corpus 193/203 passed, IDENTICAL before and after this fix (confirmed by stashing and re-running). Note: this is the actual current baseline -- zaqk's recorded 0.989 had already drifted upward from unrelated commits, unrelated to this work.
+- IMPORTANT CAVEAT discovered during verification: the oracle/report-core fidelity pipeline's `normalizeText()` (scripts/oracle-utils.js) strips ALL HTML tags (`.replace(/<[^>]+>/g, '')`) before comparing citum's output to real citeproc-js -- so it is structurally blind to this exact class of bug (raw HTML leaking into output). The identical 193/203 pre/post is a "no regression" signal only, not evidence this specific fix is correct. The real evidence for correctness is (a) the corpus grep for raw HTML tags (0/0/0/0), (b) the conversion-boundary and end-to-end unit/integration tests asserting the exact Djot-converted string, and (c) the direct real-citeproc-js field-by-field flip-flop verification above. Worth fixing separately: `normalizeText`'s HTML-stripping means the oracle can never catch a regression of this exact bug in the future -- filed as a follow-up bean.
+
+## Follow-ups (new beans to create)
+- Biblatex path diverges from CSL-JSON path on 301/344 entries in the benchmark corpus (drops authors and page ranges wholesale) -- much larger benchmark gap than this nocase leak; needs its own investigation.
+- `Name.literal` on institutional authors as a likely next HTML carrier -- none in this corpus, but plausible in real Zotero data.
+- RIS ingestion path (`citum-refs/src/formats/ris.rs`) has the same exposure, unexercised by this benchmark.
+- `page`, `volume`, `issue`, `edition` (`StringOrNumber`) -- verified via real citeproc-js that these DO flip-flop, but no fixture in this repo carries rich text there; not added speculatively.
+- The oracle's `normalizeText()` strips HTML tags before comparison, making it structurally blind to raw-HTML-leak regressions in general (not just this one). Consider a separate raw-HTML-tag assertion in the fidelity pipeline.
+- Pre-existing, not introduced here: `html_markup_to_djot`'s `classify_open_tag` has a false-positive risk -- `a < b > c` would misclassify `< b >` as a `<b>` (Strong) open tag, since it splits on whitespace and `"b"` is a recognized tag name. Only reachable in fields with both `<`/`>` and single-letter tag-name-like text; more plausible now that `abstract_text`/`dimensions` are in the allowlist than when only `title` was.

--- a/.beans/csl26-7ab8--biblatex-ingestion-path-diverges-from-csl-json-pat.md
+++ b/.beans/csl26-7ab8--biblatex-ingestion-path-diverges-from-csl-json-pat.md
@@ -1,0 +1,35 @@
+---
+# csl26-7ab8
+title: Biblatex ingestion path diverges from CSL-JSON path on 301/344 benchmark entries
+status: todo
+type: bug
+priority: high
+tags:
+    - biblatex
+    - fidelity
+    - rendering
+created_at: 2026-07-25T12:18:08Z
+updated_at: 2026-07-25T12:18:34Z
+---
+
+Discovered while fixing csl26-6eoi (raw citeproc HTML leaking into rendered output).
+Comparing citum's rendered output for the same 344-entry gb7714-bench corpus
+(typst-doc-cn/bib-csl-dev-data) via the CSL-JSON path vs the biblatex path shows
+301/344 entries differ beyond the HTML-leak fix -- the biblatex path drops authors
+and page ranges wholesale:
+
+  gbt7714.5.1:1
+    json: 博伯尔. 银行业的未来与人工智能[M]. 徐超，译. 北京：清华大学出版社，2023：35.
+    bib :        银行业的未来与人工智能[M].          北京：清华大学出版社，2023.
+
+This is a far larger benchmark fidelity gap than the nocase leak (builtin.bib rendered
+via `citum convert refs` then `citum render`). Needs its own root-cause investigation --
+likely author/contributor extraction and page-range extraction gaps in
+crates/citum-refs/src/biblatex.rs (`input_reference_from_biblatex`,
+`build_inbook_reference`, `build_article_reference`, `biblatex_monograph`).
+
+## Repro
+1. Fetch typst-doc-cn/bib-csl-dev-data's GB-T_7714—2025.builtin.json and
+   GB-T_7714—2025.builtin.bib
+2. Render both through gb-t-7714-2025-numeric --mode bib --json
+3. Diff entries by id (strip leading `[N]` numbering first) -- 301/344 differ

--- a/.beans/csl26-g9lb--oracles-normalizetext-strips-html-tags-blind-to-ra.md
+++ b/.beans/csl26-g9lb--oracles-normalizetext-strips-html-tags-blind-to-ra.md
@@ -1,0 +1,35 @@
+---
+# csl26-g9lb
+title: Oracle's normalizeText strips HTML tags, blind to raw-markup-leak regressions
+status: todo
+type: bug
+priority: normal
+tags:
+    - oracle
+    - tooling
+    - fidelity
+created_at: 2026-07-25T12:18:16Z
+updated_at: 2026-07-25T12:18:34Z
+---
+
+Discovered while verifying csl26-6eoi (raw citeproc HTML leaking into rendered output).
+scripts/oracle-utils.js's normalizeText() strips ALL HTML tags before comparing citum's
+output to real citeproc-js:
+
+  .replace(/<[^>]+>/g, '')  // Strip HTML tags
+
+This means the oracle/report-core fidelity pipeline is structurally blind to raw-HTML
+leaking into citum's rendered output -- it strips the exact defect from both sides
+before comparing, so a regression of csl26-6eoi's bug (or any similar raw-markup leak)
+would never move fidelityScore or the pass/fail counts.
+
+Confirmed empirically: gb-t-7714-2025-numeric's fidelityScore (0.996) and GB/T upstream
+corpus pass rate (193/203) were IDENTICAL before and after fixing csl26-6eoi, despite
+that fix changing citum's actual rendered text for the affected entries (raw
+`<span class="nocase">...</span>` -> clean interpreted text).
+
+## Suggested fix
+Add a raw-HTML-tag assertion to the fidelity pipeline (e.g. in report-core.js or a
+dedicated check) that fails if citum's *un-normalized* bibliography/citation output
+contains `<[a-z]+[^>]*>` -- run before normalizeText() strips it, so a future
+regression of this class of bug is actually caught.

--- a/crates/citum-engine/tests/gb7714_bench_regression.rs
+++ b/crates/citum-engine/tests/gb7714_bench_regression.rs
@@ -1,0 +1,86 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Regression coverage for a defect the [gb7714-bench] benchmark surfaced
+//! (bean `csl26-6eoi`): CSL-JSON's `container-title` carries citeproc-js's
+//! literal HTML rich-text convention (`<span class="nocase">`) just like
+//! `title` does, but it bypassed the `title`-only conversion bean
+//! `csl26-zaqk` added, so it leaked verbatim into rendered bibliography
+//! output instead of being interpreted as Djot case protection.
+//!
+//! This is the exact `gbt7714.8.6.1:5` entry from the benchmark's data
+//! source (`typst-doc-cn/bib-csl-dev-data`), rendered end to end through
+//! the embedded `gb-t-7714-2025-numeric` style, so the defect cannot
+//! silently return.
+//!
+//! [gb7714-bench]: https://gb7714.zhtyp.art/entry/gbt7714.8.6.1-5/
+
+#![allow(missing_docs, reason = "test")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "Panicking is acceptable and often desired in test code."
+)]
+
+mod common;
+use common::announce_behavior;
+
+use citum_engine::Processor;
+use citum_schema::reference::InputReference;
+use indexmap::IndexMap;
+
+/// Load the embedded zh-CN locale for GB/T fixtures — see
+/// `date_annotations.rs::zh_cn_locale` for why this must match the style's
+/// `info.default-locale` rather than `Processor::new`'s plain `en_us()`.
+fn zh_cn_locale() -> citum_schema::Locale {
+    let bytes = citum_schema::embedded::get_locale_bytes("zh-CN").expect("zh-CN must be embedded");
+    citum_schema::Locale::from_yaml_str(std::str::from_utf8(bytes).expect("valid UTF-8"))
+        .expect("zh-CN locale should parse")
+}
+
+#[test]
+fn gbt7714_8_6_1_5_container_title_nocase_spans_render_as_plain_case_protected_text() {
+    announce_behavior(
+        "CSL-JSON container-title with citeproc-js nocase spans renders clean, not raw HTML",
+    );
+
+    // Verbatim from the benchmark's source data
+    // (typst-doc-cn/bib-csl-dev-data, GB-T_7714—2025.builtin.json).
+    let legacy: csl_legacy::csl_json::Reference = serde_json::from_str(
+        r#"{
+            "id": "gbt7714.8.6.1:5",
+            "type": "paper-conference",
+            "author": [{"family": "Fourney", "given": "M. E."}],
+            "editor": [{"family": "Gottenberg", "given": "W. G."}],
+            "issued": {"date-parts": [["1971"]]},
+            "language": "en-US",
+            "page": "17-38",
+            "publisher": "ASME",
+            "publisher-place": "New York",
+            "title": "Advances in holographic photoelasticity",
+            "container-title": "<span class=\"nocase\">Symposium on Applications of Holography in Mechanics</span>, August 23-25, 1971, <span class=\"nocase\">University of Southern California</span>, <span class=\"nocase\">Los Angeles, California</span>"
+        }"#,
+    )
+    .expect("benchmark fixture should parse as CSL-JSON");
+
+    let reference: InputReference = legacy.into();
+    let bibliography = IndexMap::from([("gbt7714.8.6.1:5".to_string(), reference)]);
+
+    let style = citum_schema::embedded::get_embedded_style("gb-t-7714-2025-numeric")
+        .expect("gb-t-7714-2025-numeric should be embedded")
+        .expect("gb-t-7714-2025-numeric should parse")
+        .into_resolved();
+
+    let rendered =
+        Processor::with_locale(style, bibliography, zh_cn_locale()).render_bibliography();
+
+    assert_eq!(
+        rendered,
+        "[1]Fourney M E. Advances in holographic photoelasticity[C]//Gottenberg W G. \
+         Symposium on Applications of Holography in Mechanics, August 23-25, 1971, \
+         University of Southern California, Los Angeles, California. New York：ASME，1971：17-38."
+    );
+}

--- a/crates/citum-refs/src/biblatex.rs
+++ b/crates/citum-refs/src/biblatex.rs
@@ -11,6 +11,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use biblatex as biblatex_crate;
 use citum_schema::reference::{
     InputReference, LangID, Numbering, NumberingType, Publisher, RefID, RichText, WorkRelation,
+    citeproc_markup::html_markup_to_djot,
     contributor::{Contributor, ContributorList, StructuredName},
     date::DateValue,
     types::{
@@ -33,12 +34,21 @@ struct BibRefContext<'a> {
     publisher: Option<Publisher>,
     language: Option<LangID>,
     field_str: &'a dyn Fn(&str) -> Option<String>,
+    /// Like `field_str`, but converts citeproc-js's literal HTML rich-text
+    /// convention (`<span class="nocase">`, `<i>`, `<b>`, `<sc>`, `<sup>`,
+    /// `<sub>`) to Djot. Zotero's builtin BibTeX/BibLaTeX exporter escapes
+    /// these as `{\textless}span class="nocase"{\textgreater}…`, which the
+    /// `biblatex` parser unescapes back to literal HTML before Citum sees
+    /// it (`csl26-6eoi`) -- so free-text fields need the same conversion
+    /// the CSL-JSON path applies, not just `field_str`.
+    rich_field_str: &'a dyn Fn(&str) -> Option<String>,
 }
 
 /// Build a `CollectionComponent` from a biblatex inbook/incollection/inproceedings entry.
 fn build_inbook_reference(ctx: BibRefContext<'_>) -> InputReference {
     let field_str = ctx.field_str;
-    let parent_title = field_str("booktitle").map(Title::Single);
+    let rich_field_str = ctx.rich_field_str;
+    let parent_title = rich_field_str("booktitle").map(Title::Single);
 
     let mut parent_numbering = Vec::new();
     if let Some(n) = field_str("number") {
@@ -81,7 +91,7 @@ fn build_inbook_reference(ctx: BibRefContext<'_>) -> InputReference {
         field_languages: HashMap::new(),
         note: field_str("note").map(RichText::Plain),
         doi: field_str("doi"),
-        genre: field_str("type"),
+        genre: rich_field_str("type"),
         ..Default::default()
     }))
 }
@@ -89,8 +99,9 @@ fn build_inbook_reference(ctx: BibRefContext<'_>) -> InputReference {
 /// Build a `SerialComponent` from a biblatex article entry.
 fn build_article_reference(ctx: BibRefContext<'_>) -> InputReference {
     let field_str = ctx.field_str;
-    let parent_title = field_str("journaltitle")
-        .or_else(|| field_str("journal"))
+    let rich_field_str = ctx.rich_field_str;
+    let parent_title = rich_field_str("journaltitle")
+        .or_else(|| rich_field_str("journal"))
         .map(Title::Single);
 
     let mut component_numbering = Vec::new();
@@ -143,7 +154,7 @@ fn build_article_reference(ctx: BibRefContext<'_>) -> InputReference {
         doi: field_str("doi"),
         ads_bibcode: field_str("bibcode"),
         pages: field_str("pages"),
-        genre: field_str("type"),
+        genre: rich_field_str("type"),
         ..Default::default()
     }))
 }
@@ -167,8 +178,9 @@ pub fn input_reference_from_biblatex(entry: &biblatex_crate::Entry) -> InputRefe
                 .collect::<String>()
         })
     };
+    let rich_field_str = |key: &str| field_str(key).map(|s| html_markup_to_djot(&s));
 
-    let title = match (field_str("title"), field_str("subtitle")) {
+    let title = match (rich_field_str("title"), rich_field_str("subtitle")) {
         (Some(main), Some(sub)) => Some(Title::Structured(StructuredTitle {
             full: None,
             main,
@@ -178,13 +190,13 @@ pub fn input_reference_from_biblatex(entry: &biblatex_crate::Entry) -> InputRefe
         (None, _) => None,
     };
     let issued = field_str("date").map_or(DateValue::new(String::new()), DateValue::new);
-    let publisher = field_str("publisher")
-        .or_else(|| field_str("institution"))
-        .or_else(|| field_str("organization"))
-        .or_else(|| field_str("school"))
+    let publisher = rich_field_str("publisher")
+        .or_else(|| rich_field_str("institution"))
+        .or_else(|| rich_field_str("organization"))
+        .or_else(|| rich_field_str("school"))
         .map(|p| Publisher {
             name: p.into(),
-            place: field_str("location").map(Into::into),
+            place: rich_field_str("location").map(Into::into),
         });
 
     let author = entry
@@ -217,6 +229,7 @@ pub fn input_reference_from_biblatex(entry: &biblatex_crate::Entry) -> InputRefe
         publisher,
         language,
         field_str: &field_str,
+        rich_field_str: &rich_field_str,
     };
 
     match entry_type.as_str() {
@@ -252,6 +265,7 @@ fn biblatex_monograph(
     ctx: BibRefContext<'_>,
 ) -> Monograph {
     let field_str = ctx.field_str;
+    let rich_field_str = ctx.rich_field_str;
 
     let mut numbering = Vec::new();
     if let Some(ed) = field_str("edition") {
@@ -291,7 +305,7 @@ fn biblatex_monograph(
         language: ctx.language,
         field_languages: HashMap::new(),
         note: field_str("note").map(RichText::Plain),
-        abstract_text: field_str("abstract").map(RichText::Plain),
+        abstract_text: rich_field_str("abstract").map(RichText::Plain),
         isbn: field_str("isbn"),
         doi: field_str("doi"),
         ads_bibcode: field_str("bibcode"),
@@ -303,7 +317,7 @@ fn biblatex_monograph(
                 .collect()
         }),
         numbering,
-        genre: field_str("type"),
+        genre: rich_field_str("type"),
         ..Default::default()
     }
 }
@@ -497,6 +511,60 @@ mod tests {
             WorkRelation::Id(_) => panic!("expected an embedded container, not an id reference"),
         };
         assert_eq!(parent.isbn, Some("978-0-13-468599-1".to_string()));
+    }
+
+    #[test]
+    fn given_biblatex_title_with_escaped_html_nocase_span_when_converted_then_becomes_djot_case_protection()
+     {
+        // Zotero's builtin BibTeX/BibLaTeX exporter escapes citeproc-js's
+        // HTML rich-text convention as `{\textless}span
+        // class="nocase"{\textgreater}...`; the `biblatex` parser unescapes
+        // it back to literal `<span ...>` before Citum sees it. Confirms the
+        // biblatex path (bean csl26-6eoi) converts to Djot on ingestion,
+        // matching the CSL-JSON path, rather than leaking verbatim into
+        // rendered output.
+        let entry = parse_single_entry(
+            r#"@book{b4, title = {The genome of {\textless}span class="nocase"{\textgreater}Eucalyptus grandis{\textless}/span{\textgreater}}, date = {2014}}"#,
+        );
+
+        let converted = input_reference_from_biblatex(&entry);
+
+        assert_eq!(
+            converted.title(),
+            Some(Title::Single(
+                "The genome of [Eucalyptus grandis]{.nocase}".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn given_biblatex_booktitle_with_escaped_html_nocase_spans_when_converted_then_parent_collection_title_becomes_djot_case_protection()
+     {
+        // The gb7714-bench regression (entry gbt7714.8.6.1:5, bean
+        // csl26-6eoi): `booktitle` carries the same escaped citeproc-js
+        // convention as `title`, but through `build_inbook_reference`'s
+        // parent-collection path, which `build_title` never sees.
+        let entry = parse_single_entry(
+            r#"@inproceedings{c1, title = {Advances in holographic photoelasticity}, booktitle = {{\textless}span class="nocase"{\textgreater}Symposium on Applications of Holography in Mechanics{\textless}/span{\textgreater}}, date = {1971}}"#,
+        );
+
+        let converted = input_reference_from_biblatex(&entry);
+
+        let component = converted
+            .as_collection_component()
+            .expect("expected a CollectionComponent");
+        let parent = match component.container.as_ref().expect("expected a container") {
+            WorkRelation::Embedded(inner) => inner
+                .as_collection()
+                .expect("expected an embedded Collection"),
+            WorkRelation::Id(_) => panic!("expected an embedded container, not an id reference"),
+        };
+        assert_eq!(
+            parent.title,
+            Some(Title::Single(
+                "[Symposium on Applications of Holography in Mechanics]{.nocase}".to_string()
+            ))
+        );
     }
 
     #[rstest]

--- a/crates/citum-schema-data/src/reference/citeproc_markup.rs
+++ b/crates/citum-schema-data/src/reference/citeproc_markup.rs
@@ -1,0 +1,209 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Conversion of citeproc-js's fixed HTML rich-text tag set to Djot.
+//!
+//! citeproc-js authors title case-protection and inline formatting as literal
+//! HTML (`<span class="nocase">`, `<i>`, `<b>`, `<sc>`, `<sup>`, `<sub>`)
+//! rather than Djot, Citum's canonical inline markup for free-text fields.
+//! [`html_markup_to_djot`] converts that fixed tag set at ingestion, so it is
+//! interpreted by the renderer instead of leaking verbatim into rendered
+//! output. Not gated behind `legacy-convert`: both the CSL-JSON conversion
+//! path (`reference::conversion`) and the plain biblatex path
+//! (`citum-refs::biblatex`) need it, and neither implies the other.
+
+/// Djot equivalent of one of the fixed HTML tags citeproc-js authors as
+/// title rich-text markup.
+#[derive(Clone, Copy)]
+enum DjotTag {
+    Emph,
+    Strong,
+    SmallCaps,
+    Superscript,
+    Subscript,
+    NoCase,
+    /// A `<span>` with no recognized class/style -- kept for stack bookkeeping
+    /// so its matching `</span>` doesn't pop an unrelated tag's closer.
+    Passthrough,
+}
+
+impl DjotTag {
+    fn open(self) -> &'static str {
+        match self {
+            Self::Emph => "_",
+            Self::Strong => "*",
+            Self::SmallCaps | Self::Superscript | Self::Subscript | Self::NoCase => "[",
+            Self::Passthrough => "",
+        }
+    }
+
+    fn close(self) -> &'static str {
+        match self {
+            Self::Emph => "_",
+            Self::Strong => "*",
+            Self::SmallCaps => "]{.smallcaps}",
+            Self::Superscript => "]{.superscript}",
+            Self::Subscript => "]{.subscript}",
+            Self::NoCase => "]{.nocase}",
+            Self::Passthrough => "",
+        }
+    }
+}
+
+/// Tag names citeproc-js is known to emit for title rich-text markup.
+const RECOGNIZED_HTML_TAG_NAMES: [&str; 6] = ["i", "b", "sc", "sup", "sub", "span"];
+
+/// Classify a parsed opening-tag body (without `<`/`>`), e.g. `span
+/// class="nocase"`, returning `None` for tag names outside the fixed
+/// citeproc set.
+fn classify_open_tag(tag_inner: &str) -> Option<DjotTag> {
+    let name = tag_inner.split_whitespace().next()?.to_ascii_lowercase();
+    if !RECOGNIZED_HTML_TAG_NAMES.contains(&name.as_str()) {
+        return None;
+    }
+    Some(match name.as_str() {
+        "i" => DjotTag::Emph,
+        "b" => DjotTag::Strong,
+        "sc" => DjotTag::SmallCaps,
+        "sup" => DjotTag::Superscript,
+        "sub" => DjotTag::Subscript,
+        _ => {
+            let attrs = tag_inner.to_ascii_lowercase();
+            if attrs.contains("nocase") {
+                DjotTag::NoCase
+            } else if attrs.contains("small-caps") || attrs.contains("smallcaps") {
+                DjotTag::SmallCaps
+            } else {
+                DjotTag::Passthrough
+            }
+        }
+    })
+}
+
+/// Convert citeproc-js's fixed HTML rich-text tag set to Djot inline markup.
+///
+/// citeproc-js authors title case-protection and inline formatting as literal
+/// HTML (`<span class="nocase">`, `<i>`, `<b>`, `<sc>`, `<sup>`, `<sub>`)
+/// rather than Djot, Citum's canonical inline markup for free-text fields. Left
+/// unconverted, these tags leak verbatim into rendered output instead of being
+/// interpreted (`csl26-zaqk`, `csl26-6eoi`). Only this fixed tag set is
+/// converted -- never a generic `<...>` strip, since titles may legitimately
+/// contain literal `<`/`>` characters outside it.
+#[allow(
+    clippy::string_slice,
+    reason = "every slice boundary here is a byte offset of an ASCII '<' or '>' delimiter \
+              (from char_indices()/find('>')), which is always a valid char boundary"
+)]
+#[must_use]
+pub fn html_markup_to_djot(text: &str) -> String {
+    if !text.contains('<') {
+        return text.to_string();
+    }
+
+    let mut output = String::with_capacity(text.len());
+    let mut closers: Vec<&'static str> = Vec::new();
+    let mut chars = text.char_indices();
+
+    while let Some((start, ch)) = chars.next() {
+        if ch != '<' {
+            output.push(ch);
+            continue;
+        }
+        let Some(rel_end) = text[start..].find('>') else {
+            // Unterminated tag: keep the remainder literal.
+            output.push_str(&text[start..]);
+            break;
+        };
+        let end = start + rel_end;
+        let tag_inner = &text[start + 1..end];
+        let tag_char_len = text[start..=end].chars().count();
+        for _ in 1..tag_char_len {
+            chars.next();
+        }
+
+        if let Some(name) = tag_inner.strip_prefix('/') {
+            let name = name.trim().to_ascii_lowercase();
+            if RECOGNIZED_HTML_TAG_NAMES.contains(&name.as_str()) {
+                match closers.pop() {
+                    Some(closer) => output.push_str(closer),
+                    // Stray/mismatched close tag: keep it literal rather than
+                    // silently dropping content.
+                    None => output.push_str(&text[start..=end]),
+                }
+            } else {
+                output.push_str(&text[start..=end]);
+            }
+            continue;
+        }
+
+        match classify_open_tag(tag_inner) {
+            Some(tag) => {
+                output.push_str(tag.open());
+                closers.push(tag.close());
+            }
+            None => output.push_str(&text[start..=end]),
+        }
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn html_markup_to_djot_leaves_plain_text_unchanged() {
+        assert_eq!(
+            html_markup_to_djot("plain text with no markup"),
+            "plain text with no markup"
+        );
+    }
+
+    #[test]
+    fn html_markup_to_djot_converts_nocase_span() {
+        // The exact convention citeproc-js emits and the CSL test suite's
+        // own fixtures use, e.g. `textcase_TitleCaseWithFinalNocase.txt`.
+        assert_eq!(
+            html_markup_to_djot(r#"a <span class="nocase">Smith</span> pencil"#),
+            "a [Smith]{.nocase} pencil"
+        );
+    }
+
+    #[test]
+    fn html_markup_to_djot_converts_emphasis_and_strong() {
+        assert_eq!(html_markup_to_djot("<i>Homo Sapiens</i>"), "_Homo Sapiens_");
+        assert_eq!(html_markup_to_djot("<b>Loud</b>"), "*Loud*");
+    }
+
+    #[test]
+    fn html_markup_to_djot_converts_nested_emphasis_inside_nocase_span() {
+        assert_eq!(
+            html_markup_to_djot(r#"<span class="nocase"><i>DNA</i></span> Replication"#),
+            "[_DNA_]{.nocase} Replication"
+        );
+    }
+
+    #[test]
+    fn html_markup_to_djot_leaves_unrecognized_tags_and_bare_angle_brackets_literal() {
+        // Titles may legitimately contain `<`/`>` outside the fixed citeproc
+        // tag set (e.g. a math/comparison expression) -- must not be stripped.
+        assert_eq!(
+            html_markup_to_djot("<em>ignored</em> a < b"),
+            "<em>ignored</em> a < b"
+        );
+    }
+
+    #[test]
+    fn html_markup_to_djot_converts_superscript_ordinal() {
+        // <sup>/<sub> in a title/abstract/genre-style free-text field, e.g. a
+        // French ordinal in an edition statement. NOT applicable to CSL's
+        // `number` variable -- verified against real citeproc-js that field
+        // is exempt from flip-flop (see `normalize_rich_text_markup`'s doc
+        // comment in `conversion/mod.rs`); this function itself is field-
+        // agnostic and only converts what its caller feeds it.
+        assert_eq!(html_markup_to_djot("1<sup>er</sup>"), "1[er]{.superscript}");
+    }
+}

--- a/crates/citum-schema-data/src/reference/conversion/mod.rs
+++ b/crates/citum-schema-data/src/reference/conversion/mod.rs
@@ -28,6 +28,7 @@ mod scholarly;
 
 pub use scholarly::input_reference_from_legacy_edited_book;
 
+use crate::reference::citeproc_markup::html_markup_to_djot;
 use crate::reference::contributor::{
     Contributor, ContributorEntry, ContributorList, ContributorRole, SimpleName, StructuredName,
 };
@@ -388,147 +389,17 @@ fn normalize_broadcast_issue(
     csl_legacy::csl_json::StringOrNumber::String(normalized)
 }
 
-/// Djot equivalent of one of the fixed HTML tags citeproc-js authors as
-/// title rich-text markup.
-#[derive(Clone, Copy)]
-enum DjotTag {
-    Emph,
-    Strong,
-    SmallCaps,
-    Superscript,
-    Subscript,
-    NoCase,
-    /// A `<span>` with no recognized class/style -- kept for stack bookkeeping
-    /// so its matching `</span>` doesn't pop an unrelated tag's closer.
-    Passthrough,
-}
-
-impl DjotTag {
-    fn open(self) -> &'static str {
-        match self {
-            Self::Emph => "_",
-            Self::Strong => "*",
-            Self::SmallCaps | Self::Superscript | Self::Subscript | Self::NoCase => "[",
-            Self::Passthrough => "",
-        }
-    }
-
-    fn close(self) -> &'static str {
-        match self {
-            Self::Emph => "_",
-            Self::Strong => "*",
-            // `.superscript`/`.subscript`/`.smallcaps` spans are not yet
-            // interpreted by every `render/rich_text.rs` output format --
-            // an existing engine gap, out of scope here. Converting still
-            // drops the literal tag from output, which is strictly better
-            // than the raw HTML leak this function exists to fix.
-            Self::SmallCaps => "]{.smallcaps}",
-            Self::Superscript => "]{.superscript}",
-            Self::Subscript => "]{.subscript}",
-            Self::NoCase => "]{.nocase}",
-            Self::Passthrough => "",
-        }
-    }
-}
-
-/// Tag names citeproc-js is known to emit for title rich-text markup.
-const RECOGNIZED_HTML_TAG_NAMES: [&str; 6] = ["i", "b", "sc", "sup", "sub", "span"];
-
-/// Classify a parsed opening-tag body (without `<`/`>`), e.g. `span
-/// class="nocase"`, returning `None` for tag names outside the fixed
-/// citeproc set.
-fn classify_open_tag(tag_inner: &str) -> Option<DjotTag> {
-    let name = tag_inner.split_whitespace().next()?.to_ascii_lowercase();
-    if !RECOGNIZED_HTML_TAG_NAMES.contains(&name.as_str()) {
-        return None;
-    }
-    Some(match name.as_str() {
-        "i" => DjotTag::Emph,
-        "b" => DjotTag::Strong,
-        "sc" => DjotTag::SmallCaps,
-        "sup" => DjotTag::Superscript,
-        "sub" => DjotTag::Subscript,
-        _ => {
-            let attrs = tag_inner.to_ascii_lowercase();
-            if attrs.contains("nocase") {
-                DjotTag::NoCase
-            } else if attrs.contains("small-caps") || attrs.contains("smallcaps") {
-                DjotTag::SmallCaps
-            } else {
-                DjotTag::Passthrough
-            }
-        }
-    })
-}
-
-/// Convert citeproc-js's fixed HTML rich-text tag set to Djot inline markup.
-///
-/// citeproc-js authors title case-protection and inline formatting as literal
-/// HTML (`<span class="nocase">`, `<i>`, `<b>`, `<sc>`, `<sup>`, `<sub>`)
-/// rather than Djot, Citum's canonical inline markup for free-text fields. Left
-/// unconverted, these tags leak verbatim into rendered output instead of being
-/// interpreted (`csl26-zaqk`). Only this fixed tag set is converted -- never a
-/// generic `<...>` strip, since titles may legitimately contain literal
-/// `<`/`>` characters outside it.
-#[allow(
-    clippy::string_slice,
-    reason = "every slice boundary here is a byte offset of an ASCII '<' or '>' delimiter \
-              (from char_indices()/find('>')), which is always a valid char boundary"
-)]
-fn html_markup_to_djot(text: &str) -> String {
-    if !text.contains('<') {
-        return text.to_string();
-    }
-
-    let mut output = String::with_capacity(text.len());
-    let mut closers: Vec<&'static str> = Vec::new();
-    let mut chars = text.char_indices();
-
-    while let Some((start, ch)) = chars.next() {
-        if ch != '<' {
-            output.push(ch);
-            continue;
-        }
-        let Some(rel_end) = text[start..].find('>') else {
-            // Unterminated tag: keep the remainder literal.
-            output.push_str(&text[start..]);
-            break;
-        };
-        let end = start + rel_end;
-        let tag_inner = &text[start + 1..end];
-        let tag_char_len = text[start..=end].chars().count();
-        for _ in 1..tag_char_len {
-            chars.next();
-        }
-
-        if let Some(name) = tag_inner.strip_prefix('/') {
-            let name = name.trim().to_ascii_lowercase();
-            if RECOGNIZED_HTML_TAG_NAMES.contains(&name.as_str()) {
-                match closers.pop() {
-                    Some(closer) => output.push_str(closer),
-                    // Stray/mismatched close tag: keep it literal rather than
-                    // silently dropping content.
-                    None => output.push_str(&text[start..=end]),
-                }
-            } else {
-                output.push_str(&text[start..=end]);
-            }
-            continue;
-        }
-
-        match classify_open_tag(tag_inner) {
-            Some(tag) => {
-                output.push_str(tag.open());
-                closers.push(tag.close());
-            }
-            None => output.push_str(&text[start..=end]),
-        }
-    }
-
-    output
-}
-
 /// Build a title, optionally structured if short_title is present and title contains a colon.
+///
+/// `html_markup_to_djot` runs again here even though `normalize_rich_text_markup`
+/// (called earlier, in `From<csl_legacy::csl_json::Reference>`) already converts
+/// `legacy.title`/`legacy.title_short` -- this function is also reached with
+/// `part_title`, sourced from `legacy_extra_str(&legacy, "part-title")`
+/// (`scholarly.rs`), which lives in the `extra` map the central pass
+/// deliberately skips (see `normalize_rich_text_markup`'s doc comment). The
+/// call is idempotent on already-converted text -- recognized tags leave no
+/// `<` behind, and any text already in Djot has none to begin with -- so the
+/// redundancy for the already-normalized case is free.
 fn build_title(title: Option<String>, short_title: Option<String>) -> Option<Title> {
     let title = title.map(|t| html_markup_to_djot(&t));
     let short_title = short_title.map(|t| html_markup_to_djot(&t));
@@ -681,6 +552,64 @@ fn legacy_type_uses_created(ref_type: &str) -> bool {
     )
 }
 
+/// Convert citeproc-js's literal HTML rich-text convention to Djot across
+/// every free-text CSL-JSON field that legitimately carries it, in place.
+///
+/// citeproc-js flip-flops HTML rich-text markup (`<span class="nocase">`,
+/// `<i>`, `<b>`, `<sc>`, `<sup>`, `<sub>`) into text variables generally, not
+/// just `title` -- this benchmark's own `container-title` carries `nocase`
+/// spans (`csl26-6eoi`). Verified directly against the `citeproc` npm
+/// package (the reference implementation) for every field below: each
+/// strips `<span class="nocase">` the same way `title` does. Bean
+/// `csl26-zaqk` converted `title` and `short_title` at the `build_title`
+/// call site; this is the remaining scope that bean explicitly deferred.
+/// Runs once, immediately after `parse_note_field_hacks()` and before any
+/// per-type converter reads the reference, so no future conversion path
+/// can bypass it.
+///
+/// Deliberately does **not** touch:
+/// - `note` -- `parse_note_field_hacks()` parses it for extra-field
+///   key/value overrides; converting first would corrupt that parse.
+/// - `doi`, `url`, `isbn`, `issn`, `language` -- identifiers, not rich text.
+/// - `number` -- despite the CSL test suite's `flipflop_NumericField.json`
+///   fixture name, real citeproc-js does *not* flip-flop this field:
+///   `<number variable="number"/>` on `"number": "1<sup>er</sup>"` renders
+///   the tag literally, HTML-escaped (`1&#60;sup&#62;er&#60;/sup&#62;`),
+///   confirmed by running the fixture through the real `citeproc` engine.
+///   `number` is a CSL number-type variable, not a plain text one, and is
+///   exempt from flip-flop -- converting it here would be a regression, not
+///   a fix.
+/// - `page`, `volume`, `issue`, `edition` (the latter three `StringOrNumber`)
+///   -- real citeproc-js *does* flip-flop these (verified the same way as
+///   above), but no fixture in this repo's corpus carries rich text there;
+///   recorded as a follow-up in `csl26-6eoi` rather than guessed at here.
+/// - The `extra` map (`issued-note-literal`, `available-date`,
+///   `original-author`, etc.) -- not verified; same follow-up.
+fn normalize_rich_text_markup(legacy: &mut csl_legacy::csl_json::Reference) {
+    for value in [
+        &mut legacy.title,
+        &mut legacy.container_title,
+        &mut legacy.collection_title,
+        &mut legacy.original_title,
+        &mut legacy.publisher,
+        &mut legacy.publisher_place,
+        &mut legacy.event,
+        &mut legacy.genre,
+        &mut legacy.medium,
+        &mut legacy.section,
+        &mut legacy.authority,
+        &mut legacy.abstract_text,
+        &mut legacy.archive,
+        &mut legacy.archive_location,
+        &mut legacy.dimensions,
+    ]
+    .into_iter()
+    .flatten()
+    {
+        *value = html_markup_to_djot(value);
+    }
+}
+
 impl From<csl_legacy::csl_json::Reference> for InputReference {
     #[allow(
         clippy::too_many_lines,
@@ -688,6 +617,7 @@ impl From<csl_legacy::csl_json::Reference> for InputReference {
     )]
     fn from(mut legacy: csl_legacy::csl_json::Reference) -> Self {
         legacy.parse_note_field_hacks();
+        normalize_rich_text_markup(&mut legacy);
         let cstr = legacy_extra_str(&legacy, "CSTR");
         // GB/T 7714 §7.5.4.3 publication-year substitutes, used when the
         // true issue date is unknown. Copyright is a top-level `c<year>`
@@ -1502,48 +1432,6 @@ mod tests {
     }
 
     #[test]
-    fn html_markup_to_djot_leaves_plain_text_unchanged() {
-        assert_eq!(
-            html_markup_to_djot("plain text with no markup"),
-            "plain text with no markup"
-        );
-    }
-
-    #[test]
-    fn html_markup_to_djot_converts_nocase_span() {
-        // The exact convention citeproc-js emits and the CSL test suite's
-        // own fixtures use, e.g. `textcase_TitleCaseWithFinalNocase.txt`.
-        assert_eq!(
-            html_markup_to_djot(r#"a <span class="nocase">Smith</span> pencil"#),
-            "a [Smith]{.nocase} pencil"
-        );
-    }
-
-    #[test]
-    fn html_markup_to_djot_converts_emphasis_and_strong() {
-        assert_eq!(html_markup_to_djot("<i>Homo Sapiens</i>"), "_Homo Sapiens_");
-        assert_eq!(html_markup_to_djot("<b>Loud</b>"), "*Loud*");
-    }
-
-    #[test]
-    fn html_markup_to_djot_converts_nested_emphasis_inside_nocase_span() {
-        assert_eq!(
-            html_markup_to_djot(r#"<span class="nocase"><i>DNA</i></span> Replication"#),
-            "[_DNA_]{.nocase} Replication"
-        );
-    }
-
-    #[test]
-    fn html_markup_to_djot_leaves_unrecognized_tags_and_bare_angle_brackets_literal() {
-        // Titles may legitimately contain `<`/`>` outside the fixed citeproc
-        // tag set (e.g. a math/comparison expression) -- must not be stripped.
-        assert_eq!(
-            html_markup_to_djot("<em>ignored</em> a < b"),
-            "<em>ignored</em> a < b"
-        );
-    }
-
-    #[test]
     fn legacy_title_with_nocase_html_span_converts_to_djot_case_protection() {
         // Confirms the bean csl26-zaqk regression at the conversion boundary:
         // CSL-JSON titles carry citeproc-js's literal HTML rich-text
@@ -1561,6 +1449,61 @@ mod tests {
         assert_eq!(
             converted.title(),
             Some(Title::Single("[Library of Congress]{.nocase}".to_string()))
+        );
+    }
+
+    #[test]
+    fn legacy_container_title_with_nocase_html_spans_converts_to_djot_case_protection() {
+        // The gb7714-bench regression (bean csl26-6eoi): entry gbt7714.8.6.1:5's
+        // `container-title` carries citeproc-js's literal HTML rich-text
+        // convention, same as `title` in the csl26-zaqk case above, but through
+        // a field `build_title` never sees. Must become Djot on ingestion
+        // rather than leaking verbatim into rendered output.
+        let legacy = csl_legacy::csl_json::Reference {
+            id: "gbt7714.8.6.1:5".to_string(),
+            ref_type: "book".to_string(),
+            title: Some("Advances in holographic photoelasticity".to_string()),
+            container_title: Some(
+                r#"<span class="nocase">Symposium on Applications of Holography in Mechanics</span>, August 23-25, 1971, <span class="nocase">University of Southern California</span>, <span class="nocase">Los Angeles, California</span>"#
+                    .to_string(),
+            ),
+            ..Default::default()
+        };
+
+        let converted = InputReference::from(legacy);
+
+        assert_eq!(
+            converted.container_title(),
+            Some(Title::Single(
+                "[Symposium on Applications of Holography in Mechanics]{.nocase}, \
+                 August 23-25, 1971, [University of Southern California]{.nocase}, \
+                 [Los Angeles, California]{.nocase}"
+                    .to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn normalize_rich_text_markup_converts_collection_title_and_leaves_note_untouched() {
+        // Direct test of the new central pass: confirms it reaches a field
+        // beyond `title`/`container-title` (collection-title, i.e. a book
+        // series) and confirms the deliberate exclusion of `note`, which
+        // `parse_note_field_hacks()` depends on parsing unconverted.
+        let mut legacy = csl_legacy::csl_json::Reference {
+            collection_title: Some(r#"<i>Springer Monographs</i>"#.to_string()),
+            note: Some(r#"CSTR: <span class="nocase">unrelated</span>"#.to_string()),
+            ..Default::default()
+        };
+
+        normalize_rich_text_markup(&mut legacy);
+
+        assert_eq!(
+            legacy.collection_title,
+            Some("_Springer Monographs_".to_string())
+        );
+        assert_eq!(
+            legacy.note,
+            Some(r#"CSTR: <span class="nocase">unrelated</span>"#.to_string())
         );
     }
 }

--- a/crates/citum-schema-data/src/reference/mod.rs
+++ b/crates/citum-schema-data/src/reference/mod.rs
@@ -6,6 +6,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! A reference is a bibliographic item, such as a book, article, or web page.
 //! It is the basic unit of bibliographic data.
 
+pub mod citeproc_markup;
 pub mod contributor;
 #[cfg(feature = "legacy-convert")]
 pub mod conversion;


### PR DESCRIPTION
## Summary

- The [gb7714-bench](https://github.com/YDX-2147483647/gb7714-bench) benchmark ranked Citum highly but surfaced a raw-HTML leak: https://gb7714.zhtyp.art/entry/gbt7714.8.6.1-5/
- Bean `csl26-zaqk` converted citeproc-js's literal HTML rich-text convention (`<span class="nocase">`, `<i>`, `<b>`, `<sc>`, `<sup>`, `<sub>`) to Djot at CSL-JSON ingestion, but wired it in only for `title`/`short_title`. Every other free-text field, and the entire biblatex ingestion path, still leaked raw HTML verbatim into rendered output.
- Promotes `html_markup_to_djot` to an ungated `reference::citeproc_markup` module and applies it centrally:
  - CSL-JSON: an explicit field allowlist (`title`, `container_title`, `collection_title`, `original_title`, `publisher`, `publisher_place`, `event`, `genre`, `medium`, `section`, `authority`, `abstract_text`, `archive`, `archive_location`, `dimensions`) applied once in `InputReference::from(LegacyReference)`.
  - Biblatex (`citum-refs`): a new `rich_field_str` closure alongside the existing `field_str`, covering `title`/`subtitle`, `publisher`/`institution`/`organization`/`school`/`location`, `booktitle`, `journaltitle`/`journal`, `abstract`, and `type` (genre).
- Each allowlisted field was verified against the real `citeproc` npm package (not just Citum's own renderer) to confirm citeproc-js actually flip-flops HTML markup there. This caught a mistake before it shipped: `number` was initially added on the strength of the CSL test suite's `flipflop_NumericField.json` fixture name, but running that fixture against real citeproc-js showed the opposite — `number` is a CSL number-type variable, exempt from flip-flop, and citeproc-js renders it literally, HTML-escaped. Removed from the allowlist.

## Results

Full 344-entry corpus from all four gb7714-bench data sources (`typst-doc-cn/bib-csl-dev-data`, CSL-JSON and biblatex, both Zotero export flavors), rendered through `gb-t-7714-2025-numeric`, checked for raw HTML tags in output:

| Source | Before | After |
|---|---|---|
| `builtin.json` | 2 | 0 |
| `better.json` | 2 | 0 |
| `builtin.bib` | 9 | 0 |
| `better.bib` | 0 | 0 |

`report-core.js --style gb-t-7714-2025-numeric` fidelity is unchanged before and after (`fidelityScore: 0.996`, GB/T upstream corpus 193/203) — confirmed by stashing and re-running. This is a *no-regression* signal only: the oracle's `normalizeText()` strips all HTML tags before comparing citum's output to citeproc-js, so it cannot itself detect this class of bug either way (filed as `csl26-g9lb`). The real evidence for correctness is the raw-HTML-tag corpus sweep above, the new conversion-boundary/end-to-end tests, and the direct real-citeproc-js field verification.

## Follow-ups filed (not in this PR)

- `csl26-7ab8` — the biblatex ingestion path diverges from the CSL-JSON path on 301/344 corpus entries (drops authors and page ranges wholesale), a much larger benchmark gap than this fix.
- `csl26-g9lb` — the oracle's `normalizeText()` strips HTML tags before comparison, so it's structurally blind to this class of bug.

## Test plan

- [x] `just pre-commit` (fmt, clippy `-D warnings`, 2187 nextest tests) green
- [x] `just schema-gen` — no diff
- [x] Full 344-entry benchmark corpus (all 4 sources) renders zero raw HTML
- [x] New end-to-end regression test (`crates/citum-engine/tests/gb7714_bench_regression.rs`) renders the exact benchmark entry and asserts the clean string
- [x] New unit/integration tests at each conversion boundary (CSL-JSON and biblatex), including a negative case confirming `note` stays untouched
