### PR TITLE
docs(beans): navigate embedded parity project

### DIFF
--- a/.beans/archive/csl26-arly--embedded-tier-oracle-text-parity.md
+++ b/.beans/archive/csl26-arly--embedded-tier-oracle-text-parity.md
@@ -1,11 +1,12 @@
 ---
 # csl26-arly
 title: Embedded-tier oracle text parity
-status: in-progress
+status: completed
 type: epic
 priority: high
 created_at: 2026-07-30T14:16:05Z
-updated_at: 2026-07-30T14:55:38Z
+updated_at: 2026-07-30T19:10:05Z
+parent: csl26-w0hf
 ---
 
 Raise oracle text parity for the embedded style tier (currently 38.7% overall, 1260/3255). Baseline: docs/compat.html generated at fb0a01af. Disjoint defect taxonomy over 2501 parity mismatches (Z unclassified 925/37%, D title-quoting 421/16.8%, D2 title/term case 392/15.7%, A oracle-only number prefix 318/12.7% split into A1 harness-join + A2 rendering-omission, B punctuation-only 200/8%, J citum-only number prefix 82/3.3%, I number-prefix format 64/2.6%, F bracket medium label 30/1.2%, H year-suffix 30/1.2% (csl26-m8la), E name separator 26/1%, G/M accessed+label terms 13/0.5%).
@@ -25,3 +26,20 @@ Plan: /home/bruce/.claude/plans/ok-now-that-we-ve-iridescent-cat.md (revised sco
 **Remaining open children:** [[csl26-j7uc]] (A2 rendering-gap fix, largest deferred wave, 318 mismatches / unblocks 8 exemplars at 0% parity) and [[csl26-waly]] (RSC report-evidence bug). Chicago-family work (55.7% of all mismatches) is intentionally not tracked under this epic -- see the scope-correction note above; residual-defect evidence was fed into the existing in-progress [[csl26-giun]] and [[csl26-7jht]] beans instead.
 
 **Correction (2026-07-30, post-PR-1):** the framing above overstates csl26-40n4/csl26-h7oc as active. Its last landed PR merged 2026-07-04 (26 days idle at time of writing), csl26-giun has sat 'in-progress' with no landed work since then, and csl26-7jht/csl26-gzwj are unstarted todos. Feeding evidence into them was still correct (avoids a second competing tracking structure for the same styles), but resuming Chicago work is separate, unstarted effort -- not something already in flight. User flagged this after reading the PR; next work picked was csl26-j7uc instead.
+
+## Summary of Changes
+
+This epic's own scope is complete: [[csl26-j7uc]] (the class-A2 bibliography
+numeric-label gap, landed via PR #1119 + PR #1118), [[csl26-w1vf]] (the
+elsevier-vancouver-author-date label-mode leak), [[csl26-lf68]] (the class-A2
+root-cause spike), and [[csl26-q42m]] (baseline/ratchet tracking) are all
+done. Only [[csl26-waly]] (a low-priority RSC evidence bug) remains open.
+
+**This does not mean embedded-tier oracle parity is done.** The headline
+number barely moved from this epic's own work -- see this epic's own
+"scope correction" note above: the Chicago family (55.7% of all tracked
+mismatches) was deliberately excluded and tracked separately under
+[[csl26-40n4]], which was disconnected from this epic (no shared parent)
+until today. Both are now children of [[csl26-w0hf]] ("Embedded-tier oracle
+parity to 100%"), the actual project-level milestone -- see that bean for
+current status and next actions.

--- a/.beans/csl26-40n4--chicago-family-substrate-100-fidelity.md
+++ b/.beans/csl26-40n4--chicago-family-substrate-100-fidelity.md
@@ -5,7 +5,8 @@ status: in-progress
 type: epic
 priority: high
 created_at: 2026-06-30T14:29:06Z
-updated_at: 2026-06-30T14:29:06Z
+updated_at: 2026-07-30T19:09:41Z
+parent: csl26-w0hf
 ---
 
 Container epic for the Chicago-family pivot: stop hand-tuning chicago-author-date-18th in isolation and instead build a shared semantic/component layer plus conversion/accessor fixes that lift chicago-author-date-18th, chicago-notes-18th, chicago-shortened-notes-bibliography, and taylor-and-francis-chicago-author-date together, backed by one robust fixture exercising citation+bibliography surfaces across all four, with each variant driven to ~100% fidelity.

--- a/.beans/csl26-h7oc--drive-all-chicago-variants-to-full-fidelity.md
+++ b/.beans/csl26-h7oc--drive-all-chicago-variants-to-full-fidelity.md
@@ -1,11 +1,11 @@
 ---
 # csl26-h7oc
 title: Drive all Chicago variants to full fidelity
-status: todo
+status: in-progress
 type: epic
 priority: high
 created_at: 2026-06-30T14:30:24Z
-updated_at: 2026-06-30T18:55:01Z
+updated_at: 2026-07-30T19:09:49Z
 parent: csl26-40n4
 ---
 

--- a/.beans/csl26-w0hf--embedded-tier-oracle-parity-to-100.md
+++ b/.beans/csl26-w0hf--embedded-tier-oracle-parity-to-100.md
@@ -1,0 +1,53 @@
+---
+# csl26-w0hf
+title: Embedded-tier oracle parity to 100%
+status: in-progress
+type: milestone
+priority: high
+created_at: 2026-07-30T19:09:35Z
+updated_at: 2026-07-30T19:09:41Z
+---
+
+Reach 100% oracle text parity (byte-for-byte match with citeproc-js for
+CSL-derived styles) across the embedded style tier. Currently 38.7%
+(baseline docs/compat.html at fb0a01af) -- see docs/architecture/DESIGN_PRINCIPLES.md
+for the parity commitment this target derives from.
+
+Canonical live source: docs/compat.html (regenerate via
+`node scripts/report-core.js --write-html`).
+
+This milestone exists because the work was split across two disconnected
+epic threads with no shared parent, which made it look like the project
+was "done" when csl26-arly's children completed even though the headline
+number barely moved:
+
+- csl26-arly (completed): harness-integrity fixes, non-Chicago numeric-label
+  gap (class A2), and other narrow-scope defects. Its own scope is fully
+  closed, but it explicitly excludes the Chicago family.
+- csl26-40n4 (in-progress): the Chicago family pivot -- 55.7% of all 2501
+  tracked oracle-parity mismatches (chicago-author-date-18th,
+  chicago-notes-18th, chicago-shortened-notes-bibliography,
+  taylor-and-francis-chicago-author-date). This is where most of the
+  remaining gap to 100% lives.
+
+## Next actions (as of 2026-07-30)
+
+Verified via direct beans GraphQL queries -- these are genuinely unblocked
+right now, even though some don't surface via `beans list --ready` (its
+readiness computation appears to suppress grandchildren of a not-yet-started
+parent):
+
+- [ ] csl26-t6dg (todo, unblocked) -- "Support paired EDTF uncertainty
+      markers for Chicago guessed dates". Unblocks csl26-giun, the Chicago
+      variant with the most tuning history/momentum (chicago-author-date-18th,
+      344/400 bibliography as of 2026-07-02).
+- [ ] csl26-7jht (todo, unblocked) -- tune chicago-shortened-notes-bibliography
+      to full fidelity. Independently startable, no dependency on t6dg.
+- [ ] csl26-gzwj (todo, unblocked) -- tune taylor-and-francis-chicago-author-date
+      to full fidelity. Independently startable.
+- [ ] csl26-lxy3 (todo, unblocked) -- tune chicago-notes-18th to full
+      fidelity. Independently startable.
+
+Re-derive this list with:
+`beans query '{ bean(id: "csl26-40n4") { children { id title status blockedBy { id status } } } }'`
+and recurse into any in-progress children.


### PR DESCRIPTION
## Summary
- `csl26-arly` ("Embedded-tier oracle text parity") had all its children completed, but its own scope deliberately excluded the Chicago family — 55.7% of all 2501 tracked oracle-parity mismatches — which lived in a completely separate epic (`csl26-40n4`) with no shared parent. Closing `csl26-arly` therefore read as "the parity project is done" when the headline number (38.7%) barely moved.
- `beans list --ready` also wasn't surfacing three genuinely-unblocked Chicago tuning tasks (`csl26-7jht`, `csl26-gzwj`, `csl26-lxy3`) because their immediate parent (`csl26-h7oc`) hadn't itself been started — a beans-tool readiness-computation gap, not something fixable from this repo.
- Adds `csl26-w0hf`, a milestone bean parenting both `csl26-arly` and `csl26-40n4`, with a "Next actions" section listing the concretely-ready next steps (found via direct GraphQL queries) so this doesn't have to be re-derived by hand again.
- Flips `csl26-h7oc` to `in-progress` to match reality (active tuning is happening under it via `csl26-giun`).
- Closes `csl26-arly` with an accurate completion summary that explicitly points to the milestone for the remaining work, instead of implying the project is finished.

## Test plan
- [x] `beans query` confirms `csl26-w0hf` has both `csl26-arly` (completed) and `csl26-40n4` (in-progress) as children
- [x] `beans list --json --ready` — `csl26-t6dg` still surfaces; confirmed `csl26-7jht`/`csl26-gzwj`/`csl26-lxy3` still don't (documented as a beans-tool limitation, mitigated by the milestone's next-actions list rather than fixed)
- Docs/beans-only change — no code touched, `pre-push` correctly skipped the cargo gate
