### PR TITLE
fix(schema): multilingual config merge and example corrections

### DIFF
--- a/.beans/archive/csl26-iooh--draft-multilingual-follow-up-news-post-in-citum-or.md
+++ b/.beans/archive/csl26-iooh--draft-multilingual-follow-up-news-post-in-citum-or.md
@@ -1,0 +1,44 @@
+---
+# csl26-iooh
+title: Draft multilingual follow-up news post in citum-org
+status: completed
+type: task
+priority: normal
+tags:
+    - docs
+    - multilingual
+    - gb-t
+created_at: 2026-07-26T14:25:47Z
+updated_at: 2026-07-26T14:34:05Z
+---
+
+Follow-up to citum-org docs/news/posts/multilingual-design-review.md, demoing what shipped from epic csl26-0ugp (multilingual architecture hardening) plus the GB/T 7714-2025 styles and date.note.
+
+Deliverable: draft PR against citum/citum-org adding docs/news/posts/multilingual-shipped.md. No citum-core changes.
+
+Plan: /home/bruce/.claude/plans/you-will-create-a-warm-reddy.md
+
+## Todo
+
+- [x] Re-run all four demos against citum 0.78.0, capture real output
+- [x] Write docs/news/posts/multilingual-shipped.md
+- [x] Verify snippets round-trip (copy out of post, run fresh)
+- [x] Re-check live gb7714-bench figure
+- [x] Build site locally, review rendered page
+- [x] Verify all external links resolve
+- [x] Open draft PR on citum-org
+
+## Summary of Changes
+
+Draft PR citum/citum-org#27 adds `docs/news/posts/multilingual-shipped.md` (single file; generated HTML stays gitignored).
+
+Demos four features, all in released v0.78.0: GB/T 7714—2025 across three styles and three languages; punctuation realization via a one-line `punctuation-width: bylan` override; per-item term locale (de/fr/en role labels from one template); and `date.note` (same data rendered by `apa-7th` vs `gb-t-7714-2025-numeric`).
+
+Verification: all five YAML snippets were re-extracted from the finished Markdown, re-run, and diffed against the outputs the post claims — 8/8 blocks matched exactly. Chinese/Japanese content taken verbatim from the pinned GB/T corpus. All 21 external links plus the install URL return 200. Site builds clean.
+
+Before/after comparison blocks use a scoped `<style>` at the end of the post (positioned last so `.prose > *:first-child` still applies to the opening paragraph), using only existing `theme.css` variables. PR body offers to move them into `theme.css` if reuse is wanted.
+
+## Follow-ups not filed
+
+- YDX's corrections to the *first* post's examples are still unfixed in citum-core: `examples/multilingual-refs.yaml` splits 孔子 as family/given and has the wrong pinyin tone; `styles/experimental/multilingual-partitioned.yaml` still collapses Chinese and Japanese into one `Hani` partition. The post admits this openly.
+- Possible engine gap found while building demos, deliberately excluded from the post as unverified: a structured Chinese name (`family` + `given`) renders with a space under the GB/T styles; the standard's own corpus uses literal `name:` forms, so it does not surface in the demos.

--- a/.beans/archive/csl26-p7kj--fix-multilingual-follow-ups-from-the-news-post-rev.md
+++ b/.beans/archive/csl26-p7kj--fix-multilingual-follow-ups-from-the-news-post-rev.md
@@ -1,0 +1,50 @@
+---
+# csl26-p7kj
+title: Fix multilingual follow-ups from the news-post review
+status: completed
+type: bug
+priority: normal
+tags:
+    - multilingual
+    - schema
+    - docs
+created_at: 2026-07-26T14:44:00Z
+updated_at: 2026-07-26T15:01:41Z
+---
+
+Loose ends surfaced while drafting the citum-org multilingual follow-up post (csl26-iooh).
+
+## Findings
+
+1. **MultilingualConfig is replaced, not merged, on extends/scope merge.** Config::merge lists `multilingual` in the whole-value `merge_options!` macro, so any style that extends a parent and declares ANY multilingual key drops every inherited multilingual field. Reproduced: adding an unrelated `scripts.Hang` block to a style extending gb-t-7714-2025-numeric silently reverts Chinese punctuation from full-width to half-width, because the inherited `punctuation-width: mixed` is lost. Every other composite config in the same file (contributors, substitute, punctuation) already has a field-wise merge; multilingual is the outlier.
+
+2. **YDX-2147483647's corrections to the multilingual examples were never applied** (discussion #828): examples/multilingual-refs.yaml splits 孔子 into family 孔 / given 子 (the name cannot be split) and romanizes 论语 with the wrong tone (Lùnyǔ, should be Lúnyǔ).
+
+3. **styles/experimental/multilingual-partitioned.yaml collapses Chinese and Japanese** into one `Hani` section headed "Chinese & Japanese Sources".
+
+## Todo
+
+- [x] Add MultilingualConfig::merge and call it from Config::merge
+- [x] Regression test for the inherited punctuation-width case
+- [x] Fix the Confucius entry per YDX's guidance
+- [x] Fix the partitioning example so Chinese and Japanese separate
+- [x] File follow-up beans for what is out of scope
+- [x] just pre-commit green
+
+## Summary of Changes
+
+**Engine fix.** Added `MultilingualConfig::merge` (field-wise) and a private `Config::merge_multilingual`, removing `multilingual` from the whole-value `merge_options!` list. `scripts` merges per key; `realization_default` and `term_locale` are not `Option`, and both are `skip_serializing_if`-elided at their default, so a default value is treated as "unset" and leaves the inherited value in place.
+
+Verified end to end: a style extending `gb-t-7714-2025-numeric` with an unrelated `scripts.Hang` block previously rendered `北京: 清华大学出版社, 2023: 35.` (half-width) and now correctly renders `北京：清华大学出版社，2023：35.`. Shipped styles are byte-identical; an explicit `punctuation-width` override still wins.
+
+Coverage: `given_partial_multilingual_overlay_when_merging_then_inherited_fields_survive` (rstest, 2 cases) and `given_multilingual_overlay_setting_a_field_when_merging_then_overlay_wins`.
+
+**Examples.** `examples/multilingual-refs.yaml`: 孔子 is now a single `name:` whole-name carrying its own romanization and English form, instead of being split into `family: 孔` / `given: 子`; pinyin for 论语 corrected to `Lúnyǔ`. `styles/experimental/multilingual-partitioned.yaml`: switched to `by: language`, which separates Chinese and Japanese into their own sections (six sections verified), with a header comment explaining why script partitioning cannot.
+
+`just pre-commit` green: 2197 tests, fmt + clippy clean. `just schema-gen` produces no diff — the change adds methods only, no public shape change.
+
+## Follow-ups filed
+
+- [[csl26-kxhy]] — CJK personal names render with an inter-part space under GB/T; `scripts.Hani.delimiter` does not reach the name join.
+- [[csl26-53ek]] — `name-mode: transliterated` is not applied to whole-name (`SimpleName`) contributors, so the schema-correct way to model 孔子 loses romanization.
+- [[csl26-zq9u]] — `by: script` partitioning folds all CJK into `Hani` and cannot separate Chinese from Japanese; needs a decision on resolving from language metadata.

--- a/.beans/csl26-53ek--name-mode-transliteration-is-not-applied-to-whole.md
+++ b/.beans/csl26-53ek--name-mode-transliteration-is-not-applied-to-whole.md
@@ -1,0 +1,28 @@
+---
+# csl26-53ek
+title: name-mode transliteration is not applied to whole-name (SimpleName) contributors
+status: todo
+type: bug
+priority: normal
+tags:
+    - multilingual
+    - rendering
+    - contributors
+created_at: 2026-07-26T15:01:20Z
+updated_at: 2026-07-26T15:01:20Z
+---
+
+A contributor written as an indivisible whole name (`name:`) accepts the full multilingual form, but `options.multilingual.name-mode: transliterated` does not apply to it — the original script renders instead of the romanization.
+
+Reproduce with examples/multilingual-refs.yaml (the corrected Confucius entry) and styles/iso690-numeric.yaml, which sets `name-mode: transliterated`:
+
+    [7] 孔子. Lúnyǔ [Analects of Confucius].: 人民文学出版社.
+         ^^^ expected Kǒngzǐ under a transliterated name-mode
+
+The title on the same entry IS transliterated (`Lúnyǔ`), so the mode is active — it just does not reach the name. `name-mode` appears to be wired only to `MultilingualName` (the structured original/transliterations/translations shape), not to a `SimpleName` whose `name` field is a `MultilingualString` carrying the same information.
+
+## Why this matters now
+
+Domain-expert review (discussion #828) established that names like 孔子 must NOT be decomposed into family/given. `name:` is the correct schema answer, and csl26-p7kj adopted it in examples/multilingual-refs.yaml. But adopting it currently costs the entry its romanization support — so the schema-correct way to model an indivisible name is also the way that loses transliteration. That tension should be resolved in favor of supporting both.
+
+Scope: make name-mode/preferred-script resolution consult the `MultilingualString` inside `SimpleName.name` the same way it consults `MultilingualName`.

--- a/.beans/csl26-kxhy--cjk-personal-names-render-with-an-inter-part-space.md
+++ b/.beans/csl26-kxhy--cjk-personal-names-render-with-an-inter-part-space.md
@@ -1,0 +1,43 @@
+---
+# csl26-kxhy
+title: CJK personal names render with an inter-part space under GB/T
+status: todo
+type: bug
+priority: normal
+tags:
+    - multilingual
+    - rendering
+    - gb-t
+    - contributors
+created_at: 2026-07-26T15:00:49Z
+updated_at: 2026-07-26T15:00:49Z
+---
+
+A structured Chinese personal name (`family: 张` / `given: 伟`) renders as `张 伟` under the GB/T 7714—2025 styles. GB/T expects `张伟` — no inter-part space for CJK names.
+
+Reproduce (citum 0.78.0 or main):
+
+    references:
+      - id: zhang
+        class: serial-component
+        type: article
+        title: "环境司法制度改革对企业绿色创新的影响"
+        author:
+          - family: "张"
+            given: "伟"
+        language: "zh-CN"
+
+    citum render refs -b x.yaml -s gb-t-7714-2025-numeric
+    [1]张 伟. …        <- expected 张伟
+
+The space is correct for the Western case in the same style (`Boobier T`), so the join needs to be script-aware.
+
+## The configured mechanism does not reach it
+
+`options.multilingual.scripts.Hani.delimiter` has no effect on this output. Tested with both `delimiter: ""` and `delimiter: "·"` plus `use-native-ordering: true` on a style extending gb-t-7714-2025-numeric — output is byte-identical either way. `Hani` is a valid candidate key (see `candidate_keys` in crates/citum-engine/src/values/contributor/names.rs:681), so either `script_configs` is not threaded into this style's name path or the delimiter is not consulted for the family/given join.
+
+Investigate which, then decide whether the fix is engine-level (script-aware join) or a style-level `scripts` block on the GB/T base.
+
+## Why it does not show in the corpus
+
+The standard's own corpus writes Chinese personal names as literal whole names (`{"literal": "博伯尔"}`, 70 of them), so the pinned fixtures never exercise the structured path. Found while building demos for the citum-org news post (csl26-iooh), not by the oracle.

--- a/.beans/csl26-zq9u--script-partitioning-cannot-separate-chinese-from-j.md
+++ b/.beans/csl26-zq9u--script-partitioning-cannot-separate-chinese-from-j.md
@@ -1,0 +1,31 @@
+---
+# csl26-zq9u
+title: Script partitioning cannot separate Chinese from Japanese
+status: todo
+type: feature
+priority: normal
+tags:
+    - multilingual
+    - sorting
+    - architecture
+created_at: 2026-07-26T15:01:20Z
+updated_at: 2026-07-26T15:01:20Z
+---
+
+`sort-partitioning: { by: script }` derives its key from the characters of the author sort key (`script_partition_key` → `script_code_for_char`, crates/citum-engine/src/sort_partitioning.rs:150-166) and explicitly folds `Hant | Hans | Jpan | Kore | Hira | Kana` into a single `Hani` bucket. Chinese and Japanese therefore cannot be separated under script partitioning at all.
+
+Domain-expert review (discussion #828) is clear that they must be: they are different languages with different writing systems, and GB/T 7714—2025 §9.3.2.1 requires grouping by Chinese / Japanese / Western / Russian / other. The Unicode Consortium's own guidance is that inferring language from Han characters is "largely impossible and the attempt basically meaningless" — which is exactly what character-derived script keys attempt.
+
+## Current workaround (already applied)
+
+styles/experimental/multilingual-partitioned.yaml now uses `by: language`, which reads the item's declared `language` and separates the two correctly. That is a genuine fix for the example, and arguably the right primitive, but it leaves `by: script` unable to express a requirement a national standard imposes.
+
+## Decision needed
+
+Should `by: script` resolve from the item's declared language via the ISO 15924 resolver landed in csl26-30ga (`zh` → Hans, `ja` → Jpan; see crates/citum-engine/src/values/mod.rs:438), falling back to character detection only when there is no language evidence — preserving the positive-evidence rule?
+
+That would change partition keys from `Hani` to `Hans`/`Jpan` for items with language metadata, which is a visible behavior change for any style configuring `order`/`headings` with `Hani`. No in-repo style does (verified: zero styles declare multilingual at more than one scope, and only 6 have any multilingual block), so blast radius is limited to externally authored styles. Needs a call on whether to make the change and whether `Hani` should keep matching as a compatibility alias.
+
+## Related
+
+- Unlisted partition keys render with no heading, so their entries read as belonging to the section above (hit while fixing the example — every expected language must appear in `order` AND `headings`). Worth a lint or an explicit "other" bucket.

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -609,6 +609,22 @@ pub enum LinkAnchor {
 }
 
 impl Config {
+    /// Merge `other`'s multilingual block field-wise rather than replacing it.
+    ///
+    /// Replacing the whole block means a style that extends a parent and sets
+    /// any single multilingual key silently discards every inherited one — see
+    /// [`MultilingualConfig::merge`] and bean `csl26-p7kj`.
+    fn merge_multilingual(&mut self, other: &Config) {
+        let Some(other_multilingual) = &other.multilingual else {
+            return;
+        };
+        if let Some(multilingual) = &mut self.multilingual {
+            multilingual.merge(other_multilingual);
+        } else {
+            self.multilingual = Some(other_multilingual.clone());
+        }
+    }
+
     fn merge_punctuation(&mut self, other: &Config) {
         let Some(other_punctuation) = &other.punctuation else {
             return;
@@ -639,7 +655,6 @@ impl Config {
             processing,
             locale_override,
             localize,
-            multilingual,
             dates,
             titles,
             locators,
@@ -655,6 +670,7 @@ impl Config {
             custom,
         );
 
+        self.merge_multilingual(other);
         self.merge_punctuation(other);
         self.messages.extend(other.messages.clone());
 
@@ -1098,6 +1114,7 @@ impl<'de> Deserialize<'de> for Config {
 )]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn test_config_default() {
@@ -1647,5 +1664,66 @@ multilingual:
         let yaml2 = serde_yaml::to_string(&config).unwrap();
         let config2: Config = serde_yaml::from_str(&yaml2).unwrap();
         assert_eq!(config2.multilingual, config.multilingual);
+    }
+
+    /// An overlay that names one multilingual key must not discard the rest of
+    /// the inherited block. Regression for bean `csl26-p7kj`: `multilingual`
+    /// was merged whole-value, so a style extending `gb-t-7714-2025-numeric`
+    /// and adding an unrelated `scripts` entry silently dropped the inherited
+    /// `punctuation-width: mixed`, reverting Chinese punctuation to half-width.
+    #[rstest]
+    #[case::scripts_overlay(
+        "multilingual:\n  scripts:\n    Hang:\n      use-native-ordering: true\n",
+        "Hang"
+    )]
+    #[case::term_locale_overlay("multilingual:\n  term-locale: item\n", "Hani")]
+    fn given_partial_multilingual_overlay_when_merging_then_inherited_fields_survive(
+        #[case] overlay_yaml: &str,
+        #[case] expected_script_key: &str,
+    ) {
+        // given: a parent declaring several multilingual fields at once
+        let base_yaml = "\
+multilingual:
+  punctuation-width: mixed
+  preferred-script: Latn
+  scripts:
+    Hani:
+      use-native-ordering: true
+";
+        let mut base: Config = serde_yaml::from_str(base_yaml).unwrap();
+
+        // when: an overlay names only one of them
+        let overlay: Config = serde_yaml::from_str(overlay_yaml).unwrap();
+        base.merge(&overlay);
+
+        // then: the inherited fields the overlay never mentioned are preserved
+        let merged = base.multilingual.expect("merged multilingual block");
+        assert_eq!(
+            merged.punctuation_width,
+            Some(PunctuationWidth::Mixed),
+            "inherited punctuation-width must survive a partial overlay"
+        );
+        assert_eq!(merged.preferred_script.as_deref(), Some("Latn"));
+        assert!(
+            merged.scripts.contains_key(expected_script_key),
+            "expected scripts key {expected_script_key:?}, got {:?}",
+            merged.scripts.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// An overlay that does name a field still wins over the inherited value.
+    #[test]
+    fn given_multilingual_overlay_setting_a_field_when_merging_then_overlay_wins() {
+        let mut base: Config =
+            serde_yaml::from_str("multilingual:\n  punctuation-width: mixed\n").unwrap();
+        let overlay: Config =
+            serde_yaml::from_str("multilingual:\n  punctuation-width: bylan\n").unwrap();
+
+        base.merge(&overlay);
+
+        assert_eq!(
+            base.multilingual.unwrap().punctuation_width,
+            Some(PunctuationWidth::Bylan)
+        );
     }
 }

--- a/crates/citum-schema-style/src/options/multilingual.rs
+++ b/crates/citum-schema-style/src/options/multilingual.rs
@@ -57,6 +57,49 @@ pub struct MultilingualConfig {
     pub term_locale: TermLocale,
 }
 
+impl MultilingualConfig {
+    /// Merge another `MultilingualConfig` into this one, with `other` taking
+    /// precedence field by field.
+    ///
+    /// Without this, `Config::merge` replaces the whole block, so a style that
+    /// extends a parent and sets any single multilingual key silently discards
+    /// every inherited one — e.g. adding a `scripts` entry to a style extending
+    /// `gb-t-7714-2025-numeric` dropped the inherited `punctuation-width: mixed`
+    /// and reverted Chinese punctuation to half-width (bean `csl26-p7kj`).
+    ///
+    /// `scripts` merges per key, so an overlay redefines only the scripts it
+    /// names. `realization_default` and `term_locale` are not `Option`, and
+    /// their defaults are indistinguishable from "unset" — both are
+    /// `skip_serializing_if`-elided at their default, so this treats a default
+    /// value as "not specified" and leaves the inherited value in place.
+    pub fn merge(&mut self, other: &MultilingualConfig) {
+        if other.title_mode.is_some() {
+            self.title_mode = other.title_mode.clone();
+        }
+        if other.name_mode.is_some() {
+            self.name_mode = other.name_mode.clone();
+        }
+        if other.preferred_script.is_some() {
+            self.preferred_script = other.preferred_script.clone();
+        }
+        if other.preferred_transliteration.is_some() {
+            self.preferred_transliteration = other.preferred_transliteration.clone();
+        }
+        if other.punctuation_width.is_some() {
+            self.punctuation_width = other.punctuation_width;
+        }
+        for (script, config) in &other.scripts {
+            self.scripts.insert(script.clone(), config.clone());
+        }
+        if !other.realization_default.is_latin() {
+            self.realization_default = other.realization_default;
+        }
+        if !other.term_locale.is_style() {
+            self.term_locale = other.term_locale;
+        }
+    }
+}
+
 /// Which locale a style's engine-supplied terms/messages/date patterns
 /// resolve against: the style's own locale, or each rendered item's
 /// effective language (the biblatex `autolang` analogue). See

--- a/examples/multilingual-refs.yaml
+++ b/examples/multilingual-refs.yaml
@@ -116,7 +116,17 @@ references:
       name: "Nhà xuất bản Giáo dục Việt Nam"
     language: "vi"
 
-  # 7. Chinese book with Pinyin transliteration
+  # 7. Chinese book with Pinyin transliteration.
+  #
+  # 孔子 is a single, indivisible name: 孔 is the family name and 子 an
+  # honorific, NOT a given name, so it must never render as "Kǒng, Z."
+  # A name that cannot be decomposed is written as `name:` — a whole-name
+  # string — rather than `family:`/`given:` parts. `name:` still accepts the
+  # full multilingual form, so the romanization and the conventional English
+  # form ("Confucius") travel with it.
+  #
+  # Corrected per domain-expert review in discussion #828: the pinyin for
+  # 论语 is Lúnyǔ (second tone), not Lùnyǔ.
   - id: confucius_analects
     class: monograph
     type: book
@@ -124,22 +134,17 @@ references:
       original: "论语"
       lang: "zh"
       transliterations:
-        zh-Latn-pinyin: "Lùnyǔ"
+        zh-Latn-pinyin: "Lúnyǔ"
       translations:
         en: "Analects of Confucius"
     author:
-      - original:
-          family: "孔"
-          given: "子"
-        lang: "zh"
-        transliterations:
-          zh-Latn-pinyin:
-            family: "Kǒng"
-            given: "Zǐ"
-        translations:
-          en:
-            family: "Confucius"
-            given: ""
+      - name:
+          original: "孔子"
+          lang: "zh"
+          transliterations:
+            zh-Latn-pinyin: "Kǒngzǐ"
+          translations:
+            en: "Confucius"
     issued: "500 BCE"
     publisher:
       name: "人民文学出版社"

--- a/styles/experimental/multilingual-partitioned.yaml
+++ b/styles/experimental/multilingual-partitioned.yaml
@@ -1,7 +1,29 @@
-# Minimal style to demonstrate automatic script partitioning
+# Minimal style to demonstrate automatic bibliography partitioning.
+#
+# Partitions by LANGUAGE, not by script.
+#
+# Script partitioning (`by: script`) derives its key from the characters of
+# the author sort key and deliberately folds every CJK script into a single
+# `Hani` bucket (see `script_code_for_char` in
+# crates/citum-engine/src/sort_partitioning.rs), so it cannot separate Chinese
+# from Japanese. That is a real limitation, not a configuration mistake:
+# character evidence alone cannot answer the question. As the Unicode
+# Consortium puts it, asking whether a Han character is Chinese or Japanese is
+# "largely impossible and the attempt basically meaningless" — the same
+# character is shared by both writing systems.
+#
+# Chinese and Japanese are different languages and must be listed separately;
+# GB/T 7714—2025 §9.3.2.1 requires exactly that grouping (Chinese, Japanese,
+# Western languages, Russian, and others). Language partitioning uses the
+# item's declared `language` — positive metadata evidence — and separates them
+# correctly. Domain-expert review in discussion #828 confirmed both points.
+#
+# Note that every language you expect must appear in `order` and `headings`.
+# An unlisted language still forms its own partition, but renders with no
+# heading, so its entries read as though they belong to the section above.
 version: "0.10.0"
 info:
-  title: Multilingual Script Partitioning Demo
+  title: Multilingual Language Partitioning Demo
   id: multilingual-partitioned-demo
 extends: modern-language-association
 
@@ -13,15 +35,19 @@ options:
 bibliography:
   options:
     sort-partitioning:
-      by: script
+      by: language
       mode: sort-and-sections
-      order: [Latn, Arab, Hani, Hang]
+      order: [en, vi, ar, zh, ja, ko]
       headings:
-        Latn:
+        en:
           literal: "Western Sources"
-        Arab:
+        vi:
+          literal: "Vietnamese Sources"
+        ar:
           literal: "Arabic Sources"
-        Hani:
-          literal: "Chinese & Japanese Sources"
-        Hang:
+        zh:
+          literal: "Chinese Sources"
+        ja:
+          literal: "Japanese Sources"
+        ko:
           literal: "Korean Sources"


### PR DESCRIPTION
Loose ends from drafting the citum-org multilingual follow-up post ([citum-org#27](https://github.com/citum/citum-org/pull/27)). Two commits: one real engine bug, and the example corrections that came out of domain-expert review in [discussion #828](https://github.com/citum/citum-core/discussions/828#discussioncomment-17636439).

## 1. `fix(schema): merge multilingual config field-wise`

Found while building demos for the post, not by the oracle.

`Config::merge` listed `multilingual` in the whole-value `merge_options!` macro, so **a style that extends a parent and sets any single multilingual key silently discards every inherited one.**

Concretely — adding a completely unrelated `scripts.Hang` block to a style extending `gb-t-7714-2025-numeric`:

```
before:  [1]博伯尔. 银行业的未来与人工智能[M]. 徐超, 译. 北京: 清华大学出版社, 2023: 35.
after:   [1]博伯尔. 银行业的未来与人工智能[M]. 徐超，译. 北京：清华大学出版社，2023：35.
```

The inherited `punctuation-width: mixed` was being dropped, reverting **Chinese** punctuation to half-width — from a block that says nothing about Chinese or about punctuation.

The fix adds `MultilingualConfig::merge` plus a private `Config::merge_multilingual`, matching the field-wise pattern `contributors`, `substitute`, and `punctuation` already use in the same file. `scripts` merges per key. `realization_default` and `term_locale` are not `Option` and are both `skip_serializing_if`-elided at their default, so a default value is treated as "unset" and leaves the inherited value in place — consistent with the serialization contract.

Verified: shipped styles render byte-identically, an explicit override still wins, and the repro above is fixed. Covered by `given_partial_multilingual_overlay_when_merging_then_inherited_fields_survive` (rstest, 2 cases) and `given_multilingual_overlay_setting_a_field_when_merging_then_overlay_wins`.

**Blast radius:** zero in-repo styles declare `multilingual` at more than one scope, and only 6 have any multilingual block, so this only changes behavior for styles that were already silently broken.

## 2. `fix(styles): correct multilingual example errors`

Three errors flagged in review that were never applied:

- **孔子 was split** into `family: 孔` / `given: 子` and rendered "Kǒng, Z." 孔 is the family name and 子 an honorific, not a given name — the name cannot be decomposed. It is now a whole-name `name:`, which still carries its romanization and conventional English form ("Confucius").
- **Wrong pinyin tone** for 论语 — `Lùnyǔ` corrected to `Lúnyǔ`.
- **Chinese and Japanese shared one section** headed "Chinese & Japanese Sources". They are different languages with different writing systems and must list separately.

On that last one: `by: script` derives its key from characters and deliberately folds every CJK script into a single `Hani` bucket, so it *cannot* separate them — this is the case the Unicode Consortium describes as "largely impossible and the attempt basically meaningless." The example now uses `by: language`, which reads declared language metadata and separates them correctly (six sections verified). The header comment explains why.

Also added the missing Vietnamese partition — an unlisted language still forms its own group but renders with no heading, so its entries silently read as part of the section above. Worth knowing.

## Verification

`just pre-commit` green — **2197 tests, fmt + clippy clean**. `just schema-gen` produces no diff (methods only, no public shape change).

## Follow-ups filed, not fixed here

- `csl26-kxhy` — a structured Chinese name (`family: 张` / `given: 伟`) renders `张 伟` with a space; GB/T expects `张伟`. `scripts.Hani.delimiter` provably does not reach the name join (tested with both `""` and `"·"`). Doesn't surface in the corpus because the standard's own data uses whole names.
- `csl26-53ek` — `name-mode: transliterated` is not applied to whole-name contributors, so the schema-correct way to model 孔子 currently *loses* its romanization. Visible in this PR: the corrected entry renders `孔子` where the style asked for romanization. Worth resolving in favor of supporting both.
- `csl26-zq9u` — should `by: script` resolve from language metadata via the ISO 15924 resolver (`zh` → Hans, `ja` → Jpan) instead of character sniffing? That changes partition keys from `Hani`, which is user-visible for externally authored styles, so it needs your call rather than a drive-by change.
