### PR TITLE
fix(styles): improve Chicago exact parity

### DIFF
--- a/.beans/csl26-2nv1--allow-explicit-optional-bibliography-in-inherited.md
+++ b/.beans/csl26-2nv1--allow-explicit-optional-bibliography-in-inherited.md
@@ -1,0 +1,34 @@
+---
+# csl26-2nv1
+title: Allow explicit optional bibliography in inherited styles
+status: todo
+type: feature
+priority: high
+tags:
+    - schema
+    - engine
+    - inheritance
+    - style
+created_at: 2026-07-31T12:13:32Z
+updated_at: 2026-07-31T12:13:32Z
+parent: csl26-h7oc
+---
+
+## Problem
+
+`Style.bibliography` is already optional for standalone styles, but an extending child cannot suppress an inherited bibliography. `bibliography: null` currently leaves the parent bibliography in place, so `chicago-notes-18th` uses the semantic placeholder `bibliography.template: []`. The engine and CLI also process bibliography output even when a style has no bibliography spec.
+
+## Contract
+
+- `bibliography: null` is an explicit disable in an extending style; an absent key continues to inherit and a mapping continues to merge.
+- Resolved `Style.bibliography` is `None` after that explicit disable.
+- Engine, document pipeline, FFI, and CLI render no bibliography content or heading when the resolved style has no bibliography.
+- Replace Chicago notes’ empty template placeholder with the explicit disable.
+
+## Acceptance checklist
+
+- [ ] Add schema/overlay tests covering inherit, merge, and explicit-null disable semantics.
+- [ ] Add engine/CLI or document-pipeline regression coverage proving bibliography output is absent while citations still render.
+- [ ] Update generated schema/reference documentation if the public schema output changes.
+- [ ] Convert `chicago-notes-18th` from `bibliography.template: []` to `bibliography: null` and validate its rendered document behavior.
+- [ ] Run the Rust pre-commit gate and relevant exact-parity/oracle checks.

--- a/.beans/csl26-7jht--tune-chicago-shortened-notes-bibliography-to-full.md
+++ b/.beans/csl26-7jht--tune-chicago-shortened-notes-bibliography-to-full.md
@@ -5,7 +5,7 @@ status: todo
 type: task
 priority: high
 created_at: 2026-06-30T18:46:09Z
-updated_at: 2026-07-30T14:17:58Z
+updated_at: 2026-07-31T12:16:50Z
 parent: csl26-h7oc
 blocked_by:
     - csl26-lxy3
@@ -59,3 +59,13 @@ C: State of JS Team, The State of JavaScript 2023, 2023, https://stateofjs.com/2
 ```
 
 This style is `chicago-shortened-notes-bibliography-core.yaml` (284 lines) extending `chicago-notes-18th` (731 lines). Given `303a38f0 feat(schema)!: deep-merge options on extends` and `0b8efb77 fix(styles): fix two title deep-merge regressions` landed recently, this looks like deep-merge fallout from a shared root cause (delimiter/quoting/case options not surviving the extends chain), not N independent per-type bugs — worth checking the resolved merged template against `chicago-notes-18th`'s bibliography delimiters/affixes before doing per-entry tuning. Not independently root-caused — recorded as a strong lead for this bean's fidelity loop. Full clustering data path is stale (/tmp/prd_report.json); regenerate via `node scripts/report-core.js --styles chicago-shortened-notes-bibliography --parallelism 2`. See [[csl26-arly]].
+
+
+
+## 2026-07-31 shared terminal-link punctuation progress
+
+Enabled `bibliography.options.entry-suffix-after-url` and `entry-suffix-after-doi` in the shared shortened-notes bibliography core, so terminal URLs and DOIs receive its declared `entry-suffix: .`. The current broad exact-parity fixture remains **11/465**: no broad-match count lifted because its terminal-link entries also have structural template differences. This is shared punctuation progress only; it does not start or complete this task’s full tuning loop.
+
+
+
+Direct verification: `just workflow-test styles-legacy/chicago-shortened-notes-bibliography.csl` passed **20/20 citations** and **46/46 bibliography entries** against citeproc-js after the suffix-policy change.

--- a/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
+++ b/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
@@ -5,7 +5,7 @@ status: in-progress
 type: task
 priority: high
 created_at: 2026-06-30T18:46:08Z
-updated_at: 2026-07-30T20:35:16Z
+updated_at: 2026-07-31T12:15:53Z
 parent: csl26-h7oc
 ---
 
@@ -157,3 +157,7 @@ Not independently investigated/fixed — recorded as residual-defect input for t
 
 
 - Follow-up exact-parity pass: enabled `entry-suffix-after-url` and `entry-suffix-after-doi` for Chicago bibliography output. Fresh `report-core` exact parity improved **156/540 -> 165/540** (+9) with SQI unchanged at 0.920. The remaining 133 URL/DOI-ending mismatches also have structural differences, so this global option is exhausted; next cluster is type-specific quote/template selection.
+
+
+
+- 2026-07-31: extended the terminal-link policy to the other active Chicago bibliography head, `chicago-shortened-notes-bibliography-core` (`entry-suffix-after-url: true`, `entry-suffix-after-doi: true`). Author-date already carries both flags, and its dependent T&F variant retains the verified **165/540** exact-parity result. The isolated author-date report rerun hit a snapshot-oracle exit-2 infrastructure failure before producing a new comparison; this change does not modify author-date YAML. [[csl26-2nv1]] tracks the separate inheritance/engine feature required to replace Chicago notes’ `bibliography.template: []` sentinel with an explicit disabled bibliography.

--- a/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
+++ b/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
@@ -5,7 +5,7 @@ status: in-progress
 type: task
 priority: high
 created_at: 2026-06-30T18:46:08Z
-updated_at: 2026-07-30T20:23:05Z
+updated_at: 2026-07-30T20:35:16Z
 parent: csl26-h7oc
 ---
 
@@ -153,3 +153,7 @@ Not independently investigated/fixed — recorded as residual-defect input for t
 - Fresh `report-core` evidence: exact parity improved from **105/540 (19.4%)** to **156/540 (28.9%)**, a gain of 51 byte-identical observations.
 - The behavioral fidelity score is diagnostic for this pass and remains below the embedded-style tuning gate; exact parity is still incomplete, so the task remains in progress.
 - Remaining exact clusters include rich reference-type templates (legal, media, web, and document/archive variants) and author-date citation formatting.
+
+
+
+- Follow-up exact-parity pass: enabled `entry-suffix-after-url` and `entry-suffix-after-doi` for Chicago bibliography output. Fresh `report-core` exact parity improved **156/540 -> 165/540** (+9) with SQI unchanged at 0.920. The remaining 133 URL/DOI-ending mismatches also have structural differences, so this global option is exhausted; next cluster is type-specific quote/template selection.

--- a/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
+++ b/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
@@ -5,7 +5,7 @@ status: in-progress
 type: task
 priority: high
 created_at: 2026-06-30T18:46:08Z
-updated_at: 2026-07-30T14:17:47Z
+updated_at: 2026-07-30T20:23:05Z
 parent: csl26-h7oc
 ---
 
@@ -143,3 +143,13 @@ Full-portfolio oracle-parity clustering (not shared-corpus, the broader referenc
 - **B: name-list conjunction dropped between two authors (subset of 62 punctuation-only diffs).** `O: Smith, Jane, and Robert Williams. 2020.` vs `C: Smith, Jane and Robert Williams. 2020.` — missing comma before \"and\" in a 2-author list.
 
 Not independently investigated/fixed — recorded as residual-defect input for this bean's ongoing fidelity loop. Full clustering data: /tmp/prd_report.json (stale path, regenerate via `node scripts/report-core.js --styles chicago-author-date-18th --parallelism 2`). See [[csl26-arly]] for the harness-side finding that class A (bib-number prefix) is a separate, likely-unrelated measurement artifact — do not chase it from this bean.
+
+
+
+## 2026-07-30: exact-parity punctuation pass
+
+- Prioritized `exactParity` for milestone `csl26-w0hf` rather than the behavioral fidelity score.
+- Corrected Chicago bibliography serial commas, grouped journal container/volume/page/identifier punctuation, and quoted archival manuscript/collection titles.
+- Fresh `report-core` evidence: exact parity improved from **105/540 (19.4%)** to **156/540 (28.9%)**, a gain of 51 byte-identical observations.
+- The behavioral fidelity score is diagnostic for this pass and remains below the embedded-style tuning gate; exact parity is still incomplete, so the task remains in progress.
+- Remaining exact clusters include rich reference-type templates (legal, media, web, and document/archive variants) and author-date citation formatting.

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -185,6 +185,8 @@ bibliography:
         delimiter-precedes-last: contextual
     hanging-indent: true
     entry-suffix: .
+    entry-suffix-after-url: true
+    entry-suffix-after-doi: true
     separator: ". "
     anonymous-entries: notes-only
   groups:

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -175,6 +175,9 @@ bibliography:
       - title
     contributors:
       display-as-sort: first
+      # The Chicago bibliography uses a serial comma before the final
+      # conjunction, including two-contributor entries.
+      delimiter-precedes-last: always
       shorten:
         min: 7
         use-first: 3
@@ -232,24 +235,30 @@ bibliography:
     - title: primary
       wrap:
         punctuation: quotes
-    - title: parent-serial
-      emph: true
     - group:
-      - number: volume
-      - number: issue
-        prefix: " ("
-        suffix: ")"
+      - title: parent-serial
+        emph: true
+      - group:
+        - number: volume
+        - number: issue
+          prefix: " ("
+          suffix: ")"
+        delimiter: ''
+        prefix: " "
+      - number: pages
+        prefix: ": "
+      - variable: number
+        prefix: ": "
+      - variable: doi
+        prefix: ". https://doi.org/"
+        suffix: "."
+      - group:
+        - variable: url
+        prefix: ". "
+        suffix: "."
+        render-when:
+          field-absent: doi
       delimiter: ''
-    - number: pages
-      prefix: ": "
-    - variable: number
-      prefix: ": "
-    - variable: doi
-      prefix: https://doi.org/
-    - group:
-      - variable: url
-      render-when:
-        field-absent: doi
     article-magazine:
     - contributor: author
       form: long
@@ -459,6 +468,10 @@ bibliography:
       render-when:
         field-present: issued
     - title: primary
+      # Archival manuscript and collection titles are quoted in the source
+      # Chicago style.
+      wrap:
+        punctuation: quotes
     - date: issued
       form: month-day
     - variable: raw-genre

--- a/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
@@ -87,6 +87,8 @@ bibliography:
         delimiter-precedes-last: contextual
     hanging-indent: true
     entry-suffix: .
+    entry-suffix-after-url: true
+    entry-suffix-after-doi: true
     separator: ", "
     anonymous-entries: notes-only
   type-variants:


### PR DESCRIPTION
## Summary

Improves byte-for-byte citeproc-js parity for the embedded Chicago author-date style.

## Scope

- Restores Chicago's serial comma in bibliography contributor lists.
- Keeps journal container, volume, pages, DOI, and URL in one punctuation group.
- Quotes archival manuscript and collection titles.
- Records the exact-parity evidence on bean `csl26-giun`.

## Validation

- `node scripts/report-core.js --style chicago-author-date-18th --parallelism 2 --cache-dir <fresh temporary directory>`
  - exact parity: 105/540 -> 156/540 (+51 byte-identical observations)
- `cargo run --bin citum -- render refs -b tests/fixtures/references-expanded.json -s crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml`
- `bash .agents/skills/beans/bin/citum-bean hygiene`

## Risk and follow-up

This is a deliberately narrow exact-parity progress pass for milestone `csl26-w0hf`. Rich reference-type templates and author-date citation formatting remain in `csl26-giun`.
