### PR TITLE
feat(schema): flush numeric bibliography labels

### DIFF
--- a/.beans/archive/csl26-ecwd--make-bibliographyoptionslabel-mode-handle-flush-nu.md
+++ b/.beans/archive/csl26-ecwd--make-bibliographyoptionslabel-mode-handle-flush-nu.md
@@ -1,0 +1,67 @@
+---
+# csl26-ecwd
+title: Make bibliography.options.label-mode handle flush numeric labels without per-type-variant duplication
+status: completed
+type: task
+priority: high
+created_at: 2026-07-30T16:02:04Z
+updated_at: 2026-07-30T16:47:20Z
+parent: csl26-arly
+---
+
+Design smell surfaced by csl26-j7uc (bibliography numeric-label rendering gap): CSL 1.0 specifies second-field-align numbering once at the bibliography level; Citum currently requires hand-authoring a 'number: citation-number' component into every single bibliography type-variant plus the default template (18 type-variants for american-medical-association.yaml alone, repeated again for nature/ACS/AMA-alphabetical -- ~25 near-identical edits total across 4 style files).
+
+The engine already has a partial mechanism for exactly this, but it's unusable as-is:
+1. crates/citum-schema-style/src/options/scoped.rs apply_bibliography_options reads bibliography.options.label-mode (BibliographyLabelMode: none/numeric/author-date) and label-wrap (BibliographyLabelWrap: none/parentheses/brackets), meant to auto-insert the label once via a style option instead of per-type-variant authoring.
+2. Bug: update_label_mode's Numeric branch inserts the citation-number component as a bare list item (template.insert(0, TemplateComponent::Number(..Default::default()))) with NO delimiter: "" wrapping against the next component. This means the outer list's default separator (e.g. bibliography.options.separator: '. ') leaks in between the number and the following text -- confirmed empirically: trying label-mode: numeric on american-medical-association.yaml produced '1. Kuhn TS.' instead of the oracle-correct flush '1.Kuhn TS.', which is why csl26-j7uc had to hand-author every type-variant instead of using this one-line option.
+3. Gap: BibliographyLabelWrap only covers none/parentheses/brackets. Three of the four styles fixed in csl26-j7uc (american-medical-association, nature, american-medical-association-alphabetical) needed a plain period suffix ('1.'), which has no representation in BibliographyLabelWrap at all -- only american-chemical-society's parenthetical '(1)' format maps onto an existing variant.
+
+Fix would be: (a) wrap the auto-inserted number + the original first component in a delimiter: "" group in update_label_mode's Numeric branch, matching the pattern now hand-authored in ieee.yaml, elsevier-vancouver-core.yaml, and the 4 csl26-j7uc styles; (b) add a period/full-stop variant to BibliographyLabelWrap (or a separate label-suffix option). Once both land, all 4 csl26-j7uc styles' ~25 hand-authored wrap blocks could collapse to a single 'label-mode: numeric' + 'label-wrap: ...' declaration each, and any future numeric-style migration gets this for free instead of repeating the same per-type-variant surgery.
+
+Not urgent -- the 4 styles already fixed render correctly today. This is a maintainability/DRY improvement for future numeric-style work, not a correctness bug.
+
+## Plan (2026-07-30, post-#1118 review)
+
+Sequencing agreed: fix this bean first, merge it, THEN revise fix/bib-numeric-label-gap (#1118) to use the resulting one-line label-mode/label-wrap declarations instead of its current ~25 hand-authored delimiter:"" wrap blocks across american-medical-association.yaml, nature.yaml, american-chemical-society.yaml, and american-medical-association-alphabetical.yaml.
+
+**Acceptance target:** styles/embedded/ieee.yaml and styles/embedded/elsevier-vancouver-core.yaml already hand-author the correct delimiter:""-wrapped pattern -- the fixed label-mode/label-wrap machinery should be able to reproduce their rendered output exactly via the declarative option instead.
+
+**#1118 is intentionally held unmerged** pending this bean, to avoid landing the verbose hand-authored version and then immediately superseding it.
+
+## Summary of Changes
+
+- `crates/citum-schema-style/src/options/scoped.rs`: `update_label_mode`'s `Numeric`
+  branch now wraps the auto-inserted `citation-number` and the template's original
+  first component in a `delimiter: ""` group instead of inserting a bare list item,
+  matching the hand-authored pattern. `BibliographyLabelWrap` gained a `Period`
+  variant (sets `rendering.suffix = "."` and clears `wrap`; the other variants now
+  symmetrically clear `suffix` when applied). `has_label` detection, wrap
+  application, and the `None`/`AuthorDate` strip all recurse into groups now, and
+  the strip collapses groups left empty or with a single trivial child — required
+  for idempotent re-application across inheritance levels (parent + child both
+  declaring `label-mode: numeric`) and for `elsevier-vancouver-author-date`'s
+  `author-date` override to strip a label its numeric parent inserted into a group.
+- Converted `styles/embedded/ieee.yaml` and
+  `styles/embedded/elsevier-vancouver-core.yaml` to the declarative form: removed
+  the hand-authored `citation-number` component from the default template and
+  every `Full` type-variant, added `bibliography.options.label-mode: numeric` +
+  `label-wrap: brackets`. `ieee.yaml`'s `patent`/`standard` variants (a
+  non-flush, comma-separated label style, not the group pattern) were left
+  untouched — the option only inserts/rewraps a label when none is present, and
+  update_label_wrap is idempotent on their existing bare `wrap: brackets`, so
+  they're unaffected either way.
+- Verified with `scripts/report-core.js`: fidelity, citation, and bibliography
+  match rates for `ieee`, `elsevier-vancouver`, and `elsevier-vancouver-author-date`
+  are byte-identical before/after (only the SQI quality score changed, and it
+  improved, since the duplicated per-variant number components are gone).
+- Added resolution-level tests in `crates/citum-schema-style/src/tests.rs` and
+  render-level tests in `crates/citum-engine/tests/bibliography.rs` covering the
+  flush-group shape, `label-wrap: period`, idempotent double-resolution, and the
+  author-date strip-from-inherited-group case.
+- `just schema-gen` run for the new `Period` enum variant (`docs/schemas/style.json`).
+
+Follow-up (separate, not done here): revise PR #1118
+(`fix/bib-numeric-label-gap`) to replace its hand-authored wrap blocks in
+`american-medical-association.yaml`, `nature.yaml`,
+`american-chemical-society.yaml`, and `american-medical-association-alphabetical.yaml`
+with `label-mode: numeric` + `label-wrap: period`/`parentheses`.

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -28,11 +28,12 @@ use citum_schema::{
     BibliographySpec, CitationSpec, Style, StyleInfo,
     options::{
         AndOptions, ArticleJournalBibliographyConfig, ArticleJournalNoPageFallback,
-        BibliographyOptions, BibliographyPartitionHeading, BibliographyPartitionKind,
-        BibliographyPartitionMode, BibliographySortPartitioning, Config, ContributorConfig,
-        DelimiterPrecedesLast, DemoteNonDroppingParticle, DisplayAsSort, LinkAnchor, LinkTarget,
-        LinksConfig, MultilingualConfig, MultilingualMode, Processing, ProcessingCustom, Sort,
-        SortKey, SortSpec, SortingConfig, SortingMultilingualMode,
+        BibliographyLabelMode, BibliographyLabelWrap, BibliographyOptions,
+        BibliographyPartitionHeading, BibliographyPartitionKind, BibliographyPartitionMode,
+        BibliographySortPartitioning, Config, ContributorConfig, DelimiterPrecedesLast,
+        DemoteNonDroppingParticle, DisplayAsSort, LinkAnchor, LinkTarget, LinksConfig,
+        MultilingualConfig, MultilingualMode, Processing, ProcessingCustom, Sort, SortKey,
+        SortSpec, SortingConfig, SortingMultilingualMode,
     },
     reference::{
         Contributor, ContributorList, DateValue, InputReference, Monograph, MonographType,
@@ -42,10 +43,10 @@ use citum_schema::{
         types::{ArchiveInfo, EprintInfo, MultilingualComplex, MultilingualString},
     },
     template::{
-        DateForm, DateVariable, DelimiterPunctuation, NumberVariable, Rendering, SimpleVariable,
-        TemplateComponent, TemplateConditionField, TemplateDate, TemplateGroup,
-        TemplateGroupCondition, TemplateNumber, TemplateTitle, TemplateVariable, TitleForm,
-        TitleType,
+        ContributorForm, ContributorRole, DateForm, DateVariable, DelimiterPunctuation,
+        NumberVariable, Rendering, SimpleVariable, TemplateComponent, TemplateConditionField,
+        TemplateContributor, TemplateDate, TemplateGroup, TemplateGroupCondition, TemplateNumber,
+        TemplateTitle, TemplateVariable, TitleForm, TitleType,
     },
 };
 use indexmap::IndexMap;
@@ -5203,6 +5204,65 @@ fn explicit_label_wrap_preserves_prefix_placement_spacing() {
     let result = processor.render_bibliography();
 
     assert_eq!(result, "(Eds.) John Smith, Jane Doe");
+}
+
+#[rstest]
+#[case::period(BibliographyLabelWrap::Period, "1.Thomas Kuhn")]
+#[case::brackets(BibliographyLabelWrap::Brackets, "[1]Thomas Kuhn")]
+fn given_numeric_label_mode_when_label_wrap_varies_then_label_renders_flush_against_author(
+    #[case] label_wrap: BibliographyLabelWrap,
+    #[case] expected: &str,
+) {
+    // Regression test for csl26-ecwd: `label-mode: numeric` used to insert
+    // the auto-generated citation-number as a bare top-level list item, so
+    // the bibliography's `separator` leaked between the label and the next
+    // component ("1. Kuhn" instead of the oracle-correct "1.Kuhn").
+    let style = Style {
+        info: StyleInfo {
+            title: Some("Numeric Label Wrap Test".to_string()),
+            id: Some("numeric-label-wrap-test".into()),
+            ..Default::default()
+        },
+        options: Some(Config {
+            processing: Some(Processing::Numeric),
+            ..Default::default()
+        }),
+        bibliography: Some(BibliographySpec {
+            options: Some(BibliographyOptions {
+                label_mode: Some(BibliographyLabelMode::Numeric),
+                label_wrap: Some(label_wrap),
+                separator: Some(". ".into()),
+                ..Default::default()
+            }),
+            template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author.into(),
+                form: ContributorForm::Long,
+                ..Default::default()
+            })]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let reference = InputReference::Monograph(Box::new(Monograph {
+        id: Some("kuhn-1962".into()),
+        r#type: MonographType::Book,
+        title: Some(Title::Single(
+            "The Structure of Scientific Revolutions".to_string(),
+        )),
+        author: Some(Contributor::StructuredName(StructuredName {
+            given: "Thomas".into(),
+            family: "Kuhn".into(),
+            ..Default::default()
+        })),
+        issued: DateValue::new("1962".to_string()),
+        ..Default::default()
+    }));
+    let bib = citum_schema::bib_map!["kuhn-1962" => reference];
+    let processor = Processor::new(style, bib);
+
+    let result = processor.render_bibliography();
+
+    assert_eq!(result, expected);
 }
 
 /// Regression test for the `Date`-key engine fix (`get_variable_key` in

--- a/crates/citum-schema-style/embedded/styles/elsevier-vancouver-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/elsevier-vancouver-core.yaml
@@ -48,11 +48,10 @@ bibliography:
   options:
     entry-suffix: .
     separator: ''
+    label-mode: numeric
+    label-wrap: brackets
   type-variants:
     article-journal:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
     - contributor: author
       form: long
       suffix: '. '
@@ -112,9 +111,6 @@ bibliography:
           after:
             title: primary
     book:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
     - contributor: author
       form: long
       suffix: '. '
@@ -140,9 +136,6 @@ bibliography:
           before:
             date: issued
     chapter:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
     - contributor: author
       form: long
       suffix: '. '
@@ -239,9 +232,6 @@ bibliography:
           before:
             date: issued
     webpage:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
     - contributor: author
       form: long
       suffix: '. '
@@ -278,9 +268,6 @@ bibliography:
           before:
             date: issued
   template:
-  - number: citation-number
-    wrap:
-      punctuation: brackets
   - contributor: author
     form: long
     suffix: '. '

--- a/crates/citum-schema-style/embedded/styles/ieee.yaml
+++ b/crates/citum-schema-style/embedded/styles/ieee.yaml
@@ -49,6 +49,8 @@ bibliography:
     separator: ", "
     entry-suffix: .
     entry-suffix-after-doi: true
+    label-mode: numeric
+    label-wrap: brackets
   type-variants:
     article-journal:
       modify:
@@ -61,18 +63,13 @@ bibliography:
             number: pages
           label-form: short
     book:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 7
-          use-first: 1
+    - contributor: author
+      form: long
+      and: text
+      name-order: given-first
+      shorten:
+        min: 7
+        use-first: 1
     - title: primary
     - title: parent-monograph
       emph: true
@@ -94,18 +91,13 @@ bibliography:
       prefix: ", doi: "
     - variable: url
     broadcast:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 7
-          use-first: 1
+    - contributor: author
+      form: long
+      and: text
+      name-order: given-first
+      shorten:
+        min: 7
+        use-first: 1
     - title: primary
     - title: parent-monograph
       emph: true
@@ -126,18 +118,13 @@ bibliography:
       prefix: ", doi: "
     - variable: url
     chapter:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 7
-          use-first: 1
+    - contributor: author
+      form: long
+      and: text
+      name-order: given-first
+      shorten:
+        min: 7
+        use-first: 1
     - title: primary
       wrap:
         punctuation: quotes
@@ -163,18 +150,13 @@ bibliography:
     - number: pages
       label-form: short
     dataset:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 7
-          use-first: 1
+    - contributor: author
+      form: long
+      and: text
+      name-order: given-first
+      shorten:
+        min: 7
+        use-first: 1
     - title: primary
     - title: parent-monograph
       emph: true
@@ -201,18 +183,13 @@ bibliography:
             number: pages
           label-form: short
     motion-picture:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 7
-          use-first: 1
+    - contributor: author
+      form: long
+      and: text
+      name-order: given-first
+      shorten:
+        min: 7
+        use-first: 1
     - title: primary
     - title: parent-monograph
       emph: true
@@ -233,18 +210,13 @@ bibliography:
       prefix: ", doi: "
     - variable: url
     paper-conference:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 7
-          use-first: 1
+    - contributor: author
+      form: long
+      and: text
+      name-order: given-first
+      shorten:
+        min: 7
+        use-first: 1
     - title: primary
       wrap:
         punctuation: quotes
@@ -276,18 +248,13 @@ bibliography:
     - date: issued
       form: full
     personal_communication:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 7
-          use-first: 1
+    - contributor: author
+      form: long
+      and: text
+      name-order: given-first
+      shorten:
+        min: 7
+        use-first: 1
     - title: primary
       wrap:
         punctuation: quotes
@@ -310,18 +277,13 @@ bibliography:
       prefix: ", doi: "
     - variable: url
     report:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 7
-          use-first: 1
+    - contributor: author
+      form: long
+      and: text
+      name-order: given-first
+      shorten:
+        min: 7
+        use-first: 1
     - title: primary
     - title: parent-monograph
       emph: true
@@ -342,18 +304,13 @@ bibliography:
       prefix: ", doi: "
     - variable: url
     thesis:
-    - delimiter: ""
-      group:
-      - number: citation-number
-        wrap:
-          punctuation: brackets
-      - contributor: author
-        form: long
-        and: text
-        name-order: given-first
-        shorten:
-          min: 7
-          use-first: 1
+    - contributor: author
+      form: long
+      and: text
+      name-order: given-first
+      shorten:
+        min: 7
+        use-first: 1
     - title: primary
       emph: false
       wrap:
@@ -375,18 +332,13 @@ bibliography:
     - variable: doi
       prefix: "doi: "
   template:
-  - delimiter: ""
-    group:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
-    - contributor: author
-      form: long
-      and: text
-      name-order: given-first
-      shorten:
-        min: 7
-        use-first: 1
+  - contributor: author
+    form: long
+    and: text
+    name-order: given-first
+    shorten:
+      min: 7
+      use-first: 1
   - title: primary
     wrap:
       punctuation: quotes

--- a/crates/citum-schema-style/src/options/scoped.rs
+++ b/crates/citum-schema-style/src/options/scoped.rs
@@ -51,18 +51,35 @@ pub enum BibliographyLabelWrap {
     Parentheses,
     /// Brackets.
     Brackets,
+    /// A trailing period, flush against the following component (no outer wrap).
+    Period,
 }
 
 impl BibliographyLabelWrap {
     /// Convert a supported punctuation style into a concrete wrap config.
+    ///
+    /// Returns `None` for [`BibliographyLabelWrap::Period`], since a period is
+    /// expressed as a rendering suffix rather than an outer wrap; see
+    /// [`BibliographyLabelWrap::as_suffix`].
     #[must_use]
     pub fn as_wrap_config(self) -> Option<WrapConfig> {
         match self {
-            BibliographyLabelWrap::None => None,
+            BibliographyLabelWrap::None | BibliographyLabelWrap::Period => None,
             BibliographyLabelWrap::Parentheses => {
                 Some(WrapConfig::from(WrapPunctuation::Parentheses))
             }
             BibliographyLabelWrap::Brackets => Some(WrapConfig::from(WrapPunctuation::Brackets)),
+        }
+    }
+
+    /// Return the literal suffix this wrap style appends to the label, if any.
+    #[must_use]
+    pub fn as_suffix(self) -> Option<&'static str> {
+        match self {
+            BibliographyLabelWrap::Period => Some("."),
+            BibliographyLabelWrap::None
+            | BibliographyLabelWrap::Parentheses
+            | BibliographyLabelWrap::Brackets => None,
         }
     }
 }
@@ -290,51 +307,119 @@ fn apply_repeated_author_rendering(
     }
 }
 
+/// Whether `component` is the citation-number/citation-label variable used
+/// as a bibliography entry label.
+fn is_bibliography_label(component: &TemplateComponent) -> bool {
+    matches!(
+        component,
+        TemplateComponent::Number(number)
+            if matches!(
+                number.number,
+                crate::template::NumberVariable::CitationNumber
+                    | crate::template::NumberVariable::CitationLabel
+            )
+    )
+}
+
+/// Whether a label is present anywhere in `components`, including nested groups —
+/// e.g. the `delimiter: ""` group the `Numeric` branch below wraps it in.
+fn template_has_label(components: &[TemplateComponent]) -> bool {
+    components.iter().any(|component| {
+        is_bibliography_label(component)
+            || matches!(
+                component,
+                TemplateComponent::Group(group) if template_has_label(&group.group)
+            )
+    })
+}
+
+/// Remove any bibliography label from `components`, recursing into groups and
+/// collapsing groups left empty or with a single trivial child behind.
+fn strip_bibliography_label(components: &mut Vec<TemplateComponent>) {
+    components.retain_mut(|component| {
+        if is_bibliography_label(component) {
+            return false;
+        }
+        if let TemplateComponent::Group(group) = component {
+            strip_bibliography_label(&mut group.group);
+        }
+        true
+    });
+    collapse_trivial_groups(components);
+}
+
+/// Drop empty groups and flatten groups left with exactly one child that carry
+/// no other semantics (no render condition, rendering affixes, or custom fields).
+fn collapse_trivial_groups(components: &mut Vec<TemplateComponent>) {
+    let mut index = 0;
+    while index < components.len() {
+        let Some(TemplateComponent::Group(group)) = components.get(index) else {
+            index += 1;
+            continue;
+        };
+        if group.group.is_empty() {
+            components.remove(index);
+            continue;
+        }
+        if group.group.len() == 1
+            && group.render_when.is_none()
+            && group.rendering == crate::template::Rendering::default()
+            && group.custom.is_none()
+        {
+            if let TemplateComponent::Group(mut group) = components.remove(index)
+                && let Some(child) = group.group.pop()
+            {
+                components.insert(index, child);
+            }
+            continue;
+        }
+        index += 1;
+    }
+}
+
 fn update_label_mode(template: Option<&mut Template>, mode: BibliographyLabelMode) {
     let Some(template) = template else {
         return;
     };
     match mode {
         BibliographyLabelMode::None | BibliographyLabelMode::AuthorDate => {
-            template.retain(|component| {
-                !matches!(
-                    component,
-                    TemplateComponent::Number(number)
-                        if matches!(
-                            number.number,
-                            crate::template::NumberVariable::CitationNumber
-                                | crate::template::NumberVariable::CitationLabel
-                        )
-                )
-            });
+            strip_bibliography_label(template);
         }
         BibliographyLabelMode::Numeric => {
-            let has_label = template.iter().any(|component| {
-                matches!(
-                    component,
-                    TemplateComponent::Number(number)
-                        if matches!(
-                            number.number,
-                            crate::template::NumberVariable::CitationNumber
-                                | crate::template::NumberVariable::CitationLabel
-                        )
-                )
-            });
-            if !has_label {
-                template.insert(
-                    0,
-                    TemplateComponent::Number(crate::TemplateNumber {
-                        number: crate::template::NumberVariable::CitationNumber,
-                        ..Default::default()
-                    }),
-                );
+            if template_has_label(template) {
+                return;
             }
+            let label = TemplateComponent::Number(crate::TemplateNumber {
+                number: crate::template::NumberVariable::CitationNumber,
+                ..Default::default()
+            });
+            if template.is_empty() {
+                template.push(label);
+                return;
+            }
+            let following = template.remove(0);
+            template.insert(
+                0,
+                TemplateComponent::Group(crate::template::TemplateGroup {
+                    group: vec![label, following],
+                    delimiter: Some(crate::template::DelimiterPunctuation::Custom(String::new())),
+                    ..Default::default()
+                }),
+            );
         }
     }
 }
 
 trait LabelWrapConfig {
     fn wrap_config(self) -> Option<WrapConfig>;
+
+    /// Literal suffix this wrap style appends to the label, if any.
+    fn suffix(self) -> Option<&'static str>
+    where
+        Self: Sized,
+    {
+        None
+    }
 }
 
 impl LabelWrapConfig for LabelWrap {
@@ -347,6 +432,10 @@ impl LabelWrapConfig for BibliographyLabelWrap {
     fn wrap_config(self) -> Option<WrapConfig> {
         self.as_wrap_config()
     }
+
+    fn suffix(self) -> Option<&'static str> {
+        self.as_suffix()
+    }
 }
 
 fn update_label_wrap<W>(template: Option<&mut Template>, wrap: W)
@@ -356,15 +445,29 @@ where
     let Some(template) = template else {
         return;
     };
-    for component in template.iter_mut() {
-        if let TemplateComponent::Number(number) = component
-            && matches!(
-                number.number,
-                crate::template::NumberVariable::CitationNumber
-                    | crate::template::NumberVariable::CitationLabel
-            )
-        {
-            number.rendering.wrap = wrap.wrap_config();
+    update_label_wrap_components(template, wrap);
+}
+
+fn update_label_wrap_components<W>(components: &mut [TemplateComponent], wrap: W)
+where
+    W: Copy + LabelWrapConfig,
+{
+    for component in components.iter_mut() {
+        match component {
+            TemplateComponent::Number(number)
+                if matches!(
+                    number.number,
+                    crate::template::NumberVariable::CitationNumber
+                        | crate::template::NumberVariable::CitationLabel
+                ) =>
+            {
+                number.rendering.wrap = wrap.wrap_config();
+                number.rendering.suffix = wrap.suffix().map(ToString::to_string).map(Into::into);
+            }
+            TemplateComponent::Group(group) => {
+                update_label_wrap_components(&mut group.group, wrap);
+            }
+            _ => {}
         }
     }
 }

--- a/crates/citum-schema-style/src/tests.rs
+++ b/crates/citum-schema-style/src/tests.rs
@@ -2224,3 +2224,214 @@ bibliography:
     );
     assert_eq!(realization.colon, None);
 }
+
+#[test]
+fn numeric_label_mode_wraps_auto_inserted_label_flush_against_next_component() {
+    let resolved = Style::from_yaml_str(
+        r#"
+info: { id: numeric-flush-wrap, title: Numeric Flush Wrap }
+bibliography:
+  options:
+    label-mode: numeric
+  template:
+    - contributor: author
+      form: long
+    - title: primary
+"#,
+    )
+    .unwrap()
+    .try_into_resolved()
+    .expect("numeric label-mode should resolve");
+
+    let template = resolved
+        .bibliography
+        .as_ref()
+        .and_then(|bib| bib.template.as_ref())
+        .expect("bibliography template should be present");
+
+    let template::TemplateComponent::Group(group) = &template[0] else {
+        panic!(
+            "expected the auto-inserted label wrapped in a group, got {:?}",
+            template[0]
+        );
+    };
+    assert_eq!(
+        group.delimiter,
+        Some(template::DelimiterPunctuation::Custom(String::new()))
+    );
+    assert_eq!(group.group.len(), 2);
+    assert!(matches!(
+        &group.group[0],
+        template::TemplateComponent::Number(number)
+            if number.number == template::NumberVariable::CitationNumber
+    ));
+    assert!(matches!(
+        &group.group[1],
+        template::TemplateComponent::Contributor(contributor)
+            if contributor.contributor == template::ContributorRoles::Single(template::ContributorRole::Author)
+    ));
+}
+
+#[test]
+fn label_wrap_period_sets_suffix_and_clears_an_inherited_bracket_wrap() {
+    let resolved = Style::from_yaml_str(
+        r#"
+info: { id: numeric-period-wrap, title: Numeric Period Wrap }
+bibliography:
+  options:
+    label-mode: numeric
+    label-wrap: period
+  template:
+    - number: citation-number
+      wrap:
+        punctuation: brackets
+    - contributor: author
+      form: long
+"#,
+    )
+    .unwrap()
+    .try_into_resolved()
+    .expect("period label-wrap should resolve");
+
+    let template = resolved
+        .bibliography
+        .as_ref()
+        .and_then(|bib| bib.template.as_ref())
+        .expect("bibliography template should be present");
+
+    let template::TemplateComponent::Number(number) = &template[0] else {
+        panic!("expected a bare label component, got {:?}", template[0]);
+    };
+    assert_eq!(number.rendering.suffix.as_deref(), Some("."));
+    assert_eq!(number.rendering.wrap, None);
+}
+
+#[test]
+fn numeric_label_mode_is_idempotent_across_inheritance_levels() {
+    use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .subsec_nanos();
+    let dir = std::env::temp_dir().join(format!("citum_numeric_idempotent_{nanos}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    let parent_path = dir.join("parent.yaml");
+    std::fs::File::create(&parent_path)
+        .unwrap()
+        .write_all(
+            br#"
+info: { id: numeric-idempotent-parent, title: Numeric Idempotent Parent }
+bibliography:
+  options:
+    label-mode: numeric
+  template:
+    - contributor: author
+      form: long
+"#,
+        )
+        .unwrap();
+
+    let child_yaml = format!(
+        "info: {{ id: numeric-idempotent-child, title: Numeric Idempotent Child }}\nextends: \"file://{}\"\n",
+        parent_path.display()
+    );
+    let resolved = Style::from_yaml_str(&child_yaml)
+        .unwrap()
+        .try_into_resolved()
+        .expect("child inheriting numeric label-mode should resolve");
+    std::fs::remove_dir_all(&dir).ok();
+
+    let template = resolved
+        .bibliography
+        .as_ref()
+        .and_then(|bib| bib.template.as_ref())
+        .expect("bibliography template should be present");
+
+    let label_count = template
+        .iter()
+        .flat_map(|component| match component {
+            template::TemplateComponent::Group(group) => group.group.iter().collect::<Vec<_>>(),
+            other => vec![other],
+        })
+        .filter(|component| {
+            matches!(
+                component,
+                template::TemplateComponent::Number(number)
+                    if number.number == template::NumberVariable::CitationNumber
+            )
+        })
+        .count();
+    assert_eq!(
+        label_count, 1,
+        "resolving citation-number twice (parent then child) must not duplicate the label"
+    );
+}
+
+#[test]
+fn author_date_label_mode_strips_label_inherited_from_a_numeric_parent() {
+    use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .subsec_nanos();
+    let dir = std::env::temp_dir().join(format!("citum_author_date_strip_{nanos}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    let parent_path = dir.join("parent.yaml");
+    std::fs::File::create(&parent_path)
+        .unwrap()
+        .write_all(
+            br#"
+info: { id: author-date-strip-parent, title: Author Date Strip Parent }
+bibliography:
+  options:
+    label-mode: numeric
+  template:
+    - contributor: author
+      form: long
+    - title: primary
+"#,
+        )
+        .unwrap();
+
+    let child_yaml = format!(
+        "info: {{ id: author-date-strip-child, title: Author Date Strip Child }}\nextends: \"file://{}\"\nbibliography:\n  options:\n    label-mode: author-date\n",
+        parent_path.display()
+    );
+    let resolved = Style::from_yaml_str(&child_yaml)
+        .unwrap()
+        .try_into_resolved()
+        .expect("author-date override should resolve");
+    std::fs::remove_dir_all(&dir).ok();
+
+    let template = resolved
+        .bibliography
+        .as_ref()
+        .and_then(|bib| bib.template.as_ref())
+        .expect("bibliography template should be present");
+
+    assert!(
+        !template.iter().any(|component| matches!(
+            component,
+            template::TemplateComponent::Number(number)
+                if number.number == template::NumberVariable::CitationNumber
+        ) || matches!(
+            component,
+            template::TemplateComponent::Group(group)
+                if group.group.iter().any(|inner| matches!(
+                    inner,
+                    template::TemplateComponent::Number(number)
+                        if number.number == template::NumberVariable::CitationNumber
+                ))
+        )),
+        "author-date label-mode must strip the label the numeric parent inserted, got {template:?}"
+    );
+    assert!(matches!(
+        &template[0],
+        template::TemplateComponent::Contributor(contributor)
+            if contributor.contributor == template::ContributorRoles::Single(template::ContributorRole::Author)
+    ));
+}

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -7852,6 +7852,11 @@
           "description": "Brackets.",
           "type": "string",
           "const": "brackets"
+        },
+        {
+          "description": "A trailing period, flush against the following component (no outer wrap).",
+          "type": "string",
+          "const": "period"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Fixes `bibliography.options.label-mode: numeric` so the auto-inserted `citation-number` label is wrapped flush against the following component instead of leaking the bibliography `separator` between them ("1. Kuhn." → "1.Kuhn.").
- Adds a `label-wrap: period` variant to `BibliographyLabelWrap` for trailing-period numeric styles.
- Makes label detection/wrap/strip recurse into groups, so the option is idempotent across inheritance levels and composes correctly with a child's `label-mode: author-date` override stripping a label its numeric parent inserted.
- Converts `styles/embedded/ieee.yaml` and `styles/embedded/elsevier-vancouver-core.yaml` from ~15 hand-authored `citation-number` components to the declarative `label-mode`/`label-wrap` options, proving the machinery reproduces their existing rendered output.

Closes bean `csl26-ecwd`.

## Test plan
- [x] `cargo nextest run` — 2299 tests pass (full pre-push gate)
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`
- [x] New resolution-level tests in `crates/citum-schema-style/src/tests.rs`: flush-group shape, `label-wrap: period` suffix/wrap clearing, idempotent double-resolution across parent+child, author-date strip from an inherited group
- [x] New render-level tests in `crates/citum-engine/tests/bibliography.rs`: `#[rstest]` cases for `period` and `brackets` label-wrap producing flush output
- [x] `scripts/report-core.js` before/after diff for `ieee`, `elsevier-vancouver`, `elsevier-vancouver-author-date`: citation/bibliography match rates and rendered text byte-identical (only the SQI quality score changed, and improved)
- [x] `just schema-gen` run for the new `Period` enum variant (`docs/schemas/style.json`)

## Follow-up (not in this PR)
Revise #1118 (`fix/bib-numeric-label-gap`) to replace its hand-authored wrap blocks in `american-medical-association.yaml`, `nature.yaml`, `american-chemical-society.yaml`, and `american-medical-association-alphabetical.yaml` with `label-mode: numeric` + `label-wrap: period`/`parentheses`.
