### PR TITLE
docs(report): refresh compat.html read-this copy

### DIFF
--- a/.beans/archive/csl26-wolw--refresh-compathtml-how-to-read-section-for-portfol.md
+++ b/.beans/archive/csl26-wolw--refresh-compathtml-how-to-read-section-for-portfol.md
@@ -1,0 +1,33 @@
+---
+# csl26-wolw
+title: Refresh compat.html How-To-Read section for portfolio
+status: completed
+type: task
+priority: normal
+created_at: 2026-07-30T13:05:02Z
+updated_at: 2026-07-30T13:10:48Z
+parent: csl26-s2rw
+---
+
+PR D of style-corpus split cleanup. Update generateHtmlSqiExplainer() in scripts/report-core.js to explain the three-tier portfolio (embedded/exemplar/community), the family header rows in generateHtmlTable(), and that biblatex is a separate authority from citeproc-js. Verify the compatibility and SQI targets still hold post-refocus before restating them. Regenerate docs/compat.html via node scripts/report-core.js --write-html; refresh styles/README.md and docs/reference/SQI.md if targets change. Closes csl26-20l7 and csl26-zi01. Depends on PR A (csl26-5lt5, archived/completed). Full plan: /home/bruce/.claude/plans/there-are-some-style-imperative-wand.md section D
+
+## Summary of Changes
+
+Made generateHtmlSqiExplainer() data-driven (takes report, computes live
+embedded-tier mean compatibility/SQI) instead of static text. Added: the
+three-tier portfolio explanation (embedded/exemplar/community, with current
+counts), an explanation of the family header rows generateHtmlTable() emits
+(root = top of the extends chain; most styles are still singleton families),
+and a note that biblatex is a separate authority from citeproc-js, naming
+numeric-comp as the current example.
+
+Verified the stated ">=95% compatibility / >=90 SQI" targets: they were
+never enforced as literal numbers anywhere in code (the real gate,
+check-core-quality.js, checks per-style baseline drift, not an aggregate).
+Current live measurement is 94.7% mean compatibility / 96.9 mean SQI across
+the 19 embedded styles -- kept as directional working targets, but the
+explainer now shows the current measured value alongside the target instead
+of only the stale target, and docs/reference/SQI.md was updated to match
+(mean-across-embedded-tier framing, explicit pointer to the real gate).
+
+docs/compat.html regenerated via --write-html; 216/216 JS tests pass.

--- a/.beans/csl26-20l7--refocus-compat-report-headline-on-embedded-set.md
+++ b/.beans/csl26-20l7--refocus-compat-report-headline-on-embedded-set.md
@@ -8,7 +8,7 @@ tags:
     - scorecard
     - styles
 created_at: 2026-07-28T14:40:02Z
-updated_at: 2026-07-28T14:40:19Z
+updated_at: 2026-07-30T13:11:14Z
 parent: csl26-s2rw
 blocked_by:
     - csl26-pt1f
@@ -20,3 +20,5 @@ After the community split, scripts/report-core.js default selection = embedded s
 - [ ] Headline portfolio metrics computed over embedded tier only
 - [ ] Refresh docs/compat.html and core-quality baseline
 - [ ] Keep --styles-dir escape hatch for community-repo runs
+
+Progress from csl26-wolw (docs/compat-how-to-read-refresh branch): docs/compat.html regenerated via --write-html with the embedded-tier headline explainer, tier counts, and live-computed mean compat/SQI. The other three checklist items (default embedded+exemplar selection, headline-over-embedded metrics, --styles-dir escape hatch) already existed in report-core.js pre-dating this work -- not re-verified against every acceptance detail here, so leaving this bean open rather than closing outright. core-quality-baseline.json was not touched (baseline refresh is a distinct, deliberate step).

--- a/.beans/csl26-zi01--update-style-corpus-docs-and-why-citum-framing.md
+++ b/.beans/csl26-zi01--update-style-corpus-docs-and-why-citum-framing.md
@@ -8,7 +8,7 @@ tags:
     - styles
     - dx
 created_at: 2026-07-28T14:40:02Z
-updated_at: 2026-07-28T14:40:19Z
+updated_at: 2026-07-30T13:11:14Z
 parent: csl26-s2rw
 blocked_by:
     - csl26-20l7
@@ -19,3 +19,5 @@ After split + report refocus: update styles/README.md, crates/README.md pointers
 - [ ] styles/README.md: three-tier table, link disposition TSV and spec
 - [ ] README/crates README: corpus references updated
 - [ ] Why-Citum narrative reviewed by Bruce before merge (content decision)
+
+styles/README.md three-tier table already exists (updated for numeric-comp counts in csl26-5lt5/PR A). The why-Citum narrative review and README/crates README pointer updates are not addressed by this session's work -- leaving open.

--- a/docs/compat.html
+++ b/docs/compat.html
@@ -142,10 +142,10 @@
                 </div>
             </div>
             <div class="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
-                <div class="text-sm text-slate-500 font-mono">Generated: Wed, 29 Jul 2026 19:42:35 GMT</div>
+                <div class="text-sm text-slate-500 font-mono">Generated: Thu, 30 Jul 2026 13:09:25 GMT</div>
                 <div class="inline-flex items-center gap-2 px-3 py-1 rounded bg-slate-100 text-slate-700 text-xs font-mono border border-slate-200">
                     <span class="material-icons text-sm">code</span>
-                    <span>4bc9fb3e</span>
+                    <span>fb0a01af</span>
                 </div>
             </div>
             <div class="mt-5 flex flex-wrap gap-3 text-sm font-medium">
@@ -164,7 +164,7 @@
                 <div class="bg-[var(--citum-surface)] rounded-xl border border-slate-200 p-6">
                     <div class="text-sm font-medium text-slate-500 mb-2">Embedded Styles</div>
                     <div class="text-3xl font-bold text-slate-900">19</div>
-                    <div class="text-xs text-slate-400 mt-2">57.87% known CSL dependent coverage · 15 exemplars reported separately</div>
+                    <div class="text-xs text-slate-400 mt-2">57.87% known CSL dependent coverage · 16 exemplars reported separately</div>
                 </div>
 
                 <!-- Citations Overall -->
@@ -177,15 +177,15 @@
                 <!-- Bibliography Overall -->
                 <div class="bg-[var(--citum-surface)] rounded-xl border border-slate-200 p-6">
                     <div class="text-sm font-medium text-slate-500 mb-2">Bibliography</div>
-                    <div class="text-3xl font-bold text-slate-900">2385/2609</div>
-                    <div class="text-xs text-slate-400 mt-2">91.4% pass rate · 74 unresolved pairing candidates excluded</div>
+                    <div class="text-3xl font-bold text-slate-900">2383/2609</div>
+                    <div class="text-xs text-slate-400 mt-2">91.3% pass rate · 74 unresolved pairing candidates excluded</div>
                 </div>
 
                 <!-- Unadjudicated Oracle Text Parity -->
                 <div class="bg-[var(--citum-surface)] rounded-xl border border-slate-200 p-6">
                     <div class="text-sm font-medium text-slate-500 mb-2">Oracle Text Parity</div>
-                    <div class="text-3xl font-bold text-slate-900">1252/3255</div>
-                    <div class="text-xs text-slate-400 mt-2">38.5% unadjudicated, non-gating · 74 N/A</div>
+                    <div class="text-3xl font-bold text-slate-900">1260/3255</div>
+                    <div class="text-xs text-slate-400 mt-2">38.7% unadjudicated, non-gating · 74 N/A</div>
                 </div>
 
                 <!-- Quality Overall -->
@@ -204,16 +204,40 @@
             <div class="bg-[var(--citum-surface)] rounded-xl border border-slate-200 p-6">
                 <h2 class="text-lg font-semibold text-slate-900 mb-2">How To Read This Report</h2>
                 <p class="text-sm text-slate-600 mb-3">
+                    This report covers a three-tier style portfolio. <strong>Embedded</strong> (19 styles) is
+                    Citum's compiled product surface and the headline this report scores against; the stats above and the
+                    working targets below cover this tier only. <strong>Exemplar</strong> (16 styles,
+                    listed separately in the table below) are Rust-test fixtures, embedded-parent wrapper examples, or unique
+                    behavior coverage — reported for visibility, not gated. The long-tail <strong>community</strong> corpus lives
+                    in <a class="text-primary hover:underline" href="https://github.com/citum/citum-styles">citum-styles</a>; its
+                    parity values are advisory and do not appear in this report at all.
+                </p>
+                <p class="text-sm text-slate-600 mb-3">
                     <strong>Compatibility</strong> is the existing lenient regression gate; it can tolerate meaningful text-level drift.
                     <strong>Oracle text parity</strong> is the stricter, symmetric comparison of visible renderer text.
                     <strong>SQI</strong> (Style Quality Index) is secondary: it scores maintainability and fallback quality.
+                    Most styles are verified against the <strong>citeproc-js</strong> oracle; a small number of biblatex-derived
+                    styles (currently just <code>numeric-comp</code>, in the exemplar tier) instead use
+                    <strong>biblatex</strong> as their primary authority, because biblatex is the only origin format for the
+                    compound-numeric grouping feature they exercise — the <strong>Authority</strong> column shows which applies
+                    per style.
                 </p>
                 <p class="text-sm text-slate-600 mb-4">
-                    Current working targets remain <code>&gt;=95% compatibility</code> and <code>&gt;=90 SQI</code>.
-                    Oracle text parity is informational until each drift is adjudicated and family-level ratchets are defined.
+                    Working targets for the embedded tier remain <code>&gt;=95% mean compatibility</code> and
+                    <code>&gt;=90 mean SQI</code>; as of this report the embedded tier measures
+                    <code>94.7% compatibility</code> and <code>96.9 SQI</code> (mean across 19 styles).
+                    These are directional targets, not a per-style gate — the enforced gate
+                    (<code>scripts/check-core-quality.js</code>) checks fidelity and SQI drift against a recorded baseline per
+                    style, not this aggregate. Oracle text parity is informational until each drift is adjudicated and
+                    family-level ratchets are defined.
                 </p>
                 <p class="text-sm text-slate-600 mb-4">
-                    <strong>Lineage</strong> shows the source family a style derives from.
+                    <strong>Lineage</strong> shows the source family a style derives from. Below the headline tiles, styles are
+                    grouped under <strong>family header rows</strong> (root style name, member count, alias count, aggregate CSL
+                    reach): the root is the top of a style's <code>extends</code> chain, so a family groups only styles that
+                    literally extend a common ancestor. A style with no <code>extends</code> is its own singleton family, root
+                    equal to itself — most embedded and exemplar styles fall in this category today; visually related styles
+                    (e.g. same publisher) are not automatically grouped unless one actually extends another.
                     <strong>Oracle text parity</strong> preserves numbering, case, punctuation, brackets, and role labels after transport markup is removed.
                     A drift may be a Citum defect, an oracle defect, an intentional divergence, or unresolved; parity alone does not assign fault.
                     Similarity outputs without an established counterpart are excluded from both metrics and appear only as neutral pairing diagnostics.
@@ -37931,6 +37955,689 @@
                 </tr>
 
                 <tr class="family-header border-y border-slate-300 bg-slate-100"
+                    data-family-root="numeric-comp">
+                    <td colspan="13" class="px-6 py-3">
+                        <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
+                            <span class="font-semibold text-slate-900">numeric-comp</span>
+                            <span class="text-xs text-slate-500">1 member</span>
+                            <span class="text-xs text-slate-500">no aliases</span>
+                            <span class="text-xs font-mono text-slate-600">aggregate CSL reach 0</span>
+                        </div>
+                    </td>
+                </tr>
+
+                <tr class="border-b border-slate-200 hover:bg-slate-50 accordion-toggle"
+                    data-toggle="toggle-numeric-comp"
+                    data-detail-id="content-numeric-comp"
+                    data-family-root="numeric-comp"
+                    data-style-name="numeric-comp"
+                    data-search="numeric-comp numeric-comp standalone numeric-comp unavailable"
+                    data-format="numeric"
+                    data-origin="biblatex-derived"
+                    data-csl-reach="-1"
+                    data-citation-rate="-1"
+                    data-bibliography-rate="0.9361702127659575"
+                    data-component-rate="0.996"
+                    data-fidelity="0.936"
+                    data-exact-parity="0"
+                    data-quality="0.893"
+                    data-sqi-tier-rank="3">
+                    <td class="px-6 py-4 text-sm font-medium text-slate-900">
+                        <div>numeric-comp</div>
+                        <div class="mt-1 text-[11px] font-normal text-slate-500">
+                            standalone · numeric-comp
+                        </div>
+                    </td>
+                    <td class="hidden md:table-cell px-6 py-4 text-sm text-slate-600">numeric</td>
+                    <td class="hidden md:table-cell px-6 py-4 text-sm text-slate-600">biblatex-derived</td>
+                    <td class="hidden md:table-cell px-6 py-4 text-sm text-slate-500 font-mono">biblatex: numeric-comp</td>
+                    <td class="hidden md:table-cell px-6 py-4 text-sm text-slate-600">—</td>
+                    <td class="hidden md:table-cell px-6 py-4">
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-pending">
+                            0/0
+                        </span>
+                    </td>
+                    <td class="hidden md:table-cell px-6 py-4">
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-partial">
+                            44/47
+                        </span>
+
+                    </td>
+                    <td class="hidden md:table-cell px-6 py-4">
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
+                    </td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">93.6%</td>
+                    <td class="px-6 py-4">
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-failing">
+                            0/47
+                        </span>
+
+                    </td>
+                    <td class="hidden md:table-cell px-6 py-4 text-sm font-mono text-slate-600">89.3%</td>
+                    <td class="px-6 py-4">
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-blue-100 text-blue-700">
+                            B
+                        </span>
+                    </td>
+                    <td class="px-6 py-4 text-right">
+                        <button class="text-slate-500 hover:text-primary text-xs font-medium transition-colors" onclick="toggleAccordion('content-numeric-comp')">
+                            <span class="material-icons text-base align-middle">expand_more</span>
+                        </button>
+                    </td>
+                </tr>
+                <tr class="accordion-content" id="content-numeric-comp">
+                    <td colspan="13" class="px-6 py-4 bg-slate-50">
+                        <div class="max-w-4xl">
+
+                            <div class="mb-4 p-3 rounded border border-slate-200 bg-[var(--citum-surface)]">
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Verification Context</div>
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-2 text-xs">
+                                    <div><span class="font-semibold text-slate-700">Lineage:</span> <span class="font-mono text-slate-600">biblatex-derived</span></div>
+                                    <div><span class="font-semibold text-slate-700">Authority:</span> <span class="font-mono text-slate-600">biblatex: numeric-comp</span></div>
+
+
+                                    <div><span class="font-semibold text-slate-700">Secondary:</span> <span class="font-mono text-slate-600">citeproc-js</span></div>
+                                    <div><span class="font-semibold text-slate-700">Regression baseline:</span> <span class="font-mono text-slate-600">Citum baseline</span></div>
+                                    <div><span class="font-semibold text-slate-700">CSL Reach:</span> <span class="font-mono text-slate-600">—</span></div>
+                                    <div><span class="font-semibold text-slate-700">Family:</span> <span class="font-mono text-slate-600">numeric-comp</span></div>
+                                    <div><span class="font-semibold text-slate-700">Implementation:</span> <span class="font-mono text-slate-600">standalone</span></div>
+                                    <div class="md:col-span-2"><span class="font-semibold text-slate-700">Inheritance:</span> <span class="font-mono text-slate-600">numeric-comp</span></div>
+                                    <div><span class="font-semibold text-slate-700">Registry kind:</span> <span class="font-mono text-slate-600">independent</span></div>
+                                    <div><span class="font-semibold text-slate-700">Aliases (0):</span> <span class="font-mono text-slate-600">—</span></div>
+                                    <div><span class="font-semibold text-slate-700">Near-clone band:</span> <span class="font-mono text-slate-600">unavailable</span></div>
+                                    <div><span class="font-semibold text-slate-700">Derivability:</span> <span class="font-mono text-slate-600">unavailable</span></div>
+                                </div>
+
+                                <div class="mt-3 text-xs text-slate-600"><strong>Note:</strong> Authority follows biblatex numeric-comp. Citum snapshots remain only as a regression baseline.</div>
+                            </div>
+
+                            <div class="mb-4 p-3 rounded border border-slate-200 bg-[var(--citum-surface)]">
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Quality (SQI): 89.3%</div>
+                                <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs font-mono">
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">type 92.2%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">fallback 100.0%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">concision 80.2%</div>
+                                    <div class="px-2 py-1 rounded bg-slate-100 text-slate-700">presets 80.0%</div>
+                                </div>
+                                <div class="mt-2 text-xs text-slate-500 font-mono">
+                                    scopes 5 · variants 4 · exact dupes 2 · near dupes 3
+                                </div>
+                            </div>
+
+                            <div class="mb-4">
+                                <div class="text-xs font-semibold text-slate-900 mb-2">Citation Type Coverage (27 types)</div>
+                                <div class="flex flex-wrap gap-2">
+
+                                    <span class="px-2 py-1 rounded bg-red-100 text-red-700 text-xs font-mono">
+                                        entry-dictionary 0/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-red-100 text-red-700 text-xs font-mono">
+                                        map 0/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-red-100 text-red-700 text-xs font-mono">
+                                        patent 0/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        article-journal 15/15
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        article-magazine 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        article-newspaper 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        bill 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        book 6/6
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        broadcast 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        chapter 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        dataset 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        entry-encyclopedia 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        hearing 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        interview 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        legal_case 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        legislation 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        manuscript 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        motion_picture 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        paper-conference 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        personal_communication 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        regulation 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        report 2/2
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        software 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        standard 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        thesis 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        treaty 1/1
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-emerald-100 text-emerald-700 text-xs font-mono">
+                                        webpage 1/1
+                                    </span>
+
+                                </div>
+                            </div>
+
+                            <div class="mt-4">
+                                <div class="text-xs font-semibold text-slate-900 mb-1">Bibliography Evidence</div>
+                                <div class="text-xs text-slate-500 mb-3">47 paired · 0 unresolved-unpaired · 0 ID-proven one-sided</div>
+
+                                <section class="mb-5 rounded border border-slate-200 bg-[var(--citum-surface)] p-3">
+                                    <div class="mb-1 text-xs font-semibold text-slate-800">Core compatibility baseline</div>
+                                    <div class="mb-3 text-[11px] text-slate-500">Authority: biblatex: numeric-comp · 47 paired · 0 unresolved · 0 ID-proven one-sided</div>
+
+                                <div class="overflow-x-auto">
+                                    <table class="w-full text-xs border-collapse">
+                                        <thead>
+                                            <tr class="border-b border-slate-300 bg-slate-100">
+                                                <th class="text-left px-2 py-1 font-medium text-slate-700">Item</th>
+                                                <th class="text-left px-2 py-1 font-medium text-slate-700">Benchmark</th>
+                                                <th class="text-left px-2 py-1 font-medium text-slate-700">Citum</th>
+                                                <th class="text-center px-2 py-1 font-medium text-slate-700">Compatibility</th>
+                                                <th class="text-center px-2 py-1 font-medium text-slate-700">Oracle Text</th>
+                                                <th class="text-left px-2 py-1 font-medium text-slate-700">Issues</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[1] Thomas S. Kuhn. “The Structure of Scientific Revolutions”. In: International Encyclopedia of Unified Science 2.2 (1962). doi: 10.1234/example.">[1] Thomas S. Kuhn. “The <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Structure of Scientific Revolutions”. In: International Encyclopedia of …</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[1] Thomas S. Kuhn. “The structure of scientific revolutions” In: International Encyclopedia of Unified Science. University of Chicago Press. 2 (1962) doi: 10.1234/example">[1] Thomas S. Kuhn. “The <mark class="rounded bg-amber-200 px-0.5 text-slate-900">structure of scientific revolutions” In: International Encyclopedia of U…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ26)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[2] Stephen Hawking. A Brief History of Time. New York: Bantam Dell Publishing Group, 1988.">[2] Stephen Hawking. A <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Brief History of Time. New York: Bantam Dell Publishing Group, 1988</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[2] Stephen Hawking. A brief history of time. Bantam Dell Publishing Group: New York (1988).">[2] Stephen Hawking. A <mark class="rounded bg-amber-200 px-0.5 text-slate-900">brief history of time. Bantam Dell Publishing Group: New York (1988)</mark>.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ24)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[3] Yann LeCun, Yoshua Bengio, and Geoffrey Hinton. “Deep Learning”. In: Nature 521 (2015), pp. 436–444. doi: 10.1038/nature14539.">[3] Yann LeCun, Yoshua Bengio<mark class="rounded bg-amber-200 px-0.5 text-slate-900">, and Geoffrey Hinton. “Deep Learning”. In: Nature 521 (2015), pp. 436–4…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[3] Yann LeCun, Yoshua Bengio and Geoffrey Hinton. “Deep learning” In: Nature. 521 (2015). 436–444 doi: 10.1038/nature14539">[3] Yann LeCun, Yoshua Bengio<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> and Geoffrey Hinton. “Deep learning” In: Nature. 521 (2015). 436–444 do…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ30)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[4] K. Anders Ericsson. “The Role of Deliberate Practice”. In: The Cambridge Handbook of Expertise and Expert Performance. Ed. by K. Anders Ericsson et al. Cambridge University Press, 2006, pp. 683–703.">[4] K. Anders Ericsson. “The <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Role of Deliberate Practice”. In: The Cambridge Handbook of Expertise an…</mark>. 683–703.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[4] K. Anders Ericsson. “The role of deliberate practice” In: The cambridge handbook of expertise and expert performance. Edited by K. Anders Ericsson et al. Cambridge University Press (2006). 683–703.">[4] K. Anders Ericsson. “The <mark class="rounded bg-amber-200 px-0.5 text-slate-900">role of deliberate practice” In: The cambridge handbook of expertise and…</mark>. 683–703.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ30)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[5] World Bank. World Development Report 2023. Tech. rep. Washington, DC, 2023.">[5] World Bank. World <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Development Report 2023. Tech. rep. Washington, DC, 2023</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[5] World Bank. World development report 2023. World Bank Group: Washington, DC (2023).">[5] World Bank. World <mark class="rounded bg-amber-200 px-0.5 text-slate-900">development report 2023. World Bank Group: Washington, DC (2023)</mark>.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ23)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[6] Gerald M. Weinberg and Daniel P. Freedman. The Psychology of Computer Programming. New York: Van Nostrand Reinhold, 1971.">… Gerald M. Weinberg and Daniel P. Freedman. The <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Psychology of Computer Programming. New York: Van Nostrand Reinhold, 197…</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[6] Gerald M. Weinberg and Daniel P. Freedman. The psychology of computer programming. Van Nostrand Reinhold: New York (1971).">… Gerald M. Weinberg and Daniel P. Freedman. The <mark class="rounded bg-amber-200 px-0.5 text-slate-900">psychology of computer programming. Van Nostrand Reinhold: New York (197…</mark>.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ52)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[7] Ashish Vaswani et al. “Attention Is All You Need”. In: Advances in Neural Information Processing Systems 30 (2017), pp. 5998–6008.">[7] Ashish Vaswani et al. “Attention <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Is All You Need”. In: Advances in Neural Information Processing Systems …</mark>. 5998–6008.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[7] Ashish Vaswani et al. “Attention is all you need” In: Advances in Neural Information Processing Systems. 30 (2017). 5998–6008.">[7] Ashish Vaswani et al. “Attention <mark class="rounded bg-amber-200 px-0.5 text-slate-900">is all you need” In: Advances in Neural Information Processing Systems. …</mark>. 5998–6008.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ38)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[8] Thomas S. Kuhn. “Scientific Paradigms and Normal Science”. In: Philosophy of Science 37.1 (1970), pp. 1–13. doi: 10.1086/288273.">[8] Thomas S. Kuhn. “Scientific <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Paradigms and Normal Science”. In: Philosophy of Science 37.1 (1970), pp…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[8] Thomas S. Kuhn. “Scientific paradigms and normal science” In: Philosophy of Science. 37 (1970). 1–13 doi: 10.1086/288273">[8] Thomas S. Kuhn. “Scientific <mark class="rounded bg-amber-200 px-0.5 text-slate-900">paradigms and normal science” In: Philosophy of Science. 37 (1970). 1–13…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ33)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[9] John Smith and Mary Anderson. “Climate Change and Extreme Weather Events”. In: Nature Climate Change 10 (2020), pp. 850–855. doi: 10 . 1038/s41558-020-0871-4.">[9] John Smith and Mary Anderson. “Climate <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Change and Extreme Weather Events”. In: Nature Climate Change 10 (2020),…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[9] John Smith and Mary Anderson. “Climate change and extreme weather events” In: Nature Climate Change. 10 (2020). 850–855 doi: 10.1038/s41558-020-0871-4">[9] John Smith and Mary Anderson. “Climate <mark class="rounded bg-amber-200 px-0.5 text-slate-900">change and extreme weather events” In: Nature Climate Change. 10 (2020).…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ44)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[10] Jane Smith and Robert Williams. “Machine Learning for Climate Prediction”. In: Environmental Research Letters 15.11 (2020), p. 114042. doi: 10.1088/1748-9326/abc123.">[10] Jane Smith and Robert Williams. “Machine <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Learning for Climate Prediction”. In: Environmental Research Letters 15.…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[10] Jane Smith and Robert Williams. “Machine learning for climate prediction” In: Environmental Research Letters. 15 (2020). 114042 doi: 10.1088/1748-9326/abc123">[10] Jane Smith and Robert Williams. “Machine <mark class="rounded bg-amber-200 px-0.5 text-slate-900">learning for climate prediction” In: Environmental Research Letters. 15 …</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ47)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[11] Wei Chen. “Neural Networks for Natural Language Understanding”. phdthesis. 2019.">[11] Wei Chen. “Neural <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Networks for Natural Language Understanding”. phdthesis. 2019</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[11] Wei Chen. “Neural networks for natural language understanding”. Stanford University (2019).">[11] Wei Chen. “Neural <mark class="rounded bg-amber-200 px-0.5 text-slate-900">networks for natural language understanding”. Stanford University (2019)</mark>.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ24)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[12] Tomas Mikolov et al. “Distributed Representations of Words and Phrases”. In: Proceedings of NIPS 2013. 2013, pp. 3111–3119.">[12] Tomas Mikolov et al. “Distributed <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Representations of Words and Phrases”. In: Proceedings of NIPS 2013. 201…</mark>. 3111–3119.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[12] Tomas Mikolov et al. “Distributed representations of words and phrases” In: Proceedings of NIPS 2013 (2013). 3111–3119.">[12] Tomas Mikolov et al. “Distributed <mark class="rounded bg-amber-200 px-0.5 text-slate-900">representations of words and phrases” In: Proceedings of NIPS 2013 (2013…</mark>. 3111–3119.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ40)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[13] State of JS Team. The State of JavaScript 2023. 2023. url: https:// stateofjs.com/2023 (visited on 01/15/2024).">…] State of JS Team. The State of JavaScript 2023<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2023. url: https:// stateofjs.com/2023 (visited on 01/15/2024).</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[13] State of JS Team. The State of JavaScript 2023 (2023). https://stateofjs.com/2023">…] State of JS Team. The State of JavaScript 2023<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> (2023). https://stateofjs.com/2023</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ52)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[14] Harry T. Reis and Charles M. Judd, eds. Handbook of Research Methods in Social Psychology. Cambridge: Cambridge University Press, 2000.">[14] Harry T. Reis and Charles M. Judd<mark class="rounded bg-amber-200 px-0.5 text-slate-900">, eds. Handbook of Research Methods in Social Psychology. Cambridge: Cam…</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[14] Harry T. Reis and Charles M. Judd. Handbook of research methods in social psychology. Cambridge University Press: Cambridge (2000).">[14] Harry T. Reis and Charles M. Judd<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. Handbook of research methods in social psychology. Cambridge Universit…</mark>.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ39)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[15] “The Role of Theory in Research”. In: Journal of Theoretical Psychology 28.3 (2018), pp. 201–215.">[15] <mark class="rounded bg-amber-200 px-0.5 text-slate-900">“The Role of Theory in Research”. In: Journal of Theoretical Psychology …</mark>. 201–215.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[15] The role of theory in research In: Journal of Theoretical Psychology. 28 (2018). 201–215.">[15] <mark class="rounded bg-amber-200 px-0.5 text-slate-900">The role of theory in research In: Journal of Theoretical Psychology. 28…</mark>. 201–215.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ6)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[16] Maria Rodriguez. “Major Breakthrough in Quantum Computing Announced”. In: The New York Times (2024).">[16] Maria Rodriguez. “Major <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Breakthrough in Quantum Computing Announced”.</mark> In: The New York Times (2024).</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[16] Maria Rodriguez. “Major breakthrough in quantum computing announced” In: The New York Times (2024).">[16] Maria Rodriguez. “Major <mark class="rounded bg-amber-200 px-0.5 text-slate-900">breakthrough in quantum computing announced”</mark> In: The New York Times (2024).</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ30)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[17] Alexander Thompson. “The Art of Minimalism in Modern Design”. In: Wired 31.6 (2023), pp. 42–49.">[17] Alexander Thompson. “The <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Art of Minimalism in Modern Design”. In: Wired 31.6 (2023), pp</mark>. 42–49.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[17] Alexander Thompson. “The art of minimalism in modern design” In: Wired. 31 (2023). 42–49.">[17] Alexander Thompson. “The <mark class="rounded bg-amber-200 px-0.5 text-slate-900">art of minimalism in modern design” In: Wired. 31 (2023)</mark>. 42–49.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ31)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[18] Giorgio Vasari. Renaissance Art and Culture. In: Encyclopedia of World History. Vol. 5. Oxford University Press, 2022, pp. 234–256.">[18] Giorgio Vasari. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Renaissance Art and Culture. In: Encyclopedia of World History. Vol. 5. …</mark>. 234–256.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[18] Giorgio Vasari. “Renaissance art and culture” In: Encyclopedia of world history. Oxford University Press. 5 (2022). 234–256.">[18] Giorgio Vasari. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">“Renaissance art and culture” In: Encyclopedia of world history. Oxford …</mark>. 234–256.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ22)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[19] NASA Goddard Institute for Space Studies. Global Temperature Anomalies 1880-2023. NASA, 2024. url: https : / / data . giss . nasa . gov / gistemp/ (visited on 01/20/2024).">[19] NASA Goddard Institute for Space Studies. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Global Temperature Anomalies 1880-2023. NASA, 2024. url: https : / / dat…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[19] NASA Goddard Institute for Space Studies. “Global Temperature Anomalies 1880-2023”. NASA (2024). https://data.giss.nasa.gov/gistemp/">[19] NASA Goddard Institute for Space Studies. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">“Global Temperature Anomalies 1880-2023”. NASA (2024). https://data.giss…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ48)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[20] Brown v. Board of Education. 1954.">[20] Brown v. Board of Education<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 1954</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[20] Brown v. Board of Education In: U.S. Reports. 347 (1954). 483.">[20] Brown v. Board of Education<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> In: U.S. Reports. 347 (1954). 483</mark>.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ33)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[21] David Johnson and Sarah Lee. “Method for Efficient Data Compression”. US 11,043,211 B2. David Johnson and Sarah Lee. 2021.">…h Lee. “Method for Efficient Data Compression”. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">US 11,043,211 B2. David Johnson and Sarah Lee. </mark>2021.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[21] David Johnson and Sarah Lee. “Method for Efficient Data Compression”. 2021.">…h Lee. “Method for Efficient Data Compression”. <mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark>2021.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-red-600">✗</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">—</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[22] Louis Lumière. The Arrival of a Train at La Ciotat Station. 1896.">[22] Louis Lumi<mark class="rounded bg-amber-200 px-0.5 text-slate-900">ère. The Arrival of a Train at La Ciotat Station. 1896</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[22] Louis Lumière. “The Arrival of a Train at La Ciotat Station” (1896).">[22] Louis Lumi<mark class="rounded bg-amber-200 px-0.5 text-slate-900">ère. “The Arrival of a Train at La Ciotat Station” (1896)</mark>.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ16)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[23] Carl Sagan. The Universe in a Nutshell. 1980.">[23] Carl Sagan. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">The Universe in a Nutshell. 1980</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[23] Carl Sagan. “The Universe in a Nutshell” In: Cosmos: A Spacetime Odyssey (1980).">[23] Carl Sagan. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">“The Universe in a Nutshell” In: Cosmos: A Spacetime Odyssey (1980)</mark>.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ18)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[24] Yoshua Bengio. The Future of Artificial Intelligence. 2023. url: https: //example.com/interview.">[24] Yoshua Bengio. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">The Future of Artificial Intelligence. 2023. url: https: //example.com/i…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[24] Yoshua Bengio. “The Future of Artificial Intelligence” (2023). https://example.com/interview">[24] Yoshua Bengio. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">“The Future of Artificial Intelligence” (2023). https://example.com/inte…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ21)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[25] Franz Kafka. Metamorphosis. Leipzig: Kurt Wolff Verlag, 1915.">[25] Franz Kafka. Metamorphosis. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Leipzig: Kurt Wolff Verlag, 1915</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[25] Franz Kafka. Metamorphosis. Kurt Wolff Verlag: Leipzig (1915).">[25] Franz Kafka. Metamorphosis. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Kurt Wolff Verlag: Leipzig (1915)</mark>.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ34)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[26] Baruch Spinoza. Éthique. Amsterdam: Jan Rieuwertsz, 1677.">[26] Baruch Spinoza. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Éthique. Amsterdam: Jan Rieuwertsz, 1677</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[26] Baruch Spinoza. Éthique. Jan Rieuwertsz: Amsterdam (1677).">[26] Baruch Spinoza. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Éthique. Jan Rieuwertsz: Amsterdam (1677)</mark>.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ22)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[27] United Nations Environment Programme. State of the World’s Biodiversity. assessment-report. Nairobi, 2019.">…ted Nations Environment Programme. State of the <mark class="rounded bg-amber-200 px-0.5 text-slate-900">World’s Biodiversity. assessment-report. Nairobi, 2019</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[27] United Nations Environment Programme. State of the world’s biodiversity. Edited by Sandra Díaz. UNEP: Nairobi (2019).">…ted Nations Environment Programme. State of the <mark class="rounded bg-amber-200 px-0.5 text-slate-900">world’s biodiversity. Edited by Sandra Díaz. UNEP: Nairobi (2019)</mark>.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ57)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[28] Patricia Smith. Discussion on Citum Schema Design. 2024.">[28] Patricia Smith. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Discussion on Citum Schema Design. 2024</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[28] Patricia Smith. “Discussion on Citum Schema Design” (2024).">[28] Patricia Smith. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">“Discussion on Citum Schema Design” (2024)</mark>.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ22)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[29] John Smith et al. “Adaptive Climate Risk Modeling in Coastal Cities”. In: Journal of Climate Analytics 12.2 (2021), pp. 101–119. doi: 10.5555/ jca.2021.12.2.101.">[29] John Smith et al. “Adaptive <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Climate Risk Modeling in Coastal Cities”. In: Journal of Climate Analyti…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[29] John Smith et al. “Adaptive climate risk modeling in coastal cities” In: Journal of Climate Analytics. 12 (2021). 101–119 doi: 10.5555/jca.2021.12.2.101">[29] John Smith et al. “Adaptive <mark class="rounded bg-amber-200 px-0.5 text-slate-900">climate risk modeling in coastal cities” In: Journal of Climate Analytic…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ34)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[30] John Smith et al. “Adaptive Climate Risk Modeling for Inland Regions”. In: Journal of Climate Analytics 12.3 (2021), pp. 201–219. doi: 10.5555/ jca.2021.12.3.201.">[30] John Smith et al. “Adaptive <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Climate Risk Modeling for Inland Regions”. In: Journal of Climate Analyt…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[30] John Smith et al. “Adaptive climate risk modeling for inland regions” In: Journal of Climate Analytics. 12 (2021). 201–219 doi: 10.5555/jca.2021.12.3.201">[30] John Smith et al. “Adaptive <mark class="rounded bg-amber-200 px-0.5 text-slate-900">climate risk modeling for inland regions” In: Journal of Climate Analyti…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ34)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[31] Maria Garcia. “Methods for Robust Climate Attribution”. In: Annual Review of Climate Science 4 (2019), pp. 55–80. doi: 10 . 5555 / arcs . 2019.4.55.">[31] Maria Garcia. “Methods for <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Robust Climate Attribution”. In: Annual Review of Climate Science 4 (201…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[31] Maria Garcia. “Methods for robust climate attribution” In: Annual Review of Climate Science. 4 (2019). 55–80 doi: 10.5555/arcs.2019.4.55">[31] Maria Garcia. “Methods for <mark class="rounded bg-amber-200 px-0.5 text-slate-900">robust climate attribution” In: Annual Review of Climate Science. 4 (201…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ33)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[32] Maria Garcia. “Methods for Probabilistic Climate Attribution”. In: Annual Review of Climate Science 4 (2019), pp. 81–104. doi: 10.5555/arcs. 2019.4.81.">[32] Maria Garcia. “Methods for <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Probabilistic Climate Attribution”. In: Annual Review of Climate Science…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[32] Maria Garcia. “Methods for probabilistic climate attribution” In: Annual Review of Climate Science. 4 (2019). 81–104 doi: 10.5555/arcs.2019.4.81">[32] Maria Garcia. “Methods for <mark class="rounded bg-amber-200 px-0.5 text-slate-900">probabilistic climate attribution” In: Annual Review of Climate Science.…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ33)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[33] A. Forthcoming. Foundations of Declarative Bibliography. Cambridge: University Press.">[33] A. Forthcoming. Foundations of <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Declarative Bibliography. Cambridge: University Press</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[33] A. Forthcoming. Foundations of declarative bibliography. University Press: Cambridge (n.d.).">[33] A. Forthcoming. Foundations of <mark class="rounded bg-amber-200 px-0.5 text-slate-900">declarative bibliography. University Press: Cambridge (n.d.)</mark>.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ37)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[34] John Adams. Letter to James Smith. 1797.">[34] John Adams. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Letter to James Smith. 1797</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[34] John Adams. “Letter to James Smith” (1797).">[34] John Adams. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">“Letter to James Smith” (1797)</mark>.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ18)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[35] Alice Johnson. “Quantitative Methods in Sociology”. In: Sociological Review 68 (2020), pp. 23–45.">[35] Alice Johnson. “Quantitative <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Methods in Sociology”. In: Sociological Review 68 (2020), pp</mark>. 23–45.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[35] Alice Johnson. “Quantitative methods in sociology” In: Sociological Review. 68 (2020). 23–45.">[35] Alice Johnson. “Quantitative <mark class="rounded bg-amber-200 px-0.5 text-slate-900">methods in sociology” In: Sociological Review. 68 (2020)</mark>. 23–45.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ35)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[36] Brian Johnson. “Qualitative Methods in Sociology”. In: Sociological Review 68 (2020), pp. 89–112.">[36] Brian Johnson. “Qualitative <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Methods in Sociology”. In: Sociological Review 68 (2020), pp</mark>. 89–112.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[36] Brian Johnson. “Qualitative methods in sociology” In: Sociological Review. 68 (2020). 89–112.">[36] Brian Johnson. “Qualitative <mark class="rounded bg-amber-200 px-0.5 text-slate-900">methods in sociology” In: Sociological Review. 68 (2020)</mark>. 89–112.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ34)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[37] Wei Chen. “Urban Heat Island Mitigation Strategies”. In: Urban Climate 15 (2022), pp. 1–18. doi: 10.5555/uc.2022.15.1.">[37] Wei Chen. “Urban <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Heat Island Mitigation Strategies”. In: Urban Climate 15 (2022), pp. 1–1…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[37] Wei Chen. “Urban heat island mitigation strategies” In: Urban Climate. 15 (2022). 1–18 doi: 10.5555/uc.2022.15.1">[37] Wei Chen. “Urban <mark class="rounded bg-amber-200 px-0.5 text-slate-900">heat island mitigation strategies” In: Urban Climate. 15 (2022). 1–18 do…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ23)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[38] Wei Chen. “Urban Heat Island Measurement Techniques”. In: Urban Climate 18 (2024), pp. 45–62. doi: 10.5555/uc.2024.18.45.">[38] Wei Chen. “Urban <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Heat Island Measurement Techniques”. In: Urban Climate 18 (2024), pp. 45…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[38] Wei Chen. “Urban heat island measurement techniques” In: Urban Climate. 18 (2024). 45–62 doi: 10.5555/uc.2024.18.45">[38] Wei Chen. “Urban <mark class="rounded bg-amber-200 px-0.5 text-slate-900">heat island measurement techniques” In: Urban Climate. 18 (2024). 45–62 …</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ23)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[39] Self-report. url: https : / / www . merriam - webster . com / dictionary / self-report (visited on 07/12/2019).">[39] Self-report<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. url: https : / / www . merriam - webster . com / dictionary / self-rep…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[39] Self-report In: Merriam-Webster.com dictionary (n.d.). https://www.merriam-webster.com/dictionary/self-report">[39] Self-report<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> In: Merriam-Webster.com dictionary (n.d.). https://www.merriam-webster.…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-red-600">✗</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">—</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[40] Every Student Succeeds Act. 2015. url: https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf.">[40] Every Student Succeeds Act. 20<mark class="rounded bg-amber-200 px-0.5 text-slate-900">15. url: https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[40] Every Student Succeeds Act. 20 (2015). https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf">[40] Every Student Succeeds Act. 20<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> (2015). https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ36)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[41] D. Cable. The racial dot map. 2013. url: https : / / demographics . coopercenter.org/Racial-Dot-Map (visited on 10/27/2019).">[41] D. Cable. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">The racial dot map. 2013. url: https : / / demographics . coopercenter.o…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[41] D. Cable. “The racial dot map”. University of Virginia, Weldon Cooper Center for Public Service (2013). https://demographics.coopercenter.org/Racial-Dot-Map">[41] D. Cable. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">“The racial dot map”. University of Virginia, Weldon Cooper Center for P…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-red-600">✗</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">—</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[42] Bibliographic references. Bethesda, MD, 2010. doi: 10.3789/ansi.niso. z39 . 29 - 2005R2010. url: https : / / www . niso . org / publications / ansiniso-z3929-2005-r2010 (visited on 04/11/2025).">[42] Bibliographic references. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Bethesda, MD, 2010. doi: 10.3789/ansi.niso. z39 . 29 - 2005R2010. url: h…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[42] Bibliographic references. NISO: Bethesda, MD (2010) doi: 10.3789/ansi.niso.z39.29-2005R2010. https://www.niso.org/publications/ansiniso-z3929-2005-r2010">[42] Bibliographic references. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">NISO: Bethesda, MD (2010) doi: 10.3789/ansi.niso.z39.29-2005R2010. https…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ32)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[43] Mental Health on Campus Improvement Act. 2013. url: https://www.congress.gov/bill/113th-congress/housebill/1100.">[43] Mental Health on Campus Improvement Act<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2013. url: https://www.congress.gov/bill/113th-congress/housebill/1100…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[43] Mental Health on Campus Improvement Act (2013). https://www.congress.gov/bill/113th-congress/housebill/1100">[43] Mental Health on Campus Improvement Act<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> (2013). https://www.congress.gov/bill/113th-congress/housebill/1100</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ45)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[44] Strengthening the federal student loan program for borrowers. 2014. url: https : / / www . help . senate . gov / hearings / strengthening - the federal-student-loan-program-for-borrowers.">…g the federal student loan program for borrowers<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2014. url: https : / / www . help . senate . gov / hearings / strength…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[44] Strengthening the federal student loan program for borrowers (2014). https://www.help.senate.gov/hearings/strengthening-the-federal-student-loan-program-for-borrowers">…g the federal student loan program for borrowers<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> (2014). https://www.help.senate.gov/hearings/strengthening-the-federal-…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ66)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[45] Tactile Labs. Latero tactile display. 2015. url: http : / / tactilelabs . com/products/haptics/latero-tactile-display/.">[45] Tactile Labs. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Latero tactile display. 2015. url: http : / / tactilelabs . com/products…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[45] Tactile Labs. “Latero tactile display” (2015). http://tactilelabs.com/products/haptics/latero-tactile-display/">[45] Tactile Labs. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">“Latero tactile display” (2015). http://tactilelabs.com/products/haptics…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ20)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[46] U.K., U.S., and U.S.S.R. Treaty Banning Nuclear Weapon Tests in the Atmosphere, in Outer Space and Under Water. 1963.">[46] U.K., U.S.<mark class="rounded bg-amber-200 px-0.5 text-slate-900">, and U.S.S.R. Treaty Banning Nuclear Weapon Tests in the Atmosphere, in…</mark>3.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[46] U.K., U.S. and U.S.S.R. “Treaty Banning Nuclear Weapon Tests in the Atmosphere, in Outer Space and Under Water” In: U.S.T. 14 (1963). 1313.">[46] U.K., U.S.<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> and U.S.S.R. “Treaty Banning Nuclear Weapon Tests in the Atmosphere, in…</mark>3.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ16)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">—</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[47] Protection of Human Subjects. 2009. url: https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrpregulations.pdf.">[47] Protection of Human Subjects. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">2009. url: https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrp…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[47] Protection of Human Subjects. 45 (2009). https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrpregulations.pdf">[47] Protection of Human Subjects. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">45 (2009). https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrp…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ36)</td>
+                                            </tr>
+
+                                        </tbody>
+                                    </table>
+                                </div>
+
+
+
+                                </section>
+
+                            </div>
+
+                        </div>
+                    </td>
+                </tr>
+
+                <tr class="family-header border-y border-slate-300 bg-slate-100"
                     data-family-root="oscola">
                     <td colspan="13" class="px-6 py-3">
                         <div class="flex flex-wrap items-center gap-x-3 gap-y-1">
@@ -40639,9 +41346,9 @@
                     data-csl-reach="-1"
                     data-citation-rate="0.95"
                     data-bibliography-rate="0.9361702127659575"
-                    data-component-rate="0.992"
+                    data-component-rate="0.994"
                     data-fidelity="0.94"
-                    data-exact-parity="0.19402985074626866"
+                    data-exact-parity="0.31343283582089554"
                     data-quality="0.996"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">
@@ -40671,7 +41378,7 @@
                     <td class="px-6 py-4 text-sm font-mono text-slate-600">94.0%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-partial">
-                            13/67
+                            21/67
                         </span>
 
                     </td>
@@ -40731,19 +41438,15 @@
                                 <div class="flex flex-wrap gap-2">
 
                                     <span class="px-2 py-1 rounded bg-slate-100 text-slate-600 text-xs font-mono">
-                                        containerTitle:extra <span class="font-bold">×1</span>
-                                    </span>
-
-                                    <span class="px-2 py-1 rounded bg-slate-100 text-slate-600 text-xs font-mono">
-                                        volume:extra <span class="font-bold">×1</span>
-                                    </span>
-
-                                    <span class="px-2 py-1 rounded bg-slate-100 text-slate-600 text-xs font-mono">
-                                        pages:extra <span class="font-bold">×1</span>
+                                        containerTitle:missing <span class="font-bold">×1</span>
                                     </span>
 
                                     <span class="px-2 py-1 rounded bg-slate-100 text-slate-600 text-xs font-mono">
                                         publisher:extra <span class="font-bold">×1</span>
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-slate-100 text-slate-600 text-xs font-mono">
+                                        doi:missing <span class="font-bold">×1</span>
                                     </span>
 
                                 </div>
@@ -40871,413 +41574,413 @@
                                         <tbody>
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">1</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Adams J. 1797. Letter to James Smith.">Adams J<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 1797. Letter to James Smith.</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Adams J 1797. Letter to James Smith">Adams J<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 1797. Letter to James Smith</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ8)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">2</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Bengio Y. 2023. The Future of Artificial Intelligence [Internet]. https://example.com/interview">Bengio Y<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2023. The Future of Artificial Intelligence [Internet]</mark>. https://example.com/interview</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Bengio Y 2023. The Future of Artificial Intelligence. https://example.com/interview">Bengio Y<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2023. The Future of Artificial Intelligence</mark>. https://example.com/interview</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ9)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">3</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W. 2022. Urban Heat Island Mitigation Strategies. Urban Climate. 15:1–18. https://doi.org/10.5555/uc.2022.15.1">Chen W<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2022. Urban Heat Island Mitigation Strategies. Urban Climate. 15:</mark>1–18. https://doi.org/10.5555/uc…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W 2022. Urban Heat Island Mitigation Strategies. Urban Climate. 15; 1–18. https://doi.org/10.5555/uc.2022.15.1">Chen W<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2022. Urban Heat Island Mitigation Strategies. Urban Climate. 15; </mark>1–18. https://doi.org/10.5555/uc…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ7)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">4</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W. 2024. Urban Heat Island Measurement Techniques. Urban Climate. 18:45–62. https://doi.org/10.5555/uc.2024.18.45">Chen W<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2024. Urban Heat Island Measurement Techniques. Urban Climate. 18:</mark>45–62. https://doi.org/10.5555/u…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W 2024. Urban Heat Island Measurement Techniques. Urban Climate. 18; 45–62. https://doi.org/10.5555/uc.2024.18.45">Chen W<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2024. Urban Heat Island Measurement Techniques. Urban Climate. 18; </mark>45–62. https://doi.org/10.5555/u…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ7)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">5</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Forthcoming A. Foundations of Declarative Bibliography. Cambridge: University Press.">Forthcoming A<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. Foundations of Declarative Bibliography. Cambridge: University Press.</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Forthcoming A n.d. Foundations of Declarative Bibliography. University Press. Cambridge">Forthcoming A<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> n.d. Foundations of Declarative Bibliography. University Press. Cambrid…</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ14)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">6</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Hawking S. 1988. A Brief History of Time. New York: Bantam Dell Publishing Group.">Hawking S<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 1988. A Brief History of Time. New York: Bantam Dell Publishing Group.</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Hawking S 1988. A Brief History of Time. Bantam Dell Publishing Group. New York">Hawking S<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 1988. A Brief History of Time. Bantam Dell Publishing Group. New York</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ10)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">7</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson D, Lee S. 2021. Method for Efficient Data Compression.">Johnson D, Lee S<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2021. Method for Efficient Data Compression.</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson D, Lee S 2021. Method for Efficient Data Compression">Johnson D, Lee S<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2021. Method for Efficient Data Compression</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ17)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">8</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kuhn TS. 1970. Scientific Paradigms and Normal Science. Philosophy of Science. 37(1):1–13. https://doi.org/10.1086/288273">Kuhn TS<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 1970. Scientific Paradigms and Normal Science. Philosophy of Science. …</mark>1–13. https://doi.org/10.1086/28…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kuhn TS 1970. Scientific Paradigms and Normal Science. Philosophy of Science. 37, (1); 1–13. https://doi.org/10.1086/288273">Kuhn TS<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 1970. Scientific Paradigms and Normal Science. Philosophy of Science. 3…</mark>1–13. https://doi.org/10.1086/28…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ8)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">9</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="LeCun Y, Bengio Y, Hinton G. 2015. Deep Learning. Nature. 521:436–444. https://doi.org/10.1038/nature14539">LeCun Y, Bengio Y, Hinton G<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2015. Deep Learning. Nature. 521:</mark>436–444. https://doi.org/10.1038…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="LeCun Y, Bengio Y, Hinton G 2015. Deep Learning. Nature. 521; 436–444. https://doi.org/10.1038/nature14539">LeCun Y, Bengio Y, Hinton G<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2015. Deep Learning. Nature. 521; </mark>436–444. https://doi.org/10.1038…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ28)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">10</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Reis HT, Judd CM, editors. 2000. Handbook of Research Methods in Social Psychology. Cambridge: Cambridge University Press.">Reis HT, Judd CM, editors<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2000. Handbook of Research Methods in Social Psychology. Cambridge: Ca…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Reis HT, Judd CM, editors 2000. Handbook of Research Methods in Social Psychology. Cambridge University Press. Cambridge">Reis HT, Judd CM, editors<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2000. Handbook of Research Methods in Social Psychology. Cambridge Univ…</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ26)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">11</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Rodriguez M. 2024. Major Breakthrough in Quantum Computing Announced. The New York Times.">Rodriguez M<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2024. Major Breakthrough in Quantum Computing Announced. The New York …</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Rodriguez M 2024. Major Breakthrough in Quantum Computing Announced. The New York Times">Rodriguez M<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2024. Major Breakthrough in Quantum Computing Announced. The New York T…</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ12)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">12</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Sagan C. 1980. The Universe in a Nutshell. Cosmos: A Spacetime Odyssey.">Sagan C<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 1980. The Universe in a Nutshell. Cosmos: A Spacetime Odyssey.</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Sagan C 1980. The Universe in a Nutshell. Cosmos: A Spacetime Odyssey (1)">Sagan C<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 1980. The Universe in a Nutshell. Cosmos: A Spacetime Odyssey (1)</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ8)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">13</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Anderson M. 2020. Climate Change and Extreme Weather Events. Nature Climate Change. 10:850–855. https://doi.org/10.1038/s41558-020-0871-4">Smith J, Anderson M<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2020. Climate Change and Extreme Weather Events. Nature Climate Change…</mark>850–855. https://doi.org/10.1038…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Anderson M 2020. Climate Change and Extreme Weather Events. Nature Climate Change. 10; 850–855. https://doi.org/10.1038/s41558-020-0871-4">Smith J, Anderson M<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2020. Climate Change and Extreme Weather Events. Nature Climate Change.…</mark>850–855. https://doi.org/10.1038…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ20)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">14</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Williams R. 2020. Machine Learning for Climate Prediction. Environmental Research Letters. 15(11):114042. https://doi.org/10.1088/1748-9326/abc123">Smith J, Williams R<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2020. Machine Learning for Climate Prediction. Environmental Research …</mark>114042. https://doi.org/10.1088/…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Williams R 2020. Machine Learning for Climate Prediction. Environmental Research Letters. 15, (11); 114042. https://doi.org/10.1088/1748-9326/abc123">Smith J, Williams R<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2020. Machine Learning for Climate Prediction. Environmental Research L…</mark>114042. https://doi.org/10.1088/…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ20)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">15</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith P. 2024. Discussion on Citum Schema Design.">Smith P<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2024. Discussion on Citum Schema Design.</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith P 2024. Discussion on Citum Schema Design">Smith P<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2024. Discussion on Citum Schema Design</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ8)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">16</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Spinoza B. 1677. Éthique. Amsterdam: Jan Rieuwertsz.">Spinoza B<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 1677. Éthique. Amsterdam: Jan Rieuwertsz.</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Spinoza B 1677. Éthique. Jan Rieuwertsz. Amsterdam">Spinoza B<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 1677. Éthique. Jan Rieuwertsz. Amsterdam</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ10)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">17</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Strengthening the federal student loan program for borrowers. 2014. https://www.help.senate.gov/hearings/strengthening-the-federal-student-loan-program-for-borrowers">…g the federal student loan program for borrowers<mark class="rounded bg-amber-200 px-0.5 text-slate-900">.</mark> 2014. https://www.help.senate.g…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Strengthening the federal student loan program for borrowers 2014. https://www.help.senate.gov/hearings/strengthening-the-federal-student-loan-program-for-borrowers">…g the federal student loan program for borrowers<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark> 2014. https://www.help.senate.g…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ61)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">18</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Tactile Labs. 2015. Latero tactile display [Internet]. http://tactilelabs.com/products/haptics/latero-tactile-display/">Tactile Labs<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2015. Latero tactile display [Internet]</mark>. http://tactilelabs.com/product…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Tactile Labs 2015. Latero tactile display. http://tactilelabs.com/products/haptics/latero-tactile-display/">Tactile Labs<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2015. Latero tactile display</mark>. http://tactilelabs.com/product…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ13)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">19</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="The Role of Theory in Research. 2018. Journal of Theoretical Psychology. 28(3):201–215.">The Role of Theory in Research<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2018. Journal of Theoretical Psychology. 28(3):201–215.</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="The Role of Theory in Research 2018. Journal of Theoretical Psychology. 28, (3); 201–215">The Role of Theory in Research<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2018. Journal of Theoretical Psychology. 28, (3); 201–215</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ31)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">20</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Thompson A. 2023. The Art of Minimalism in Modern Design. Wired. 31(6):42–49.">Thompson A<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2023. The Art of Minimalism in Modern Design. Wired. 31(6):42–49.</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Thompson A 2023. The Art of Minimalism in Modern Design. Wired. 31, (6); 42–49">Thompson A<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2023. The Art of Minimalism in Modern Design. Wired. 31, (6); 42–49</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ11)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">21</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Vaswani A, Shazeer N, Parmar N, Uszkoreit J, Jones L, Gomez AN, Kaiser L, Polosukhin I. 2017. Attention Is All You Need. Advances in Neural Information Processing Systems. 30:5998–6008.">…eit J, Jones L, Gomez AN, Kaiser L, Polosukhin I<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2017. Attention Is All You Need. Advances in Neural Information Proces…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Vaswani A, Shazeer N, Parmar N, Uszkoreit J, Jones L, Gomez AN, Kaiser L, Polosukhin I 2017. Attention Is All You Need. Advances in Neural Information Processing Systems. 30; 5998–6008">…eit J, Jones L, Gomez AN, Kaiser L, Polosukhin I<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2017. Attention Is All You Need. Advances in Neural Information Process…</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ87)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">22</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="World Bank. 2023. World Development Report 2023. Washington, DC: World Bank Group.">World Bank<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2023. World Development Report 2023. Washington, DC: World Bank Group.</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="World Bank 2023. World Development Report 2023. World Bank Group. Washington, DC">World Bank<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2023. World Development Report 2023. World Bank Group. Washington, DC</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ11)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">23</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Protection of Human Subjects. 2009. CFR [Internet]. 45. https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrpregulations.pdf">Protection of Human Subjects<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2009. CFR [Internet]</mark>. 45. https://www.hhs.gov/ohrp/s…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Protection of Human Subjects 2009. 45. https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrpregulations.pdf">Protection of Human Subjects<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2009</mark>. 45. https://www.hhs.gov/ohrp/s…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ29)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">24</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="U.K., U.S., U.S.S.R. 1963. Treaty Banning Nuclear Weapon Tests in the Atmosphere, in Outer Space and Under Water. UST. 14:1313.">…he Atmosphere, in Outer Space and Under Water. U<mark class="rounded bg-amber-200 px-0.5 text-slate-900">ST. 14:1313.</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="U.K., U.S., U.S.S.R. 1963. Treaty Banning Nuclear Weapon Tests in the Atmosphere, in Outer Space and Under Water. U.S.T. 14; 1313">…he Atmosphere, in Outer Space and Under Water. U<mark class="rounded bg-amber-200 px-0.5 text-slate-900">.S.T. 14; 1313</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ116)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">25</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Lee A, Kumar P, Zhou M. 2021. Adaptive Climate Risk Modeling in Coastal Cities. Journal of Climate Analytics. 12(2):101–119. https://doi.org/10.5555/jca.2021.12.2.101">Smith J, Lee A, Kumar P, Zhou M<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2021. Adaptive Climate Risk Modeling in Coastal Cities. Journal of Cli…</mark>101–119. https://doi.org/10.5555…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Lee A, Kumar P, Zhou M 2021b. Adaptive Climate Risk Modeling in Coastal Cities. Journal of Climate Analytics. 12, (2); 101–119. https://doi.org/10.5555/jca.2021.12.2.101">Smith J, Lee A, Kumar P, Zhou M<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2021b. Adaptive Climate Risk Modeling in Coastal Cities. Journal of Cli…</mark>101–119. https://doi.org/10.5555…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ32)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">26</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Lee A, Nguyen B, Patel R. 2021. Adaptive Climate Risk Modeling for Inland Regions. Journal of Climate Analytics. 12(3):201–219. https://doi.org/10.5555/jca.2021.12.3.201">Smith J, Lee A, Nguyen B, Patel R<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2021. Adaptive Climate Risk Modeling for Inland Regions. Journal of Cl…</mark>201–219. https://doi.org/10.5555…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Lee A, Nguyen B, Patel R 2021a. Adaptive Climate Risk Modeling for Inland Regions. Journal of Climate Analytics. 12, (3); 201–219. https://doi.org/10.5555/jca.2021.12.3.201">Smith J, Lee A, Nguyen B, Patel R<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2021a. Adaptive Climate Risk Modeling for Inland Regions. Journal of Cl…</mark>201–219. https://doi.org/10.5555…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ34)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">27</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Garcia M. 2019a. Methods for Robust Climate Attribution. Annual Review of Climate Science. 4:55–80. https://doi.org/10.5555/arcs.2019.4.55">Garcia M<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2019a. Methods for Robust Climate Attribution. Annual Review of Climat…</mark>55–80. https://doi.org/10.5555/a…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Garcia M 2019b. Methods for Robust Climate Attribution. Annual Review of Climate Science. 4; 55–80. https://doi.org/10.5555/arcs.2019.4.55">Garcia M<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2019b. Methods for Robust Climate Attribution. Annual Review of Climate…</mark>55–80. https://doi.org/10.5555/a…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ9)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">28</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Garcia M. 2019b. Methods for Probabilistic Climate Attribution. Annual Review of Climate Science. 4:81–104. https://doi.org/10.5555/arcs.2019.4.81">Garcia M<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2019b. Methods for Probabilistic Climate Attribution. Annual Review of…</mark>81–104. https://doi.org/10.5555/…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Garcia M 2019a. Methods for Probabilistic Climate Attribution. Annual Review of Climate Science. 4; 81–104. https://doi.org/10.5555/arcs.2019.4.81">Garcia M<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2019a. Methods for Probabilistic Climate Attribution. Annual Review of …</mark>81–104. https://doi.org/10.5555/…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ9)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">29</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Mental Health on Campus Improvement Act. 2013. [place unknown]. https://www.congress.gov/bill/113th-congress/housebill/1100">Mental Health on Campus Improvement Act<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2013. [place unknown]</mark>. https://www.congress.gov/bill/…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Mental Health on Campus Improvement Act 2013. https://www.congress.gov/bill/113th-congress/housebill/1100">Mental Health on Campus Improvement Act<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2013</mark>. https://www.congress.gov/bill/…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ40)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">30</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Every Student Succeeds Act. 2015. [place unknown]. https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf">Every Student Succeeds Act<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2015. [place unknown]</mark>. https://www.congress.gov/114/p…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Every Student Succeeds Act 2015. 20. https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf">Every Student Succeeds Act<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2015. 20</mark>. https://www.congress.gov/114/p…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ27)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">31</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson A. 2020. Quantitative Methods in Sociology. Sociological Review. 68:23–45.">Johnson A<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2020. Quantitative Methods in Sociology. Sociological Review. 68:23–45…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson A 2020b. Quantitative Methods in Sociology. Sociological Review. 68; 23–45">Johnson A<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2020b. Quantitative Methods in Sociology. Sociological Review. 68; 23–4…</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ10)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">32</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson B. 2020. Qualitative Methods in Sociology. Sociological Review. 68:89–112.">Johnson B<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2020. Qualitative Methods in Sociology. Sociological Review. 68:89–112…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson B 2020a. Qualitative Methods in Sociology. Sociological Review. 68; 89–112">Johnson B<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2020a. Qualitative Methods in Sociology. Sociological Review. 68; 89–11…</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ10)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">33</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Lumière L. 1896. The Arrival of a Train at La Ciotat Station. [place unknown].">Lumière L<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 1896. The Arrival of a Train at La Ciotat Station. [place unknown].</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Lumière L 1896. The Arrival of a Train at La Ciotat Station">Lumière L<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 1896. The Arrival of a Train at La Ciotat Station</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ10)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">34</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Weinberg GM, Freedman DP. 1971. The Psychology of Computer Programming. Silver Anniversary Edition. New York: Van Nostrand Reinhold.">Weinberg GM, Freedman DP<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 1971. The Psychology of Computer Programming. Silver Anniversary Editi…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Weinberg GM, Freedman DP 1971. The Psychology of Computer Programming. Van Nostrand Reinhold. New York">Weinberg GM, Freedman DP<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 1971. The Psychology of Computer Programming. Van Nostrand Reinhold. Ne…</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ25)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">35</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kuhn TS. 1962. The Structure of Scientific Revolutions. International Encyclopedia of Unified Science. 2(2). https://doi.org/10.1234/example">Kuhn TS<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 1962. The Structure of Scientific Revolutions. International Encyclope…</mark>. https://doi.org/10.1234/exampl…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kuhn TS 1962. The Structure of Scientific Revolutions. International Encyclopedia of Unified Science. 2, (2). University of Chicago Press. https://doi.org/10.1234/example">Kuhn TS<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 1962. The Structure of Scientific Revolutions. International Encycloped…</mark>. https://doi.org/10.1234/exampl…</td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ8)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">36</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Mikolov T, Sutskever I, Chen K, Corrado G, Dean J. 2013. Distributed Representations of Words and Phrases. In: Proceedings of NIPS 2013. [place unknown]; p. 3111–3119.">…ikolov T, Sutskever I, Chen K, Corrado G, Dean J<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2013. Distributed Representations of Words and Phrases. In: Proceeding…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Mikolov T, Sutskever I, Chen K, Corrado G, Dean J 2013. Distributed Representations of Words and Phrases. Proceedings of NIPS 2013; pp. 3111–3119">…ikolov T, Sutskever I, Chen K, Corrado G, Dean J<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2013. Distributed Representations of Words and Phrases. Proceedings of …</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
-                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ50)</td>
-                                            </tr>
-
-                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">37</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="United Nations Environment Programme. 2019. State of the World’s Biodiversity. Díaz S, editor. Nairobi: UNEP.">United Nations Environment Programme<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2019. State of the World’s Biodiversity. Díaz S, editor. Nairobi: UNEP…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="United Nations Environment Programme 2019. State of the World’s Biodiversity. Edited by S Díaz. UNEP. Nairobi">United Nations Environment Programme<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2019. State of the World’s Biodiversity. Edited by S Díaz. UNEP. Nairob…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Adams J. 1797. Letter to James Smith.">Adams J. 1797. Letter to James Smith<mark class="rounded bg-amber-200 px-0.5 text-slate-900">.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Adams J. 1797. Letter to James Smith">Adams J. 1797. Letter to James Smith<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ37)</td>
                                             </tr>
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
-                                                <td class="px-2 py-1 text-slate-600">38</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Vasari G. 2022. Renaissance Art and Culture. Encyclopedia of World History. 5:234–256.">Vasari G<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2022. Renaissance Art and Culture. Encyclopedia of World History. 5:23…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Vasari G 2022. Renaissance Art and Culture. Encyclopedia of World History. 5. Oxford University Press; 234–256">Vasari G<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2022. Renaissance Art and Culture. Encyclopedia of World History. 5. Ox…</mark></td>
+                                                <td class="px-2 py-1 text-slate-600">2</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Bengio Y. 2023. The Future of Artificial Intelligence [Internet]. https://example.com/interview">…o Y. 2023. The Future of Artificial Intelligence<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> [Internet]</mark>. https://example.com/interview</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Bengio Y. 2023. The Future of Artificial Intelligence. https://example.com/interview">…o Y. 2023. The Future of Artificial Intelligence<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark>. https://example.com/interview</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ9)</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ54)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">3</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W. 2022. Urban Heat Island Mitigation Strategies. Urban Climate. 15:1–18. https://doi.org/10.5555/uc.2022.15.1">Chen W. 2022. Urban Heat Island Mitigation Strategies. Urban Climate. 15:1–18. https://doi.org/10.5555/uc.2022.15.1</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W. 2022. Urban Heat Island Mitigation Strategies. Urban Climate. 15:1–18. https://doi.org/10.5555/uc.2022.15.1">Chen W. 2022. Urban Heat Island Mitigation Strategies. Urban Climate. 15:1–18. https://doi.org/10.5555/uc.2022.15.1</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">—</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">4</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W. 2024. Urban Heat Island Measurement Techniques. Urban Climate. 18:45–62. https://doi.org/10.5555/uc.2024.18.45">Chen W. 2024. Urban Heat Island Measurement Techniques. Urban Climate. 18:45–62. https://doi.org/10.5555/uc.2024.18.45</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W. 2024. Urban Heat Island Measurement Techniques. Urban Climate. 18:45–62. https://doi.org/10.5555/uc.2024.18.45">Chen W. 2024. Urban Heat Island Measurement Techniques. Urban Climate. 18:45–62. https://doi.org/10.5555/uc.2024.18.45</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">—</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">5</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Forthcoming A. Foundations of Declarative Bibliography. Cambridge: University Press.">Forthcoming A. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Foundations of Declarative Bibliography. Cambridge: University Press.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Forthcoming A. n.d. Foundations of Declarative Bibliography. Cambridge: University Press">Forthcoming A. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">n.d. Foundations of Declarative Bibliography. Cambridge: University Pres…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ16)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">6</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Hawking S. 1988. A Brief History of Time. New York: Bantam Dell Publishing Group.">… of Time. New York: Bantam Dell Publishing Group<mark class="rounded bg-amber-200 px-0.5 text-slate-900">.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Hawking S. 1988. A Brief History of Time. New York: Bantam Dell Publishing Group">… of Time. New York: Bantam Dell Publishing Group<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ81)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">7</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson D, Lee S. 2021. Method for Efficient Data Compression.">…e S. 2021. Method for Efficient Data Compression<mark class="rounded bg-amber-200 px-0.5 text-slate-900">.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson D, Lee S. 2021. Method for Efficient Data Compression">…e S. 2021. Method for Efficient Data Compression<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ62)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">8</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kuhn TS. 1962. The Structure of Scientific Revolutions. International Encyclopedia of Unified Science. 2(2). https://doi.org/10.1234/example">Kuhn TS. 1962. The Structure of Scientific Revolutions. International Encyclopedia of Unified Science. 2(2). https://doi…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kuhn TS. 1962. The Structure of Scientific Revolutions. International Encyclopedia of Unified Science. 2(2). https://doi.org/10.1234/example">Kuhn TS. 1962. The Structure of Scientific Revolutions. International Encyclopedia of Unified Science. 2(2). https://doi…</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">—</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">9</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kuhn TS. 1970. Scientific Paradigms and Normal Science. Philosophy of Science. 37(1):1–13. https://doi.org/10.1086/288273">Kuhn TS. 1970. Scientific Paradigms and Normal Science. Philosophy of Science. 37(1):1–13. https://doi.org/10.1086/28827…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kuhn TS. 1970. Scientific Paradigms and Normal Science. Philosophy of Science. 37(1):1–13. https://doi.org/10.1086/288273">Kuhn TS. 1970. Scientific Paradigms and Normal Science. Philosophy of Science. 37(1):1–13. https://doi.org/10.1086/28827…</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">—</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">10</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="LeCun Y, Bengio Y, Hinton G. 2015. Deep Learning. Nature. 521:436–444. https://doi.org/10.1038/nature14539">LeCun Y, Bengio Y, Hinton G. 2015. Deep Learning. Nature. 521:436–444. https://doi.org/10.1038/nature14539</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="LeCun Y, Bengio Y, Hinton G. 2015. Deep Learning. Nature. 521:436–444. https://doi.org/10.1038/nature14539">LeCun Y, Bengio Y, Hinton G. 2015. Deep Learning. Nature. 521:436–444. https://doi.org/10.1038/nature14539</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">—</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">11</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Reis HT, Judd CM, editors. 2000. Handbook of Research Methods in Social Psychology. Cambridge: Cambridge University Press.">…sychology. Cambridge: Cambridge University Press<mark class="rounded bg-amber-200 px-0.5 text-slate-900">.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Reis HT, Judd CM, editors. 2000. Handbook of Research Methods in Social Psychology. Cambridge: Cambridge University Press">…sychology. Cambridge: Cambridge University Press<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ122)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">12</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Rodriguez M. 2024. Major Breakthrough in Quantum Computing Announced. The New York Times.">… Quantum Computing Announced. The New York Times<mark class="rounded bg-amber-200 px-0.5 text-slate-900">.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Rodriguez M. 2024. Major Breakthrough in Quantum Computing Announced. The New York Times">… Quantum Computing Announced. The New York Times<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ89)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">13</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Anderson M. 2020. Climate Change and Extreme Weather Events. Nature Climate Change. 10:850–855. https://doi.org/10.1038/s41558-020-0871-4">Smith J, Anderson M. 2020. Climate Change and Extreme Weather Events. Nature Climate Change. 10:850–855. https://doi.org…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Anderson M. 2020. Climate Change and Extreme Weather Events. Nature Climate Change. 10:850–855. https://doi.org/10.1038/s41558-020-0871-4">Smith J, Anderson M. 2020. Climate Change and Extreme Weather Events. Nature Climate Change. 10:850–855. https://doi.org…</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">—</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">14</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Williams R. 2020. Machine Learning for Climate Prediction. Environmental Research Letters. 15(11):114042. https://doi.org/10.1088/1748-9326/abc123">Smith J, Williams R. 2020. Machine Learning for Climate Prediction. Environmental Research Letters. 15(11):114042. https…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Williams R. 2020. Machine Learning for Climate Prediction. Environmental Research Letters. 15(11):114042. https://doi.org/10.1088/1748-9326/abc123">Smith J, Williams R. 2020. Machine Learning for Climate Prediction. Environmental Research Letters. 15(11):114042. https…</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">—</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">15</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith P. 2024. Discussion on Citum Schema Design.">Smith P. 2024. Discussion on Citum Schema Design<mark class="rounded bg-amber-200 px-0.5 text-slate-900">.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith P. 2024. Discussion on Citum Schema Design">Smith P. 2024. Discussion on Citum Schema Design<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ49)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">16</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Spinoza B. 1677. Éthique. Amsterdam: Jan Rieuwertsz.">…noza B. 1677. Éthique. Amsterdam: Jan Rieuwertsz<mark class="rounded bg-amber-200 px-0.5 text-slate-900">.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Spinoza B. 1677. Éthique. Amsterdam: Jan Rieuwertsz">…noza B. 1677. Éthique. Amsterdam: Jan Rieuwertsz<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ52)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">17</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Strengthening the federal student loan program for borrowers. 2014. https://www.help.senate.gov/hearings/strengthening-the-federal-student-loan-program-for-borrowers">Strengthening the federal student loan program for borrowers. 2014. https://www.help.senate.gov/hearings/strengthening-t…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Strengthening the federal student loan program for borrowers. 2014. https://www.help.senate.gov/hearings/strengthening-the-federal-student-loan-program-for-borrowers">Strengthening the federal student loan program for borrowers. 2014. https://www.help.senate.gov/hearings/strengthening-t…</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">—</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">18</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Tactile Labs. 2015. Latero tactile display [Internet]. http://tactilelabs.com/products/haptics/latero-tactile-display/">Tactile Labs. 2015. Latero tactile display<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> [Internet]</mark>. http://tactilelabs.com/product…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Tactile Labs. 2015. Latero tactile display. http://tactilelabs.com/products/haptics/latero-tactile-display/">Tactile Labs. 2015. Latero tactile display<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark>. http://tactilelabs.com/product…</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ43)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">19</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="The Role of Theory in Research. 2018. Journal of Theoretical Psychology. 28(3):201–215.">…Journal of Theoretical Psychology. 28(3):201–215<mark class="rounded bg-amber-200 px-0.5 text-slate-900">.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="The Role of Theory in Research. 2018. Journal of Theoretical Psychology. 28(3):201–215">…Journal of Theoretical Psychology. 28(3):201–215<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ87)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">20</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Thompson A. 2023. The Art of Minimalism in Modern Design. Wired. 31(6):42–49.">… Minimalism in Modern Design. Wired. 31(6):42–49<mark class="rounded bg-amber-200 px-0.5 text-slate-900">.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Thompson A. 2023. The Art of Minimalism in Modern Design. Wired. 31(6):42–49">… Minimalism in Modern Design. Wired. 31(6):42–49<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ77)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">21</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Vaswani A, Shazeer N, Parmar N, Uszkoreit J, Jones L, Gomez AN, Kaiser L, Polosukhin I. 2017. Attention Is All You Need. Advances in Neural Information Processing Systems. 30:5998–6008.">…ral Information Processing Systems. 30:5998–6008<mark class="rounded bg-amber-200 px-0.5 text-slate-900">.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Vaswani A, Shazeer N, Parmar N, Uszkoreit J, Jones L, Gomez AN, Kaiser L, Polosukhin I. 2017. Attention Is All You Need. Advances in Neural Information Processing Systems. 30:5998–6008">…ral Information Processing Systems. 30:5998–6008<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ185)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">22</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="World Bank. 2023. World Development Report 2023. Washington, DC: World Bank Group.">…nt Report 2023. Washington, DC: World Bank Group<mark class="rounded bg-amber-200 px-0.5 text-slate-900">.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="World Bank. 2023. World Development Report 2023. Washington, DC: World Bank Group">…nt Report 2023. Washington, DC: World Bank Group<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ82)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">23</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Ericsson KA. 2006. The Role of Deliberate Practice. In: Ericsson KA, Charness N, Feltovich PJ, Hoffman RR, editors. The Cambridge Handbook of Expertise and Expert Performance. [place unknown]: Cambridge University Press; p. 683–703.">…A, Charness N, Feltovich PJ, Hoffman RR, editors<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. The Cambridge Handbook of Expertise and Expert Performance. [place unk…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Ericsson KA. 2006. The Role of Deliberate Practice. In: Ericsson KA, Charness N, Feltovich PJ, Hoffman RR, editors The Cambridge Handbook of Expertise and Expert Performance. Cambridge University Press. p. 683–703">…A, Charness N, Feltovich PJ, Hoffman RR, editors<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> The Cambridge Handbook of Expertise and Expert Performance. Cambridge U…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ115)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">24</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Lee A, Kumar P, Zhou M. 2021. Adaptive Climate Risk Modeling in Coastal Cities. Journal of Climate Analytics. 12(2):101–119. https://doi.org/10.5555/jca.2021.12.2.101">Smith J, Lee A, Kumar P, Zhou M. 2021<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark>. Adaptive Climate Risk Modeling…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Lee A, Kumar P, Zhou M. 2021b. Adaptive Climate Risk Modeling in Coastal Cities. Journal of Climate Analytics. 12(2):101–119. https://doi.org/10.5555/jca.2021.12.2.101">Smith J, Lee A, Kumar P, Zhou M. 2021<mark class="rounded bg-amber-200 px-0.5 text-slate-900">b</mark>. Adaptive Climate Risk Modeling…</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ38)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">25</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Lee A, Nguyen B, Patel R. 2021. Adaptive Climate Risk Modeling for Inland Regions. Journal of Climate Analytics. 12(3):201–219. https://doi.org/10.5555/jca.2021.12.3.201">Smith J, Lee A, Nguyen B, Patel R. 2021<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark>. Adaptive Climate Risk Modeling…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Lee A, Nguyen B, Patel R. 2021a. Adaptive Climate Risk Modeling for Inland Regions. Journal of Climate Analytics. 12(3):201–219. https://doi.org/10.5555/jca.2021.12.3.201">Smith J, Lee A, Nguyen B, Patel R. 2021<mark class="rounded bg-amber-200 px-0.5 text-slate-900">a</mark>. Adaptive Climate Risk Modeling…</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ40)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">26</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Garcia M. 2019a. Methods for Robust Climate Attribution. Annual Review of Climate Science. 4:55–80. https://doi.org/10.5555/arcs.2019.4.55">Garcia M. 2019<mark class="rounded bg-amber-200 px-0.5 text-slate-900">a</mark>. Methods for Robust Climate Att…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Garcia M. 2019b. Methods for Robust Climate Attribution. Annual Review of Climate Science. 4:55–80. https://doi.org/10.5555/arcs.2019.4.55">Garcia M. 2019<mark class="rounded bg-amber-200 px-0.5 text-slate-900">b</mark>. Methods for Robust Climate Att…</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ15)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">27</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Garcia M. 2019b. Methods for Probabilistic Climate Attribution. Annual Review of Climate Science. 4:81–104. https://doi.org/10.5555/arcs.2019.4.81">Garcia M. 2019<mark class="rounded bg-amber-200 px-0.5 text-slate-900">b</mark>. Methods for Probabilistic Clim…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Garcia M. 2019a. Methods for Probabilistic Climate Attribution. Annual Review of Climate Science. 4:81–104. https://doi.org/10.5555/arcs.2019.4.81">Garcia M. 2019<mark class="rounded bg-amber-200 px-0.5 text-slate-900">a</mark>. Methods for Probabilistic Clim…</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ15)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">28</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Protection of Human Subjects. 2009. CFR [Internet]. 45. https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrpregulations.pdf">Protection of Human Subjects. 2009. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">CFR [Internet]. 45. </mark>https://www.hhs.gov/ohrp/sites/d…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Protection of Human Subjects. 2009. https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrpregulations.pdf">Protection of Human Subjects. 2009. <mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark>https://www.hhs.gov/ohrp/sites/d…</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ37)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">29</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Mental Health on Campus Improvement Act. 2013. [place unknown]. https://www.congress.gov/bill/113th-congress/housebill/1100">Mental Health on Campus Improvement Act. 2013. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">[place unknown]. </mark>https://www.congress.gov/bill/11…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Mental Health on Campus Improvement Act. 2013. https://www.congress.gov/bill/113th-congress/housebill/1100">Mental Health on Campus Improvement Act. 2013. <mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark>https://www.congress.gov/bill/11…</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ48)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">30</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Every Student Succeeds Act. 2015. [place unknown]. https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf">Every Student Succeeds Act. 2015. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">[place unknown]. </mark>https://www.congress.gov/114/pla…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Every Student Succeeds Act. 2015. https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf">Every Student Succeeds Act. 2015. <mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark>https://www.congress.gov/114/pla…</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ35)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">31</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Mikolov T, Sutskever I, Chen K, Corrado G, Dean J. 2013. Distributed Representations of Words and Phrases. In: Proceedings of NIPS 2013. [place unknown]; p. 3111–3119.">…stributed Representations of Words and Phrases. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">In: Proceedings of NIPS 2013. [place unknown]; p. 3111–3119.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Mikolov T, Sutskever I, Chen K, Corrado G, Dean J. 2013. Distributed Representations of Words and Phrases. Proceedings of NIPS 2013. p. 3111–3119">…stributed Representations of Words and Phrases. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Proceedings of NIPS 2013. p. 3111–3119</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ108)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">32</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="United Nations Environment Programme. 2019. State of the World’s Biodiversity. Díaz S, editor. Nairobi: UNEP.">…ramme. 2019. State of the World’s Biodiversity. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Díaz S, editor. Nairobi: UNEP.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="United Nations Environment Programme. 2019. State of the World’s Biodiversity. Nairobi: UNEP">…ramme. 2019. State of the World’s Biodiversity. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Nairobi: UNEP</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ80)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">33</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson A. 2020. Quantitative Methods in Sociology. Sociological Review. 68:23–45.">Johnson A. 2020<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. Quantitative Methods in Sociology. Sociological Review. 68:23–45.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson A. 2020b. Quantitative Methods in Sociology. Sociological Review. 68:23–45">Johnson A. 2020<mark class="rounded bg-amber-200 px-0.5 text-slate-900">b. Quantitative Methods in Sociology. Sociological Review. 68:23–45</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ16)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">34</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson B. 2020. Qualitative Methods in Sociology. Sociological Review. 68:89–112.">Johnson B. 2020<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. Qualitative Methods in Sociology. Sociological Review. 68:89–112.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson B. 2020a. Qualitative Methods in Sociology. Sociological Review. 68:89–112">Johnson B. 2020<mark class="rounded bg-amber-200 px-0.5 text-slate-900">a. Qualitative Methods in Sociology. Sociological Review. 68:89–112</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ16)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">35</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Lumière L. 1896. The Arrival of a Train at La Ciotat Station. [place unknown].">…896. The Arrival of a Train at La Ciotat Station<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. [place unknown].</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Lumière L. 1896. The Arrival of a Train at La Ciotat Station">…896. The Arrival of a Train at La Ciotat Station<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ61)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">36</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="U.K., U.S., U.S.S.R. 1963. Treaty Banning Nuclear Weapon Tests in the Atmosphere, in Outer Space and Under Water. UST. 14:1313.">…n the Atmosphere, in Outer Space and Under Water<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. UST. 14:1313.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="U.K., U.S., U.S.S.R. 1963. Treaty Banning Nuclear Weapon Tests in the Atmosphere, in Outer Space and Under Water">…n the Atmosphere, in Outer Space and Under Water<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ113)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">37</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Weinberg GM, Freedman DP. 1971. The Psychology of Computer Programming. Silver Anniversary Edition. New York: Van Nostrand Reinhold.">…. 1971. The Psychology of Computer Programming. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Silver Anniversary Edition. New York: Van Nostrand Reinhold.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Weinberg GM, Freedman DP. 1971. The Psychology of Computer Programming. New York: Van Nostrand Reinhold">…. 1971. The Psychology of Computer Programming. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">New York: Van Nostrand Reinhold</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ73)</td>
+                                            </tr>
+
+                                            <tr class="border-b border-slate-200 hover:bg-slate-50">
+                                                <td class="px-2 py-1 text-slate-600">38</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="NASA Goddard Institute for Space Studies. 2024. Global Temperature Anomalies 1880-2023 [Internet]. [accessed 2024 Jan 20]. https://data.giss.nasa.gov/gistemp/">…es. 2024. Global Temperature Anomalies 1880-2023<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> [Internet]. [accessed 2024 Jan 20]</mark>. https://data.giss.nasa.gov/gis…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="NASA Goddard Institute for Space Studies. 2024. Global Temperature Anomalies 1880-2023. https://data.giss.nasa.gov/gistemp/">…es. 2024. Global Temperature Anomalies 1880-2023<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark>. https://data.giss.nasa.gov/gis…</td>
+                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ87)</td>
                                             </tr>
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">39</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="NASA Goddard Institute for Space Studies. 2024. Global Temperature Anomalies 1880-2023 [Internet]. [accessed 2024 Jan 20]. https://data.giss.nasa.gov/gistemp/">NASA Goddard Institute for Space Studies<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2024. Global Temperature Anomalies 1880-2023 [Internet]. [accessed 202…</mark>. https://data.giss.nasa.gov/gis…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="NASA Goddard Institute for Space Studies 2024. Global Temperature Anomalies 1880-2023. NASA. https://data.giss.nasa.gov/gistemp/">NASA Goddard Institute for Space Studies<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2024. Global Temperature Anomalies 1880-2023. NASA</mark>. https://data.giss.nasa.gov/gis…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kafka F. 1915. Metamorphosis. Wyllie D, translator. Leipzig: Kurt Wolff Verlag.">Kafka F. 1915. Metamorphosis. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Wyllie D, translator. Leipzig: Kurt Wolff Verlag.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kafka F. 1915. Metamorphosis. Leipzig: Kurt Wolff Verlag">Kafka F. 1915. Metamorphosis. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Leipzig: Kurt Wolff Verlag</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ41)</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ31)</td>
                                             </tr>
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">40</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Ericsson KA. 2006. The Role of Deliberate Practice. In: Ericsson KA, Charness N, Feltovich PJ, Hoffman RR, editors. The Cambridge Handbook of Expertise and Expert Performance. [place unknown]: Cambridge University Press; p. 683–703.">Ericsson KA<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2006. The Role of Deliberate Practice. In: Ericsson KA, Charness N, Fe…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Ericsson KA 2006. The Role of Deliberate Practice. On edited by KA Ericsson, N Charness, PJ Feltovich, RR Hoffman, The Cambridge Handbook of Expertise and Expert Performance. Cambridge University Press; pp. 683–703">Ericsson KA<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2006. The Role of Deliberate Practice. On edited by KA Ericsson, N Char…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="State of JS Team. 2023. The State of JavaScript 2023 [Internet]. [accessed 2024 Jan 15]. https://stateofjs.com/2023">…e of JS Team. 2023. The State of JavaScript 2023<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> [Internet]. [accessed 2024 Jan 15]</mark>. https://stateofjs.com/2023</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="State of JS Team. 2023. The State of JavaScript 2023. https://stateofjs.com/2023">…e of JS Team. 2023. The State of JavaScript 2023<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark>. https://stateofjs.com/2023</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ12)</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ53)</td>
                                             </tr>
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">41</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kafka F. 1915. Metamorphosis. Wyllie D, translator. Leipzig: Kurt Wolff Verlag.">Kafka F<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 1915. Metamorphosis. Wyllie D, translator. Leipzig: Kurt Wolff Verlag.</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kafka F 1915. Metamorphosis. Kurt Wolff Verlag. Leipzig">Kafka F<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 1915. Metamorphosis. Kurt Wolff Verlag. Leipzig</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Brown v. Board of Education. 1954. [place unknown].">Brown v. Board of Education. 1954<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. [place unknown].</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Brown v. Board of Education. 1954">Brown v. Board of Education. 1954<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ8)</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ34)</td>
                                             </tr>
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">42</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Self-report. Merriam-Webster.com dictionary [Internet]. [accessed 2019 July 12]. https://www.merriam-webster.com/dictionary/self-report">Self-report<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. Merriam-Webster.com dictionary [Internet]. [accessed 2019 July 12]</mark>. https://www.merriam-webster.co…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Self-report n.d. Merriam-Webster.com dictionary. https://www.merriam-webster.com/dictionary/self-report">Self-report<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> n.d. Merriam-Webster.com dictionary</mark>. https://www.merriam-webster.co…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W. 2019. Neural Networks for Natural Language Understanding [phd-thesis]. [place unknown]: Stanford University.">…ural Networks for Natural Language Understanding<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> [phd-thesis]. [place unknown]: Stanford University.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W. 2019. Neural Networks for Natural Language Understanding. Stanford University">…ural Networks for Natural Language Understanding<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. Stanford University</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ12)</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ65)</td>
                                             </tr>
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">43</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="State of JS Team. 2023. The State of JavaScript 2023 [Internet]. [accessed 2024 Jan 15]. https://stateofjs.com/2023">State of JS Team<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2023. The State of JavaScript 2023 [Internet]. [accessed 2024 Jan 15]</mark>. https://stateofjs.com/2023</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="State of JS Team 2023. The State of JavaScript 2023. https://stateofjs.com/2023">State of JS Team<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2023. The State of JavaScript 2023</mark>. https://stateofjs.com/2023</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Sagan C. 1980. The Universe in a Nutshell. Cosmos: A Spacetime Odyssey.">Sagan C. 1980. The Universe in a Nutshell<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. Cosmos: A Spacetime Odyssey.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Sagan C. 1980. The Universe in a Nutshell">Sagan C. 1980. The Universe in a Nutshell<mark class="rounded bg-amber-200 px-0.5 text-slate-900"></mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ17)</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ42)</td>
                                             </tr>
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">44</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W. 2019. Neural Networks for Natural Language Understanding [phd-thesis]. [place unknown]: Stanford University.">Chen W<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2019. Neural Networks for Natural Language Understanding [phd-thesis].…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W 2019. Neural Networks for Natural Language Understanding. Stanford University">Chen W<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2019. Neural Networks for Natural Language Understanding. Stanford Univ…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Vasari G. 2022. Renaissance Art and Culture. Encyclopedia of World History. 5:234–256.">Vasari G. 2022. Renaissance Art and Culture. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Encyclopedia of World History. 5:234–256.</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Vasari G. 2022. Renaissance Art and Culture. 5:234–256">Vasari G. 2022. Renaissance Art and Culture. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">5:234–256</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ7)</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ46)</td>
                                             </tr>
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">45</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Brown v. Board of Education. 1954. [place unknown].">Brown v. Board of Education<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 1954. [place unknown].</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Brown v. Board of Education 1954. U.S. Reports. 347; 483">Brown v. Board of Education<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 1954. U.S. Reports. 347; 483</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Self-report. Merriam-Webster.com dictionary [Internet]. [accessed 2019 July 12]. https://www.merriam-webster.com/dictionary/self-report">Self-report. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Merriam-Webster.com dictionary [Internet]. [accessed 2019 July 12]</mark>. https://www.merriam-webster.co…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Self-report. n.d. https://www.merriam-webster.com/dictionary/self-report">Self-report. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">n.d</mark>. https://www.merriam-webster.co…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-red-600">✗</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">containerTitle:extra, volume:extra, pages:extra</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">containerTitle:missing</td>
                                             </tr>
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">46</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Cable D. 2013. The racial dot map [Internet]. [accessed 2019 Oct 27]. https://demographics.coopercenter.org/Racial-Dot-Map">Cable D<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2013. The racial dot map [Internet]. [accessed 2019 Oct 27]</mark>. https://demographics.coopercen…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Cable D 2013. The racial dot map. University of Virginia, Weldon Cooper Center for Public Service. https://demographics.coopercenter.org/Racial-Dot-Map">Cable D<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2013. The racial dot map. University of Virginia, Weldon Cooper Center …</mark>. https://demographics.coopercen…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Cable D. 2013. The racial dot map [Internet]. [accessed 2019 Oct 27]. https://demographics.coopercenter.org/Racial-Dot-Map">Cable D. 2013. The racial dot map<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> [Internet]. [accessed 2019 Oct 27]</mark>. https://demographics.coopercen…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Cable D. 2013. The racial dot map. University of Virginia, Weldon Cooper Center for Public Service. https://demographics.coopercenter.org/Racial-Dot-Map">Cable D. 2013. The racial dot map<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. University of Virginia, Weldon Cooper Center for Public Service</mark>. https://demographics.coopercen…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-red-600">✗</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">publisher:extra</td>
@@ -41285,11 +41988,11 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">47</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Bibliographic references. 2010. [accessed 2025 Apr 11]. https://doi.org/10.3789/ansi.niso.z39.29-2005R2010">Bibliographic references<mark class="rounded bg-amber-200 px-0.5 text-slate-900">. 2010. [accessed 2025 Apr 11]. https://doi.org/10.3789/ansi.niso.z39.29…</mark>2010</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Bibliographic references 2010. NISO. 10.3789/ansi.niso.z39.29-2005R2010. Bethesda, MD. https://www.niso.org/publications/ansiniso-z3929-2005-r2010">Bibliographic references<mark class="rounded bg-amber-200 px-0.5 text-slate-900"> 2010. NISO. 10.3789/ansi.niso.z39.29-2005R2010. Bethesda, MD. https://w…</mark>2010</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Bibliographic references. 2010. [accessed 2025 Apr 11]. https://doi.org/10.3789/ansi.niso.z39.29-2005R2010">Bibliographic references. 2010. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">[accessed 2025 Apr 11]. https://doi.org/10.3789/ansi.niso.z39.29-2005R</mark>2010</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Bibliographic references. 2010. Bethesda, MD: NISO. https://www.niso.org/publications/ansiniso-z3929-2005-r2010">Bibliographic references. 2010. <mark class="rounded bg-amber-200 px-0.5 text-slate-900">Bethesda, MD: NISO. https://www.niso.org/publications/ansiniso-z3929-200…</mark>2010</td>
                                                 <td class="px-2 py-1 text-center font-bold text-red-600">✗</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">—</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">doi:missing</td>
                                             </tr>
 
                                         </tbody>
@@ -41328,9 +42031,9 @@
                     data-origin="csl-derived"
                     data-csl-reach="-1"
                     data-citation-rate="1"
-                    data-bibliography-rate="1"
-                    data-component-rate="1"
-                    data-fidelity="1"
+                    data-bibliography-rate="0.9574468085106383"
+                    data-component-rate="0.992"
+                    data-fidelity="0.97"
                     data-exact-parity="0.208955223880597"
                     data-quality="1"
                     data-sqi-tier-rank="4">
@@ -41350,15 +42053,15 @@
                         </span>
                     </td>
                     <td class="hidden md:table-cell px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-perfect">
-                            47/47
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-partial">
+                            45/47
                         </span>
 
                     </td>
                     <td class="hidden md:table-cell px-6 py-4">
-                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">100%</span>
+                        <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium bg-emerald-100 text-emerald-700">99%</span>
                     </td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">100.0%</td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">97.0%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-partial">
                             14/67
@@ -41413,6 +42116,25 @@
                                 </div>
                                 <div class="mt-2 text-xs text-slate-500 font-mono">
                                     scopes 0 · variants 0 · exact dupes 0 · near dupes 0
+                                </div>
+                            </div>
+
+                            <div class="mb-4">
+                                <div class="text-xs font-semibold text-slate-700 mb-2">Top Component Issues</div>
+                                <div class="flex flex-wrap gap-2">
+
+                                    <span class="px-2 py-1 rounded bg-slate-100 text-slate-600 text-xs font-mono">
+                                        containerTitle:missing <span class="font-bold">×2</span>
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-slate-100 text-slate-600 text-xs font-mono">
+                                        volume:extra <span class="font-bold">×1</span>
+                                    </span>
+
+                                    <span class="px-2 py-1 rounded bg-slate-100 text-slate-600 text-xs font-mono">
+                                        publisher:missing <span class="font-bold">×1</span>
+                                    </span>
+
                                 </div>
                             </div>
 
@@ -41531,8 +42253,8 @@
                                         <tbody>
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">1</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[2] Hawking S. A Brief History of Time. New York: Bantam Dell Publishing Group; 1988."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[2] Hawking S. A Brief History of Time. New York: Bantam Dell Publishing…</mark>.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Hawking S A Brief History of Time. 1988. New York: Bantam Dell Publishing Group."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Hawking S A Brief History of Time. 1988. New York: Bantam Dell Publishin…</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[2] Hawking S. A Brief History of Time. New York: Bantam Dell Publishing Group; 1988."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[2]</mark> Hawking S. A Brief History of T…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="2. Hawking S. A Brief History of Time. New York: Bantam Dell Publishing Group; 1988."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">2.</mark> Hawking S. A Brief History of T…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41540,8 +42262,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">2</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[5] World Bank. World Development Report 2023. Washington, DC: World Bank Group; 2023."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[5] World Bank. World Development Report 2023. Washington, DC: World Ban…</mark>.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="World Bank World Development Report 2023. 2023. Washington, DC: World Bank Group."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">World Bank World Development Report 2023. 2023. Washington, DC: World Ba…</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[4] Ericsson KA. The Role of Deliberate Practice. In: Ericsson KA, Charness N, Feltovich PJ, et al., editors. The Cambridge Handbook of Expertise and Expert Performance. Cambridge University Press; 2006. p. 683–703."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[4] Ericsson KA. The Role of Deliberate Practice. In: Ericsson KA, Charn…</mark> The Cambridge Handbook of Exper…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="4. Ericsson KA. The Role of Deliberate Practice. In: Ericsson KA, Charness N, Feltovich PJ, et al., editors The Cambridge Handbook of Expertise and Expert Performance. Cambridge University Press; 2006. p. 683–703."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">4. Ericsson KA. The Role of Deliberate Practice. In: Ericsson KA, Charne…</mark> The Cambridge Handbook of Exper…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41549,8 +42271,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">3</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[7] Vaswani A, Shazeer N, Parmar N, et al. Attention Is All You Need. Advances in Neural Information Processing Systems. 2017;30:5998–6008."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[7] Vaswani A, Shazeer N, Parmar N, et al. Attention Is All You Need. Ad…</mark>5998–6008.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Vaswani A, Shazeer N, Parmar N, et al. Attention Is All You Need. Advances in Neural Information Processing Systems. 30. 5998–6008."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Vaswani A, Shazeer N, Parmar N, et al. Attention Is All You Need. Advanc…</mark>5998–6008.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[5] World Bank. World Development Report 2023. Washington, DC: World Bank Group; 2023."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[5]</mark> World Bank. World Development R…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="5. World Bank. World Development Report 2023. Washington, DC: World Bank Group; 2023."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">5.</mark> World Bank. World Development R…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41558,8 +42280,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">4</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[14] Reis HT, Judd CM, editors. Handbook of Research Methods in Social Psychology. Cambridge: Cambridge University Press; 2000."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[14] Reis HT, Judd CM, editors. Handbook of Research Methods in Social P…</mark>.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Reis HT, Judd CM, editors Handbook of Research Methods in Social Psychology. 2000. Cambridge: Cambridge University Press."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Reis HT, Judd CM, editors Handbook of Research Methods in Social Psychol…</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[7] Vaswani A, Shazeer N, Parmar N, et al. Attention Is All You Need. Advances in Neural Information Processing Systems. 2017;30:5998–6008."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[7]</mark> Vaswani A, Shazeer N, Parmar N,…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="7. Vaswani A, Shazeer N, Parmar N, et al. Attention Is All You Need. Advances in Neural Information Processing Systems. 2017;30:5998–6008."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">7.</mark> Vaswani A, Shazeer N, Parmar N,…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41567,8 +42289,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">5</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[9] Smith J, Anderson M. Climate Change and Extreme Weather Events. Nature Climate Change. 2020;10:850–855."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[9] Smith J, Anderson M. Climate Change and Extreme Weather Events. Natu…</mark>850–855.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Anderson M Climate Change and Extreme Weather Events. Nature Climate Change. 10. 850–855."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Smith J, Anderson M Climate Change and Extreme Weather Events. Nature Cl…</mark>850–855.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[14] Reis HT, Judd CM, editors. Handbook of Research Methods in Social Psychology. Cambridge: Cambridge University Press; 2000."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[14]</mark> Reis HT, Judd CM, editors. Hand…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="14. Reis HT, Judd CM, editors. Handbook of Research Methods in Social Psychology. Cambridge: Cambridge University Press; 2000."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">14.</mark> Reis HT, Judd CM, editors. Hand…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41576,8 +42298,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">6</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[8] Kuhn TS. Scientific Paradigms and Normal Science. Philosophy of Science. 1970;37(1):1–13."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[8] Kuhn TS. Scientific Paradigms and Normal Science. Philosophy of Scie…</mark>1–13.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kuhn TS Scientific Paradigms and Normal Science. Philosophy of Science. 37, (1). 1–13."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Kuhn TS Scientific Paradigms and Normal Science. Philosophy of Science. …</mark>1–13.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[15] The Role of Theory in Research. Journal of Theoretical Psychology. 2018;28(3):201–215."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[15]</mark> The Role of Theory in Research.…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="15. The Role of Theory in Research. Journal of Theoretical Psychology. 2018;28(3):201–215."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">15.</mark> The Role of Theory in Research.…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41585,8 +42307,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">7</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[22] Lumière L. The Arrival of a Train at La Ciotat Station. 1896."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[22] Lumière L.</mark> The Arrival of a Train at La Ci…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Lumière L The Arrival of a Train at La Ciotat Station. 1896."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Lumière L</mark> The Arrival of a Train at La Ci…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[35] Johnson A. Quantitative Methods in Sociology. Sociological Review. 2020;68:23–45."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[35]</mark> Johnson A. Quantitative Methods…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="35. Johnson A. Quantitative Methods in Sociology. Sociological Review. 2020;68:23–45."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">35.</mark> Johnson A. Quantitative Methods…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41594,8 +42316,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">8</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[3] LeCun Y, Bengio Y, Hinton G. Deep Learning. Nature. 2015;521:436–444."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[3] LeCun Y, Bengio Y, Hinton G. Deep Learning. Nature. 2015;521:</mark>436–444.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="LeCun Y, Bengio Y, Hinton G Deep Learning. Nature. 521. 436–444."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">LeCun Y, Bengio Y, Hinton G Deep Learning. Nature. 521. </mark>436–444.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[36] Johnson B. Qualitative Methods in Sociology. Sociological Review. 2020;68:89–112."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[36]</mark> Johnson B. Qualitative Methods …</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="36. Johnson B. Qualitative Methods in Sociology. Sociological Review. 2020;68:89–112."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">36.</mark> Johnson B. Qualitative Methods …</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41603,8 +42325,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">9</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[23] Sagan C. The Universe in a Nutshell. Cosmos: A Spacetime Odyssey. 1980."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[23] Sagan C. The Universe in a Nutshell. Cosmos: A Spacetime Odyssey. 1…</mark>.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Sagan C The Universe in a Nutshell. Cosmos: A Spacetime Odyssey. 1980 (1)."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Sagan C The Universe in a Nutshell. Cosmos: A Spacetime Odyssey. 1980 (1…</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[22] Lumière L. The Arrival of a Train at La Ciotat Station. 1896."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[22]</mark> Lumière L. The Arrival of a Tra…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="22. Lumière L. The Arrival of a Train at La Ciotat Station. 1896."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">22.</mark> Lumière L. The Arrival of a Tra…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41612,8 +42334,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">10</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[21] Johnson D, Lee S. Method for Efficient Data Compression. 2021."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[21] Johnson D, Lee S.</mark> Method for Efficient Data Compr…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson D, Lee S Method for Efficient Data Compression. 2021."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Johnson D, Lee S</mark> Method for Efficient Data Compr…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[21] Johnson D, Lee S. Method for Efficient Data Compression. 2021."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[21]</mark> Johnson D, Lee S. Method for Ef…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="21. Johnson D, Lee S. Method for Efficient Data Compression. 2021."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">21.</mark> Johnson D, Lee S. Method for Ef…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41622,7 +42344,7 @@
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">11</td>
                                                 <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[33] Forthcoming A. Foundations of Declarative Bibliography. Cambridge: University Press;"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[33] Forthcoming A. Foundations of Declarative Bibliography. Cambridge: …</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Forthcoming A Foundations of Declarative Bibliography. n.d. Cambridge: University Press."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Forthcoming A Foundations of Declarative Bibliography. n.d. Cambridge: U…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="33. Forthcoming A. Foundations of Declarative Bibliography. Cambridge: University Press; n.d."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">33. Forthcoming A. Foundations of Declarative Bibliography. Cambridge: U…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41630,8 +42352,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">12</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[46] U.K., U.S., U.S.S.R. Treaty Banning Nuclear Weapon Tests in the Atmosphere, in Outer Space and Under Water. U.S.T. 1963. p. 1313."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[46] U.K., U.S., U.S.S.R. Treaty Banning Nuclear Weapon Tests in the Atm…</mark>. 1313.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="U.K., U.S., U.S.S.R. Treaty Banning Nuclear Weapon Tests in the Atmosphere, in Outer Space and Under Water. U.S.T. 1963. 14. 1313."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">U.K., U.S., U.S.S.R. Treaty Banning Nuclear Weapon Tests in the Atmosphe…</mark>. 1313.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[44] Strengthening the federal student loan program for borrowers [Internet]. 2014. Available from: https://www.help.senate.gov/hearings/strengthening-the-federal-student-loan-program-for-borrowers."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[44] Strengthening the federal student loan program for borrowers [Inter…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="44. Strengthening the federal student loan program for borrowers. 2014. https://www.help.senate.gov/hearings/strengthening-the-federal-student-loan-program-for-borrowers"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">44. Strengthening the federal student loan program for borrowers. 2014. …</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41639,8 +42361,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">13</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[44] Strengthening the federal student loan program for borrowers [Internet]. 2014. Available from: https://www.help.senate.gov/hearings/strengthening-the-federal-student-loan-program-for-borrowers."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[44] Strengthening the federal student loan program for borrowers [Inter…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Strengthening the federal student loan program for borrowers. 2014. https://www.help.senate.gov/hearings/strengthening-the-federal-student-loan-program-for-borrowers"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Strengthening the federal student loan program for borrowers. 2014. http…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[46] U.K., U.S., U.S.S.R. Treaty Banning Nuclear Weapon Tests in the Atmosphere, in Outer Space and Under Water. U.S.T. 1963. p. 1313."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[46] U.K., U.S., U.S.S.R. Treaty Banning Nuclear Weapon Tests in the Atm…</mark>3.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="46. U.K., U.S., U.S.S.R. Treaty Banning Nuclear Weapon Tests in the Atmosphere, in Outer Space and Under Water. 1963."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">46. U.K., U.S., U.S.S.R. Treaty Banning Nuclear Weapon Tests in the Atmo…</mark>3.</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41648,8 +42370,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">14</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[18] Vasari G. Renaissance Art and Culture. Encyclopedia of World History. Oxford University Press; 2022. p. 234–256."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[18] Vasari G. Renaissance Art and Culture. Encyclopedia of World Histor…</mark>p. 234–256.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Vasari G Renaissance Art and Culture. Encyclopedia of World History. 2022. 5: Oxford University Press. pp. 234–256."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Vasari G Renaissance Art and Culture. Encyclopedia of World History. 202…</mark>p. 234–256.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[25] Kafka F. Metamorphosis. Leipzig: Kurt Wolff Verlag; 1915."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[25]</mark> Kafka F. Metamorphosis. Leipzig…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="25. Kafka F. Metamorphosis. Leipzig: Kurt Wolff Verlag; 1915."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">25.</mark> Kafka F. Metamorphosis. Leipzig…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41657,8 +42379,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">15</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[25] Kafka F. Metamorphosis. Leipzig: Kurt Wolff Verlag; 1915."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[25] Kafka F. Metamorphosis. Leipzig: Kurt Wolff Verlag; 1915</mark>.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kafka F Metamorphosis. 1915. Leipzig: Kurt Wolff Verlag."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Kafka F Metamorphosis. 1915. Leipzig: Kurt Wolff Verlag</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[28] Smith P. Discussion on Citum Schema Design. 2024."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[28]</mark> Smith P. Discussion on Citum Sc…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="28. Smith P. Discussion on Citum Schema Design. 2024."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">28.</mark> Smith P. Discussion on Citum Sc…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41666,8 +42388,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">16</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[28] Smith P. Discussion on Citum Schema Design. 2024."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[28] Smith P.</mark> Discussion on Citum Schema Desi…</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith P Discussion on Citum Schema Design. 2024."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Smith P</mark> Discussion on Citum Schema Desi…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[17] Thompson A. The Art of Minimalism in Modern Design. Wired. 2023 June;31(6):42–49."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[17] Thompson A. The Art of Minimalism in Modern Design. Wired. 2023 Jun…</mark>;31(6):42–49.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="17. Thompson A. The Art of Minimalism in Modern Design. Wired. 2023;31(6):42–49."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">17. Thompson A. The Art of Minimalism in Modern Design. Wired. 2023</mark>;31(6):42–49.</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41675,8 +42397,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">17</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[10] Smith J, Williams R. Machine Learning for Climate Prediction. Environmental Research Letters. 2020;15(11):114042."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[10] Smith J, Williams R. Machine Learning for Climate Prediction. Envir…</mark>114042.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Williams R Machine Learning for Climate Prediction. Environmental Research Letters. 15, (11). 114042."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Smith J, Williams R Machine Learning for Climate Prediction. Environment…</mark>114042.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[26] Spinoza B. Éthique. Amsterdam: Jan Rieuwertsz; 1677."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[26]</mark> Spinoza B. Éthique. Amsterdam: …</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="26. Spinoza B. Éthique. Amsterdam: Jan Rieuwertsz; 1677."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">26.</mark> Spinoza B. Éthique. Amsterdam: …</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41684,8 +42406,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">18</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[15] The Role of Theory in Research. Journal of Theoretical Psychology. 2018;28(3):201–215."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[15] The Role of Theory in Research. Journal of Theoretical Psychology. …</mark>201–215.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="The Role of Theory in Research. Journal of Theoretical Psychology. 28, (3). 201–215."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">The Role of Theory in Research. Journal of Theoretical Psychology. 28, (…</mark>201–215.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[34] Adams J. Letter to James Smith. 1797."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[34]</mark> Adams J. Letter to James Smith.…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="34. Adams J. Letter to James Smith. 1797."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">34.</mark> Adams J. Letter to James Smith.…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41693,8 +42415,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">19</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[31] Garcia M. Methods for Robust Climate Attribution. Annual Review of Climate Science. 2019;4:55–80."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[31] Garcia M. Methods for Robust Climate Attribution. Annual Review of …</mark>55–80.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Garcia M Methods for Robust Climate Attribution. Annual Review of Climate Science. 4. 55–80."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Garcia M Methods for Robust Climate Attribution. Annual Review of Climat…</mark>55–80.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[47] Protection of Human Subjects [Internet]. C.F.R. 2009. Available from: https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrpregulations.pdf."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[47] Protection of Human Subjects [Internet]. C.F.R. 2009. Available fro…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="47. Protection of Human Subjects. 2009. https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrpregulations.pdf"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">47. Protection of Human Subjects. 2009. https://www.hhs.gov/ohrp/sites/d…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41702,8 +42424,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">20</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[32] Garcia M. Methods for Probabilistic Climate Attribution. Annual Review of Climate Science. 2019;4:81–104."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[32] Garcia M. Methods for Probabilistic Climate Attribution. Annual Rev…</mark>81–104.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Garcia M Methods for Probabilistic Climate Attribution. Annual Review of Climate Science. 4. 81–104."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Garcia M Methods for Probabilistic Climate Attribution. Annual Review of…</mark>81–104.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[6] Weinberg GM, Freedman DP. The Psychology of Computer Programming. Silver Anniversary Edition. New York: Van Nostrand Reinhold; 1971."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[6] Weinberg GM, Freedman DP. The Psychology of Computer Programming. Si…</mark>. New York: Van Nostrand Reinhol…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="6. Weinberg GM, Freedman DP. The Psychology of Computer Programming. New York: Van Nostrand Reinhold; 1971."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">6. Weinberg GM, Freedman DP. The Psychology of Computer Programming</mark>. New York: Van Nostrand Reinhol…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41711,8 +42433,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">21</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[39] Self-report [Internet]. Merriam-Webster.com dictionary. [cited 2019 July 12]. Available from: https://www.merriam-webster.com/dictionary/self-report."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[39] Self-report [Internet]. Merriam-Webster.com dictionary. [cited 2019…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Self-report. Merriam-Webster.com dictionary. [Cited 2019, July 12]. Available at https://www.merriam-webster.com/dictionary/self-report"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Self-report. Merriam-Webster.com dictionary. [Cited 2019, July 12]. Avai…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[45] Tactile Labs. Latero tactile display [Internet]. 2015. Available from: http://tactilelabs.com/products/haptics/latero-tactile-display/."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[45] Tactile Labs. Latero tactile display [Internet]. 2015. Available fr…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="45. Tactile Labs. Latero tactile display. 2015. http://tactilelabs.com/products/haptics/latero-tactile-display/"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">45. Tactile Labs. Latero tactile display. 2015. http://tactilelabs.com/p…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41720,8 +42442,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">22</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[26] Spinoza B. Éthique. Amsterdam: Jan Rieuwertsz; 1677."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[26] Spinoza B. Éthique. Amsterdam: Jan Rieuwertsz; 1677</mark>.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Spinoza B Éthique. 1677. Amsterdam: Jan Rieuwertsz."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Spinoza B Éthique. 1677. Amsterdam: Jan Rieuwertsz</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[16] Rodriguez M. Major Breakthrough in Quantum Computing Announced. The New York Times. 2024 Mar 15;"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[16] Rodriguez M. Major Breakthrough in Quantum Computing Announced. The…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="16. Rodriguez M. Major Breakthrough in Quantum Computing Announced. The New York Times. 2024;."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">16. Rodriguez M. Major Breakthrough in Quantum Computing Announced. The …</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41729,8 +42451,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">23</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[34] Adams J. Letter to James Smith. 1797."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[34] Adams J.</mark> Letter to James Smith. 1797.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Adams J Letter to James Smith. 1797."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Adams J</mark> Letter to James Smith. 1797.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[27] United Nations Environment Programme. State of the World’s Biodiversity. Díaz S, editor. Nairobi: UNEP; 2019."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[27] United Nations Environment Programme. State of the World’s Biodiver…</mark>. Nairobi: UNEP; 2019.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="27. United Nations Environment Programme. State of the World’s Biodiversity. Nairobi: UNEP; 2019."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">27. United Nations Environment Programme. State of the World’s Biodivers…</mark>. Nairobi: UNEP; 2019.</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41738,8 +42460,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">24</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[38] Chen W. Urban Heat Island Measurement Techniques. Urban Climate. 2024;18:45–62."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[38] Chen W. Urban Heat Island Measurement Techniques. Urban Climate. 20…</mark>45–62.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W Urban Heat Island Measurement Techniques. Urban Climate. 18. 45–62."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Chen W Urban Heat Island Measurement Techniques. Urban Climate. 18. </mark>45–62.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[43] Mental Health on Campus Improvement Act [Internet]. 1100 2013. Available from: https://www.congress.gov/bill/113th-congress/housebill/1100."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[43] Mental Health on Campus Improvement Act [Internet]. 1100 2013. Avai…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="43. Mental Health on Campus Improvement Act. 2013. https://www.congress.gov/bill/113th-congress/housebill/1100"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">43. Mental Health on Campus Improvement Act. 2013. https://www.congress.…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41747,8 +42469,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">25</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[6] Weinberg GM, Freedman DP. The Psychology of Computer Programming. Silver Anniversary Edition. New York: Van Nostrand Reinhold; 1971."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[6] Weinberg GM, Freedman DP. The Psychology of Computer Programming. Si…</mark>.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Weinberg GM, Freedman DP The Psychology of Computer Programming. 1971. New York: Van Nostrand Reinhold."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Weinberg GM, Freedman DP The Psychology of Computer Programming. 1971. N…</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[24] Bengio Y. The Future of Artificial Intelligence [Internet]. 2023. Available from: https://example.com/interview."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[24] Bengio Y. The Future of Artificial Intelligence [Internet]. 2023. A…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="24. Bengio Y. The Future of Artificial Intelligence. 2023. https://example.com/interview"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">24. Bengio Y. The Future of Artificial Intelligence. 2023. https://examp…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41756,8 +42478,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">26</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[35] Johnson A. Quantitative Methods in Sociology. Sociological Review. 2020;68:23–45."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[35] Johnson A. Quantitative Methods in Sociology. Sociological Review. …</mark>23–45.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson A Quantitative Methods in Sociology. Sociological Review. 68. 23–45."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Johnson A Quantitative Methods in Sociology. Sociological Review. 68. </mark>23–45.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[11] Chen W. Neural Networks for Natural Language Understanding [phd-thesis]. Stanford University; 2019."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[11] Chen W. Neural Networks for Natural Language Understanding [phd-the…</mark>. Stanford University; 2019.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="11. Chen W. Neural Networks for Natural Language Understanding. Stanford University; 2019."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">11. Chen W. Neural Networks for Natural Language Understanding</mark>. Stanford University; 2019.</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41765,8 +42487,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">27</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[36] Johnson B. Qualitative Methods in Sociology. Sociological Review. 2020;68:89–112."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[36] Johnson B. Qualitative Methods in Sociology. Sociological Review. 2…</mark>89–112.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Johnson B Qualitative Methods in Sociology. Sociological Review. 68. 89–112."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Johnson B Qualitative Methods in Sociology. Sociological Review. 68. </mark>89–112.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[1] Kuhn TS. The Structure of Scientific Revolutions. International Encyclopedia of Unified Science. 1962;2(2)."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[1] Kuhn TS. The Structure of Scientific Revolutions. International Ency…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="1. Kuhn TS. The Structure of Scientific Revolutions. International Encyclopedia of Unified Science. 1962;2(2). doi:10.1234/example"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">1. Kuhn TS. The Structure of Scientific Revolutions. International Encyc…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41774,8 +42496,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">28</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[37] Chen W. Urban Heat Island Mitigation Strategies. Urban Climate. 2022;15:1–18."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[37] Chen W. Urban Heat Island Mitigation Strategies. Urban Climate. 202…</mark>1–18.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W Urban Heat Island Mitigation Strategies. Urban Climate. 15. 1–18."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Chen W Urban Heat Island Mitigation Strategies. Urban Climate. 15. </mark>1–18.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[8] Kuhn TS. Scientific Paradigms and Normal Science. Philosophy of Science. 1970;37(1):1–13."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[8] Kuhn TS. Scientific Paradigms and Normal Science. Philosophy of Scie…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="8. Kuhn TS. Scientific Paradigms and Normal Science. Philosophy of Science. 1970;37(1):1–13. doi:10.1086/288273"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">8. Kuhn TS. Scientific Paradigms and Normal Science. Philosophy of Scien…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41783,8 +42505,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">29</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[4] Ericsson KA. The Role of Deliberate Practice. In: Ericsson KA, Charness N, Feltovich PJ, et al., editors. The Cambridge Handbook of Expertise and Expert Performance. Cambridge University Press; 2006. p. 683–703."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[4] Ericsson KA. The Role of Deliberate Practice. In: Ericsson KA, Charn…</mark>p. 683–703.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Ericsson KA The Role of Deliberate Practice. On edited by KA Ericsson, N Charness, PJ Feltovich, et al., The Cambridge Handbook of Expertise and Expert Performance. 2006: Cambridge University Press. pp. 683–703."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Ericsson KA The Role of Deliberate Practice. On edited by KA Ericsson, N…</mark>p. 683–703.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[12] Mikolov T, Sutskever I, Chen K, et al. Distributed Representations of Words and Phrases. Proceedings of NIPS 2013. 2013. p. 3111–3119."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[12] Mikolov T, Sutskever I, Chen K, et al</mark>. Distributed Representations of…</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="12. Mikolov T, Sutskever I, Chen K, Corrado G, Dean J. Distributed Representations of Words and Phrases. Proceedings of NIPS 2013. 2013. p. 3111–3119."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">12. Mikolov T, Sutskever I, Chen K, Corrado G, Dean J</mark>. Distributed Representations of…</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41792,8 +42514,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">30</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[45] Tactile Labs. Latero tactile display [Internet]. 2015. Available from: http://tactilelabs.com/products/haptics/latero-tactile-display/."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[45] Tactile Labs. Latero tactile display [Internet]. 2015. Available fr…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Tactile Labs Latero tactile display. 2015. http://tactilelabs.com/products/haptics/latero-tactile-display/"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Tactile Labs Latero tactile display. 2015. http://tactilelabs.com/produc…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[41] Cable D. The racial dot map [Internet]. University of Virginia, Weldon Cooper Center for Public Service; 2013 [cited 2019 Oct 27]. Available from: https://demographics.coopercenter.org/Racial-Dot-Map."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[41] Cable D. The racial dot map [Internet]. University of Virginia, Wel…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="41. Cable D. The racial dot map. University of Virginia, Weldon Cooper Center for Public Service; 2013. https://demographics.coopercenter.org/Racial-Dot-Map"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">41. Cable D. The racial dot map. University of Virginia, Weldon Cooper C…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41801,8 +42523,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">31</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[47] Protection of Human Subjects [Internet]. C.F.R. 2009. Available from: https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrpregulations.pdf."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[47] Protection of Human Subjects [Internet]. C.F.R. 2009. Available fro…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Protection of Human Subjects. 2009. 45. https://www.hhs.gov/ohrp/sites/default/files/ohrp/policy/ohrpregulations.pdf"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Protection of Human Subjects. 2009. 45. https://www.hhs.gov/ohrp/sites/d…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[10] Smith J, Williams R. Machine Learning for Climate Prediction. Environmental Research Letters. 2020;15(11):114042."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[10] Smith J, Williams R. Machine Learning for Climate Prediction. Envir…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="10. Smith J, Williams R. Machine Learning for Climate Prediction. Environmental Research Letters. 2020;15(11):114042. doi:10.1088/1748-9326/abc123"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">10. Smith J, Williams R. Machine Learning for Climate Prediction. Enviro…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41810,8 +42532,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">32</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[17] Thompson A. The Art of Minimalism in Modern Design. Wired. 2023 June;31(6):42–49."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[17] Thompson A. The Art of Minimalism in Modern Design. Wired. 2023 Jun…</mark>42–49.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Thompson A The Art of Minimalism in Modern Design. Wired. 31, (6). 42–49."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Thompson A The Art of Minimalism in Modern Design. Wired. 31, (6). </mark>42–49.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[40] Every Student Succeeds Act [Internet]. U.S.C. Sect. 6301 2015. Available from: https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[40] Every Student Succeeds Act [Internet]. U.S.C. Sect. 6301 2015. Avai…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="40. Every Student Succeeds Act. 2015. https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">40. Every Student Succeeds Act. 2015. https://www.congress.gov/114/plaws…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41819,8 +42541,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">33</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[43] Mental Health on Campus Improvement Act [Internet]. 1100 2013. Available from: https://www.congress.gov/bill/113th-congress/housebill/1100."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[43] Mental Health on Campus Improvement Act [Internet]. 1100 2013. Avai…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Mental Health on Campus Improvement Act. 2013. https://www.congress.gov/bill/113th-congress/housebill/1100"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Mental Health on Campus Improvement Act. 2013. https://www.congress.gov/…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[3] LeCun Y, Bengio Y, Hinton G. Deep Learning. Nature. 2015;521:436–444."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[3] LeCun Y, Bengio Y, Hinton G. Deep Learning. Nature. 2015;521:436–444…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="3. LeCun Y, Bengio Y, Hinton G. Deep Learning. Nature. 2015;521:436–444. doi:10.1038/nature14539"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">3. LeCun Y, Bengio Y, Hinton G. Deep Learning. Nature. 2015;521:436–444.…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41828,8 +42550,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">34</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[24] Bengio Y. The Future of Artificial Intelligence [Internet]. 2023. Available from: https://example.com/interview."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[24] Bengio Y. The Future of Artificial Intelligence [Internet]. 2023. A…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Bengio Y The Future of Artificial Intelligence. 2023. https://example.com/interview"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Bengio Y The Future of Artificial Intelligence. 2023. https://example.co…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[9] Smith J, Anderson M. Climate Change and Extreme Weather Events. Nature Climate Change. 2020;10:850–855."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[9] Smith J, Anderson M. Climate Change and Extreme Weather Events. Natu…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="9. Smith J, Anderson M. Climate Change and Extreme Weather Events. Nature Climate Change. 2020;10:850–855. doi:10.1038/s41558-020-0871-4"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">9. Smith J, Anderson M. Climate Change and Extreme Weather Events. Natur…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41837,8 +42559,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">35</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[20] Brown v. Board of Education. U.S. Reports. 1954. p. 483."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[20] Brown v. Board of Education. U.S. Reports. 1954. p</mark>. 483.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Brown v. Board of Education. U.S. Reports. 1954. 347. 483."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Brown v. Board of Education. U.S. Reports. 1954. 347</mark>. 483.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[19] NASA Goddard Institute for Space Studies. Global Temperature Anomalies 1880-2023 [Internet]. NASA; 2024 [cited 2024 Jan 20]. Available from: https://data.giss.nasa.gov/gistemp/."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[19] NASA Goddard Institute for Space Studies. Global Temperature Anomal…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="19. NASA Goddard Institute for Space Studies. Global Temperature Anomalies 1880-2023. 2024; https://data.giss.nasa.gov/gistemp/"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">19. NASA Goddard Institute for Space Studies. Global Temperature Anomali…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41846,8 +42568,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">36</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[29] Smith J, Lee A, Kumar P, et al. Adaptive Climate Risk Modeling in Coastal Cities. Journal of Climate Analytics. 2021;12(2):101–119."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[29] Smith J, Lee A, Kumar P, et al. Adaptive Climate Risk Modeling in C…</mark>101–119.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Lee A, Kumar P, Zhou M Adaptive Climate Risk Modeling in Coastal Cities. Journal of Climate Analytics. 12, (2). 101–119."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Smith J, Lee A, Kumar P, Zhou M Adaptive Climate Risk Modeling in Coasta…</mark>101–119.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[42] Bibliographic references [Internet]. Bethesda, MD: NISO; 2010 [cited 2025 Apr 11]. Available from: https://www.niso.org/publications/ansiniso-z3929-2005-r2010."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[42] Bibliographic references [Internet]. Bethesda, MD: NISO; 2010 [cite…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="42. Bibliographic references. Bethesda, MD: NISO; 2010. https://www.niso.org/publications/ansiniso-z3929-2005-r2010"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">42. Bibliographic references. Bethesda, MD: NISO; 2010. https://www.niso…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41855,8 +42577,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">37</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[30] Smith J, Lee A, Nguyen B, et al. Adaptive Climate Risk Modeling for Inland Regions. Journal of Climate Analytics. 2021;12(3):201–219."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[30] Smith J, Lee A, Nguyen B, et al. Adaptive Climate Risk Modeling for…</mark>201–219.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Smith J, Lee A, Nguyen B, Patel R Adaptive Climate Risk Modeling for Inland Regions. Journal of Climate Analytics. 12, (3). 201–219."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Smith J, Lee A, Nguyen B, Patel R Adaptive Climate Risk Modeling for Inl…</mark>201–219.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[13] State of JS Team. The State of JavaScript 2023 [Internet]. 2023 [cited 2024 Jan 15]. Available from: https://stateofjs.com/2023."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[13] State of JS Team. The State of JavaScript 2023 [Internet]. 2023 [ci…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="13. State of JS Team. The State of JavaScript 2023. 2023. https://stateofjs.com/2023"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">13. State of JS Team. The State of JavaScript 2023. 2023. https://stateo…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41864,8 +42586,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">38</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[11] Chen W. Neural Networks for Natural Language Understanding [phd-thesis]. Stanford University; 2019."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[11] Chen W. Neural Networks for Natural Language Understanding [phd-the…</mark>.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Chen W Neural Networks for Natural Language Understanding. 2019: Stanford University."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Chen W Neural Networks for Natural Language Understanding. 2019: Stanfor…</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[31] Garcia M. Methods for Robust Climate Attribution. Annual Review of Climate Science. 2019;4:55–80."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[31] Garcia M. Methods for Robust Climate Attribution. Annual Review of …</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="31. Garcia M. Methods for Robust Climate Attribution. Annual Review of Climate Science. 2019;4:55–80. doi:10.5555/arcs.2019.4.55"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">31. Garcia M. Methods for Robust Climate Attribution. Annual Review of C…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41873,8 +42595,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">39</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[27] United Nations Environment Programme. State of the World’s Biodiversity. Díaz S, editor. Nairobi: UNEP; 2019."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[27] United Nations Environment Programme. State of the World’s Biodiver…</mark>.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="United Nations Environment Programme State of the World’s Biodiversity. Edited by S Díaz. 2019. Nairobi: UNEP."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">United Nations Environment Programme State of the World’s Biodiversity. …</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[32] Garcia M. Methods for Probabilistic Climate Attribution. Annual Review of Climate Science. 2019;4:81–104."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[32] Garcia M. Methods for Probabilistic Climate Attribution. Annual Rev…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="32. Garcia M. Methods for Probabilistic Climate Attribution. Annual Review of Climate Science. 2019;4:81–104. doi:10.5555/arcs.2019.4.81"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">32. Garcia M. Methods for Probabilistic Climate Attribution. Annual Revi…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41882,8 +42604,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">40</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[41] Cable D. The racial dot map [Internet]. University of Virginia, Weldon Cooper Center for Public Service; 2013 [cited 2019 Oct 27]. Available from: https://demographics.coopercenter.org/Racial-Dot-Map."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[41] Cable D. The racial dot map [Internet]. University of Virginia, Wel…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Cable D The racial dot map. 2013: University of Virginia, Weldon Cooper Center for Public Service. https://demographics.coopercenter.org/Racial-Dot-Map"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Cable D The racial dot map. 2013: University of Virginia, Weldon Cooper …</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[20] Brown v. Board of Education. U.S. Reports. 1954. p. 483."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[20] Brown v. Board of Education. U.S. Reports. 1954. p. 483</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="20. Brown v. Board of Education. 1954."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">20. Brown v. Board of Education. 1954</mark>.</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41891,8 +42613,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">41</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[16] Rodriguez M. Major Breakthrough in Quantum Computing Announced. The New York Times. 2024 Mar 15;"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[16] Rodriguez M. Major Breakthrough in Quantum Computing Announced. The…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Rodriguez M Major Breakthrough in Quantum Computing Announced. The New York Times."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Rodriguez M Major Breakthrough in Quantum Computing Announced. The New Y…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[29] Smith J, Lee A, Kumar P, et al. Adaptive Climate Risk Modeling in Coastal Cities. Journal of Climate Analytics. 2021;12(2):101–119."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[29] Smith J, Lee A, Kumar P, et al. Adaptive Climate Risk Modeling in C…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="29. Smith J, Lee A, Kumar P, Zhou M. Adaptive Climate Risk Modeling in Coastal Cities. Journal of Climate Analytics. 2021;12(2):101–119. doi:10.5555/jca.2021.12.2.101"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">29. Smith J, Lee A, Kumar P, Zhou M. Adaptive Climate Risk Modeling in C…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41900,8 +42622,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">42</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[12] Mikolov T, Sutskever I, Chen K, et al. Distributed Representations of Words and Phrases. Proceedings of NIPS 2013. 2013. p. 3111–3119."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[12] Mikolov T, Sutskever I, Chen K, et al. Distributed Representations …</mark>p. 3111–3119.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Mikolov T, Sutskever I, Chen K, Corrado G, Dean J Distributed Representations of Words and Phrases. Proceedings of NIPS 2013. 2013. pp. 3111–3119."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Mikolov T, Sutskever I, Chen K, Corrado G, Dean J Distributed Representa…</mark>p. 3111–3119.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[30] Smith J, Lee A, Nguyen B, et al. Adaptive Climate Risk Modeling for Inland Regions. Journal of Climate Analytics. 2021;12(3):201–219."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[30] Smith J, Lee A, Nguyen B, et al. Adaptive Climate Risk Modeling for…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="30. Smith J, Lee A, Nguyen B, Patel R. Adaptive Climate Risk Modeling for Inland Regions. Journal of Climate Analytics. 2021;12(3):201–219. doi:10.5555/jca.2021.12.3.201"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">30. Smith J, Lee A, Nguyen B, Patel R. Adaptive Climate Risk Modeling fo…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41909,8 +42631,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">43</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[40] Every Student Succeeds Act [Internet]. U.S.C. Sect. 6301 2015. Available from: https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[40] Every Student Succeeds Act [Internet]. U.S.C. Sect. 6301 2015. Avai…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Every Student Succeeds Act. 2015. 20. https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Every Student Succeeds Act. 2015. 20. https://www.congress.gov/114/plaws…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[37] Chen W. Urban Heat Island Mitigation Strategies. Urban Climate. 2022;15:1–18."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[37] Chen W. Urban Heat Island Mitigation Strategies. Urban Climate. 202…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="37. Chen W. Urban Heat Island Mitigation Strategies. Urban Climate. 2022;15:1–18. doi:10.5555/uc.2022.15.1"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">37. Chen W. Urban Heat Island Mitigation Strategies. Urban Climate. 2022…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41918,8 +42640,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">44</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[1] Kuhn TS. The Structure of Scientific Revolutions. International Encyclopedia of Unified Science. 1962;2(2)."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[1] Kuhn TS. The Structure of Scientific Revolutions. International Ency…</mark>.</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Kuhn TS The Structure of Scientific Revolutions. International Encyclopedia of Unified Science. 2, (2): University of Chicago Press."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Kuhn TS The Structure of Scientific Revolutions. International Encyclope…</mark>.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[23] Sagan C. The Universe in a Nutshell. Cosmos: A Spacetime Odyssey. 1980."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[23] Sagan C. The Universe in a Nutshell. Cosmos: A Spacetime Odyssey</mark>. 1980.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="23. Sagan C. The Universe in a Nutshell. 1980."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">23. Sagan C. The Universe in a Nutshell</mark>. 1980.</td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41927,8 +42649,8 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">45</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[19] NASA Goddard Institute for Space Studies. Global Temperature Anomalies 1880-2023 [Internet]. NASA; 2024 [cited 2024 Jan 20]. Available from: https://data.giss.nasa.gov/gistemp/."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[19] NASA Goddard Institute for Space Studies. Global Temperature Anomal…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="NASA Goddard Institute for Space Studies Global Temperature Anomalies 1880-2023: NASA. https://data.giss.nasa.gov/gistemp/"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">NASA Goddard Institute for Space Studies Global Temperature Anomalies 18…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[38] Chen W. Urban Heat Island Measurement Techniques. Urban Climate. 2024;18:45–62."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[38] Chen W. Urban Heat Island Measurement Techniques. Urban Climate. 20…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="38. Chen W. Urban Heat Island Measurement Techniques. Urban Climate. 2024;18:45–62. doi:10.5555/uc.2024.18.45"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">38. Chen W. Urban Heat Island Measurement Techniques. Urban Climate. 202…</mark></td>
                                                 <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
                                                 <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
@@ -41936,20 +42658,20 @@
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">46</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[42] Bibliographic references [Internet]. Bethesda, MD: NISO; 2010 [cited 2025 Apr 11]. Available from: https://www.niso.org/publications/ansiniso-z3929-2005-r2010."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[42] Bibliographic references [Internet]. Bethesda, MD: NISO; 2010 [cite…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="Bibliographic references. 2010. Bethesda, MD: NISO. https://www.niso.org/publications/ansiniso-z3929-2005-r2010"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">Bibliographic references. 2010. Bethesda, MD: NISO. https://www.niso.org…</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[18] Vasari G. Renaissance Art and Culture. Encyclopedia of World History. Oxford University Press; 2022. p. 234–256."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[18] Vasari G. Renaissance Art and Culture. Encyclopedia of World Histor…</mark>234–256.</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="18. Vasari G. Renaissance Art and Culture. 2022;5:234–256."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">18. Vasari G. Renaissance Art and Culture. 2022;5:</mark>234–256.</td>
+                                                <td class="px-2 py-1 text-center font-bold text-red-600">✗</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">containerTitle:missing, volume:extra, publisher:missing</td>
                                             </tr>
 
                                             <tr class="border-b border-slate-200 hover:bg-slate-50">
                                                 <td class="px-2 py-1 text-slate-600">47</td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[13] State of JS Team. The State of JavaScript 2023 [Internet]. 2023 [cited 2024 Jan 15]. Available from: https://stateofjs.com/2023."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[13] State of JS Team. The State of JavaScript 2023 [Internet]. 2023 [ci…</mark></td>
-                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="State of JS Team The State of JavaScript 2023. https://stateofjs.com/2023"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">State of JS Team The State of JavaScript 2023. https://stateofjs.com/202…</mark></td>
-                                                <td class="px-2 py-1 text-center font-bold text-emerald-600">✓</td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="[39] Self-report [Internet]. Merriam-Webster.com dictionary. [cited 2019 July 12]. Available from: https://www.merriam-webster.com/dictionary/self-report."><mark class="rounded bg-amber-200 px-0.5 text-slate-900">[39] Self-report [Internet]. Merriam-Webster.com dictionary. [cited 2019…</mark></td>
+                                                <td class="px-2 py-1 font-mono text-slate-600 text-xs" title="39. Self-report. n.d. https://www.merriam-webster.com/dictionary/self-report"><mark class="rounded bg-amber-200 px-0.5 text-slate-900">39. Self-report. n.d. https://www.merriam-webster.com/dictionary/self-re…</mark></td>
+                                                <td class="px-2 py-1 text-center font-bold text-red-600">✗</td>
                                                 <td class="px-2 py-1 text-center font-bold text-amber-700">✗</td>
-                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">Unresolved Oracle Drift (Δ1)</td>
+                                                <td class="px-2 py-1 text-slate-600 text-xs font-mono">containerTitle:missing</td>
                                             </tr>
 
                                         </tbody>

--- a/docs/reference/SQI.md
+++ b/docs/reference/SQI.md
@@ -33,12 +33,18 @@ Overall SQI is reported as a 0.0-1.0 score in JSON and as a percentage in `docs/
 
 ## Working Thresholds
 
-Current wave target:
+Current wave target, as a mean across the **embedded tier only**
+(`docs/compat.html`'s headline; exemplar and community styles are reported
+separately and are not held to this target):
 
-- `>= 0.95` fidelity
-- `>= 0.90` SQI
+- `>= 0.95` mean fidelity
+- `>= 0.90` mean SQI
 
-These thresholds are used for wave planning and tracking, not as a replacement for oracle checks.
+These are directional wave-planning targets, not a per-style gate and not a
+replacement for oracle checks. The actual enforced gate is
+`scripts/check-core-quality.js`, which checks each style's fidelity and SQI
+drift against a recorded baseline (`scripts/report-data/core-quality-baseline.json`),
+not this aggregate.
 
 ## Commands
 

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -2959,7 +2959,7 @@ async function generateReport(options) {
 function generateHtml(report) {
   const headerHtml = generateHtmlHeader(report);
   const statsHtml = generateHtmlStats(report);
-  const sqiExplainerHtml = generateHtmlSqiExplainer();
+  const sqiExplainerHtml = generateHtmlSqiExplainer(report);
   const tableHtml = generateHtmlTable(report);
   const footerHtml = generateHtmlFooter();
 
@@ -3187,7 +3187,18 @@ function generateHtmlStats(report) {
 `;
 }
 
-function generateHtmlSqiExplainer() {
+function generateHtmlSqiExplainer(report) {
+  const embeddedNames = new Set(report.metadata?.portfolioTiers?.embedded || []);
+  const embeddedStyles = report.styles.filter((style) => embeddedNames.has(style.name));
+  const embeddedCompat = embeddedStyles.map((style) => (style.compatibilityScore ?? style.fidelityScore) * 100);
+  const embeddedSqi = embeddedStyles.map((style) => style.qualityBreakdown?.score ?? (style.qualityScore || 0) * 100);
+  const meanCompat = embeddedCompat.length > 0
+    ? (embeddedCompat.reduce((sum, v) => sum + v, 0) / embeddedCompat.length).toFixed(1)
+    : 'n/a';
+  const meanSqi = embeddedSqi.length > 0
+    ? (embeddedSqi.reduce((sum, v) => sum + v, 0) / embeddedSqi.length).toFixed(1)
+    : 'n/a';
+
   return `
     <!-- SQI Explainer -->
     <section class="py-8 px-6">
@@ -3195,16 +3206,40 @@ function generateHtmlSqiExplainer() {
             <div class="bg-[var(--citum-surface)] rounded-xl border border-slate-200 p-6">
                 <h2 class="text-lg font-semibold text-slate-900 mb-2">How To Read This Report</h2>
                 <p class="text-sm text-slate-600 mb-3">
+                    This report covers a three-tier style portfolio. <strong>Embedded</strong> (${embeddedStyles.length} styles) is
+                    Citum's compiled product surface and the headline this report scores against; the stats above and the
+                    working targets below cover this tier only. <strong>Exemplar</strong> (${report.exemplarStyles || 0} styles,
+                    listed separately in the table below) are Rust-test fixtures, embedded-parent wrapper examples, or unique
+                    behavior coverage — reported for visibility, not gated. The long-tail <strong>community</strong> corpus lives
+                    in <a class="text-primary hover:underline" href="https://github.com/citum/citum-styles">citum-styles</a>; its
+                    parity values are advisory and do not appear in this report at all.
+                </p>
+                <p class="text-sm text-slate-600 mb-3">
                     <strong>Compatibility</strong> is the existing lenient regression gate; it can tolerate meaningful text-level drift.
                     <strong>Oracle text parity</strong> is the stricter, symmetric comparison of visible renderer text.
                     <strong>SQI</strong> (Style Quality Index) is secondary: it scores maintainability and fallback quality.
+                    Most styles are verified against the <strong>citeproc-js</strong> oracle; a small number of biblatex-derived
+                    styles (currently just <code>numeric-comp</code>, in the exemplar tier) instead use
+                    <strong>biblatex</strong> as their primary authority, because biblatex is the only origin format for the
+                    compound-numeric grouping feature they exercise — the <strong>Authority</strong> column shows which applies
+                    per style.
                 </p>
                 <p class="text-sm text-slate-600 mb-4">
-                    Current working targets remain <code>&gt;=95% compatibility</code> and <code>&gt;=90 SQI</code>.
-                    Oracle text parity is informational until each drift is adjudicated and family-level ratchets are defined.
+                    Working targets for the embedded tier remain <code>&gt;=95% mean compatibility</code> and
+                    <code>&gt;=90 mean SQI</code>; as of this report the embedded tier measures
+                    <code>${meanCompat}% compatibility</code> and <code>${meanSqi} SQI</code> (mean across ${embeddedStyles.length} styles).
+                    These are directional targets, not a per-style gate — the enforced gate
+                    (<code>scripts/check-core-quality.js</code>) checks fidelity and SQI drift against a recorded baseline per
+                    style, not this aggregate. Oracle text parity is informational until each drift is adjudicated and
+                    family-level ratchets are defined.
                 </p>
                 <p class="text-sm text-slate-600 mb-4">
-                    <strong>Lineage</strong> shows the source family a style derives from.
+                    <strong>Lineage</strong> shows the source family a style derives from. Below the headline tiles, styles are
+                    grouped under <strong>family header rows</strong> (root style name, member count, alias count, aggregate CSL
+                    reach): the root is the top of a style's <code>extends</code> chain, so a family groups only styles that
+                    literally extend a common ancestor. A style with no <code>extends</code> is its own singleton family, root
+                    equal to itself — most embedded and exemplar styles fall in this category today; visually related styles
+                    (e.g. same publisher) are not automatically grouped unless one actually extends another.
                     <strong>Oracle text parity</strong> preserves numbering, case, punctuation, brackets, and role labels after transport markup is removed.
                     A drift may be a Citum defect, an oracle defect, an intentional divergence, or unresolved; parity alone does not assign fault.
                     Similarity outputs without an established counterpart are excluded from both metrics and appear only as neutral pairing diagnostics.


### PR DESCRIPTION
## Summary

Stacked on #1114 (base branch set to `fix/style-split-fallout`, not `main`) — the exemplar/embedded counts and `numeric-comp` authority note this PR adds depend on that restore. Retarget the base to `main` after #1114 merges, or just merge #1114 first.

- Makes `generateHtmlSqiExplainer()` data-driven (takes `report`, computes live embedded-tier mean compatibility/SQI) instead of static text.
- Adds: the three-tier portfolio explanation (embedded/exemplar/community, current counts), an explanation of the family header rows `generateHtmlTable()` emits (root = top of the `extends` chain; most styles are still singleton families), and a note that biblatex is a separate authority from citeproc-js, naming `numeric-comp` as the current example.
- Verifies the stated ">=95% compatibility / >=90 SQI" targets: never enforced as literal numbers anywhere in code (the real gate, `check-core-quality.js`, checks per-style baseline drift, not an aggregate). Current live measurement is 94.7% mean compatibility / 96.9 mean SQI across the 19 embedded styles — the explainer now shows the current measured value alongside the target instead of only the stale target. `docs/reference/SQI.md` updated to match.
- `docs/compat.html` regenerated via `--write-html`.

## Test plan

- [x] `node --test scripts/*.test.js scripts/lib/*.test.js` — 216 passed
- [x] `node scripts/report-core.js --write-html` — regenerated, spot-checked against live tiles and family rows
- [x] `node scripts/check-doc-links.js` — no new broken links (6 pre-existing, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
