### PR TITLE
fix(styles): bibliography numbering gap (csl26-j7uc, complete)

### DIFF
--- a/.beans/archive/csl26-j7uc--engine-gap-bibliography-numeric-label-rendering-fo.md
+++ b/.beans/archive/csl26-j7uc--engine-gap-bibliography-numeric-label-rendering-fo.md
@@ -1,11 +1,11 @@
 ---
 # csl26-j7uc
 title: 'Engine gap: bibliography numeric-label rendering for second-field-align-derived styles'
-status: in-progress
+status: completed
 type: task
 priority: normal
 created_at: 2026-07-30T14:28:57Z
-updated_at: 2026-07-30T15:02:35Z
+updated_at: 2026-07-30T15:50:31Z
 parent: csl26-arly
 ---
 
@@ -24,3 +24,16 @@ americnn-medical-association-alphabetical inherits via 'extends: american-medica
 - Remaining 15/67 mismatches are unrelated small defects (case: 'In:' vs 'in:'; abbreviation: 'phd-thesis' vs 'PhD thesis', 'CFR' vs 'C.F.R.'; a couple of stray leading-space quirks) -- out of scope for this bean, not investigated further.
 
 **Remaining scope (not done):** nature (101 mismatches), american-chemical-society (53), american-medical-association-alphabetical (47) -- all exemplar tier, same mechanical pattern, each needs its own type-variant-by-type-variant pass (verified per-style, not just copy-pasted, since each style's component structure differs). royal-society-of-chemistry is explicitly NOT part of this fix -- its report evidence doesn't match its actual rendered output (separate bug, csl26-waly).
+
+## Progress: nature, american-chemical-society, american-medical-association-alphabetical fixed (exemplar tier)
+
+Mechanized the same transform via a small text-based Python script (finds the type-variant/default-template anchor, wraps its first list item in `delimiter: ""` + `group: [number: citation-number <wrap>, <original first item>]`), since the per-file repetition is genuinely mechanical once the wrap format is known. The wrap format itself is NOT mechanical -- had to read oracle output per style: nature and american-medical-association-alphabetical use plain `suffix: "."`; american-chemical-society uses `wrap: punctuation: parentheses` (already partially present on its own `patent` type-variant, but broken by the same delimiter-leak bug -- fixed as a one-off, not via the generic script).
+
+**Script bug caught before landing:** the generic script matched the FIRST literal `  template:` line in american-medical-association-alphabetical.yaml, which was the citation template (also called `template:`), not bibliography's -- would have double-wrapped the citation-number/locator group. Fixed by anchoring searches to start after `bibliography:`, reverted and reran clean.
+
+**Verified (node scripts/report-core.js --styles nature,american-chemical-society,american-medical-association-alphabetical):**
+- american-medical-association-alphabetical: fidelity 1.0 (unchanged), citations/bibliography unchanged, exactParity 12/67 (17.9%) -> 33/67 (49.3%).
+- american-chemical-society: citations 28/28 (unchanged), exactParity 24/82 (29.3%) -> 30/82 (36.6%). fidelityScore ticked down 0.951 -> 0.939 and lenient bibliography match 50/54 -> 49/54 -- investigated, NOT a regression: bibliography pairing is similarity-based, and adding numbers changed the pairing solution. One 'hearing'-type entry that was previously mis-paired against a different, coincidentally-similar oracle line (falsely showing match:true) now correctly pairs with its real oracle counterpart and correctly shows match:false on a PRE-EXISTING title-case/trailing-period defect unrelated to numbering (confirmed: the diff never touches title-casing; direct citum render output for that item is unchanged aside from the added number). Net effect is more accurate measurement, not worse rendering. Flagging the exposed hearing-type title-case defect for a future style-maintain pass, not filing a new bean for one entry.
+- nature: fidelity 0.966 (unchanged), citations/bibliography unchanged, **exactParity unchanged at 40/149 (26.8%)** despite the fix working correctly (direct render confirms every entry now carries its number, byte-identical to oracle on that boundary). Nearly all of nature's 101 originally-attributed 'class A' mismatches are actually COMPOUND defects -- number missing AND a second, independent defect (name-list '&' vs ',' conjunction, container-title trailing punctuation) on the same entry. Fixing only the number doesn't flip these to exact match. This means the original taxonomy's per-class counts overstate what a single-class fix buys when defects co-occur -- worth remembering for future wave planning.
+
+All three: citum check OK, node --test scripts/oracle.test.js 53/53 passing, no .rs touched.

--- a/.beans/csl26-j7uc--engine-gap-bibliography-numeric-label-rendering-fo.md
+++ b/.beans/csl26-j7uc--engine-gap-bibliography-numeric-label-rendering-fo.md
@@ -1,12 +1,26 @@
 ---
 # csl26-j7uc
 title: 'Engine gap: bibliography numeric-label rendering for second-field-align-derived styles'
-status: todo
+status: in-progress
 type: task
 priority: normal
 created_at: 2026-07-30T14:28:57Z
-updated_at: 2026-07-30T14:28:57Z
+updated_at: 2026-07-30T15:02:35Z
 parent: csl26-arly
 ---
 
 Class A2 (318 of 2501 parity mismatches, the largest single class). citeproc-js's second-field-align is a processor-level feature: for numeric CSL styles that declare it, the processor generates the bibliography list number itself (rendered into a separate csl-left-margin DOM node) independent of whether the CSL template also renders a number inline. Citum has no equivalent -- a style only gets a bibliography number if its template explicitly includes a 'number: citation-number' component (confirmed: ieee.yaml has this, american-medical-association.yaml does not). Affects at minimum: nature (101 mismatches), american-chemical-society (53), american-medical-association + american-medical-association-alphabetical (47 each), and unblocks up to 8 exemplar styles currently reading exactly 0.0% oracle text parity. Root cause and disposition options (processor-level auto-numbering vs. requiring each affected style to add an explicit number component) documented in docs/architecture/audits/2026-07-30_EMBEDDED_PARITY_CLASS_A.md. Not started.
+
+## Progress: american-medical-association fixed (embedded tier)
+
+Fix: explicitly authored a `number: citation-number, suffix: '.'` component as the first element of every bibliography type-variant (18 variants) and the default template, wrapped together with the variant's original first component in a `delimiter: ""` group so the number sits flush against the following text (matches oracle exactly -- confirmed no join-space bug per the class-A audit). ieee.yaml already uses this exact pattern; american-medical-association.yaml had never had it authored.
+
+americnn-medical-association-alphabetical inherits via 'extends: american-medical-association' for its citation/options blocks, but **redefines its own separate bibliography.type-variants** -- so it does NOT automatically inherit this fix. Needs the same 18-variant treatment applied to its own file.
+
+**Verified (american-medical-association only):**
+- node scripts/report-core.js --styles american-medical-association: fidelity 1.0 (unchanged), citations 20/20 (unchanged), bibliography 47/47 (unchanged, was already lenient-passing), **exactParity 16/67 (23.9%) -> 48/67 (71.6%)** -- 32 additional exact matches, all from the number-prefix fix.
+- Direct render diff: all 47 entries now carry the number prefix, byte-identical to oracle on that boundary.
+- citum check: OK (schema-valid).
+- Remaining 15/67 mismatches are unrelated small defects (case: 'In:' vs 'in:'; abbreviation: 'phd-thesis' vs 'PhD thesis', 'CFR' vs 'C.F.R.'; a couple of stray leading-space quirks) -- out of scope for this bean, not investigated further.
+
+**Remaining scope (not done):** nature (101 mismatches), american-chemical-society (53), american-medical-association-alphabetical (47) -- all exemplar tier, same mechanical pattern, each needs its own type-variant-by-type-variant pass (verified per-style, not just copy-pasted, since each style's component structure differs). royal-society-of-chemistry is explicitly NOT part of this fix -- its report evidence doesn't match its actual rendered output (separate bug, csl26-waly).

--- a/crates/citum-schema-style/embedded/styles/american-medical-association.yaml
+++ b/crates/citum-schema-style/embedded/styles/american-medical-association.yaml
@@ -59,19 +59,17 @@ bibliography:
     entry-suffix: .
     hanging-indent: false
     separator: ". "
+    label-mode: numeric
+    label-wrap: period
   type-variants:
     [article-journal, article-magazine]:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 7
-          use-first: 3
-          and-others: et-al
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 7
+        use-first: 3
+        and-others: et-al
     - title: primary
     - title: parent-serial
       form: short
@@ -92,13 +90,9 @@ bibliography:
     - variable: doi
       prefix: ". doi:"
     [book, report, thesis]:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
+    - contributor: author
+      form: long
+      name-order: family-first
     - title: primary
     - variable: genre
     - number: edition
@@ -107,13 +101,9 @@ bibliography:
     - date: issued
       form: year
     [chapter, paper-conference]:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
+    - contributor: author
+      form: long
+      name-order: family-first
     - title: primary
     - delimiter: " "
       group:
@@ -136,13 +126,9 @@ bibliography:
       - number: pages
         prefix: ":"
     webpage:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
+    - contributor: author
+      form: long
+      name-order: family-first
     - title: primary
     - date: issued
       form: year
@@ -160,13 +146,9 @@ bibliography:
       suffix: ". "
     - variable: url
     article-newspaper:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
+    - contributor: author
+      form: long
+      name-order: family-first
     - title: primary
     - title: parent-serial
     - date: issued
@@ -188,13 +170,9 @@ bibliography:
       suffix: ". "
     - variable: url
     entry-encyclopedia:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
+    - contributor: author
+      form: long
+      name-order: family-first
     - title: primary
     - message: pattern.in-container-colon
       args:
@@ -224,11 +202,7 @@ bibliography:
           before:
             date: issued
     legal-case:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - title: primary
+    - title: primary
     - delimiter: " "
       group:
       - variable: reporter
@@ -243,13 +217,9 @@ bibliography:
       - date: issued
         form: year
     patent:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
+    - contributor: author
+      form: long
+      name-order: family-first
     - title: primary
     - delimiter: ""
       group:
@@ -278,13 +248,9 @@ bibliography:
           before:
             date: issued
     broadcast:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
+    - contributor: author
+      form: long
+      name-order: family-first
     - title: primary
     - title: parent-serial
     - delimiter: ""
@@ -315,13 +281,9 @@ bibliography:
       suffix: ". "
     - variable: url
     [interview, personal-communication]:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
+    - contributor: author
+      form: long
+      name-order: family-first
     - title: primary
     - delimiter: ""
       group:
@@ -337,13 +299,9 @@ bibliography:
             delimiter: " "
     - variable: url
     entry-dictionary:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
+    - contributor: author
+      form: long
+      name-order: family-first
     - title: primary
     - message: pattern.in-container-colon
       args:
@@ -368,22 +326,14 @@ bibliography:
     software:
       extends: dataset
     statute:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - title: primary
+    - title: primary
     - number: volume
       prefix: "Vol "
     - date: issued
       form: year
     - variable: url
     hearing:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - title: primary
+    - title: primary
     - delimiter: ""
       group:
       - message: pattern.published-online-date
@@ -393,11 +343,7 @@ bibliography:
             form: year
     - variable: url
     standard:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - title: primary
+    - title: primary
     - delimiter: ""
       group:
       - message: pattern.published-online-date
@@ -415,11 +361,7 @@ bibliography:
     - variable: doi
       prefix: ". doi:"
     regulation:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - title: primary
+    - title: primary
     - variable: code
     - delimiter: ""
       group:
@@ -429,13 +371,9 @@ bibliography:
       - number: volume
     - variable: url
   template:
-  - delimiter: ""
-    group:
-    - number: citation-number
-      suffix: "."
-    - contributor: author
-      form: long
-      name-order: family-first
+  - contributor: author
+    form: long
+    name-order: family-first
   - title: primary
   - variable: publisher
     suffix: "; "

--- a/crates/citum-schema-style/embedded/styles/american-medical-association.yaml
+++ b/crates/citum-schema-style/embedded/styles/american-medical-association.yaml
@@ -61,13 +61,17 @@ bibliography:
     separator: ". "
   type-variants:
     [article-journal, article-magazine]:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 7
-        use-first: 3
-        and-others: et-al
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
+        shorten:
+          min: 7
+          use-first: 3
+          and-others: et-al
     - title: primary
     - title: parent-serial
       form: short
@@ -88,9 +92,13 @@ bibliography:
     - variable: doi
       prefix: ". doi:"
     [book, report, thesis]:
-    - contributor: author
-      form: long
-      name-order: family-first
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
     - title: primary
     - variable: genre
     - number: edition
@@ -99,9 +107,13 @@ bibliography:
     - date: issued
       form: year
     [chapter, paper-conference]:
-    - contributor: author
-      form: long
-      name-order: family-first
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
     - title: primary
     - delimiter: " "
       group:
@@ -124,9 +136,13 @@ bibliography:
       - number: pages
         prefix: ":"
     webpage:
-    - contributor: author
-      form: long
-      name-order: family-first
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
     - title: primary
     - date: issued
       form: year
@@ -144,9 +160,13 @@ bibliography:
       suffix: ". "
     - variable: url
     article-newspaper:
-    - contributor: author
-      form: long
-      name-order: family-first
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
     - title: primary
     - title: parent-serial
     - date: issued
@@ -168,9 +188,13 @@ bibliography:
       suffix: ". "
     - variable: url
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
     - title: primary
     - message: pattern.in-container-colon
       args:
@@ -200,7 +224,11 @@ bibliography:
           before:
             date: issued
     legal-case:
-    - title: primary
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - title: primary
     - delimiter: " "
       group:
       - variable: reporter
@@ -215,9 +243,13 @@ bibliography:
       - date: issued
         form: year
     patent:
-    - contributor: author
-      form: long
-      name-order: family-first
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
     - title: primary
     - delimiter: ""
       group:
@@ -246,9 +278,13 @@ bibliography:
           before:
             date: issued
     broadcast:
-    - contributor: author
-      form: long
-      name-order: family-first
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
     - title: primary
     - title: parent-serial
     - delimiter: ""
@@ -279,9 +315,13 @@ bibliography:
       suffix: ". "
     - variable: url
     [interview, personal-communication]:
-    - contributor: author
-      form: long
-      name-order: family-first
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
     - title: primary
     - delimiter: ""
       group:
@@ -297,9 +337,13 @@ bibliography:
             delimiter: " "
     - variable: url
     entry-dictionary:
-    - contributor: author
-      form: long
-      name-order: family-first
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
     - title: primary
     - message: pattern.in-container-colon
       args:
@@ -324,14 +368,22 @@ bibliography:
     software:
       extends: dataset
     statute:
-    - title: primary
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - title: primary
     - number: volume
       prefix: "Vol "
     - date: issued
       form: year
     - variable: url
     hearing:
-    - title: primary
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - title: primary
     - delimiter: ""
       group:
       - message: pattern.published-online-date
@@ -341,7 +393,11 @@ bibliography:
             form: year
     - variable: url
     standard:
-    - title: primary
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - title: primary
     - delimiter: ""
       group:
       - message: pattern.published-online-date
@@ -359,7 +415,11 @@ bibliography:
     - variable: doi
       prefix: ". doi:"
     regulation:
-    - title: primary
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - title: primary
     - variable: code
     - delimiter: ""
       group:
@@ -369,9 +429,13 @@ bibliography:
       - number: volume
     - variable: url
   template:
-  - contributor: author
-    form: long
-    name-order: family-first
+  - delimiter: ""
+    group:
+    - number: citation-number
+      suffix: "."
+    - contributor: author
+      form: long
+      name-order: family-first
   - title: primary
   - variable: publisher
     suffix: "; "

--- a/styles/american-chemical-society.yaml
+++ b/styles/american-chemical-society.yaml
@@ -46,6 +46,8 @@ bibliography:
       sort-separator: ", "
     entry-suffix: .
     separator: ". "
+    label-mode: numeric
+    label-wrap: parentheses
   type-variants:
     article-journal:
       modify:
@@ -78,26 +80,16 @@ bibliography:
         - match:
             date: issued
     patent:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: parentheses
-      - contributor: author
-        form: long
-        sort-separator: ", "
+    - contributor: author
+      form: long
+      sort-separator: ", "
     - title: primary
     - date: issued
       form: full
   template:
-  - delimiter: ""
-    group:
-    - number: citation-number
-      wrap:
-        punctuation: parentheses
-    - contributor: author
-      form: long
-      name-order: family-first
+  - contributor: author
+    form: long
+    name-order: family-first
   - title: primary
     prefix: " "
   - title: parent-monograph

--- a/styles/american-chemical-society.yaml
+++ b/styles/american-chemical-society.yaml
@@ -78,19 +78,26 @@ bibliography:
         - match:
             date: issued
     patent:
+    - delimiter: ""
+      group:
+      - number: citation-number
+        wrap:
+          punctuation: parentheses
+      - contributor: author
+        form: long
+        sort-separator: ", "
+    - title: primary
+    - date: issued
+      form: full
+  template:
+  - delimiter: ""
+    group:
     - number: citation-number
       wrap:
         punctuation: parentheses
     - contributor: author
       form: long
-      sort-separator: ", "
-    - title: primary
-    - date: issued
-      form: full
-  template:
-  - contributor: author
-    form: long
-    name-order: family-first
+      name-order: family-first
   - title: primary
     prefix: " "
   - title: parent-monograph

--- a/styles/american-medical-association-alphabetical.yaml
+++ b/styles/american-medical-association-alphabetical.yaml
@@ -56,18 +56,16 @@ bibliography:
         and-others: et-al
         delimiter-precedes-last: contextual
     separator: '. '
+    label-mode: numeric
+    label-wrap: period
   type-variants:
     article-journal:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 8
-          use-first: 3
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
     - title: primary
       prefix: ' '
     - group:
@@ -89,16 +87,12 @@ bibliography:
     - variable: doi
     - variable: url
     article-magazine:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 8
-          use-first: 3
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
     - title: primary
       prefix: ' '
     - group:
@@ -120,16 +114,12 @@ bibliography:
     - variable: doi
     - variable: url
     broadcast:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 8
-          use-first: 3
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
     - title: primary
       prefix: ' '
     - group:
@@ -151,16 +141,12 @@ bibliography:
     - variable: doi
     - variable: url
     chapter:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 8
-          use-first: 3
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
     - title: primary
       prefix: ' '
     - group:
@@ -183,16 +169,12 @@ bibliography:
     - variable: doi
     - variable: url
     entry-encyclopedia:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 8
-          use-first: 3
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
     - title: primary
       prefix: ' '
     - group:
@@ -214,16 +196,12 @@ bibliography:
     - variable: doi
     - variable: url
     patent:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        suffix: "."
-      - contributor: author
-        form: long
-        name-order: family-first
-        shorten:
-          min: 8
-          use-first: 3
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
     - title: primary
       prefix: ' '
     - delimiter: ""
@@ -241,16 +219,12 @@ bibliography:
     - variable: patent-number
       prefix: ':'
   template:
-  - delimiter: ""
-    group:
-    - number: citation-number
-      suffix: "."
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
+  - contributor: author
+    form: long
+    name-order: family-first
+    shorten:
+      min: 8
+      use-first: 3
   - title: primary
     prefix: ' '
   - group:

--- a/styles/american-medical-association-alphabetical.yaml
+++ b/styles/american-medical-association-alphabetical.yaml
@@ -58,12 +58,16 @@ bibliography:
     separator: '. '
   type-variants:
     article-journal:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
+        shorten:
+          min: 8
+          use-first: 3
     - title: primary
       prefix: ' '
     - group:
@@ -85,12 +89,16 @@ bibliography:
     - variable: doi
     - variable: url
     article-magazine:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
+        shorten:
+          min: 8
+          use-first: 3
     - title: primary
       prefix: ' '
     - group:
@@ -112,12 +120,16 @@ bibliography:
     - variable: doi
     - variable: url
     broadcast:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
+        shorten:
+          min: 8
+          use-first: 3
     - title: primary
       prefix: ' '
     - group:
@@ -139,12 +151,16 @@ bibliography:
     - variable: doi
     - variable: url
     chapter:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
+        shorten:
+          min: 8
+          use-first: 3
     - title: primary
       prefix: ' '
     - group:
@@ -167,12 +183,16 @@ bibliography:
     - variable: doi
     - variable: url
     entry-encyclopedia:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
+        shorten:
+          min: 8
+          use-first: 3
     - title: primary
       prefix: ' '
     - group:
@@ -194,12 +214,16 @@ bibliography:
     - variable: doi
     - variable: url
     patent:
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 3
+    - delimiter: ""
+      group:
+      - number: citation-number
+        suffix: "."
+      - contributor: author
+        form: long
+        name-order: family-first
+        shorten:
+          min: 8
+          use-first: 3
     - title: primary
       prefix: ' '
     - delimiter: ""
@@ -217,12 +241,16 @@ bibliography:
     - variable: patent-number
       prefix: ':'
   template:
-  - contributor: author
-    form: long
-    name-order: family-first
-    shorten:
-      min: 8
-      use-first: 3
+  - delimiter: ""
+    group:
+    - number: citation-number
+      suffix: "."
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
   - title: primary
     prefix: ' '
   - group:

--- a/styles/nature.yaml
+++ b/styles/nature.yaml
@@ -52,6 +52,8 @@ bibliography:
       sort-separator: ", "
     entry-suffix: .
     separator: ". "
+    label-mode: numeric
+    label-wrap: period
   type-variants:
     report:
       remove:
@@ -60,16 +62,12 @@ bibliography:
         - match:
             variable: publisher-place
   template:
-  - delimiter: ""
-    group:
-    - number: citation-number
-      suffix: "."
-    - contributor: author
-      form: long
-      name-order: family-first
-      shorten:
-        min: 8
-        use-first: 1
+  - contributor: author
+    form: long
+    name-order: family-first
+    shorten:
+      min: 8
+      use-first: 1
   - title: primary
     prefix: " "
   - group:

--- a/styles/nature.yaml
+++ b/styles/nature.yaml
@@ -60,12 +60,16 @@ bibliography:
         - match:
             variable: publisher-place
   template:
-  - contributor: author
-    form: long
-    name-order: family-first
-    shorten:
-      min: 8
-      use-first: 1
+  - delimiter: ""
+    group:
+    - number: citation-number
+      suffix: "."
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 1
   - title: primary
     prefix: " "
   - group:


### PR DESCRIPTION
## Summary
- Fixes class-A2 embedded-parity gap: `american-medical-association`, `nature`, `american-chemical-society`, and `american-medical-association-alphabetical` never rendered their numeric bibliography label (CSL 1.0's second-field-align numbering is processor-generated, not template content — Citum had no equivalent).
- The style templates declare `bibliography.options.label-mode: numeric` + `label-wrap` (a `period` or `parentheses` suffix on the label), which the engine (#1119, already merged to `main`) resolves into the correct flush-labeled bibliography template for every type-variant automatically — no per-type-variant authoring needed.
- `american-medical-association`, `nature`, `american-medical-association-alphabetical` use `label-wrap: period` (`1.`); `american-chemical-society` uses `label-wrap: parentheses` (`(1)`), matching its pre-existing `patent` variant format.

Closes bean `csl26-j7uc`.

## Parity impact

Nothing in this branch has merged to `main` yet — this table is the actual delta this PR introduces, verified by running `scripts/report-core.js` against `main`'s current (unfixed) style files vs. this branch's final state:

| Style | fidelity: main → branch | exact parity: main → branch | case mismatches: main → branch |
|---|---|---|---|
| american-medical-association | 1.000 → 1.000 | 16/67 (23.9%) → 48/67 (71.6%) | 0 → 0 |
| nature | 0.966 → 0.966 | 40/149 (26.8%) → 40/149 (26.8%) | 0 → 0 |
| american-chemical-society | 0.951 → 0.939 | 24/82 (29.3%) → 30/82 (36.6%) | 0 → 1 |
| american-medical-association-alphabetical | 1.000 → 1.000 | 12/67 (17.9%) → 33/67 (49.3%) | 0 → 0 |

Notes on the two styles that didn't move to 100%:
- **nature**: the numeric label now renders correctly (verified by direct render), but exact-parity didn't move — most of its remaining mismatches are compound (missing number *and* an unrelated second defect), so fixing the label alone doesn't flip the pass/fail bit.
- **american-chemical-society**: fidelity dipped slightly (0.951 → 0.939) and one case mismatch appeared. This is a re-pairing artifact from the lenient bibliography matcher exposing a pre-existing, unrelated title-case defect that was previously masked — not a regression from this change. Not investigated further here; out of scope for this PR.

I additionally verified the last commit in this branch (collapsing the hand-authored `delimiter: ""` blocks into the declarative `label-mode`/`label-wrap` form) makes **no rendering change at all** relative to the hand-authored version it replaces — same `report-core` run, byte-identical citation/bibliography output, only the SQI concision score improved.

## Test plan
- [x] `cargo nextest run` — 2299 tests pass (full pre-push gate)
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `scripts/report-core.js`, `main` vs. this branch, all 4 styles — see table above
- [x] `scripts/report-core.js`, hand-authored vs. declarative form on this branch — byte-identical

## Notes
- No engine or schema changes in this PR — it only consumes the `label-mode`/`label-wrap` machinery merged in #1119.
- Rebased onto updated `main` after #1119 merged; dropped the branch's draft `csl26-ecwd` bean file, now superseded by the real one merged via #1119.
