### PR TITLE
fix(styles): embedded parity wave 1 — measurement + elsevier-vancouver fix

### DIFF
--- a/.beans/archive/csl26-lf68--fixreport-normalize-second-field-align-transport-s.md
+++ b/.beans/archive/csl26-lf68--fixreport-normalize-second-field-align-transport-s.md
@@ -1,0 +1,22 @@
+---
+# csl26-lf68
+title: 'fix(report): normalize second-field-align transport + spike class-A2 rendering gap'
+status: completed
+type: task
+priority: high
+created_at: 2026-07-30T14:18:11Z
+updated_at: 2026-07-30T14:29:07Z
+parent: csl26-arly
+---
+
+citeproc-js emits second-field-align bibliographies as sibling <div class=csl-left-margin>/<div class=csl-right-inline>; stripping tags in scripts/oracle-utils.js / scripts/report-core.js (~line 1308) concatenates them with no separator (class A1, harness bug — join with a single space, extend scripts/oracle.test.js's existing csl-left-margin fixture at line 969). Separately: class A2 is real and larger (318 mismatches, 12.7% of all parity failures) — Citum's bibliography string omits the number entirely for some styles (AMA: 0/14 sampled have it) but includes it for others (IEEE: 14/14) and is inconsistent within a single style (RSC: mixed). Time-box a spike to determine whether this is an engine rendering gap or a report-harness invocation gap; file the finding as a follow-up bean, do not fix A2 rendering in this task. Part of PR-1 (fix/embedded-parity-wave-1).
+
+## Summary of Changes
+
+Time-boxed spike, findings written up in docs/architecture/audits/2026-07-30_EMBEDDED_PARITY_CLASS_A.md. No production fix lands here.
+
+**Corrected the plan's own premise:** the 'A1 join-space bug' hypothesis (normalizeExactText concatenating csl-left-margin/csl-right-inline transport without a boundary space) does not hold -- verified zero of 2501 mismatches are whitespace-only, and the IEEE control case (already flush-concatenated on both sides, already exactMatch:true) proves inserting a join space would have been a regression, not a fix. No change made to scripts/oracle-utils.js. Added a regression test in scripts/oracle.test.js documenting why, so this dead end isn't re-walked.
+
+**Root-caused class A2** (the real defect, 318/2501 mismatches, largest single class): Citum has no processor-level equivalent to citeproc-js's second-field-align auto-numbering. A style's bibliography only gets a numeric label if its template explicitly includes a 'number: citation-number' component (ieee.yaml does; american-medical-association.yaml does not) -- confirmed via direct 'citum render refs --json' output on both styles. Filed as a follow-up task under this epic.
+
+**Found and filed a separate report-harness bug**, not root-caused (out of time-box): royal-society-of-chemistry's oracleDetail shows a Citum-side number present on some entries/absent on others under the same evidenceRunId, but direct CLI rendering of that style produces zero numbered entries consistently -- the report's evidence for those indices doesn't match what the style actually renders. Filed as a follow-up bug under this epic.

--- a/.beans/archive/csl26-q42m--chorereport-baseline-all-embedded-styles-pre-fix-p.md
+++ b/.beans/archive/csl26-q42m--chorereport-baseline-all-embedded-styles-pre-fix-p.md
@@ -1,0 +1,18 @@
+---
+# csl26-q42m
+title: 'chore(report): baseline all embedded styles pre-fix + parity ratchet'
+status: completed
+type: task
+priority: high
+created_at: 2026-07-30T14:18:11Z
+updated_at: 2026-07-30T14:21:07Z
+parent: csl26-arly
+---
+
+scripts/report-data/core-quality-baseline.json currently only records ieee and springer-vancouver-brackets (2 of 19 embedded styles). check-core-quality.js's hard fidelity<1.0 gate is therefore vacuous for the other 17. Record all 19 at current pre-fix values (including a new non-gating exactParity field per style), confirm check-core-quality.js tolerates the new field, then re-ratchet post-fix at the end of this PR. Part of PR-1 (fix/embedded-parity-wave-1).
+
+## Summary of Changes
+
+Recorded a non-gating oracle-text-parity snapshot for all 19 embedded styles at HEAD (828cb9d2, matches the branch commit — verified before writing, since the source report used for taxonomy analysis was stamped at fb0a01af and intervening commits included style YAML changes) in scripts/report-data/embedded-parity-baseline.json.
+
+**Correction from the original plan:** the plan called for adding all 19 styles to scripts/report-data/core-quality-baseline.json. That file's `styles` map is read by scripts/check-core-quality.js as a hard fidelityScore==1.0 gate keyed by membership -- adding any style below 1.0 fidelity (17 of 19 embedded styles today) would have immediately broken that gate for the whole embedded tier. core-quality-baseline.json is correctly scoped as a ratchet for styles that have *already* reached 1.0 fidelity (today: ieee, springer-vancouver-brackets only) and is left untouched. Sub-1.0 ratchets for benchmark-run pass rates already exist per-style in scripts/report-data/verification-policy.yaml (min_pass_rate, actively used by the Chicago-tuning epic csl26-40n4) -- but nothing recorded oracle text parity (exactParity) anywhere. That's the actual gap this closes: a snapshot for future parity-improvement waves to diff against. Confirmed no other script reads core-quality-baseline.json besides check-core-quality.js and its test (check-testing-infra.js/.test.js) and the fidelity.yml CI workflow -- the new file is fully independent, no collision risk.

--- a/.beans/archive/csl26-w1vf--fixstyles-drop-stray-numeric-prefix-from-elsevier.md
+++ b/.beans/archive/csl26-w1vf--fixstyles-drop-stray-numeric-prefix-from-elsevier.md
@@ -1,0 +1,20 @@
+---
+# csl26-w1vf
+title: 'fix(styles): drop stray numeric prefix from elsevier-vancouver-author-date bibliography'
+status: completed
+type: bug
+priority: normal
+created_at: 2026-07-30T14:18:11Z
+updated_at: 2026-07-30T14:33:05Z
+parent: csl26-arly
+---
+
+Class J, 47 of 67 sampled bibliography entries: elsevier-vancouver-author-date (an author-date style) emits a leaked numeric/bracket prefix Citum-side that the oracle doesn't have, e.g. O: 'Bengio Y. The Future of Artificial Intelligence 2023.' vs C: '[2]. Bengio Y. The Future of Artificial Intelligence 2023.' Confine the fix so the elsevier-vancouver-core sibling (elsevier-vancouver, 82.1% parity, CSL reach 502) does not regress. Part of PR-1 (fix/embedded-parity-wave-1).
+
+## Summary of Changes
+
+Root cause: styles/elsevier-vancouver-author-date.yaml extends elsevier-vancouver -> elsevier-vancouver-core (the numeric Vancouver family), which sets bibliography.options.label-mode: numeric and also directly authors bracket-wrapped 'number: citation-number' components into several inherited type-variant/default templates. The author-date variant didn't override bibliography.options.label-mode, so it inherited numeric labeling wholesale -- both the auto-inserted plain number ('33. ') and the pre-authored bracketed number ('[2]. ') for reference types it doesn't itself redefine.
+
+Fix: set bibliography.options.label-mode: author-date on elsevier-vancouver-author-date.yaml. This is a first-class engine feature (crates/citum-schema-style/src/options/scoped.rs update_label_mode) that strips any citation-number/citation-label component from every resolved bibliography template regardless of origin -- exactly matches this case.
+
+Verified via direct 'citum render refs --json' before/after diff: all 47 of 47 bibliography entries changed, every change is exactly the leading numeric-prefix removal with no other text disturbed (matches class J from the taxonomy exactly). elsevier-vancouver (the numeric embedded sibling) confirmed byte-identical before/after -- no regression, since it explicitly sets its own citation-number components and doesn't rely on the parent's auto-insertion path being available for override. node scripts/report-core.js --styles elsevier-vancouver-author-date,elsevier-vancouver: elsevier-vancouver unchanged (fidelity 0.97, exactParity 55/67); elsevier-vancouver-author-date fidelity 0.955->0.97, exactParity 0/67 (0.0%) -> 14/67 (20.9%), citations unaffected (20/20 both before and after). Style YAML only, no .rs touched -- Rust pre-commit gate not applicable.

--- a/.beans/csl26-7jht--tune-chicago-shortened-notes-bibliography-to-full.md
+++ b/.beans/csl26-7jht--tune-chicago-shortened-notes-bibliography-to-full.md
@@ -5,7 +5,7 @@ status: todo
 type: task
 priority: high
 created_at: 2026-06-30T18:46:09Z
-updated_at: 2026-06-30T18:55:24Z
+updated_at: 2026-07-30T14:17:58Z
 parent: csl26-h7oc
 blocked_by:
     - csl26-lxy3
@@ -42,3 +42,20 @@ already improved, leaving this bean to focus on its own bibliography surface
       citation deltas
 - [ ] SQI loop
 - [ ] style-qa-reviewer handoff (tier: embedded-core)
+
+## 2026-07-30: oracle text-parity evidence (worst style in the portfolio: 2.4% parity, 0.751 fidelity)
+
+Full-portfolio oracle-parity clustering (references-expanded run, report at fb0a01af) shows chicago-shortened-notes-bibliography's bibliography failure shape is systemic, not per-entry — comma delimiters where Chicago wants periods, quotes dropped, terms lowercased, across nearly every sampled entry:
+
+```
+O: Kafka, Franz. Metamorphosis. Translated by David Wyllie. Kurt Wolff Verlag, 1915.
+C: Kafka, Franz, Metamorphosis. translated by David Wyllie, Kurt Wolff Verlag, 1915.
+
+O: NASA Goddard Institute for Space Studies. \"Global Temperature Anomalies 1880-2023.\" NASA, 2024. https://data.giss.nasa.gov/gistemp/.
+C: NASA Goddard Institute for Space Studies, Global Temperature Anomalies 1880-2023, NASA, 2024, https://data.giss.nasa.gov/gistemp/
+
+O: State of JS Team. \"The State of JavaScript 2023.\" 2023. https://stateofjs.com/2023.
+C: State of JS Team, The State of JavaScript 2023, 2023, https://stateofjs.com/2023
+```
+
+This style is `chicago-shortened-notes-bibliography-core.yaml` (284 lines) extending `chicago-notes-18th` (731 lines). Given `303a38f0 feat(schema)!: deep-merge options on extends` and `0b8efb77 fix(styles): fix two title deep-merge regressions` landed recently, this looks like deep-merge fallout from a shared root cause (delimiter/quoting/case options not surviving the extends chain), not N independent per-type bugs — worth checking the resolved merged template against `chicago-notes-18th`'s bibliography delimiters/affixes before doing per-entry tuning. Not independently root-caused — recorded as a strong lead for this bean's fidelity loop. Full clustering data path is stale (/tmp/prd_report.json); regenerate via `node scripts/report-core.js --styles chicago-shortened-notes-bibliography --parallelism 2`. See [[csl26-arly]].

--- a/.beans/csl26-arly--embedded-tier-oracle-text-parity.md
+++ b/.beans/csl26-arly--embedded-tier-oracle-text-parity.md
@@ -1,0 +1,27 @@
+---
+# csl26-arly
+title: Embedded-tier oracle text parity
+status: in-progress
+type: epic
+priority: high
+created_at: 2026-07-30T14:16:05Z
+updated_at: 2026-07-30T14:55:38Z
+---
+
+Raise oracle text parity for the embedded style tier (currently 38.7% overall, 1260/3255). Baseline: docs/compat.html generated at fb0a01af. Disjoint defect taxonomy over 2501 parity mismatches (Z unclassified 925/37%, D title-quoting 421/16.8%, D2 title/term case 392/15.7%, A oracle-only number prefix 318/12.7% split into A1 harness-join + A2 rendering-omission, B punctuation-only 200/8%, J citum-only number prefix 82/3.3%, I number-prefix format 64/2.6%, F bracket medium label 30/1.2%, H year-suffix 30/1.2% (csl26-m8la), E name separator 26/1%, G/M accessed+label terms 13/0.5%).
+
+**Scope correction (discovered after epic creation):** the chicago-18-base family (1392/2501, 55.7% of all mismatches) is already under active, in-progress tuning at [[csl26-40n4]] -> [[csl26-h7oc]] -> per-variant children ([[csl26-giun]] chicago-author-date-18th, [[csl26-7jht]] chicago-shortened-notes-bibliography, [[csl26-gzwj]] T&F chicago, [[csl26-lxy3]] chicago-notes-18th), with deep implementation history (title-case engine fixes, original/reprint dates, manuscript/archive block, contributor label punctuation). This epic does NOT duplicate that work. Instead: (a) my new D/D2/C-class parity evidence (title quoting, term case, stray container-title period) is appended to csl26-giun and csl26-7jht as fresh residual-defect input for their existing tuning loops; (b) this epic covers the genuinely uncovered territory: measurement-harness integrity (class A1/A2), the baseline/ratchet gate gap, and non-Chicago style fixes (elsevier-vancouver-author-date numeric-prefix leak, class J).
+
+Plan: /home/bruce/.claude/plans/ok-now-that-we-ve-iridescent-cat.md (revised scope per this note).
+
+## PR-1 landed on fix/embedded-parity-wave-1 (3 commits)
+
+1. chore(report): snapshot embedded parity -- scripts/report-data/embedded-parity-baseline.json, all 19 embedded styles' fidelity/quality/citations/bibliography/exactParity at HEAD (828cb9d2). Non-gating (see [[csl26-q42m]] summary for why the original 'add to core-quality-baseline.json' plan was wrong and corrected).
+2. docs(report): spike class-A parity gap -- root-caused the 318-mismatch class A2 (bibliography numeric-label rendering gap for second-field-align-derived styles), corrected the false 'A1 join-space bug' hypothesis with a regression test, found and filed a separate RSC report-evidence bug. See docs/architecture/audits/2026-07-30_EMBEDDED_PARITY_CLASS_A.md and [[csl26-lf68]].
+3. fix(styles): elsevier-vancouver label-mode leak -- fixed class J (47 mismatches) in elsevier-vancouver-author-date via bibliography.options.label-mode: author-date. See [[csl26-w1vf]].
+
+**Honest scope note:** PR-1 does not move the headline 38.7% oracle-parity number much. The elsevier-vancouver-author-date fix is exemplar-tier (not embedded), and none of the 19 embedded styles' fidelity or exactParity changed in this PR -- so no baseline ratchet was needed, and docs/compat.html was not regenerated (would require a full community-corpus sweep, out of proportion to what changed here; left as a separate concern). PR-1's real deliverables are the parity-tracking gap closed (embedded-parity-baseline.json) and the class-A2 root cause that unblocks the largest deferred wave, not a parity-percentage win.
+
+**Remaining open children:** [[csl26-j7uc]] (A2 rendering-gap fix, largest deferred wave, 318 mismatches / unblocks 8 exemplars at 0% parity) and [[csl26-waly]] (RSC report-evidence bug). Chicago-family work (55.7% of all mismatches) is intentionally not tracked under this epic -- see the scope-correction note above; residual-defect evidence was fed into the existing in-progress [[csl26-giun]] and [[csl26-7jht]] beans instead.
+
+**Correction (2026-07-30, post-PR-1):** the framing above overstates csl26-40n4/csl26-h7oc as active. Its last landed PR merged 2026-07-04 (26 days idle at time of writing), csl26-giun has sat 'in-progress' with no landed work since then, and csl26-7jht/csl26-gzwj are unstarted todos. Feeding evidence into them was still correct (avoids a second competing tracking structure for the same styles), but resuming Chicago work is separate, unstarted effort -- not something already in flight. User flagged this after reading the PR; next work picked was csl26-j7uc instead.

--- a/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
+++ b/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
@@ -5,7 +5,7 @@ status: in-progress
 type: task
 priority: high
 created_at: 2026-06-30T18:46:08Z
-updated_at: 2026-07-02T23:19:17Z
+updated_at: 2026-07-30T14:17:47Z
 parent: csl26-h7oc
 ---
 
@@ -133,3 +133,13 @@ are layered on.
   index-misaligned tail (classic/legal-citation placeholder items the
   oracle doesn't render at all). Bean stays in-progress; 100% + clean-SQI
   gate not met.
+
+## 2026-07-30: oracle text-parity residuals (new class evidence, from citum-core#embedded-parity report at fb0a01af)
+
+Full-portfolio oracle-parity clustering (not shared-corpus, the broader references-expanded run) surfaces residual classes on chicago-author-date-18th (byte-identical on taylor-and-francis-chicago-author-date, so any fix here pays twice — see csl26-gzwj):
+
+- **D: title quoting differs (111 of this style's mismatches).** Oracle quotes titles/chapter-titles with curly quotes on types this style doesn't (e.g. archival letters, dictionary entries, newspaper articles): `O: Adams, John. 1797. \"Letter to James Smith.\" Adams Papers, reel 45.` vs `C: Adams, John. 1797. Letter to James Smith. Adams Papers, reel 45.` Also the inverse — Citum quotes a map/dataset the oracle doesn't: `O: Cable, D. 2013. The Racial Dot Map. Map. …` vs `C: Cable, D. 2013. \"The racial dot map.\" …` — suggests a type-variant boundary issue, not a uniform quoting rule.
+- **C: stray period after container-title, before volume/issue locator (68 occurrences).** `O: … Urban Climate 15: 1–18.` vs `C: … Urban Climate. 15: 1–18` — container-title is getting a terminal period before the volume:issue:page block where CMOS wants none.
+- **B: name-list conjunction dropped between two authors (subset of 62 punctuation-only diffs).** `O: Smith, Jane, and Robert Williams. 2020.` vs `C: Smith, Jane and Robert Williams. 2020.` — missing comma before \"and\" in a 2-author list.
+
+Not independently investigated/fixed — recorded as residual-defect input for this bean's ongoing fidelity loop. Full clustering data: /tmp/prd_report.json (stale path, regenerate via `node scripts/report-core.js --styles chicago-author-date-18th --parallelism 2`). See [[csl26-arly]] for the harness-side finding that class A (bib-number prefix) is a separate, likely-unrelated measurement artifact — do not chase it from this bean.

--- a/.beans/csl26-j7uc--engine-gap-bibliography-numeric-label-rendering-fo.md
+++ b/.beans/csl26-j7uc--engine-gap-bibliography-numeric-label-rendering-fo.md
@@ -1,0 +1,12 @@
+---
+# csl26-j7uc
+title: 'Engine gap: bibliography numeric-label rendering for second-field-align-derived styles'
+status: todo
+type: task
+priority: normal
+created_at: 2026-07-30T14:28:57Z
+updated_at: 2026-07-30T14:28:57Z
+parent: csl26-arly
+---
+
+Class A2 (318 of 2501 parity mismatches, the largest single class). citeproc-js's second-field-align is a processor-level feature: for numeric CSL styles that declare it, the processor generates the bibliography list number itself (rendered into a separate csl-left-margin DOM node) independent of whether the CSL template also renders a number inline. Citum has no equivalent -- a style only gets a bibliography number if its template explicitly includes a 'number: citation-number' component (confirmed: ieee.yaml has this, american-medical-association.yaml does not). Affects at minimum: nature (101 mismatches), american-chemical-society (53), american-medical-association + american-medical-association-alphabetical (47 each), and unblocks up to 8 exemplar styles currently reading exactly 0.0% oracle text parity. Root cause and disposition options (processor-level auto-numbering vs. requiring each affected style to add an explicit number component) documented in docs/architecture/audits/2026-07-30_EMBEDDED_PARITY_CLASS_A.md. Not started.

--- a/.beans/csl26-waly--report-bug-rsc-oracle-parity-evidence-indices-dont.md
+++ b/.beans/csl26-waly--report-bug-rsc-oracle-parity-evidence-indices-dont.md
@@ -1,0 +1,12 @@
+---
+# csl26-waly
+title: 'Report bug: RSC oracle-parity evidence indices don''t match rendered output'
+status: todo
+type: bug
+priority: low
+created_at: 2026-07-30T14:28:57Z
+updated_at: 2026-07-30T14:28:57Z
+parent: csl26-arly
+---
+
+royal-society-of-chemistry's oracleDetail entries show a Citum-side bibliography number present on some entries and absent on others, all tagged evidenceRunId: baseline (looks like within-run inconsistency). Direct CLI rendering (citum render refs -s styles/royal-society-of-chemistry.yaml --mode bib, and --mode both with a citations fixture) produces zero numbered entries, consistently, for every reference -- the numbered oracleDetail entries don't correspond to what the style actually renders against references-expanded.json. Likely an evidence-index mislabeling/merging bug in report-core.js's benchmark-run assembly, not a rendering defect. Not root-caused; time-boxed out of the 2026-07-30 class-A spike. See docs/architecture/audits/2026-07-30_EMBEDDED_PARITY_CLASS_A.md finding 3.

--- a/docs/architecture/audits/2026-07-30_EMBEDDED_PARITY_CLASS_A.md
+++ b/docs/architecture/audits/2026-07-30_EMBEDDED_PARITY_CLASS_A.md
@@ -1,0 +1,117 @@
+# Embedded-Tier Oracle Parity — Class A (Bibliography Numeric Label) Spike
+
+- **Date:** 2026-07-30
+- **Bean:** `csl26-lf68` (under epic `csl26-arly`)
+- **Question:** the largest single defect class in the embedded+exemplar
+  oracle text-parity taxonomy (318 mismatches, 12.7% of 2,501) is styles
+  where the citeproc-js oracle's bibliography entry has a leading list number
+  (`1.`, `[2]`, `11`) that Citum's rendered text lacks. Is this a comparator
+  join-space bug (`normalizeExactText` stripping tags without inserting a
+  boundary space) or a real rendering gap? Time-boxed spike, not a fix.
+- **Instrument:** direct `citum render refs -b tests/fixtures/references-expanded.json
+  -s <style>.yaml --json --mode bib` against `american-medical-association`,
+  `ieee`, and `royal-society-of-chemistry`, cross-checked against the
+  `oracleDetail[]` entries in a full `report-core.js` run.
+
+## Finding 1: there is no join-space bug (the "A1" hypothesis is wrong)
+
+The initial hypothesis, based on eyeballing one AMA entry
+(`1.Kuhn TS. …` vs `Kuhn TS. …`), was that citeproc-js's
+`second-field-align` transport — sibling `<div class="csl-left-margin">` /
+`<div class="csl-right-inline">` divs with no whitespace between them in the
+raw HTML — was being tag-stripped into a flush join that should have had a
+space inserted at the boundary.
+
+This does not hold. Computed over every `exactMatch: false` entry in the
+full oracle-parity corpus (2,501 mismatches): **zero** are resolved by
+collapsing all whitespace on both sides before comparing (i.e., there is no
+case where the only difference is a missing/extra space at this boundary).
+The control case proves the opposite of the hypothesis: IEEE already
+concatenates flush with no space (`[2]S. Hawking, …` on both the oracle and
+Citum side) and **is currently `exactMatch: true`** for that pairing — the
+visual gap between the two `<div>`s is CSS-rendered, not a text character,
+and citeproc-js's actual text output has none either. Inserting a join space
+would have *regressed* every currently-passing flush-numbered entry (IEEE,
+and any other style whose template renders its own literal number). No
+change to `scripts/oracle-utils.js` was made; a regression test
+(`compareText exact parity: second-field-align left-margin and
+right-inline concatenate flush, no inserted space`, `scripts/oracle.test.js`)
+guards against reintroducing this.
+
+## Finding 2: the real defect is a genuine rendering gap (confirmed "A2")
+
+Direct CLI rendering confirms the number is absent from Citum's own output,
+not lost in transport:
+
+```
+$ citum render refs -b tests/fixtures/references-expanded.json \
+    -s styles/embedded/american-medical-association.yaml --json --mode bib
+{"id": "ITEM-1", "text": "Kuhn TS. The Structure of Scientific Revolutions. …"}
+
+$ citum render refs -b tests/fixtures/references-expanded.json \
+    -s styles/embedded/ieee.yaml --json --mode bib
+{"id": "ITEM-1", "text": "[1]T. S. Kuhn, “The Structure of Scientific Revolutions,” …"}
+```
+
+The `entries[].text` field has no separate label/number field alongside it
+— whatever isn't in `text` isn't rendered anywhere. Comparing the two
+styles' bibliography YAML explains the split:
+
+- `styles/embedded/ieee.yaml` — every `type-variants` entry opens with a
+  literal template component, `- number: citation-number` (wrapped in
+  `punctuation: brackets`), as the first element of the component group. The
+  number is bibliography template *content*.
+- `styles/embedded/american-medical-association.yaml` — no bibliography
+  `type-variant` includes a `number: citation-number` component anywhere;
+  entries open directly with the author.
+
+citeproc-js's `second-field-align` is a *processor-level* feature: for
+numeric CSL styles that declare it, the processor generates the list number
+itself and places it in `csl-left-margin`, independent of whether the CSL
+`<bibliography>` layout also renders a number inline. Citum has no
+equivalent processor-generated numbering — a style only gets a bibliography
+number if its template explicitly renders one via a `number:
+citation-number` component. AMA's original CSL relies on the processor
+behavior and therefore has no such component to migrate; Citum's rendering
+is faithful to AMA's template as authored, but the template alone can't
+reproduce citeproc-js's implicit list numbering. This is a genuine
+style/engine gap, not a comparator or harness defect.
+
+## Finding 3: Royal Society of Chemistry's apparent within-run inconsistency does not reproduce
+
+The original class taxonomy flagged RSC as inconsistent *within a single
+run* — some entries in `oracleDetail` show a Citum-side number (`11W. Chen,
+PhD thesis…`), others don't (`T. S. Kuhn, International…`), all tagged with
+the same `evidenceRunId: "baseline"`. Direct CLI rendering of RSC's
+bibliography (`styles/royal-society-of-chemistry.yaml`, both `--mode bib`
+alone and `--mode both` with a citations fixture) produces **zero** entries
+with any numeric label — consistently, for every reference. The numbered
+entries seen in `oracleDetail` do not match what `citum render refs`
+actually outputs for this style against `references-expanded.json`, which
+means the report's evidence for those specific indices is drawn from a
+different fixture or evidence source than the one implied by the shared
+`evidenceRunId` label. This is a distinct report-harness bug (evidence-index
+mislabeling/merging), separate from the class-A2 rendering gap above, and
+was **not** root-caused further within this spike's time-box.
+
+## Disposition
+
+- No class-A fix lands in this PR (a different commit in the same PR fixes
+  an unrelated defect, class J — see below). `csl26-lf68` is being closed
+  as a completed spike; findings above are the deliverable for class A.
+- Follow-up bean filed for class A2 (bibliography numeric-label rendering
+  gap for `second-field-align`-derived styles: AMA, ACS, nature, and others)
+  under `csl26-arly`.
+- Follow-up bean filed for the RSC evidence-mislabeling report bug, also
+  under `csl26-arly`.
+- `scripts/oracle-utils.js` is unchanged; the added regression test in
+  `scripts/oracle.test.js` documents why a join-space fix is wrong so the
+  next person investigating class A doesn't re-walk this same dead end.
+
+Separately, this PR *does* fix class J (47 mismatches, a leaked numeric
+bibliography label in `elsevier-vancouver-author-date`) — see
+`fix(styles): elsevier-vancouver label-mode leak` and `csl26-w1vf`. That fix
+is unrelated to the class-A/A2 finding above (different style, different
+root cause: an inherited `label-mode: numeric` option, not a missing
+template component) and does not change any of the conclusions in this
+document.

--- a/scripts/oracle.test.js
+++ b/scripts/oracle.test.js
@@ -1192,6 +1192,28 @@ test('compareText exact parity preserves bracketed and parenthesized numbering',
   assert.equal(parenthesized.exactAdjudication, 'unresolved');
 });
 
+test('compareText exact parity: second-field-align left-margin and right-inline concatenate flush, no inserted space', () => {
+  // citeproc-js renders second-field-align bibliographies (numeric styles
+  // like IEEE) as adjacent sibling <div class="csl-left-margin"> (list
+  // number) and <div class="csl-right-inline"> (entry body) divs with the
+  // visual gap done via CSS, not a text character -- there is genuinely no
+  // space in the rendered text between them. A style whose own bibliography
+  // template renders the same bracketed number as literal content (IEEE)
+  // therefore already agrees with the oracle on a flush, spaceless join;
+  // verified across the full embedded+exemplar oracle-parity corpus that
+  // zero mismatches are whitespace-only at this boundary (2026-07-30 spike,
+  // see docs/architecture/audits/2026-07-30_EMBEDDED_PARITY_CLASS_A.md).
+  // This test guards against reintroducing a join-space "fix" that would
+  // regress this currently-passing pairing.
+  const comparison = compareText(
+    '<div class="csl-left-margin">[2]</div><div class="csl-right-inline">S. Hawking, A Brief History of Time.</div>',
+    '[2]S. Hawking, A Brief History of Time.'
+  );
+  assert.equal(comparison.exactExpected, '[2]S. Hawking, A Brief History of Time.');
+  assert.equal(comparison.exactActual, '[2]S. Hawking, A Brief History of Time.');
+  assert.equal(comparison.exactMatch, true);
+});
+
 test('compareComponents reports differing component values as mismatches', () => {
   const { differences, matches } = compareComponents(
     {

--- a/scripts/report-data/embedded-parity-baseline.json
+++ b/scripts/report-data/embedded-parity-baseline.json
@@ -1,0 +1,350 @@
+{
+  "generated": "2026-07-30T14:20:04.489Z",
+  "commit": "828cb9d2",
+  "source": "scripts/report-core.js",
+  "purpose": "Non-gating snapshot of embedded-tier oracle text parity (exactParity) and headline fidelity, recorded per csl26-arly. NOT read by scripts/check-core-quality.js's hard fidelity gate (that gate is reserved for styles that have reached fidelityScore 1.0 in scripts/report-data/core-quality-baseline.json). Sub-1.0 fidelity ratchets are tracked separately per-style in scripts/report-data/verification-policy.yaml (min_pass_rate floors). This file exists because nothing previously recorded exactParity at all -- it is the input for future parity-improvement waves to compare against.",
+  "styles": {
+    "american-medical-association": {
+      "tier": "embedded",
+      "fidelityScore": 1,
+      "qualityScore": 0.972,
+      "citations": {
+        "passed": 20,
+        "total": 20
+      },
+      "bibliography": {
+        "passed": 47,
+        "total": 47
+      },
+      "exactParity": {
+        "passed": 16,
+        "total": 67,
+        "rate": 0.239
+      }
+    },
+    "apa-7th": {
+      "tier": "embedded",
+      "fidelityScore": 0.986,
+      "qualityScore": 0.914,
+      "citations": {
+        "passed": 48,
+        "total": 48
+      },
+      "bibliography": {
+        "passed": 96,
+        "total": 98
+      },
+      "exactParity": {
+        "passed": 89,
+        "total": 146,
+        "rate": 0.61
+      }
+    },
+    "chicago-author-date-18th": {
+      "tier": "embedded",
+      "fidelityScore": 0.926,
+      "qualityScore": 0.921,
+      "citations": {
+        "passed": 63,
+        "total": 63
+      },
+      "bibliography": {
+        "passed": 437,
+        "total": 477
+      },
+      "exactParity": {
+        "passed": 104,
+        "total": 540,
+        "rate": 0.193
+      }
+    },
+    "chicago-notes-18th": {
+      "tier": "embedded",
+      "fidelityScore": 0.986,
+      "qualityScore": 0.914,
+      "citations": {
+        "passed": 73,
+        "total": 74
+      },
+      "bibliography": {
+        "passed": 0,
+        "total": 0
+      },
+      "exactParity": {
+        "passed": 8,
+        "total": 74,
+        "rate": 0.108
+      }
+    },
+    "chicago-shortened-notes-bibliography": {
+      "tier": "embedded",
+      "fidelityScore": 0.751,
+      "qualityScore": 1,
+      "citations": {
+        "passed": 40,
+        "total": 49
+      },
+      "bibliography": {
+        "passed": 309,
+        "total": 416
+      },
+      "exactParity": {
+        "passed": 11,
+        "total": 465,
+        "rate": 0.024
+      }
+    },
+    "elsevier-harvard": {
+      "tier": "embedded",
+      "fidelityScore": 1,
+      "qualityScore": 1,
+      "citations": {
+        "passed": 20,
+        "total": 20
+      },
+      "bibliography": {
+        "passed": 47,
+        "total": 47
+      },
+      "exactParity": {
+        "passed": 40,
+        "total": 67,
+        "rate": 0.597
+      }
+    },
+    "elsevier-vancouver": {
+      "tier": "embedded",
+      "fidelityScore": 0.97,
+      "qualityScore": 1,
+      "citations": {
+        "passed": 20,
+        "total": 20
+      },
+      "bibliography": {
+        "passed": 45,
+        "total": 47
+      },
+      "exactParity": {
+        "passed": 55,
+        "total": 67,
+        "rate": 0.821
+      }
+    },
+    "elsevier-with-titles": {
+      "tier": "embedded",
+      "fidelityScore": 0.985,
+      "qualityScore": 1,
+      "citations": {
+        "passed": 20,
+        "total": 20
+      },
+      "bibliography": {
+        "passed": 46,
+        "total": 47
+      },
+      "exactParity": {
+        "passed": 27,
+        "total": 67,
+        "rate": 0.403
+      }
+    },
+    "gb-t-7714-2025-author-date": {
+      "tier": "embedded",
+      "fidelityScore": 0.701,
+      "qualityScore": 0.909,
+      "citations": {
+        "passed": 19,
+        "total": 20
+      },
+      "bibliography": {
+        "passed": 28,
+        "total": 47
+      },
+      "exactParity": {
+        "passed": 32,
+        "total": 67,
+        "rate": 0.478
+      }
+    },
+    "gb-t-7714-2025-note": {
+      "tier": "embedded",
+      "fidelityScore": 0.982,
+      "qualityScore": 0.941,
+      "citations": {
+        "passed": 31,
+        "total": 35
+      },
+      "bibliography": {
+        "passed": 249,
+        "total": 250
+      },
+      "exactParity": {
+        "passed": 240,
+        "total": 285,
+        "rate": 0.842
+      }
+    },
+    "gb-t-7714-2025-numeric": {
+      "tier": "embedded",
+      "fidelityScore": 0.996,
+      "qualityScore": 0.985,
+      "citations": {
+        "passed": 21,
+        "total": 21
+      },
+      "bibliography": {
+        "passed": 249,
+        "total": 250
+      },
+      "exactParity": {
+        "passed": 257,
+        "total": 271,
+        "rate": 0.948
+      }
+    },
+    "ieee": {
+      "tier": "embedded",
+      "fidelityScore": 1,
+      "qualityScore": 0.87,
+      "citations": {
+        "passed": 48,
+        "total": 48
+      },
+      "bibliography": {
+        "passed": 101,
+        "total": 101
+      },
+      "exactParity": {
+        "passed": 84,
+        "total": 149,
+        "rate": 0.564
+      }
+    },
+    "modern-language-association": {
+      "tier": "embedded",
+      "fidelityScore": 0.948,
+      "qualityScore": 0.99,
+      "citations": {
+        "passed": 43,
+        "total": 45
+      },
+      "bibliography": {
+        "passed": 66,
+        "total": 70
+      },
+      "exactParity": {
+        "passed": 38,
+        "total": 115,
+        "rate": 0.33
+      }
+    },
+    "springer-basic-author-date": {
+      "tier": "embedded",
+      "fidelityScore": 0.955,
+      "qualityScore": 0.996,
+      "citations": {
+        "passed": 19,
+        "total": 20
+      },
+      "bibliography": {
+        "passed": 45,
+        "total": 47
+      },
+      "exactParity": {
+        "passed": 43,
+        "total": 67,
+        "rate": 0.642
+      }
+    },
+    "springer-basic-brackets": {
+      "tier": "embedded",
+      "fidelityScore": 0.97,
+      "qualityScore": 1,
+      "citations": {
+        "passed": 20,
+        "total": 20
+      },
+      "bibliography": {
+        "passed": 45,
+        "total": 47
+      },
+      "exactParity": {
+        "passed": 49,
+        "total": 67,
+        "rate": 0.731
+      }
+    },
+    "springer-vancouver-brackets": {
+      "tier": "embedded",
+      "fidelityScore": 1,
+      "qualityScore": 1,
+      "citations": {
+        "passed": 20,
+        "total": 20
+      },
+      "bibliography": {
+        "passed": 47,
+        "total": 47
+      },
+      "exactParity": {
+        "passed": 28,
+        "total": 67,
+        "rate": 0.418
+      }
+    },
+    "taylor-and-francis-chicago-author-date": {
+      "tier": "embedded",
+      "fidelityScore": 0.926,
+      "qualityScore": 1,
+      "citations": {
+        "passed": 63,
+        "total": 63
+      },
+      "bibliography": {
+        "passed": 437,
+        "total": 477
+      },
+      "exactParity": {
+        "passed": 104,
+        "total": 540,
+        "rate": 0.193
+      }
+    },
+    "taylor-and-francis-council-of-science-editors-author-date": {
+      "tier": "embedded",
+      "fidelityScore": 0.94,
+      "qualityScore": 0.996,
+      "citations": {
+        "passed": 19,
+        "total": 20
+      },
+      "bibliography": {
+        "passed": 44,
+        "total": 47
+      },
+      "exactParity": {
+        "passed": 21,
+        "total": 67,
+        "rate": 0.313
+      }
+    },
+    "taylor-and-francis-national-library-of-medicine": {
+      "tier": "embedded",
+      "fidelityScore": 0.97,
+      "qualityScore": 1,
+      "citations": {
+        "passed": 20,
+        "total": 20
+      },
+      "bibliography": {
+        "passed": 45,
+        "total": 47
+      },
+      "exactParity": {
+        "passed": 14,
+        "total": 67,
+        "rate": 0.209
+      }
+    }
+  }
+}

--- a/styles/elsevier-vancouver-author-date.yaml
+++ b/styles/elsevier-vancouver-author-date.yaml
@@ -73,6 +73,17 @@ bibliography:
     contributors: numeric-compact
     entry-suffix: .
     separator: '. '
+    # This author-date style extends the numeric Vancouver family
+    # (elsevier-vancouver -> elsevier-vancouver-core), which sets
+    # bibliography.options.label-mode: numeric and pre-authors bracketed
+    # `number: citation-number` components directly into several
+    # type-variant/default templates. Left unset, this style inherits both,
+    # leaking a numeric list label (`[2]. `, `33. `) into an author-date
+    # bibliography that should have none -- confirmed via oracle text
+    # parity (class J, 47 mismatches). label-mode: author-date strips any
+    # citation-number/citation-label component from every resolved
+    # bibliography template, whether locally authored or inherited.
+    label-mode: author-date
   type-variants:
     article-journal:
     - contributor: author


### PR DESCRIPTION
## Bottom line

One real, verified bug fix (`elsevier-vancouver-author-date`). Everything else is measurement/tracking infrastructure. **This PR does not move the embedded-tier headline parity number (38.7%)** — the fix is exemplar-tier, and no embedded style changed. The rest of the work is tracked in epic `csl26-arly`.

## What changed

1. **Fix:** `elsevier-vancouver-author-date` leaked a numeric bibliography label (`[2]. `, `33. `) inherited from its numeric-Vancouver parent style. `label-mode: author-date` removes it.
   - Parity 0% → 20.9%, fidelity 0.955 → 0.97
   - Sibling style `elsevier-vancouver` confirmed byte-identical before/after (no regression)

2. **New tracking:** `scripts/report-data/embedded-parity-baseline.json` — first recorded oracle-text-parity snapshot for all 19 embedded styles. (Not added to `core-quality-baseline.json`, which hard-gates fidelity == 1.0 and would break CI immediately for 17 of 19 styles.)

3. **Investigated, no fix:** the single largest parity defect class (318 mismatches — Citum's rendered bibliography is missing a numeric label the oracle has). Ruled out a comparator bug (proved a proposed fix would regress IEEE), found the real cause (Citum has no equivalent to citeproc-js's automatic bibliography numbering), and filed it as follow-up work rather than fixing it here. Details: `docs/architecture/audits/2026-07-30_EMBEDDED_PARITY_CLASS_A.md`.

## Why so little in this PR

Mid-work I found a pre-existing epic (`csl26-40n4`/`csl26-h7oc`) scoped to exactly the Chicago style family (55.7% of all mismatches). It is **not currently active** — its last landed PR merged 26 days ago and its remaining child beans are stale/unstarted. To avoid creating a second, conflicting tracking structure for the same styles, I fed my new findings into that existing epic rather than opening parallel beans here — but resuming it is separate, unstarted work, not something already in flight.

## Follow-ups (epic `csl26-arly`)

- `csl26-j7uc` — fix the 318-mismatch numbering gap (unblocks 8 exemplar styles stuck at 0% parity)
- `csl26-waly` — unrelated report-harness bug found along the way (RSC's report data doesn't match what it actually renders)

## Test plan

- [x] `node --test scripts/oracle.test.js` — 53/53 passing
- [x] Before/after render diff on `elsevier-vancouver-author-date`: all 47 leaks removed, nothing else changed
- [x] `elsevier-vancouver` sibling: byte-identical, no regression
- [x] Re-measured all 19 embedded styles: 0 changed (confirms nothing needs re-baselining)
- [x] No `.rs` files touched — Rust gate not applicable
