### PR TITLE
fix(engine): align title-case stop words

### DIFF
--- a/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
+++ b/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
@@ -5,7 +5,7 @@ status: in-progress
 type: task
 priority: high
 created_at: 2026-06-30T18:46:08Z
-updated_at: 2026-07-31T15:23:21Z
+updated_at: 2026-07-31T16:29:00Z
 parent: csl26-h7oc
 ---
 
@@ -163,3 +163,7 @@ Not independently investigated/fixed — recorded as residual-defect input for t
 - 2026-07-31: extended the terminal-link policy to the other active Chicago bibliography head, `chicago-shortened-notes-bibliography-core` (`entry-suffix-after-url: true`, `entry-suffix-after-doi: true`). Author-date already carries both flags, and its dependent T&F variant retains the verified **165/540** exact-parity result. The isolated author-date report rerun hit a snapshot-oracle exit-2 infrastructure failure before producing a new comparison; this change does not modify author-date YAML. [[csl26-2nv1]] tracks the separate inheritance/engine feature required to replace Chicago notes’ `bibliography.template: []` sentinel with an explicit disabled bibliography.
 
 2026-07-31 progress: fixed a shared engine title-case defect for Chicago's interior stop words and hyphenated compounds (including with, during, along, between, and Text-to-Speech). On a clean isolated Cargo target, shared-corpus bibliography improved 334/379 -> 339/379 with citations steady at 15/15; embedded report fidelity improved 0.917 -> 0.926, exact parity 165/540 -> 170/540, and SQI stayed 0.920. The inherited Taylor & Francis Chicago style matched the improvement with no regression. Full fidelity, clean-SQI completion, and final QA closure remain open; this is a bounded processor-defect progress pass.
+
+
+
+2026-07-31 follow-up: reclassified the stale container-period cluster against current evidence and fixed the live paper-conference fallback template instead. Pages now use a colon when volume/issue is present and a comma when both are absent. Added a focused paper-conference fixture and bibliography regression test. Fresh selected report: exact parity improved 170/540 -> 172/540; embedded fidelity stayed 0.926 with citations 63/63 and bibliography 437/477; shared Chicago corpus stayed 15/15 citations and 339/379 bibliography; inherited Taylor & Francis matched 172/540 with no regression; SQI stayed 0.920. The escalated authoritative gate passed format, clippy, and 2,304 nextest tests. Full fidelity, clean SQI, and final QA remain open.

--- a/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
+++ b/.beans/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
@@ -5,7 +5,7 @@ status: in-progress
 type: task
 priority: high
 created_at: 2026-06-30T18:46:08Z
-updated_at: 2026-07-31T12:15:53Z
+updated_at: 2026-07-31T15:23:21Z
 parent: csl26-h7oc
 ---
 
@@ -161,3 +161,5 @@ Not independently investigated/fixed — recorded as residual-defect input for t
 
 
 - 2026-07-31: extended the terminal-link policy to the other active Chicago bibliography head, `chicago-shortened-notes-bibliography-core` (`entry-suffix-after-url: true`, `entry-suffix-after-doi: true`). Author-date already carries both flags, and its dependent T&F variant retains the verified **165/540** exact-parity result. The isolated author-date report rerun hit a snapshot-oracle exit-2 infrastructure failure before producing a new comparison; this change does not modify author-date YAML. [[csl26-2nv1]] tracks the separate inheritance/engine feature required to replace Chicago notes’ `bibliography.template: []` sentinel with an explicit disabled bibliography.
+
+2026-07-31 progress: fixed a shared engine title-case defect for Chicago's interior stop words and hyphenated compounds (including with, during, along, between, and Text-to-Speech). On a clean isolated Cargo target, shared-corpus bibliography improved 334/379 -> 339/379 with citations steady at 15/15; embedded report fidelity improved 0.917 -> 0.926, exact parity 165/540 -> 170/540, and SQI stayed 0.920. The inherited Taylor & Francis Chicago style matched the improvement with no regression. Full fidelity, clean-SQI completion, and final QA closure remain open; this is a bounded processor-defect progress pass.

--- a/crates/citum-engine/src/values/text_case.rs
+++ b/crates/citum-engine/src/values/text_case.rs
@@ -392,7 +392,7 @@ pub(crate) fn apply_text_case_markup_aware_with_language(
 // English title-case stop words (articles, short conjunctions, short prepositions).
 const TITLE_CASE_STOP_WORDS: &[&str] = &[
     "a", "an", "and", "as", "at", "but", "by", "for", "from", "in", "nor", "of", "on", "or", "so",
-    "the", "to", "up", "yet", "v", "vs",
+    "the", "to", "up", "yet", "along", "between", "during", "with", "v", "vs",
 ];
 
 /// Hyphen-like characters that join compound words for title-case purposes.
@@ -407,23 +407,26 @@ fn contains_hyphen_like(text: &str) -> bool {
     text.contains(HYPHEN_LIKE_CHARS)
 }
 
-/// Capitalize each component of a hyphen-joined compound word for title case.
+/// Capitalize non-stop-word components of a hyphen-joined compound for title case.
 ///
-/// When `force_all` is true (first/last word, post-punctuation), every component
-/// is capitalized. Otherwise interior stop-word components stay lowercase.
 /// Splits on both the ASCII hyphen and the en dash (see [`HYPHEN_LIKE_CHARS`]),
 /// preserving whichever separator character was actually used.
-fn capitalize_hyphenated(word: &str, force_all: bool, language: &LanguageIdentifier) -> String {
+fn capitalize_hyphenated(word: &str, language: &LanguageIdentifier) -> String {
     let mut result = String::with_capacity(word.len());
     let mut last_end = 0;
-    for (idx, sep) in word.match_indices(HYPHEN_LIKE_CHARS) {
+    let part_count = word.matches(HYPHEN_LIKE_CHARS).count() + 1;
+    for (part_index, (idx, sep)) in word.match_indices(HYPHEN_LIKE_CHARS).enumerate() {
         let part = word.get(last_end..idx).unwrap_or_default();
-        result.push_str(&capitalize_hyphen_part(part, force_all, language));
+        result.push_str(&capitalize_hyphen_part(
+            part,
+            part_index == 0 || part_index + 1 == part_count,
+            language,
+        ));
         result.push_str(sep);
         last_end = idx + sep.len();
     }
     let tail = word.get(last_end..).unwrap_or_default();
-    result.push_str(&capitalize_hyphen_part(tail, force_all, language));
+    result.push_str(&capitalize_hyphen_part(tail, false, language));
     result
 }
 
@@ -479,7 +482,7 @@ fn to_title_case_with_language_id(text: &str, language: &LanguageIdentifier) -> 
             let lower = lowercase(word, language);
             if i == 0 || i == last_idx || capitalize_next {
                 if contains_hyphen_like(&lower) {
-                    parts.push(capitalize_hyphenated(&lower, true, language));
+                    parts.push(capitalize_hyphenated(&lower, language));
                 } else {
                     parts.push(capitalize_first_word_with_language_id(&lower, language));
                 }
@@ -490,7 +493,7 @@ fn to_title_case_with_language_id(text: &str, language: &LanguageIdentifier) -> 
                 if TITLE_CASE_STOP_WORDS.contains(&alpha_core) {
                     parts.push(lower);
                 } else if contains_hyphen_like(&lower) {
-                    parts.push(capitalize_hyphenated(&lower, false, language));
+                    parts.push(capitalize_hyphenated(&lower, language));
                 } else {
                     parts.push(capitalize_first_word_with_language_id(&lower, language));
                 }
@@ -831,6 +834,25 @@ mod tests {
     fn test_title_case_hyphenated_stop_word_part() {
         // "well-to-do": "to" is a stop word → stays lowercase in interior position
         assert_eq!(to_title_case("a well-to-do family"), "A Well-to-Do Family");
+    }
+
+    #[test]
+    fn given_hyphenated_title_with_stop_word_when_title_case_then_interior_stop_word_stays_lowercase()
+     {
+        assert_eq!(
+            to_title_case("text-to-speech systems"),
+            "Text-to-Speech Systems"
+        );
+    }
+
+    #[test]
+    fn given_long_title_prepositions_when_title_case_then_interior_stop_words_stay_lowercase() {
+        assert_eq!(
+            to_title_case(
+                "fighting for forests: protection and exploitation during the war with China"
+            ),
+            "Fighting for Forests: Protection and Exploitation during the War with China"
+        );
     }
 
     #[test]

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -85,6 +85,26 @@ fn build_numeric_style() -> Style {
     }
 }
 
+#[test]
+fn chicago_author_date_uses_comma_before_conference_pages_without_volume_or_issue() {
+    let style = load_style("styles/embedded/chicago-author-date-18th.yaml");
+    let bibliography = citum_io::load_bibliography(
+        &project_root()
+            .join("tests/fixtures/style-regressions/chicago-author-date-conference-pages.json"),
+    )
+    .expect("Chicago conference punctuation fixture should load");
+
+    let processor = Processor::new(style, bibliography);
+    let rendered = processor.render_selected_bibliography_with_format_standalone::<PlainText, _>([
+        "chicago-conference-no-volume-pages".to_string(),
+    ]);
+
+    assert_eq!(
+        rendered.trim(),
+        "Mikolov, Tomas. 2013. “Distributed Representations of Words and Phrases.” _Proceedings of NIPS 2013_, 3111–19."
+    );
+}
+
 fn build_sorted_style(sort: Vec<SortSpec>) -> Style {
     Style {
         info: StyleInfo {

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -945,8 +945,16 @@ bibliography:
       suffix: ")"
     prefix: " "
     delimiter: ""
-  - number: pages
+  - group:
+    - number: pages
     prefix: ": "
+    render-when:
+      field-present: volume-or-issue
+  - group:
+    - number: pages
+    prefix: ", "
+    render-when:
+      field-absent: volume-or-issue
   - variable: publisher
   - variable: doi
   - variable: url

--- a/tests/fixtures/coverage-manifest.json
+++ b/tests/fixtures/coverage-manifest.json
@@ -220,6 +220,23 @@
       "notes": "Dedicated citation sequence for first, ibid, and subsequent note-position audits."
     },
     {
+      "fixture": "tests/fixtures/style-regressions/chicago-author-date-conference-pages.json",
+      "domain": "core",
+      "kind": "references",
+      "reference_types": [
+        "paper-conference"
+      ],
+      "citation_scenarios": [],
+      "rendering_risks": [
+        "conditional container locator punctuation"
+      ],
+      "used_by": [
+        "crates/citum-engine/tests/bibliography.rs"
+      ],
+      "ci_status": "required",
+      "notes": "Focused Chicago author-date regression for conference pages when volume and issue are absent."
+    },
+    {
       "fixture": "tests/fixtures/compound-numeric-refs.json",
       "domain": "core",
       "kind": "references",

--- a/tests/fixtures/style-regressions/chicago-author-date-conference-pages.json
+++ b/tests/fixtures/style-regressions/chicago-author-date-conference-pages.json
@@ -1,0 +1,23 @@
+{
+  "chicago-conference-no-volume-pages": {
+    "id": "chicago-conference-no-volume-pages",
+    "type": "paper-conference",
+    "title": "Distributed Representations of Words and Phrases",
+    "author": [
+      {
+        "family": "Mikolov",
+        "given": "Tomas"
+      }
+    ],
+    "issued": {
+      "date-parts": [
+        [
+          2013
+        ]
+      ]
+    },
+    "container-title": "Proceedings of NIPS 2013",
+    "page": "3111-3119",
+    "event": "Neural Information Processing Systems"
+  }
+}


### PR DESCRIPTION
## Summary

- Fix engine title-case handling for interior stop words in hyphenated and en-dash compounds.
- Correct Chicago fallback bibliography punctuation: conference pages use a comma when volume and issue are absent, while retaining the colon when a volume or issue is present.
- Add focused regression coverage and record measured progress on bean `csl26-giun`.

## Why

The shared processor previously forced every component of a hyphenated word to title case, producing output such as `Text-To-Speech`. Chicago title case keeps interior stop words lowercase, including `with`, `during`, `along`, and `between`.

The current Chicago residual evidence also includes proceedings rendered as `Proceedings of NIPS 2013: 3111–19.`. The CSL oracle expects `Proceedings of NIPS 2013, 3111–19.` when no volume or issue is present. The fallback template now expresses that distinction with explicit field-presence conditions.

## Evidence

- Shared Chicago corpus: citations **15/15**; bibliography **339/379**, unchanged by the bounded punctuation slice.
- Embedded report: fidelity **0.926**; exact parity **170/540 → 172/540**; SQI **0.920** unchanged.
- Full embedded report: citations **63/63**; bibliography **437/477**.
- Inherited Taylor & Francis Chicago style matched **172/540** exact parity with no regression.
- Focused citeproc-js/Citum oracle: **1/1 exact**; focused Rust bibliography regression passed.
- Authoritative gate: formatting and clippy passed; **2,304/2,304** nextest tests passed with `CARGO_INCREMENTAL=0` against the populated workspace target.
- Rust review-smell audit and bean hygiene passed; the unrelated advisory stale bean `csl26-0ugp` remains informational.

## Status

This is a draft progress PR for `csl26-giun`. Remaining structural and title/template residuals mean the bean stays in progress; the full 100% fidelity, clean-SQI, and final style-QA objectives are not claimed complete.
