### PR TITLE
feat(engine): configure EDTF year ranges

### DIFF
--- a/.beans/archive/csl26-93yz--add-configurable-edtf-date-range-formatting.md
+++ b/.beans/archive/csl26-93yz--add-configurable-edtf-date-range-formatting.md
@@ -1,0 +1,26 @@
+---
+# csl26-93yz
+title: Add configurable EDTF date-range formatting
+status: completed
+type: feature
+priority: high
+created_at: 2026-07-26T18:16:38Z
+updated_at: 2026-07-26T18:35:27Z
+---
+
+Implement docs/specs/EDTF_DATE_RANGE_FORMATTING.md: date-local expanded/chicago year-range formatting; enable Chicago 18; tests and generated schema.
+
+
+
+## Checklist
+
+- [x] Add the date-range configuration and shared Chicago formatter helper.
+- [x] Configure Chicago 18 and add an active feature spec.
+- [x] Regenerate schema and validate the implementation.
+- [x] Complete the feature bean with verification results.
+
+
+
+## Summary of Changes
+
+Added date-local EDTF year-range formatting with expanded and Chicago modes, enabled Chicago 18 condensation, regenerated the schema, and verified with targeted tests, the Chicago workflow test, and `just pre-commit`.

--- a/.beans/archive/csl26-n54z--generalize-edtf-date-range-formatting.md
+++ b/.beans/archive/csl26-n54z--generalize-edtf-date-range-formatting.md
@@ -1,0 +1,23 @@
+---
+# csl26-n54z
+title: Generalize EDTF date-range formatting
+status: completed
+type: feature
+priority: high
+created_at: 2026-07-26T19:23:00Z
+updated_at: 2026-07-26T19:35:56Z
+---
+
+Extend docs/specs/EDTF_DATE_RANGE_FORMATTING.md for PR #1103: locale MF2 shared-year patterns, same-era BCE Chicago condensation, tests, schema, and documentation.
+
+
+## Checklist
+
+- [x] Add locale MF2 shared-year date-range rendering.
+- [x] Extend Chicago year-range abbreviation to same-era BCE/CE.
+- [x] Update docs, schema, and verification evidence.
+
+
+## Summary of Changes
+
+Added locale-driven shared-year EDTF interval patterns, same-era BCE/CE Chicago year abbreviation, Spanish MF2 examples, documentation, and regression coverage. Verified schema generation, focused tests, Chicago oracle/workflow batch, smell audit, and the full pre-commit gate.

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -12,7 +12,7 @@ use crate::reference::{DateValue, Reference};
 use crate::values::{ComponentValues, ProcHints, ProcValues, RenderOptions};
 use citum_edtf::{Edtf, Timezone, UnspecifiedYear, Year};
 use citum_schema::locale::{GeneralTerm, TermForm};
-use citum_schema::options::dates::TimeFormat;
+use citum_schema::options::dates::{DateRangeFormat, TimeFormat};
 use citum_schema::reference::types::RefDate;
 use citum_schema::reference::{ClassExtension, WorkRelation};
 use citum_schema::template::{
@@ -324,12 +324,18 @@ fn format_closed_range(
     date_config: Option<&citum_schema::options::dates::DateConfig>,
     delimiter: &str,
 ) -> Option<String> {
+    if let Some(rendered) =
+        format_chicago_year_range(interval, form, locale, date_config, delimiter)
+    {
+        return Some(rendered);
+    }
+
     let same_year = interval.start.year.value == interval.end.year.value;
     let both_have_month =
         interval.start.month_or_season.is_some() && interval.end.month_or_season.is_some();
 
     if same_year
-        && both_have_month
+        && (both_have_month || matches!(form, DateForm::Year))
         && let Some(collapsed) = format_same_year_range(
             &interval.start,
             &interval.end,
@@ -358,12 +364,82 @@ fn format_closed_range(
     }
 }
 
+/// Format a closed year interval with Chicago's inclusive-number abbreviation.
+///
+/// EDTF represents BCE years astronomically, so this deliberately formats the
+/// displayed historical numbers rather than relying on ascending numeric input.
+fn format_chicago_year_range(
+    interval: &citum_edtf::Interval,
+    form: &DateForm,
+    locale: &citum_schema::locale::Locale,
+    date_config: Option<&citum_schema::options::dates::DateConfig>,
+    delimiter: &str,
+) -> Option<String> {
+    if !matches!(form, DateForm::Year)
+        || !matches!(
+            date_config.map(|config| &config.range_format),
+            Some(DateRangeFormat::Chicago)
+        )
+        || interval.start.year.unspecified != UnspecifiedYear::None
+        || interval.end.year.unspecified != UnspecifiedYear::None
+        || interval.start.month_or_season.is_some()
+        || interval.end.month_or_season.is_some()
+    {
+        return None;
+    }
+
+    let start_is_bce = interval.start.year.value <= 0;
+    let end_is_bce = interval.end.year.value <= 0;
+    if start_is_bce != end_is_bce || interval.end.year.value <= interval.start.year.value {
+        return None;
+    }
+
+    let start = display_year_number(interval.start.year.value)?;
+    let end = display_year_number(interval.end.year.value)?;
+    let abbreviated_end = crate::values::number::format_chicago_range_end(start, end);
+    let era = chicago_year_range_era_suffix(start_is_bce, locale, date_config);
+    Some(format!("{start}{delimiter}{abbreviated_end}{era}"))
+}
+
+fn display_year_number(year: i64) -> Option<u32> {
+    let historical_year = if year <= 0 {
+        1_i64.checked_sub(year)?
+    } else {
+        year
+    };
+    u32::try_from(historical_year).ok()
+}
+
+fn chicago_year_range_era_suffix(
+    is_bce: bool,
+    locale: &citum_schema::locale::Locale,
+    date_config: Option<&citum_schema::options::dates::DateConfig>,
+) -> String {
+    use citum_schema::options::dates::EraLabels;
+
+    let era_labels = date_config
+        .map(|config| &config.era_labels)
+        .unwrap_or(&EraLabels::Default);
+    let label = match (is_bce, era_labels) {
+        (true, EraLabels::Default) => locale.dates.before_era.as_deref(),
+        (true, EraLabels::BcAd) => locale.dates.bc.as_deref(),
+        (true, EraLabels::BceCe) => locale.dates.bce.as_deref(),
+        (false, EraLabels::Default) => None,
+        (false, EraLabels::BcAd) => locale.dates.ad.as_deref(),
+        (false, EraLabels::BceCe) => locale.dates.ce.as_deref(),
+    };
+    label
+        .filter(|value| !value.is_empty())
+        .map(|value| format!(" {value}"))
+        .unwrap_or_default()
+}
+
 /// Format a closed range whose endpoints share a year, suppressing the
 /// redundant year on one side (e.g. "May 14–June 2, 2023").
 ///
-/// Only forms with a defined month-suppressed companion collapse; other
-/// forms (e.g. abbreviated-month forms with no such companion) return
-/// `None` so the caller falls back to the uncollapsed rendering.
+/// Locale interval patterns receive reduced endpoints and the common year.
+/// When a locale has no pattern, the pre-existing English layouts remain the
+/// fallback for forms that already supported same-year suppression.
 fn format_same_year_range(
     start: &citum_edtf::Date,
     end: &citum_edtf::Date,
@@ -372,26 +448,104 @@ fn format_same_year_range(
     date_config: Option<&citum_schema::options::dates::DateConfig>,
     delimiter: &str,
 ) -> Option<String> {
-    let (start_form, end_form) = match form {
-        DateForm::Full => (DateForm::MonthDay, DateForm::Full),
-        DateForm::YearMonth => (DateForm::Month, DateForm::YearMonth),
-        DateForm::YearMonthDay => (DateForm::YearMonthDay, DateForm::MonthDay),
-        _ => return None,
-    };
+    let start_date = DateValue::new(start.to_string());
+    let end_date = DateValue::new(end.to_string());
+    let start_fragment = format_same_year_fragment(&start_date, form, locale, date_config)?;
+    let end_fragment = format_same_year_fragment(&end_date, form, locale, date_config)?;
+    let shared_year = date_form_displays_year(form)
+        .then(|| format_single_date(&start_date, &DateForm::Year, locale, date_config))
+        .flatten();
 
-    let start_str = format_single_date(
-        &DateValue::new(start.to_string()),
-        &start_form,
-        locale,
-        date_config,
-    )?;
-    let end_str = format_single_date(
-        &DateValue::new(end.to_string()),
-        &end_form,
-        locale,
-        date_config,
-    )?;
-    Some(format!("{start_str}{delimiter}{end_str}"))
+    if let Some(pattern_id) = date_range_pattern_id(form)
+        && let Some(rendered) = locale.resolve_date_range_pattern(
+            pattern_id,
+            &start_fragment,
+            &end_fragment,
+            shared_year.as_deref(),
+        )
+    {
+        return Some(rendered);
+    }
+
+    match form {
+        DateForm::Full => {
+            let end_full = format_single_date(&end_date, &DateForm::Full, locale, date_config)?;
+            Some(format!("{start_fragment}{delimiter}{end_full}"))
+        }
+        DateForm::YearMonth => {
+            let end_full =
+                format_single_date(&end_date, &DateForm::YearMonth, locale, date_config)?;
+            Some(format!("{start_fragment}{delimiter}{end_full}"))
+        }
+        DateForm::YearMonthDay => {
+            let start_full =
+                format_single_date(&start_date, &DateForm::YearMonthDay, locale, date_config)?;
+            Some(format!("{start_full}{delimiter}{end_fragment}"))
+        }
+        _ => None,
+    }
+}
+
+fn date_range_pattern_id(form: &DateForm) -> Option<&'static str> {
+    match form {
+        DateForm::Year => Some("pattern.date-range-year"),
+        DateForm::Month => Some("pattern.date-range-month"),
+        DateForm::MonthDay => Some("pattern.date-range-month-day"),
+        DateForm::YearMonth => Some("pattern.date-range-year-month"),
+        DateForm::Full => Some("pattern.date-range-full"),
+        DateForm::YearMonthDay => Some("pattern.date-range-year-month-day"),
+        DateForm::DayMonthAbbrYear => Some("pattern.date-range-day-month-abbr-year"),
+        DateForm::MonthAbbrDayYear => Some("pattern.date-range-month-abbr-day-year"),
+        _ => None,
+    }
+}
+
+fn format_same_year_fragment(
+    date: &DateValue,
+    form: &DateForm,
+    locale: &citum_schema::locale::Locale,
+    date_config: Option<&citum_schema::options::dates::DateConfig>,
+) -> Option<String> {
+    match form {
+        DateForm::Year => format_single_date(date, &DateForm::Year, locale, date_config),
+        DateForm::Month | DateForm::YearMonth => {
+            format_single_date(date, &DateForm::Month, locale, date_config)
+        }
+        DateForm::Full | DateForm::MonthDay | DateForm::YearMonthDay => {
+            format_single_date(date, &DateForm::MonthDay, locale, date_config)
+        }
+        DateForm::DayMonthAbbrYear | DateForm::MonthAbbrDayYear => {
+            format_abbreviated_month_day_fragment(date, form, locale, date_config)
+        }
+        _ => None,
+    }
+}
+
+fn format_abbreviated_month_day_fragment(
+    date: &DateValue,
+    form: &DateForm,
+    locale: &citum_schema::locale::Locale,
+    date_config: Option<&citum_schema::options::dates::DateConfig>,
+) -> Option<String> {
+    let numeric_months = date_config
+        .is_some_and(|config| config.month == citum_schema::options::MonthFormat::Numeric);
+    if numeric_months && let Some(month) = extract_month_numeric(date) {
+        return Some(match date.day() {
+            Some(day) => format!("{month}-{day:02}"),
+            None => month,
+        });
+    }
+
+    let month = extract_month(date, &locale.dates.months.short, &locale.dates.seasons);
+    if month.is_empty() {
+        return None;
+    }
+    match (form, date.day()) {
+        (DateForm::DayMonthAbbrYear, Some(day)) => Some(format!("{day} {month}")),
+        (DateForm::MonthAbbrDayYear, Some(day)) => Some(format!("{month} {day}")),
+        (_, None) => Some(month),
+        _ => None,
+    }
 }
 
 /// Append a date's opaque `note` (e.g. a source-calendar annotation), wrapped
@@ -1717,6 +1871,7 @@ mod numeric_month_tests {
 mod range_tests {
     use super::*;
     use citum_schema::locale::Locale;
+    use citum_schema::options::dates::{DateConfig, EraLabels};
 
     fn en_us() -> Locale {
         Locale::from_yaml_str(include_str!("../../../../locales/en-US.yaml"))
@@ -1732,6 +1887,33 @@ mod range_tests {
         format_date_range(&DateValue::new(edtf.to_string()), &form, locale, None)
     }
 
+    fn chicago_range(locale: &Locale, edtf: &str, form: DateForm) -> Option<String> {
+        let config = DateConfig {
+            range_format: DateRangeFormat::Chicago,
+            ..Default::default()
+        };
+        format_date_range(
+            &DateValue::new(edtf.to_string()),
+            &form,
+            locale,
+            Some(&config),
+        )
+    }
+
+    fn range_with_config(
+        locale: &Locale,
+        edtf: &str,
+        form: DateForm,
+        config: &DateConfig,
+    ) -> Option<String> {
+        format_date_range(
+            &DateValue::new(edtf.to_string()),
+            &form,
+            locale,
+            Some(config),
+        )
+    }
+
     #[test]
     fn closed_range_year_form_regression() {
         // given a closed range with distinct years and the Year form
@@ -1739,6 +1921,96 @@ mod range_tests {
         assert_eq!(
             range(&en_us(), "2020/2022", DateForm::Year).as_deref(),
             Some("2020–2022")
+        );
+    }
+
+    #[test]
+    fn chicago_year_range_condenses_the_end_year() {
+        assert_eq!(
+            chicago_range(&en_us(), "2021/2026", DateForm::Year).as_deref(),
+            Some("2021–26")
+        );
+    }
+
+    #[test]
+    fn chicago_range_format_keeps_cross_year_month_ranges_expanded() {
+        assert_eq!(
+            chicago_range(&en_us(), "2021-05/2026-06", DateForm::YearMonth).as_deref(),
+            Some("May 2021–June 2026")
+        );
+    }
+
+    #[test]
+    fn shared_year_month_range_uses_spanish_mf2_pattern() {
+        assert_eq!(
+            range(&es_es(), "2026-05/2026-06", DateForm::YearMonth).as_deref(),
+            Some("mayo a junio, 2026")
+        );
+    }
+
+    #[test]
+    fn shared_year_full_range_uses_spanish_mf2_pattern() {
+        assert_eq!(
+            range(&es_es(), "2026-05-14/2026-06-02", DateForm::Full).as_deref(),
+            Some("14 de mayo a 2 de junio de 2026")
+        );
+    }
+
+    #[test]
+    fn chicago_year_range_condenses_same_era_bce_years() {
+        let config = DateConfig {
+            range_format: DateRangeFormat::Chicago,
+            era_labels: EraLabels::BceCe,
+            ..Default::default()
+        };
+        assert_eq!(
+            range_with_config(&en_us(), "-0326/-0020", DateForm::Year, &config).as_deref(),
+            Some("327–21 BCE")
+        );
+    }
+
+    #[test]
+    fn expanded_same_era_bce_years_keep_both_endpoints() {
+        let config = DateConfig {
+            era_labels: EraLabels::BceCe,
+            ..Default::default()
+        };
+        assert_eq!(
+            range_with_config(&en_us(), "-0326/-0020", DateForm::Year, &config).as_deref(),
+            Some("327 BCE–21 BCE")
+        );
+    }
+
+    #[test]
+    fn chicago_year_range_preserves_cross_era_endpoints() {
+        let config = DateConfig {
+            range_format: DateRangeFormat::Chicago,
+            era_labels: EraLabels::BcAd,
+            ..Default::default()
+        };
+        assert_eq!(
+            range_with_config(&en_us(), "-0114/0010", DateForm::Year, &config).as_deref(),
+            Some("115 BC–10 AD")
+        );
+    }
+
+    #[test]
+    fn chicago_year_range_keeps_reversed_input_expanded() {
+        assert_eq!(
+            chicago_range(&en_us(), "2026/2021", DateForm::Year).as_deref(),
+            Some("2026–2021")
+        );
+    }
+
+    #[test]
+    fn chicago_range_format_does_not_condense_non_four_digit_or_unspecified_years() {
+        assert_eq!(
+            chicago_range(&en_us(), "0999/1000", DateForm::Year).as_deref(),
+            Some("999–1000")
+        );
+        assert_eq!(
+            chicago_range(&en_us(), "202u/203u", DateForm::Year).as_deref(),
+            Some("202X–203X")
         );
     }
 
@@ -1800,6 +2072,14 @@ mod range_tests {
         assert_eq!(
             range(&en_us(), "2023-05/2023-06", DateForm::YearMonth).as_deref(),
             Some("May–June 2023")
+        );
+    }
+
+    #[test]
+    fn chicago_range_format_keeps_same_year_month_ranges_locale_driven() {
+        assert_eq!(
+            chicago_range(&en_us(), "2026-05/2026-06", DateForm::YearMonth).as_deref(),
+            Some("May–June 2026")
         );
     }
 

--- a/crates/citum-engine/src/values/number.rs
+++ b/crates/citum-engine/src/values/number.rs
@@ -541,7 +541,7 @@ pub fn format_page_range(
                 PageRangeFormat::Minimal => format_minimal(start, end, 1),
                 PageRangeFormat::MinimalTwo => format_minimal(start, end, 2),
                 PageRangeFormat::Chicago | PageRangeFormat::Chicago16 => {
-                    format_chicago_page_range_end(s, e)
+                    format_chicago_range_end(s, e)
                 }
                 _ => end.to_string(), // Future variants: default to expanded
             };
@@ -579,9 +579,9 @@ pub fn format_minimal(start: &str, end: &str, min_digits: usize) -> String {
         .collect()
 }
 
-/// Format the second number in a Chicago Manual of Style page range.
+/// Format the second number in a Chicago Manual of Style inclusive-number range.
 #[must_use]
-fn format_chicago_page_range_end(start: u32, end: u32) -> String {
+pub(crate) fn format_chicago_range_end(start: u32, end: u32) -> String {
     // Chicago rules:
     // - start < 100: use all digits
     // - start exact multiple of 100: use all digits
@@ -614,10 +614,10 @@ fn format_chicago_page_range_end(start: u32, end: u32) -> String {
     }
 }
 
-/// Format a Chicago Manual of Style page range end.
+/// Format a Chicago Manual of Style inclusive-number range end.
 #[must_use]
 pub fn format_chicago(start: u32, end: u32) -> String {
-    format_chicago_page_range_end(start, end)
+    format_chicago_range_end(start, end)
 }
 
 #[cfg(test)]
@@ -654,7 +654,7 @@ mod tests {
             (13792, 13803, "803"),
             (12991, 13001, "3001"),
         ] {
-            assert_eq!(format_chicago_page_range_end(start, end), expected);
+            assert_eq!(format_chicago_range_end(start, end), expected);
         }
     }
 

--- a/crates/citum-engine/tests/metadata.rs
+++ b/crates/citum-engine/tests/metadata.rs
@@ -318,6 +318,29 @@ fn test_date_rendering_range() {
 }
 
 #[test]
+fn chicago_18_condenses_edtf_year_ranges() {
+    announce_behavior(
+        "Chicago 18 condenses a closed EDTF year range using inclusive-number rules.",
+    );
+    let style = load_style("styles/embedded/chicago-author-date-18th.yaml");
+
+    let mut bib = indexmap::IndexMap::new();
+    let mut item = make_book("item1", "Smith", "J", 2021, "Title");
+    if let ClassExtension::Monograph(monograph) = item.extension_mut() {
+        monograph.issued = citum_schema::reference::DateValue::new("2021/2026".to_string());
+    }
+    bib.insert("item1".to_string(), item);
+
+    let processor = Processor::new(style, bib);
+    assert_eq!(
+        processor
+            .process_citation(&citum_schema::cite!("item1"))
+            .unwrap(),
+        "(Smith 2021–26)"
+    );
+}
+
+#[test]
 fn test_date_rendering_negative_year() {
     announce_behavior("Negative EDTF years render historical years with a locale era suffix.");
     let style = build_date_style(DateForm::Year);

--- a/crates/citum-schema-style/embedded/locales/es-ES.yaml
+++ b/crates/citum-schema-style/embedded/locales/es-ES.yaml
@@ -317,6 +317,12 @@ messages:
   pattern.date-year-month-day: "{$year}, {$day} de {$month}"
   pattern.date-day-month-abbr-year: "{$day} {$month} de {$year}"
   pattern.date-month-abbr-day-year: "{$month} {$day} de {$year}"
+  # Shared-year intervals keep the year outside both endpoint fragments.
+  pattern.date-range-year-month: "{$start} a {$end}, {$year}"
+  pattern.date-range-full: "{$start} a {$end} de {$year}"
+  pattern.date-range-year-month-day: "{$start} a {$end} de {$year}"
+  pattern.date-range-day-month-abbr-year: "{$start} a {$end} de {$year}"
+  pattern.date-range-month-abbr-day-year: "{$start} a {$end} de {$year}"
   date.open-ended: "presente"
 
 date-formats:

--- a/crates/citum-schema-style/embedded/styles/chicago-18-base.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-18-base.yaml
@@ -3,12 +3,18 @@ info:
   description: >-
     Hidden Chicago 18 component base. Carries only the options-level rules
     shared identically by the CMOS author-date and notes heads
-    (page-range format, punctuation-in-quote, demote-non-dropping-particle,
+    (page- and date-range format, punctuation-in-quote, demote-non-dropping-particle,
     multilingual). Never rendered or discovered directly — both heads
     extend it. Rendered order stays per-style; see csl26-40n4.
 options:
   multilingual: romanized-translated
   page-range-format: chicago16
+  dates:
+    month: long
+    uncertainty-marker: "?"
+    approximation-marker: "ca. "
+    range-delimiter: "–"
+    range-format: chicago
   punctuation-in-quote: true
   contributors:
     demote-non-dropping-particle: display-and-sort

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -32,7 +32,7 @@ info:
   short-name: "Chicago Author-Date"
   edition: "18th edition"
 options:
-  # multilingual, page-range-format, punctuation-in-quote, and
+  # multilingual, page-range-format, dates, punctuation-in-quote, and
   # contributors.demote-non-dropping-particle are inherited from chicago-18-base.
   locators: note
   # Chicago author-date disambiguation profile (CMOS 18): add names + global
@@ -54,7 +54,6 @@ options:
     role:
       omit:
       - translator
-  dates: long
   titles:
     # CMOS 18 title-cases nearly every reference-type title (article, book,
     # broadcast, manuscript, motion picture, song, webpage); the engine's

--- a/crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
@@ -34,14 +34,13 @@ info:
   short-name: "Chicago Notes"
   edition: "18th edition"
 options:
-  # multilingual, page-range-format, punctuation-in-quote, and
+  # multilingual, page-range-format, dates, punctuation-in-quote, and
   # contributors.demote-non-dropping-particle are inherited from chicago-18-base.
   processing: note
   substitute: editor-translator-short
   contributors:
     and: text
     delimiter-precedes-last: contextual
-  dates: long
   titles: chicago
 citation:
   delimiter: ""

--- a/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
@@ -43,7 +43,6 @@ options:
       and-others: et-al
       delimiter-precedes-last: contextual
     demote-non-dropping-particle: display-and-sort
-  dates: long
   titles: humanities
   page-range-format: chicago16
   punctuation-in-quote: true

--- a/crates/citum-schema-style/src/locale/date_patterns.rs
+++ b/crates/citum-schema-style/src/locale/date_patterns.rs
@@ -44,4 +44,31 @@ impl Locale {
         };
         self.evaluator.evaluate(message, &args)
     }
+
+    /// Resolve a shared-year `pattern.date-range-*` message with pre-formatted
+    /// endpoint fragments and their common year.
+    ///
+    /// The message is evaluated only for MF2 locales. Callers fall back to
+    /// their established date-form assembly when a locale has not authored
+    /// the requested interval pattern.
+    pub fn resolve_date_range_pattern(
+        &self,
+        message_id: &str,
+        start: &str,
+        end: &str,
+        year: Option<&str>,
+    ) -> Option<String> {
+        let message = self.messages.get(message_id)?;
+        if self.evaluation.message_syntax == MessageSyntax::Static {
+            return None;
+        }
+
+        let args = MessageArgs {
+            start: (!start.is_empty()).then_some(start),
+            end: (!end.is_empty()).then_some(end),
+            year: year.filter(|value| !value.is_empty()),
+            ..MessageArgs::default()
+        };
+        self.evaluator.evaluate(message, &args)
+    }
 }

--- a/crates/citum-schema-style/src/options/dates.rs
+++ b/crates/citum-schema-style/src/options/dates.rs
@@ -46,6 +46,18 @@ pub enum NegativeUnspecifiedYears {
     Fuzzy,
 }
 
+/// Formatting policy for closed EDTF year ranges.
+#[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum DateRangeFormat {
+    /// Render both endpoints in full (for example, `2021–2026`).
+    #[default]
+    Expanded,
+    /// Apply Chicago inclusive-number condensation (for example, `2021–26`).
+    Chicago,
+}
+
 /// Term form for the "no date" fallback when `issued` is empty.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -112,6 +124,9 @@ pub struct DateConfig {
     /// Delimiter for date ranges (default: en-dash "–").
     #[serde(default = "default_range_delimiter")]
     pub range_delimiter: String,
+    /// Formatting policy for closed year ranges (default: expanded).
+    #[serde(default)]
+    pub range_format: DateRangeFormat,
     /// Marker for open-ended ranges (e.g., "–present"). None uses locale default.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub open_range_marker: Option<String>,
@@ -175,6 +190,7 @@ impl Default for DateConfig {
             approximation_marker: Some("ca. ".to_string()),
             approximation_marker_suffix: None,
             range_delimiter: default_range_delimiter(),
+            range_format: DateRangeFormat::default(),
             open_range_marker: None,
             no_date_form: None,
             no_date_year_suffix_delimiter: default_no_date_year_suffix_delimiter(),
@@ -209,6 +225,25 @@ future-key: true
     #[test]
     fn defaults_no_date_year_suffix_delimiter_to_hyphen() {
         assert_eq!(DateConfig::default().no_date_year_suffix_delimiter, "-");
+    }
+
+    #[test]
+    fn defaults_range_format_to_expanded() {
+        assert!(matches!(
+            DateConfig::default().range_format,
+            DateRangeFormat::Expanded
+        ));
+    }
+
+    #[test]
+    fn parses_chicago_range_format() {
+        let yaml = r#"
+month: long
+range-format: chicago
+"#;
+        let cfg: DateConfig = serde_yaml::from_str(yaml).unwrap();
+
+        assert!(matches!(cfg.range_format, DateRangeFormat::Chicago));
     }
 
     #[test]

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -30,7 +30,7 @@ pub use contributors::{
     NameForm, RoleLabelDefaults, RoleLabelPresentation, RoleLabelPreset, RoleOptions,
     RoleOptionsEntry, RoleRendering, ShortenListOptions,
 };
-pub use dates::{DateConfig, DateConfigEntry, NoDateForm};
+pub use dates::{DateConfig, DateConfigEntry, DateRangeFormat, NoDateForm};
 pub use integral_name_memory::{
     IntegralNameContexts, IntegralNameMemoryConfig, IntegralNameScope, OrgAbbreviationMemoryConfig,
     ResolvedIntegralNameMemoryConfig, ResolvedOrgAbbreviationMemoryConfig, ShortNameDisplay,

--- a/crates/citum-schema-style/src/style_base.rs
+++ b/crates/citum-schema-style/src/style_base.rs
@@ -499,7 +499,7 @@ citation:
 
     #[test]
     fn chicago_18_base_carries_shared_component_options() {
-        use crate::options::PageRangeFormat;
+        use crate::options::{DateRangeFormat, PageRangeFormat};
 
         let resolved = StyleBase::Chicago18Base.base().into_resolved();
         let options = resolved.options.expect("chicago-18-base has options");
@@ -508,6 +508,10 @@ citation:
             Some(PageRangeFormat::Chicago16),
             "shared page-range-format must be present"
         );
+        assert!(matches!(
+            options.dates.as_ref().map(|dates| &dates.range_format),
+            Some(DateRangeFormat::Chicago)
+        ));
         assert!(
             options.punctuation_in_quote,
             "shared punctuation-in-quote must be present"

--- a/docs/guides/AUTHORING_LOCALES.md
+++ b/docs/guides/AUTHORING_LOCALES.md
@@ -121,7 +121,8 @@ limitation applies to other gendered locales, including French and Arabic.
 | `pattern.retrieved-from`, `pattern.available-at` | `$url` | Spec'd; not yet consumed by the engine |
 | `pattern.date-full` | `$year`, `$month`, `$day` | Active. See "Date assembly" below. |
 | `pattern.date-month-day` | `$month`, `$day` | Active. |
-| `pattern.date-year-month`, `pattern.date-year-month-day`, `pattern.date-day-month-abbr-year`, `pattern.date-month-abbr-day-year` | as named | Reserved — see spec `LOCALE_MESSAGES.md` §1.5. |
+| `pattern.date-year-month`, `pattern.date-year-month-day`, `pattern.date-day-month-abbr-year`, `pattern.date-month-abbr-day-year` | as named | Active. See spec `LOCALE_MESSAGES.md` §2. |
+| `pattern.date-range-<form>` | `$start`, `$end`, optional `$year` | Active for shared-year EDTF intervals. |
 | `date.open-ended` | none | "present" / "heute" / "presente" |
 
 > **Note on `pattern.*` messages.** No engine call site currently passes
@@ -174,6 +175,22 @@ A pattern that references a missing component (e.g. `pattern.date-full` uses
 `{$day}` but the input has no day) returns `None`, and the engine falls back
 to its English assembly. Author a separate `pattern.date-year-month` once
 that ID is wired if you need a no-day form to stay locale-shaped.
+
+### Shared-year date ranges
+
+For a closed range whose endpoints share a year, locales can control the
+connector and year placement with `pattern.date-range-<form>`. The engine
+passes pre-formatted endpoint fragments as `$start` and `$end`; `$year` is
+available when the selected date form normally displays a year.
+
+```yaml
+# es-ES
+messages:
+  pattern.date-range-year-month: "{$start} a {$end}, {$year}"
+```
+
+This renders a May-to-June 2026 interval as `mayo a junio, 2026`. Distinct-year
+ranges remain separately formatted endpoints in this release.
 
 ### Sourcing minority-language grammar
 

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -5260,6 +5260,11 @@
           "type": "string",
           "default": "–"
         },
+        "range-format": {
+          "description": "Formatting policy for closed year ranges (default: expanded).",
+          "$ref": "#/$defs/DateRangeFormat",
+          "default": "expanded"
+        },
         "open-range-marker": {
           "description": "Marker for open-ended ranges (e.g., \"–present\"). None uses locale default.",
           "type": [
@@ -5346,6 +5351,21 @@
         "long",
         "short",
         "numeric"
+      ]
+    },
+    "DateRangeFormat": {
+      "description": "Formatting policy for closed EDTF year ranges.",
+      "oneOf": [
+        {
+          "description": "Render both endpoints in full (for example, `2021–2026`).",
+          "type": "string",
+          "const": "expanded"
+        },
+        {
+          "description": "Apply Chicago inclusive-number condensation (for example, `2021–26`).",
+          "type": "string",
+          "const": "chicago"
+        }
       ]
     },
     "NoDateForm": {

--- a/docs/specs/EDTF_DATE_RANGE_FORMATTING.md
+++ b/docs/specs/EDTF_DATE_RANGE_FORMATTING.md
@@ -1,0 +1,63 @@
+# EDTF Date-Range Formatting Specification
+
+**Status:** Active
+**Version:** 1.1
+**Date:** 2026-07-26
+**Related:** `.beans/archive/csl26-n54z--generalize-edtf-date-range-formatting.md`, [CSL forum discussion](https://discourse.citationstyles.org/t/date-ranges-should-support-abbreviated-condensed-year-formatting-cmos-18-9-63-9-66/2048)
+
+## Purpose
+
+Allow styles and locales to control closed EDTF date intervals without changing canonical EDTF input, date parsing, or page-range configuration.
+
+## Scope
+
+This specification covers closed EDTF intervals. It excludes page ranges and open intervals. Distinct-year ranges retain endpoint-by-endpoint assembly; locale interval messages apply when both endpoints share a year.
+
+## Design
+
+`options.dates.range-format` accepts:
+
+```yaml
+options:
+  dates:
+    range-format: expanded | chicago
+```
+
+- `expanded` is the default and renders both endpoints in full: `2021/2026` becomes `2021–2026`.
+- `chicago` applies the existing Chicago inclusive-number algorithm: `2021/2026` becomes `2021–26`.
+
+Chicago abbreviation applies only to fully specified, year-only intervals in the
+same era. It formats displayed historical numbers, so the same rule supports
+BCE values (`-0326/-0020` becomes `327–21 BCE` when BCE/CE labels are active).
+Cross-era, unspecified, reversed, and open intervals retain endpoint-by-endpoint
+rendering.
+
+This option is independent of `page-range-format`. The Chicago 18 shared style base opts into `chicago`; all other styles retain `expanded` until explicitly configured.
+
+### Shared-year locale messages
+
+Locales may customize shared-year intervals with `pattern.date-range-<form>`
+MF2 messages. The engine supplies reduced endpoint fragments as `$start` and
+`$end`, plus `$year` when the selected date form displays a year. For example:
+
+```yaml
+messages:
+  pattern.date-range-year-month: "{$start} a {$end}, {$year}"
+```
+
+This renders `2026-05/2026-06` as `mayo a junio, 2026` in Spanish. If no
+locale pattern is authored, existing English fallback layouts remain unchanged.
+
+## Acceptance Criteria
+
+- [x] Styles can deserialize `options.dates.range-format: chicago`.
+- [x] Unconfigured styles retain expanded year ranges.
+- [x] Chicago rendering condenses `2021/2026` to `2021–26`.
+- [x] Chicago rendering supports same-era BCE intervals without changing cross-era output.
+- [x] Locales can configure shared-year interval grammar through MF2 messages.
+- [x] Non-year and exceptional EDTF ranges retain their existing rendering unless a matching locale interval pattern is authored.
+
+## Changelog
+
+- v1.0 (2026-07-26): Initial specification.
+- v1.1 (2026-07-26): Add same-era BCE Chicago abbreviation and shared-year MF2 interval patterns.

--- a/docs/specs/LOCALE_MESSAGES.md
+++ b/docs/specs/LOCALE_MESSAGES.md
@@ -398,7 +398,7 @@ message evaluation suppresses the component rather than emitting partial glue.
 
 #### Supported `pattern.date-*` IDs
 
-One ID per engine `DateForm` variant. All six are **Active** —
+One ID per year- or day-bearing engine `DateForm` variant. All six are **Active** —
 the engine consults each pattern before falling through to hardcoded English
 assembly when the locale does not author the ID.
 
@@ -416,6 +416,26 @@ A pattern that references a missing component (e.g. `pattern.date-full` uses
 and the engine falls back to its hardcoded assembly. For inflected locales
 needing year-month-only output, author `pattern.date-year-month` (see
 `es-ES.yaml` and `eu-ES.yaml` for examples).
+
+#### Supported shared-year `pattern.date-range-*` IDs
+
+The engine evaluates these interval messages only for closed ranges whose
+endpoints share a year and include a month or season, plus `DateForm::Year`.
+`$start` and `$end` are
+reduced endpoint fragments; `$year` is supplied only for date forms that
+display a year. Without an authored interval message, the engine preserves its
+existing date-form fallback layout.
+
+| Message ID | Variables | `DateForm` | Status |
+|---|---|---|---|
+| `pattern.date-range-year` | `$start`, `$end`, `$year` | `Year` | **Active** |
+| `pattern.date-range-month` | `$start`, `$end` | `Month` | **Active** |
+| `pattern.date-range-month-day` | `$start`, `$end` | `MonthDay` | **Active** |
+| `pattern.date-range-year-month` | `$start`, `$end`, `$year` | `YearMonth` | **Active** |
+| `pattern.date-range-full` | `$start`, `$end`, `$year` | `Full` | **Active** |
+| `pattern.date-range-year-month-day` | `$start`, `$end`, `$year` | `YearMonthDay` | **Active** |
+| `pattern.date-range-day-month-abbr-year` | `$start`, `$end`, `$year` | `DayMonthAbbrYear` | **Active** |
+| `pattern.date-range-month-abbr-day-year` | `$start`, `$end`, `$year` | `MonthAbbrDayYear` | **Active** |
 
 Legacy CSL-style term keys (`page`, `et_al`, `no_date`, …) remain accessible
 via the `legacyTermAliases` map on `LocalePreset`, which redirects old keys to

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -133,6 +133,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | [`CSL_TYPE_CONVERSION_CONTRACT.md`](./CSL_TYPE_CONVERSION_CONTRACT.md) — CSL 1.0.2 type vocabulary, routing closure, and note-override validation | Active | `crates/citum-schema-data/src/reference/conversion/contract_tests.rs` |
 | [`GENERALIZED_RELATIONAL_CONTAINER_MODEL.md`](./GENERALIZED_RELATIONAL_CONTAINER_MODEL.md) — recursive relational container model replacing flat variables | Active | `metadata.rs` |
 | [`DATE_MODEL.md`](./DATE_MODEL.md) — refined date model for created vs. issued distinction | Active | `metadata.rs` |
+| [`EDTF_DATE_RANGE_FORMATTING.md`](./EDTF_DATE_RANGE_FORMATTING.md) — style-configurable condensed EDTF year ranges | Active | `date.rs`, `metadata.rs` |
 | [`CALENDAR_DATE_ANNOTATIONS.md`](./CALENDAR_DATE_ANNOTATIONS.md) — EDTF dates with an optional, style-controlled opaque note | Active | `crates/citum-schema-data/src/reference/date.rs`, `crates/citum-engine/tests/date_annotations.rs` |
 | [`NUMBERING_SEMANTICS.md`](./NUMBERING_SEMANTICS.md) — canonical semantics for numbering, report, and part fields | Active | `metadata.rs` |
 | [`ARCHIVAL_UNPUBLISHED_SUPPORT.md`](./ARCHIVAL_UNPUBLISHED_SUPPORT.md) — ArchiveInfo and EprintInfo first-class source support | Active | `metadata.rs` |


### PR DESCRIPTION
## Summary

- Add `options.dates.range-format` with `expanded` (default) and `chicago` modes, independent of page-range formatting.
- Reuse Chicago inclusive-number abbreviation for closed, year-only same-era CE and BCE intervals; cross-era, reversed, open, and unspecified ranges retain endpoint rendering.
- Add MF2 `pattern.date-range-<form>` messages for shared-year intervals, with Spanish examples such as `mayo a junio, 2026`.
- Enable Chicago 18 in the shared base and document the configuration and locale-message contract.

## Validation

- `just schema-gen`
- Focused EDTF range suite: 18 passing tests
- `python3 scripts/audit-rust-review-smells.py --changed`
- Chicago oracle: 20/20 citations and 46/46 bibliography
- Batch workflow check: Chicago remains 20/20 citations and 46/46 bibliography
- `just pre-commit` (fmt, clippy, 2210 nextest cases)

## Risk

`expanded` remains the default. Chicago abbreviation is limited to fully specified, closed, year-only intervals in one era. Shared-year locale messages are opt-in; locales without a pattern retain existing fallback layouts. Distinct-year grammatical interval patterns remain a follow-up.
