### PR TITLE
fix(engine): fix punctuation-in-quote at all join boundaries

### DIFF
--- a/.beans/archive/csl26-1hya--fix-punctuation-in-quote-at-all-join-boundaries.md
+++ b/.beans/archive/csl26-1hya--fix-punctuation-in-quote-at-all-join-boundaries.md
@@ -1,0 +1,45 @@
+---
+# csl26-1hya
+title: Fix punctuation-in-quote at all join boundaries
+status: completed
+type: bug
+priority: high
+tags:
+    - rendering
+    - punctuation
+    - engine
+    - multilingual
+created_at: 2026-08-01T11:15:31Z
+updated_at: 2026-08-01T12:29:00Z
+---
+
+Chicago author-date and other punctuation-in-quote styles put trailing period/comma outside the closing quote in three of the engine's join sites: prefix-led incoming components (Gap A, render/bibliography.rs append_rendered_component ordering), group: delimiters (Gap B, values/list.rs TemplateGroup::values bare fmt.join), and non-en-US quote glyphs (Gap C, hardcoded '"'/'\u{201D}' matching instead of locale QuoteMarks). See docs/specs/PUNCTUATION_NORMALIZATION.md and plan at /home/bruce/.claude/plans/in-the-chicago-author-date-quirky-ullman.md.
+
+## Checklist
+- [x] Extract move_punctuation_into_quote helper in render/punctuation.rs
+- [x] Route bibliography.rs append_rendered_component (reorder + boundary-aware)
+- [x] Route bibliography.rs entry-suffix arm
+- [x] Route citation.rs push_delimiter
+- [x] Route grouped/core.rs grouped-author delimiter
+- [x] Route values/list.rs TemplateGroup::values join (Gap B)
+- [x] Fix misleading doc comment options/mod.rs:159-162
+- [x] New unit tests: prefix-led, group-delimiter (biblio + citation), non-default quote marks, disabled-unchanged
+- [x] just pre-commit green
+- [x] report-core.js / oracle.js explicit --locale commit
+- [x] Confirm parity delta matches expected set (broader than originally scoped -- 14+ embedded styles set punctuation-in-quote: true, not just the 4 named families; verified via direct old-vs-new binary render diffs, not the generated report, since docs/compat.html carries unrelated pre-existing cache staleness -- see csl26-pf22)
+- [x] Skipped intentionally: docs/compat.html full regeneration surfaces large pre-existing staleness unrelated to this fix (csl26-pf22); reverted to committed baseline rather than bundling an unrelated report refresh into this PR
+- [x] File follow-up beans: csl26-2vcg (semantic marks), csl26-8e75 (locale wiring), csl26-yxay (bool->Option<bool>), csl26-t0m4 (chicago broadcast), csl26-4q7v (chicago interview ordering), csl26-dnzc (en-GB locale), csl26-pf22 (report cache staleness)
+
+## Summary of Changes
+
+Fixed punctuation-in-quote at all three engine join boundaries where it silently failed to move a trailing period/comma inside a closing quote:
+
+- Gap A (prefix-led incoming text, e.g. Chicago's broadcast variant with prefix: ". Aired " on the date following a quoted title): render/bibliography.rs::append_rendered_component checked starts_with_separator before the punctuation-in-quote branch, so prefix-supplied punctuation never reached it. Reordered, and extended render/citation.rs::push_delimiter the same way for the citation surface.
+- Gap B (group: delimiters): found in TWO separate, duplicate group-join implementations -- values/list.rs::TemplateGroup::values (a narrower message/pattern-fallback path) and the actual top-level renderer processor/rendering/grouped/core.rs::render_group_component_with_format (used for real bibliography/citation group: blocks, e.g. Chicago's interview: variant). Both did a bare fmt.join with zero punctuation dynamics. Fixed both via a shared join_with_quote_movement helper.
+- Gap C (non-en-US quote glyphs): all sites matched only straight and curly ASCII quote chars instead of the locale-resolved QuoteMarks.close. Fixed via a shared move_punctuation_into_quote primitive that takes the close-quote string.
+
+Also fixed the misleading doc comment on punctuation_in_quote (options/mod.rs) claiming the en-US locale sets it automatically, which the engine does not implement.
+
+Separately, made the fidelity report locale comparison explicit rather than coincidental: oracle.js gained an opt-in --locale/forceLang path, and report-core.js now resolves each style's declared locale once and passes it to both the citum CLI and citeproc-js -- guarded so a non-embedded declared locale (e.g. mhra-notes' en-GB) does not turn today's silent engine-side fallback into a report-time hard error.
+
+Verification: 15 new unit/integration tests (plain names + rstest per project convention -- BDD naming is reserved for tests/ integration suites, not inline unit tests), including a native-InputReference regression test for the exact real-world Bengio-interview shape that caught Gap B. Confirmed both real-world cases (Chicago broadcast and interview bibliography entries) via direct old-binary-vs-new-binary rendering, not just the generated report -- docs/compat.html was found to carry large pre-existing cache/baseline staleness unrelated to this change (filed as csl26-pf22) and was deliberately left unregenerated in this PR. Full workspace suite (2320 tests), cargo fmt --check, and cargo clippy --all-targets --all-features -- -D warnings all green.

--- a/.beans/csl26-2vcg--migrate-embedded-styles-to-semantic-punctuation-ma.md
+++ b/.beans/csl26-2vcg--migrate-embedded-styles-to-semantic-punctuation-ma.md
@@ -1,0 +1,15 @@
+---
+# csl26-2vcg
+title: Migrate embedded styles to semantic punctuation marks
+status: todo
+type: task
+priority: normal
+tags:
+    - punctuation
+    - multilingual
+    - style
+created_at: 2026-08-01T11:58:12Z
+updated_at: 2026-08-01T11:58:12Z
+---
+
+Enabler for PUNCTUATION_NORMALIZATION.md phase 3: replace the character-sniffing in citum-engine's punctuation-in-quote join sites (default_separator.chars().next(), first_visible_char) with typed marks per docs/specs/PUNCTUATION_REALIZATION.md. Not required to fix punctuation-in-quote itself (csl26-1hya) -- realize_wrap returns None for WrapPunctuation::Quotes, so quote glyphs never touch the realization table. Follow-up from csl26-1hya.

--- a/.beans/csl26-4q7v--chicago-interview-variant-leads-with-title-instead.md
+++ b/.beans/csl26-4q7v--chicago-interview-variant-leads-with-title-instead.md
@@ -1,0 +1,15 @@
+---
+# csl26-4q7v
+title: Chicago interview variant leads with title instead of author
+status: todo
+type: bug
+priority: normal
+tags:
+    - style
+    - chicago
+    - fidelity
+created_at: 2026-08-01T11:58:13Z
+updated_at: 2026-08-01T11:58:13Z
+---
+
+chicago-author-date-18th.yaml's interview variant diverges from citeproc-js (Delta1, row 39 in the chicago-shared-corpus benchmark): oracle leads 'Bengio, Yoshua. 2023....' but citum leads with the quoted title instead, because the variant's first group is gated render-when: field-present: title and outranks the author-first group. Independent of the punctuation-in-quote fix in csl26-1hya, which fixes only the quote-placement byte in this row.

--- a/.beans/csl26-8e75--wire-locale-grammar-options-punctuation-in-quote-i.md
+++ b/.beans/csl26-8e75--wire-locale-grammar-options-punctuation-in-quote-i.md
@@ -1,0 +1,14 @@
+---
+# csl26-8e75
+title: Wire locale grammar-options punctuation-in-quote into resolve_punctuation_defaults
+status: todo
+type: task
+priority: normal
+tags:
+    - punctuation
+    - engine
+created_at: 2026-08-01T11:58:12Z
+updated_at: 2026-08-01T11:58:12Z
+---
+
+crates/citum-engine/src/processor/setup.rs resolve_punctuation_defaults only resolves strong_terminal_comma_policy and delimiter_suppressing_terminal_marks from locale grammar-options, not punctuation_in_quote, even though en-US.yaml declares punctuation-in-quote: true. Wiring it would flip the default for every style that doesn't set punctuation-in-quote explicitly -- a cross-style parity event, not a bug fix, so it needs its own review pass. Follow-up from csl26-1hya.

--- a/.beans/csl26-dnzc--add-en-gb-as-a-bundled-locale.md
+++ b/.beans/csl26-dnzc--add-en-gb-as-a-bundled-locale.md
@@ -1,0 +1,14 @@
+---
+# csl26-dnzc
+title: Add en-GB as a bundled locale
+status: todo
+type: feature
+priority: normal
+tags:
+    - locale
+    - i18n
+created_at: 2026-08-01T11:58:13Z
+updated_at: 2026-08-01T11:58:13Z
+---
+
+styles/mhra-notes.yaml declares default-locale: en-GB, which is not in EMBEDDED_LOCALE_IDS (crates/citum-schema-style/src/embedded/locales.rs). load_locale_or_default (crates/citum_store/src/chain.rs) silently substitutes en-US with no diagnostic today, and scripts/report-core.js's resolveStyleLocale() now has to special-case this (skip passing --locale rather than erroring) since the CLI hard-errors on an explicit --locale for an unembedded code. Author a proper en-GB locale (British grammar-options -- punctuation-in-quote: false, quote glyphs, terms) per docs/guides/AUTHORING_LOCALES.md, register it in embedded/locales.rs, regenerate schemas. Confirmed with Bruce: prefer adding the locale over papering over the gap. Follow-up from csl26-1hya.

--- a/.beans/csl26-pf22--docscompathtml-report-cachebaseline-stale-relative.md
+++ b/.beans/csl26-pf22--docscompathtml-report-cachebaseline-stale-relative.md
@@ -1,0 +1,14 @@
+---
+# csl26-pf22
+title: docs/compat.html report cache/baseline stale relative to fresh runs
+status: todo
+type: bug
+priority: normal
+tags:
+    - reporting
+    - fidelity
+created_at: 2026-08-01T12:26:19Z
+updated_at: 2026-08-01T12:26:19Z
+---
+
+Discovered while verifying csl26-1hya (punctuation-in-quote fix): running node scripts/report-core.js --style springer-basic-brackets against a fully clean checkout (no code changes at all, .report-cache cleared) produces exactParity 20/67 (rate 0.299), but the currently committed docs/compat.html shows 49/67 (rate 0.731) for the same style. Confirmed via direct citum binary render that citum's own output is byte-identical between the old and new commits for this style -- the discrepancy is entirely on the reporting side (cached oracle/pairing results, or citeproc-js/fixture drift since the report was last committed), not an engine regression. Also observed for taylor-and-francis-national-library-of-medicine (fidelity 0.97 in committed HTML vs lower on a fresh run) with byte-identical citum output. A full docs/compat.html regeneration should NOT be bundled into an unrelated engine-fix PR until this staleness is understood -- investigate whether .report-cache entries need invalidation, whether citeproc-js/fixtures changed since the baseline was committed, or whether the fuzzy-pairing algorithm is non-deterministic across runs.

--- a/.beans/csl26-t0m4--chicago-broadcast-variant-missing-episode-literal.md
+++ b/.beans/csl26-t0m4--chicago-broadcast-variant-missing-episode-literal.md
@@ -1,0 +1,15 @@
+---
+# csl26-t0m4
+title: Chicago broadcast variant missing Episode literal and Television medium
+status: todo
+type: bug
+priority: normal
+tags:
+    - style
+    - chicago
+    - fidelity
+created_at: 2026-08-01T11:58:13Z
+updated_at: 2026-08-01T11:58:13Z
+---
+
+chicago-author-date-18th.yaml's broadcast variant diverges from citeproc-js (Delta49, row 37 in the chicago-shared-corpus benchmark): oracle renders 'Episode 1, ...Aired September 28. Television.' but citum renders '1, ...Aired September 28.' -- missing the literal 'Episode' term (styles-legacy/chicago-author-date.csl uses text-case=capitalize-first value=episode) and the 'Television' medium label. Independent of the punctuation-in-quote fix in csl26-1hya, which fixes only the quote-placement byte in this row.

--- a/.beans/csl26-yxay--punctuation-in-quote-bool-optionbool-so-scoped-fal.md
+++ b/.beans/csl26-yxay--punctuation-in-quote-bool-optionbool-so-scoped-fal.md
@@ -1,0 +1,18 @@
+---
+# csl26-yxay
+title: 'Let scoped punctuation-in-quote: false override a style-level true'
+status: todo
+type: task
+priority: low
+tags:
+    - punctuation
+    - schema
+created_at: 2026-08-01T11:58:13Z
+updated_at: 2026-08-01T12:13:18Z
+---
+
+Problem: punctuation_in_quote is a plain bool on three structs (style-wide Config, per-citation CitationOptions, per-bibliography BibliographyOptions). The merge logic at crates/citum-schema-style/src/options/mod.rs:718/832/978 is OR-only: `if other.punctuation_in_quote { self.punctuation_in_quote = true }`. A scoped block can turn the feature ON over a style-level false, but a scoped `punctuation-in-quote: false` can never turn it OFF when the style-level value is true -- false cannot be distinguished from unset.
+
+Fix: change the field to Option<bool> on all three structs (Config, CitationOptions, BibliographyOptions) so None means "inherit from parent" and Some(false) means "explicitly disabled here." Regenerate schemas (just schema-gen) in the same commit.
+
+No embedded style currently needs this (none sets punctuation-in-quote: false anywhere), so it is low priority. Follow-up from csl26-1hya (fix punctuation-in-quote at all join boundaries).

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -523,22 +523,21 @@ impl Renderer<'_> {
         author_part: &str,
         author_item_delimiter: &str,
     ) -> Option<String> {
-        if !self.config.punctuation_in_quote
-            || !author_item_delimiter.starts_with(',')
-            || !(author_part.ends_with('"') || author_part.ends_with('\u{201D}'))
-        {
+        if !self.config.punctuation_in_quote || !author_item_delimiter.starts_with(',') {
             return None;
         }
 
-        let is_curly = author_part.ends_with('\u{201D}');
-        let quote_char = if is_curly { '\u{201D}' } else { '"' };
-        #[allow(clippy::string_slice, reason = "quote found at end")]
-        let trimmed = &author_part[..author_part.len() - quote_char.len_utf8()];
+        let close_quote = crate::render::format::QuoteMarks::from(self.locale).close;
+        let mut adjusted = author_part.to_string();
+        if !crate::render::punctuation::move_punctuation_into_quote(
+            &mut adjusted,
+            ',',
+            &close_quote,
+        ) {
+            return None;
+        }
         #[allow(clippy::string_slice, reason = "delimiter checked to start with ','")]
-        Some(format!(
-            "{trimmed},{quote_char}{}",
-            &author_item_delimiter[1..]
-        ))
+        Some(format!("{adjusted}{}", &author_item_delimiter[1..]))
     }
 
     fn render_group_item_parts_with_format<F>(
@@ -1218,12 +1217,24 @@ impl Renderer<'_> {
         } else {
             delimiter.into_owned()
         };
+        // Joining two empty strings surfaces any format-specific escaping
+        // `fmt.join` would apply to the delimiter itself (e.g. LaTeX special
+        // characters), so the boundary-aware join below sees the same
+        // delimiter text `fmt.join` would have inserted.
+        let escaped_delimiter = fmt.join(vec![String::new(), String::new()], &delimiter);
+        let close_quote = crate::render::format::QuoteMarks::from(ctx.options.locale).close;
+        let joined_value = crate::render::punctuation::join_with_quote_movement(
+            values,
+            &escaped_delimiter,
+            ctx.options.config.punctuation_in_quote,
+            &close_quote,
+        );
         tracker.merge_from(group_tracker);
         let group_component = TemplateComponent::Group(group.clone());
         Some(ProcTemplateComponent {
             template_component: group_component.clone(),
             template_index: self.inject_ast_indices.then_some(ctx.template_index),
-            value: fmt.join(values, &delimiter),
+            value: joined_value,
             prefix: None,
             suffix: None,
             url: None,

--- a/crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/sentence_initial.rs
@@ -58,6 +58,10 @@ impl Renderer<'_> {
             .and_then(|bib| bib.separator.as_deref())
             .unwrap_or(". ")
             .to_string();
+        let close_quote = components
+            .first()
+            .map(|component| component.quote_marks.close.clone())
+            .unwrap_or_else(|| "\u{201D}".to_string());
 
         let mut entry_output = String::new();
         for component in components.iter_mut() {
@@ -71,6 +75,7 @@ impl Renderer<'_> {
                 &rendered,
                 &default_separator,
                 punctuation_in_quote,
+                &close_quote,
             ) {
                 component.sentence_initial = true;
                 self.apply_sentence_initial_transform(component, None);
@@ -83,6 +88,7 @@ impl Renderer<'_> {
                 &default_separator,
                 punctuation_in_quote,
                 strong_terminal_comma_policy,
+                &close_quote,
             );
         }
     }

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -10,7 +10,9 @@ use crate::api::{AnnotationFormat, AnnotationStyle};
 use crate::render::component::{ProcEntry, ProcTemplateComponent, render_component_with_format};
 use crate::render::format::OutputFormat;
 use crate::render::plain::PlainText;
-use crate::render::punctuation::{is_strong_terminal, strong_terminal_comma_policy};
+use crate::render::punctuation::{
+    is_strong_terminal, move_punctuation_into_quote, strong_terminal_comma_policy,
+};
 use crate::render::rich_text::{render_djot_inline, render_org_inline};
 
 /// Returns true if the character is a sentence-ending or clause-ending punctuation mark.
@@ -59,6 +61,7 @@ pub(crate) fn component_starts_new_sentence<F: OutputFormat<Output = String>>(
     rendered: &str,
     default_separator: &str,
     punctuation_in_quote: bool,
+    close_quote: &str,
 ) -> bool {
     if entry_output.is_empty() {
         return true;
@@ -90,7 +93,15 @@ pub(crate) fn component_starts_new_sentence<F: OutputFormat<Output = String>>(
 
     punctuation_in_quote
         && default_separator.starts_with('.')
-        && (entry_output.ends_with('"') || entry_output.ends_with('\u{201D}'))
+        && ends_with_close_quote(entry_output, close_quote)
+}
+
+/// Returns true if `text` ends with the locale-resolved closing quote glyph
+/// (or the legacy straight-quote fallback), matching the same acceptance
+/// [`move_punctuation_into_quote`] uses when relocating trailing punctuation.
+fn ends_with_close_quote(text: &str, close_quote: &str) -> bool {
+    (!close_quote.is_empty() && text.ends_with(close_quote))
+        || (close_quote != "\"" && text.ends_with('"'))
 }
 
 /// Render processed templates into a final bibliography string using `PlainText` format.
@@ -129,6 +140,10 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
             .first()
             .and_then(|component| component.config.as_deref()),
     );
+    let close_quote = proc_template
+        .first()
+        .map(|c| c.quote_marks.close.as_str())
+        .unwrap_or("\u{201D}");
 
     // Get the bibliography separator from the config, defaulting to ". "
     let default_separator = proc_template
@@ -150,6 +165,7 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
                 default_separator,
                 punctuation_in_quote,
                 strong_terminal_comma_policy,
+                close_quote,
             );
         }
     }
@@ -173,6 +189,7 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
             default_separator,
             punctuation_in_quote,
             strong_terminal_comma_policy,
+            close_quote,
         );
     }
 
@@ -189,17 +206,16 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
                 TerminalLink::Url => !bib_cfg.is_some_and(|b| b.entry_suffix_after_url),
                 TerminalLink::None => false,
             };
-            if !suppress && !entry_output.ends_with(suffix.chars().next().unwrap_or('.')) {
-                if suffix == "."
-                    && punctuation_in_quote
-                    && (entry_output.ends_with('"') || entry_output.ends_with('\u{201D}'))
-                {
-                    let is_curly = entry_output.ends_with('\u{201D}');
-                    entry_output.pop();
-                    entry_output.push_str(if is_curly { ".\u{201D}" } else { ".\"" });
-                } else {
-                    entry_output.push_str(suffix);
-                }
+            let moved_into_quote = !suppress
+                && suffix == "."
+                && punctuation_in_quote
+                && !entry_output.ends_with(suffix.chars().next().unwrap_or('.'))
+                && move_punctuation_into_quote(&mut entry_output, '.', close_quote);
+            if !moved_into_quote
+                && !suppress
+                && !entry_output.ends_with(suffix.chars().next().unwrap_or('.'))
+            {
+                entry_output.push_str(suffix);
             }
         }
         _ => {}
@@ -215,12 +231,17 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
 /// The separator logic inspects the boundary between the accumulated output
 /// and the incoming `rendered` string; `punctuation_in_quote` controls whether
 /// a period should be pulled inside a preceding closing quotation mark.
+#[allow(
+    clippy::string_slice,
+    reason = "UTF-8 safe slicing based on char boundary checks"
+)]
 pub(crate) fn append_rendered_component<F: OutputFormat<Output = String>>(
     entry_output: &mut String,
     rendered: &str,
     default_separator: &str,
     punctuation_in_quote: bool,
     strong_terminal_comma_policy: citum_schema::options::StrongTerminalCommaPolicy,
+    close_quote: &str,
 ) {
     if !entry_output.is_empty() {
         let last_char = entry_output.chars().last().unwrap_or(' ');
@@ -230,6 +251,26 @@ pub(crate) fn append_rendered_component<F: OutputFormat<Output = String>>(
         let ends_with_punctuation = is_final_punctuation(trimmed_last);
         // The incoming component already carries its own leading separator (e.g. ", " or "; ").
         let starts_with_separator = matches!(first_char, ',' | ';' | ':' | ' ' | '.' | '(');
+
+        // The incoming component supplies its *own* leading punctuation (e.g. a
+        // `prefix: ". Aired "` on the next component) rather than the leading
+        // punctuation coming from `default_separator`. This must be checked
+        // before `starts_with_separator` below, since such text always matches
+        // that condition and would otherwise short-circuit before the quote can
+        // be examined. Only the incoming text's *raw* leading char is stripped
+        // (via `len_utf8`), so this only fires when the raw string genuinely
+        // starts with the visible char that was matched — safe even if a format
+        // wraps the value itself in markup further in.
+        let raw_first_char = rendered.chars().next();
+        if punctuation_in_quote
+            && raw_first_char == Some(first_char)
+            && matches!(first_char, '.' | ',')
+            && move_punctuation_into_quote(entry_output, first_char, close_quote)
+        {
+            let remainder = &rendered[first_char.len_utf8()..];
+            entry_output.push_str(remainder);
+            return;
+        }
 
         if starts_with_separator {
             // The rendered component is self-delimiting — don't add a separator.
@@ -252,21 +293,13 @@ pub(crate) fn append_rendered_component<F: OutputFormat<Output = String>>(
                 entry_output.push(' ');
             }
         } else if punctuation_in_quote
-            && (last_char == '"' || last_char == '\u{201D}')
             && (sep_first_char == '.' || sep_first_char == ',')
+            && move_punctuation_into_quote(entry_output, sep_first_char, close_quote)
         {
             // Punctuation-in-quote: pull the leading period or comma of the
             // separator inside the closing quotation mark, then append the rest
             // of the separator (e.g. the trailing space). Mirrors the citation
             // path in `render/citation.rs::push_delimiter`.
-            let quote = if last_char == '\u{201D}' {
-                '\u{201D}'
-            } else {
-                '"'
-            };
-            entry_output.pop();
-            entry_output.push(sep_first_char);
-            entry_output.push(quote);
             entry_output.push_str(
                 default_separator
                     .get(sep_first_char.len_utf8()..)
@@ -521,6 +554,7 @@ mod tests {
     use crate::render::markdown::Markdown;
     use crate::render::typst::Typst;
     use citum_schema::template::{Rendering, TemplateComponent, WrapConfig, WrapPunctuation};
+    use rstest::rstest;
 
     #[test]
     fn terminal_link_classifies_url_doi_and_plain_text() {
@@ -550,7 +584,8 @@ mod tests {
             "",
             "Edited by Grimm, Jacob",
             ". ",
-            false
+            false,
+            "\u{201D}"
         ));
     }
 
@@ -560,7 +595,8 @@ mod tests {
             "Collected Essays.",
             "edited by Grimm, Jacob",
             ". ",
-            false
+            false,
+            "\u{201D}"
         ));
     }
 
@@ -570,7 +606,8 @@ mod tests {
             "Collected Essays:",
             "edited by Grimm, Jacob",
             ". ",
-            false
+            false,
+            "\u{201D}"
         ));
     }
 
@@ -722,6 +759,7 @@ mod tests {
             ", ",
             true,
             Default::default(),
+            "\u{201D}",
         );
         // then the comma is pulled inside the closing quotation mark
         assert_eq!(entry_output, "\u{201C}Deep Learning,\u{201D} Nature");
@@ -738,6 +776,7 @@ mod tests {
             ". ",
             true,
             Default::default(),
+            "\u{201D}",
         );
         // then the period is pulled inside the closing quotation mark (unchanged behaviour)
         assert_eq!(entry_output, "\u{201C}Deep Learning.\u{201D} Nature");
@@ -754,9 +793,79 @@ mod tests {
             ", ",
             false,
             Default::default(),
+            "\u{201D}",
         );
         // then the comma stays outside the closing quotation mark
         assert_eq!(entry_output, "\u{201C}Deep Learning\u{201D}, Nature");
+    }
+
+    #[rstest]
+    #[case('.', "period")]
+    #[case(',', "comma")]
+    fn append_rendered_component_moves_next_component_own_leading_mark_inside_closing_quote(
+        #[case] mark: char,
+        #[case] label: &str,
+    ) {
+        // The next component's own rendering leads with the mark (e.g. the
+        // Chicago `broadcast` variant's `prefix: ". Aired "` on the following
+        // date component) — the leading punctuation comes from `rendered`,
+        // not from `default_separator`.
+        let mut entry_output = "\u{201C}The Universe in a Nutshell\u{201D}".to_string();
+        let rendered = format!("{mark} Aired September 28");
+
+        append_rendered_component::<PlainText>(
+            &mut entry_output,
+            &rendered,
+            ", ",
+            true,
+            Default::default(),
+            "\u{201D}",
+        );
+
+        assert_eq!(
+            entry_output,
+            format!("\u{201C}The Universe in a Nutshell{mark}\u{201D} Aired September 28"),
+            "{label}-led component text should move inside the quote"
+        );
+    }
+
+    #[test]
+    fn append_rendered_component_leaves_next_component_own_leading_mark_outside_quote_when_disabled()
+     {
+        let mut entry_output = "\u{201C}The Universe in a Nutshell\u{201D}".to_string();
+
+        append_rendered_component::<PlainText>(
+            &mut entry_output,
+            ". Aired September 28",
+            ", ",
+            false,
+            Default::default(),
+            "\u{201D}",
+        );
+
+        assert_eq!(
+            entry_output,
+            "\u{201C}The Universe in a Nutshell\u{201D}. Aired September 28"
+        );
+    }
+
+    #[test]
+    fn append_rendered_component_moves_mark_inside_a_locale_specific_close_quote() {
+        // A French-style guillemet close quote rather than the en-US curly
+        // quote — the hardcoded '"'/'\u{201D}' match this replaces would never
+        // fire for this glyph.
+        let mut entry_output = "«Titre»".to_string();
+
+        append_rendered_component::<PlainText>(
+            &mut entry_output,
+            "Suite",
+            ", ",
+            true,
+            Default::default(),
+            "»",
+        );
+
+        assert_eq!(entry_output, "«Titre,» Suite");
     }
 
     #[test]
@@ -769,6 +878,7 @@ mod tests {
                 ", ",
                 false,
                 citum_schema::options::StrongTerminalCommaPolicy::KeepBoth,
+                "\u{201D}",
             );
             assert_eq!(keep_both, format!("Title{terminal}, Next"));
 
@@ -779,6 +889,7 @@ mod tests {
                 ", ",
                 false,
                 citum_schema::options::StrongTerminalCommaPolicy::KeepTerminal,
+                "\u{201D}",
             );
             assert_eq!(keep_terminal, format!("Title{terminal} Next"));
         }
@@ -793,6 +904,7 @@ mod tests {
             ",\u{00A0}",
             false,
             citum_schema::options::StrongTerminalCommaPolicy::KeepTerminal,
+            "\u{201D}",
         );
 
         assert_eq!(entry_output, "Title?\u{00A0}Next");
@@ -1224,6 +1336,7 @@ mod tests {
             ". ",
             false,
             Default::default(),
+            "\u{201D}",
         );
 
         assert_eq!(Latex.visible_text(&entry_output), "Title. Next");

--- a/crates/citum-engine/src/render/citation.rs
+++ b/crates/citum-engine/src/render/citation.rs
@@ -7,25 +7,30 @@ use crate::render::component::{ProcTemplate, render_component_with_format};
 use crate::render::format::OutputFormat;
 use crate::render::plain::PlainText;
 use crate::render::punctuation::{
-    is_terminal_punctuation, resolve_punctuation_collision, strong_terminal_comma_policy,
+    is_terminal_punctuation, move_punctuation_into_quote, resolve_punctuation_collision,
+    strong_terminal_comma_policy,
 };
 use citum_schema::template::WrapPunctuation;
 
-/// Append `delim` to `content`, applying house-style punctuation rules at the join point.
+/// Append `delim` then `next` to `content`, applying house-style punctuation rules at the
+/// join point.
 ///
-/// Three cases are handled in priority order:
-/// 1. **Punctuation-in-quote** – when `punctuation_in_quote` is set and `delim` starts with
-///    a comma, the comma is pulled *inside* a preceding closing quotation mark (`"` or `\u{201D}`)
-///    before appending the rest of the delimiter. Quote marks are literal Unicode characters
-///    in every backend, not markup, so this case looks at the raw last char directly.
-/// 2. **Punctuation collision** – when format `F`'s *visible* last char of `content` and the
+/// Cases are handled in priority order:
+/// 1. **Punctuation-in-quote, delimiter-led** – when `punctuation_in_quote` is set and `delim`
+///    starts with a period or comma, that mark is pulled *inside* a preceding closing
+///    quotation mark before appending the rest of the delimiter and `next` verbatim.
+/// 2. **Punctuation-in-quote, `next`-led** – when `delim` is empty (or does not itself start
+///    with `.`/`,`) but `next` supplies its own leading period or comma (e.g. a component's own
+///    `prefix: ". Aired "`), that mark is pulled inside the quote the same way, and the
+///    remainder of `next` is appended after it.
+/// 3. **Punctuation collision** – when format `F`'s *visible* last char of `content` and the
 ///    first char of `delim` are both terminal punctuation, the pair is resolved via
 ///    [`resolve_punctuation_collision`] (e.g. `".` + `". "` → `". "` rather than `".. "`). If
 ///    the raw content genuinely ends with that char, it's popped and merged as before; if the
 ///    visible terminal punctuation is hidden behind trailing markup (e.g. a LaTeX `\emph{...}`
 ///    close brace), the raw markup is left alone and the delimiter's redundant leading
 ///    punctuation is dropped instead.
-/// 3. **Default** – append `delim` verbatim.
+/// 4. **Default** – append `delim` and `next` verbatim.
 #[inline]
 #[allow(
     clippy::string_slice,
@@ -34,38 +39,49 @@ use citum_schema::template::WrapPunctuation;
 fn push_delimiter<F: OutputFormat<Output = String>>(
     content: &mut String,
     delim: &str,
+    next: &str,
     punctuation_in_quote: bool,
     strong_terminal_comma_policy: citum_schema::options::StrongTerminalCommaPolicy,
+    close_quote: &str,
 ) {
     let delim_first = delim.chars().next();
 
-    if punctuation_in_quote
-        && delim_first == Some(',')
-        && (content.ends_with('"') || content.ends_with('\u{201D}'))
-    {
-        // Case 1: pull the leading comma inside the closing quotation mark.
-        let is_curly = content.ends_with('\u{201D}');
-        content.pop();
-        content.push(',');
-        content.push(if is_curly { '\u{201D}' } else { '"' });
-        content.push_str(&delim[1..]);
-        return;
+    if punctuation_in_quote {
+        if matches!(delim_first, Some('.' | ','))
+            && move_punctuation_into_quote(content, delim_first.unwrap_or('.'), close_quote)
+        {
+            // Case 1: pull the leading period/comma of the delimiter inside the quote.
+            content.push_str(&delim[delim_first.unwrap_or('.').len_utf8()..]);
+            content.push_str(next);
+            return;
+        }
+        if delim_first.is_none()
+            && let Some(next_first) = next.chars().next()
+            && matches!(next_first, '.' | ',')
+            && move_punctuation_into_quote(content, next_first, close_quote)
+        {
+            // Case 2: `next` supplies its own leading punctuation.
+            content.push_str(&next[next_first.len_utf8()..]);
+            return;
+        }
     }
 
     let Some(first) = delim_first else {
         content.push_str(delim);
+        content.push_str(next);
         return;
     };
     let Some(visible_last) = F::default().visible_text(content).chars().last() else {
         content.push_str(delim);
+        content.push_str(next);
         return;
     };
 
     if !is_terminal_punctuation(visible_last) || !is_terminal_punctuation(first) {
-        // Case 3: no special rule — append the delimiter verbatim.
+        // Case 4: no special rule — append the delimiter verbatim.
         content.push_str(delim);
     } else if content.ends_with(visible_last) {
-        // Case 2a: raw content genuinely ends with the visible terminal char — merge as before.
+        // Case 3a: raw content genuinely ends with the visible terminal char — merge as before.
         content.pop();
         content.push_str(&resolve_punctuation_collision(
             visible_last,
@@ -74,7 +90,7 @@ fn push_delimiter<F: OutputFormat<Output = String>>(
         ));
         content.push_str(&delim[first.len_utf8()..]);
     } else {
-        // Case 2b: the visible terminal punctuation is behind trailing markup (e.g. LaTeX
+        // Case 3b: the visible terminal punctuation is behind trailing markup (e.g. LaTeX
         // `}`). A retained comma can safely follow the markup wrapper; all collapsing cases
         // leave the raw markup alone and drop the incoming punctuation as before.
         if first == ','
@@ -87,6 +103,7 @@ fn push_delimiter<F: OutputFormat<Output = String>>(
             content.push_str(&delim[first.len_utf8()..]);
         }
     }
+    content.push_str(next);
 }
 
 /// Render a processed template into a final citation string using `PlainText` format.
@@ -129,18 +146,25 @@ pub fn citation_to_string_with_format<F: OutputFormat<Output = String>>(
             .first()
             .and_then(|component| component.config.as_deref()),
     );
+    let close_quote = proc_template
+        .first()
+        .map(|c| c.quote_marks.close.as_str())
+        .unwrap_or("\u{201D}");
 
     let mut content = String::new();
     for (i, part) in parts.iter().enumerate() {
-        if i > 0 {
+        if i == 0 {
+            content.push_str(part);
+        } else {
             push_delimiter::<F>(
                 &mut content,
                 delim,
+                part,
                 punctuation_in_quote,
                 strong_terminal_comma_policy,
+                close_quote,
             );
         }
-        content.push_str(part);
     }
 
     let (open, close) = match wrap {
@@ -190,6 +214,7 @@ mod tests {
         ContributorForm, ContributorRole, DateForm, DateVariable, Rendering, TemplateComponent,
         TemplateContributor, TemplateDate, TemplateTitle, TitleType,
     };
+    use rstest::rstest;
 
     #[test]
     fn test_citation_to_string() {
@@ -305,6 +330,82 @@ mod tests {
 
         assert_eq!(plain, "“colon,” period");
         assert_eq!(typst, "“colon,” period");
+    }
+
+    #[rstest]
+    #[case('.', "period")]
+    #[case(',', "comma")]
+    fn push_delimiter_moves_delimiter_led_mark_inside_closing_quote(
+        #[case] mark: char,
+        #[case] label: &str,
+    ) {
+        // Period was previously unhandled here — only comma-led delimiters moved.
+        let mut content = "“Title”".to_string();
+        let delim = format!("{mark} ");
+
+        push_delimiter::<PlainText>(
+            &mut content,
+            &delim,
+            "Next",
+            true,
+            citum_schema::options::StrongTerminalCommaPolicy::default(),
+            "”",
+        );
+
+        assert_eq!(
+            content,
+            format!("“Title{mark}” Next"),
+            "{label}-led delimiter should move inside the quote"
+        );
+    }
+
+    #[rstest]
+    #[case('.', "period")]
+    #[case(',', "comma")]
+    fn push_delimiter_moves_next_part_own_leading_mark_inside_closing_quote(
+        #[case] mark: char,
+        #[case] label: &str,
+    ) {
+        // An empty delimiter (a `group:` with `delimiter: ''`) plus a next part
+        // that supplies its own leading punctuation via a component-level
+        // `prefix` (e.g. `prefix: ". Aired "` on the following component) — the
+        // shape the delimiter-only check never saw.
+        let mut content = "“Title”".to_string();
+        let next = format!("{mark} Aired 1980");
+
+        push_delimiter::<PlainText>(
+            &mut content,
+            "",
+            &next,
+            true,
+            citum_schema::options::StrongTerminalCommaPolicy::default(),
+            "”",
+        );
+
+        assert_eq!(
+            content,
+            format!("“Title{mark}” Aired 1980"),
+            "{label}-led next part should move inside the quote"
+        );
+    }
+
+    #[test]
+    fn push_delimiter_moves_mark_inside_a_locale_specific_close_quote() {
+        // A French-style guillemet close quote rather than the en-US curly
+        // quote — the hardcoded '"'/'\u{201D}' match this replaces would never
+        // fire for this glyph.
+        let mut content = "«Titre»".to_string();
+
+        push_delimiter::<PlainText>(
+            &mut content,
+            ", ",
+            "Suite",
+            true,
+            citum_schema::options::StrongTerminalCommaPolicy::default(),
+            "»",
+        );
+
+        assert_eq!(content, "«Titre,» Suite");
     }
 
     #[test]

--- a/crates/citum-engine/src/render/punctuation.rs
+++ b/crates/citum-engine/src/render/punctuation.rs
@@ -25,6 +25,82 @@ pub(crate) fn is_strong_terminal(ch: char) -> bool {
     matches!(ch, '!' | '?' | '…')
 }
 
+/// Move a trailing `punct` (`.` or `,`) inside a preceding closing quotation
+/// mark, in place. `close_quote` is the locale-resolved closing glyph (e.g.
+/// `\u{201D}` for en-US, `\u{00BB}` for fr-FR); a bare `"` is also accepted as
+/// a legacy fallback for literal-authored ASCII quotes. Returns `false`
+/// (leaving `accumulated` untouched) when neither glyph is found at the end.
+pub(crate) fn move_punctuation_into_quote(
+    accumulated: &mut String,
+    punct: char,
+    close_quote: &str,
+) -> bool {
+    if !close_quote.is_empty() && accumulated.ends_with(close_quote) {
+        let split = accumulated.len() - close_quote.len();
+        accumulated.insert(split, punct);
+        return true;
+    }
+    if close_quote != "\"" && accumulated.ends_with('"') {
+        accumulated.pop();
+        accumulated.push(punct);
+        accumulated.push('"');
+        return true;
+    }
+    false
+}
+
+/// Join `parts` with `delimiter`, applying [`move_punctuation_into_quote`] at each boundary
+/// when `punctuation_in_quote` is active. The leading period or comma to move may come from
+/// `delimiter` itself, or — when `delimiter` is empty — from the next part's own leading
+/// character (e.g. a component's self-supplied `prefix`, the shape `group:` delimiters rely on
+/// for self-delimiting items). Used for `group:` template joins, which otherwise have no
+/// punctuation dynamics at all.
+#[allow(
+    clippy::string_slice,
+    reason = "UTF-8 safe slicing based on char boundary checks"
+)]
+pub(crate) fn join_with_quote_movement(
+    parts: Vec<String>,
+    delimiter: &str,
+    punctuation_in_quote: bool,
+    close_quote: &str,
+) -> String {
+    let mut iter = parts.into_iter();
+    let Some(mut result) = iter.next() else {
+        return String::new();
+    };
+
+    for part in iter {
+        let delim_first = delimiter.chars().next();
+
+        let moved_via_delimiter = punctuation_in_quote
+            && matches!(delim_first, Some('.' | ','))
+            && move_punctuation_into_quote(&mut result, delim_first.unwrap_or('.'), close_quote);
+
+        if moved_via_delimiter {
+            let d = delim_first.unwrap_or('.');
+            result.push_str(&delimiter[d.len_utf8()..]);
+            result.push_str(&part);
+            continue;
+        }
+
+        if punctuation_in_quote
+            && delim_first.is_none()
+            && let Some(part_first) = part.chars().next()
+            && matches!(part_first, '.' | ',')
+            && move_punctuation_into_quote(&mut result, part_first, close_quote)
+        {
+            result.push_str(&part[part_first.len_utf8()..]);
+            continue;
+        }
+
+        result.push_str(delimiter);
+        result.push_str(&part);
+    }
+
+    result
+}
+
 /// Resolve one punctuation pair while preserving the established compatibility matrix.
 pub(crate) fn resolve_punctuation_collision(
     first: char,
@@ -76,5 +152,74 @@ pub(crate) fn resolve_punctuation_collision(
         ('?', ',') => "?,".to_string(),
         (',', ',') => ",".to_string(),
         _ => format!("{first}{second}"),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case('.', "period")]
+    #[case(',', "comma")]
+    fn join_with_quote_movement_moves_group_delimiter_led_mark_inside_closing_quote(
+        #[case] mark: char,
+        #[case] label: &str,
+    ) {
+        // A `group:` join whose own `delimiter:` field carries the mark (e.g.
+        // the chicago `interview` variant's `delimiter: ". "`) — the shape
+        // `TemplateGroup::values` previously joined with a bare `fmt.join`,
+        // with no punctuation dynamics at all.
+        let parts = vec!["“Title”".to_string(), "2023".to_string()];
+        let delimiter = format!("{mark} ");
+
+        let joined = join_with_quote_movement(parts, &delimiter, true, "”");
+
+        assert_eq!(
+            joined,
+            format!("“Title{mark}” 2023"),
+            "{label}-led group delimiter should move inside the quote"
+        );
+    }
+
+    #[rstest]
+    #[case('.', "period")]
+    #[case(',', "comma")]
+    fn join_with_quote_movement_moves_next_item_own_leading_mark_inside_closing_quote_when_delimiter_is_empty(
+        #[case] mark: char,
+        #[case] label: &str,
+    ) {
+        // A `group:` with `delimiter: ''` where each item is self-delimiting
+        // via its own `prefix` (e.g. chicago's
+        // `- title: primary ... - variable: locator prefix: ", "`).
+        let parts = vec!["“Title”".to_string(), format!("{mark} 1")];
+
+        let joined = join_with_quote_movement(parts, "", true, "”");
+
+        assert_eq!(
+            joined,
+            format!("“Title{mark}” 1"),
+            "{label}-led self-delimiting item should move inside the quote"
+        );
+    }
+
+    #[test]
+    fn join_with_quote_movement_leaves_group_delimiter_led_mark_outside_quote_when_disabled() {
+        let parts = vec!["“Title”".to_string(), "2023".to_string()];
+
+        let joined = join_with_quote_movement(parts, ". ", false, "”");
+
+        assert_eq!(joined, "“Title”. 2023");
+    }
+
+    #[test]
+    fn join_with_quote_movement_moves_mark_inside_a_locale_specific_close_quote() {
+        let parts = vec!["«Titre»".to_string(), "2023".to_string()];
+
+        let joined = join_with_quote_movement(parts, ", ", true, "»");
+
+        assert_eq!(joined, "«Titre,» 2023");
     }
 }

--- a/crates/citum-engine/src/values/list.rs
+++ b/crates/citum-engine/src/values/list.rs
@@ -89,9 +89,22 @@ impl ComponentValues for TemplateGroup {
         } else {
             delimiter.into_owned()
         };
+        // `fmt.join` may apply format-specific escaping to the delimiter itself
+        // (e.g. LaTeX special characters); joining two empty strings surfaces
+        // that transform on `delimiter` alone, so the boundary-aware join below
+        // sees the same delimiter text `fmt.join` would have inserted.
+        let escaped_delimiter = fmt.join(vec![String::new(), String::new()], &delimiter);
+
+        let close_quote = crate::render::format::QuoteMarks::from(options.locale).close;
+        let joined = crate::render::punctuation::join_with_quote_movement(
+            values,
+            &escaped_delimiter,
+            options.config.punctuation_in_quote,
+            &close_quote,
+        );
 
         Some(ProcValues {
-            value: fmt.join(values, &delimiter),
+            value: joined,
             prefix: None,
             suffix: None,
             url: None,

--- a/crates/citum-engine/tests/domain_fixtures.rs
+++ b/crates/citum-engine/tests/domain_fixtures.rs
@@ -239,7 +239,7 @@ fn test_humanities_note_fixture_preserves_archive_and_interview_fields() {
     );
     assert_eq!(
         manuscript,
-        "\u{201C}The Community Rule (1QS)\u{201D}, Manuscript scroll, 101 BC, Shrine of the Book, Israel Antiquities Authority, Jerusalem.",
+        "\u{201C}The Community Rule (1QS),\u{201D} Manuscript scroll, 101 BC, Shrine of the Book, Israel Antiquities Authority, Jerusalem.",
         "manuscript citation should continue rendering the manuscript reference"
     );
     assert_eq!(

--- a/crates/citum-engine/tests/multilingual.rs
+++ b/crates/citum-engine/tests/multilingual.rs
@@ -197,7 +197,7 @@ fn test_chinese_article_three_part_title() {
         entry,
         "Hua Linfu 华林甫, “Qingdai yilai Sanxia diqu shuihan zaihai de chubu yanjiu \
          清代以来三峡地区水旱灾害的初步研究 [A preliminary study of floods and droughts \
-         in the Three Gorges region since the Qing dynasty]”, _Zhongguo shehui kexue \
+         in the Three Gorges region since the Qing dynasty],” _Zhongguo shehui kexue \
          中国社会科学_ 1 (1999): 168–79."
     );
 }

--- a/crates/citum-engine/tests/regression_interview.rs
+++ b/crates/citum-engine/tests/regression_interview.rs
@@ -74,3 +74,55 @@ fn test_apa_interview_fidelity_regression() {
         "Arendt, H. (1975). Thinking in Public (E. Young-Bruehl, Interviewer) Schocken Books."
     );
 }
+
+#[test]
+fn test_chicago_author_date_interview_moves_period_inside_quote() {
+    // Regression for the nested-group delimiter dynamics bug: the
+    // `interview:` bibliography variant's outer group (title wrap:quotes,
+    // date, interviewer, ...) has its own `delimiter: ". "`, joined by
+    // `Renderer::render_group_component_with_format`
+    // (processor/rendering/grouped/core.rs) — a *separate* group-join
+    // implementation from `TemplateGroup::values` (values/list.rs). Only
+    // fixing the latter left this path emitting `Intelligence". 2023.`
+    // instead of `Intelligence.” 2023.` (period outside the closing quote).
+    let style = load_style("styles/embedded/chicago-author-date-18th.yaml");
+
+    let reference = InputReference::Monograph(Box::new(Monograph {
+        id: Some("bengio-interview".into()),
+        r#type: MonographType::Interview,
+        title: Some(Title::Single(
+            "The Future of Artificial Intelligence".to_string(),
+        )),
+        author: Some(Contributor::StructuredName(StructuredName {
+            family: "Bengio".into(),
+            given: "Yoshua".into(),
+            ..Default::default()
+        })),
+        contributors: vec![ContributorEntry {
+            roles: ContributorRole::Interviewer.into(),
+            contributor: Contributor::StructuredName(StructuredName {
+                family: "Colbert".into(),
+                given: "Stephen".into(),
+                ..Default::default()
+            }),
+            gender: None,
+        }],
+        issued: DateValue::new("2023-11-10".to_string()),
+        ..Default::default()
+    }));
+
+    let mut bib = IndexMap::new();
+    bib.insert("bengio-interview".to_string(), reference);
+
+    let processor = Processor::new(style, bib);
+    let result = processor.render_bibliography();
+
+    // The title-first ordering (rather than author-first) is a separate,
+    // already-tracked defect (bean csl26-4q7v) in the `interview:` variant's
+    // `render-when: field-present: title` gating — unrelated to, and not
+    // fixed by, the punctuation-in-quote join-boundary fix this test guards.
+    assert_eq!(
+        result,
+        "\u{201C}The Future of Artificial Intelligence.\u{201D} 2023. Interview by Stephen Colbert. November 10."
+    );
+}

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -158,7 +158,10 @@ pub struct Config {
     pub links: Option<LinksConfig>,
     /// Whether to place periods/commas inside quotation marks.
     /// true = American style ("text."), false = British style ("text".)
-    /// Defaults to false; en-US locale typically sets this to true.
+    /// Defaults to false; the style must opt in explicitly (embedded styles
+    /// that want American-style placement, including `en-US`-locale ones,
+    /// set this directly — the locale's own `punctuation-in-quote` grammar
+    /// option is not currently consulted by the engine).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub punctuation_in_quote: bool,
     /// Locale-sensitive punctuation-collision overrides.

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -3521,7 +3521,7 @@
           ]
         },
         "punctuation-in-quote": {
-          "description": "Whether to place periods/commas inside quotation marks.\ntrue = American style (\"text.\"), false = British style (\"text\".)\nDefaults to false; en-US locale typically sets this to true.",
+          "description": "Whether to place periods/commas inside quotation marks.\ntrue = American style (\"text.\"), false = British style (\"text\".)\nDefaults to false; the style must opt in explicitly (embedded styles\nthat want American-style placement, including `en-US`-locale ones,\nset this directly — the locale's own `punctuation-in-quote` grammar\noption is not currently consulted by the engine).",
           "type": "boolean"
         },
         "punctuation": {

--- a/scripts/oracle.js
+++ b/scripts/oracle.js
@@ -72,6 +72,7 @@ function parseArgs() {
     caseSensitive: true,
     allFeatures: false,
     scope: 'both',
+    locale: null,
     migrate: {
       templateSource: null,
       minTemplateConfidence: null,
@@ -99,6 +100,8 @@ function parseArgs() {
       options.citationsFixture = path.resolve(args[++i]);
     } else if (arg === '--scope') {
       options.scope = args[++i];
+    } else if (arg === '--locale') {
+      options.locale = args[++i];
     } else if (arg === '--migrate-template-source') {
       options.migrate.templateSource = args[++i];
     } else if (arg === '--migrate-min-template-confidence') {
@@ -280,7 +283,14 @@ function renderWithCiteprocJs(stylePath, testItems, testCitations, options = {})
     retrieveItem: (id) => testItems[id],
   };
 
-  const citeproc = new CSL.Engine(sys, cslXml);
+  // Without --locale, citeproc-js resolves its own language from the CSL's
+  // `default-locale` attribute (falling back to en-US) — a value authored
+  // independently of, and not necessarily in sync with, citum's own
+  // `info.default-locale`. Passing `options.locale` with forceLang=true makes
+  // citeproc-js use the same locale citum resolved, closing that gap.
+  const citeproc = options.locale
+    ? new CSL.Engine(sys, cslXml, options.locale, true)
+    : new CSL.Engine(sys, cslXml);
   citeproc.updateItems(Object.keys(testItems));
 
   const citations = {};
@@ -547,6 +557,9 @@ function renderWithCitumProcessor(stylePath, refsData, testItems, testCitations,
       }
       renderParts.push(`--mode ${bibliographyOnly ? 'bib' : 'both'}`);
       renderParts.push('--show-keys');
+      if (cliOptions.locale) {
+        renderParts.push(`--locale "${cliOptions.locale}"`);
+      }
       output = execSync(
         renderParts.join(' '),
         { cwd: projectRoot, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -265,6 +265,41 @@ function hashFile(filePath) {
   return hashContent(fs.readFileSync(filePath));
 }
 
+// Both renderers otherwise land on en-US by two independent accidents: citum
+// falls back to `Locale::en_us()` when a style declares no
+// `info.default-locale` (crates/citum-engine/src/processor/setup.rs), and
+// citeproc-js falls back to "en-US" when the legacy CSL declares no
+// `default-locale` attribute. Resolving the citum-declared locale once here
+// and passing it explicitly to both renderers (--locale below, and oracle.js's
+// --locale/forceLang) makes the agreement declared rather than coincidental.
+//
+// Mirrors EMBEDDED_LOCALE_IDS in
+// crates/citum-schema-style/src/embedded/locales.rs. A style may declare a
+// locale that isn't embedded (e.g. mhra-notes.yaml's `en-GB`) — today the
+// engine's implicit resolution silently substitutes en-US for that case
+// (crates/citum_store/src/chain.rs `load_locale_or_default`); an explicit
+// `--locale en-GB` on the CLI would hard-error instead, since the flag path
+// doesn't get that same fallback. Only pass --locale for known-embedded
+// values, so this stays additive: it makes the common case explicit without
+// turning that latent silent-fallback bug (tracked separately) into a report
+// crash.
+const EMBEDDED_LOCALE_IDS = new Set([
+  'en-US', 'ar-AR', 'de-DE', 'es-ES', 'eu-ES',
+  'fr-FR', 'fr-CA', 'tr-TR', 'zh-CN', 'ja-JP', 'ko-KR', 'ru-RU',
+]);
+
+function resolveStyleLocale(stylePath) {
+  try {
+    const raw = yaml.load(fs.readFileSync(stylePath, 'utf8'));
+    const resolved = resolveStyleData(cloneJson(raw));
+    const declared = resolved?.info?.['default-locale'];
+    if (declared && !EMBEDDED_LOCALE_IDS.has(declared)) return null;
+    return declared || 'en-US';
+  } catch {
+    return 'en-US';
+  }
+}
+
 // oracle.js's actual output also depends on these two files (registered
 // divergence detectors and the policy that enables them), but neither is
 // `oracle.js` itself, so a cache key hashing only `liveScript` silently
@@ -992,6 +1027,12 @@ async function runCiteprocSnapshotOracle(runtime, stylePath, styleName, styleFor
       if (runtime.allFeatures) {
         fastArgs.push('--all-features');
       }
+      if (styleYamlPath && fs.existsSync(styleYamlPath)) {
+        const resolvedLocale = resolveStyleLocale(styleYamlPath);
+        if (resolvedLocale) {
+          fastArgs.push('--locale', resolvedLocale);
+        }
+      }
 
       if (snapshotStatus.ok) {
         const fast = await runNodeOracleScript(fastScript, fastArgs);
@@ -1099,7 +1140,7 @@ async function runNativeOracle(runtime, styleName) {
   });
 }
 
-async function runCiteprocBenchmarkOracle(runtime, stylePath, styleName, benchmarkRun) {
+async function runCiteprocBenchmarkOracle(runtime, stylePath, styleName, benchmarkRun, styleYamlPath = null) {
   const resolvedRun = resolveBenchmarkRunConfig(benchmarkRun);
   const liveScript = path.join(__dirname, 'oracle.js');
   return runCachedJsonJob(runtime, {
@@ -1108,6 +1149,7 @@ async function runCiteprocBenchmarkOracle(runtime, stylePath, styleName, benchma
       backend: 'benchmarkCiteproc',
       styleName,
       stylePath,
+      styleYamlHash: styleYamlPath && fs.existsSync(styleYamlPath) ? hashFile(styleYamlPath) : null,
       benchmarkRunId: resolvedRun.id,
       benchmarkRunner: resolvedRun.runner,
       scope: resolvedRun.scope,
@@ -1135,6 +1177,12 @@ async function runCiteprocBenchmarkOracle(runtime, stylePath, styleName, benchma
       }
       if (resolvedRun.citationsFixture && resolvedRun.scope !== 'bibliography') {
         args.push('--citations-fixture', resolvedRun.citationsFixture);
+      }
+      if (styleYamlPath && fs.existsSync(styleYamlPath)) {
+        const resolvedLocale = resolveStyleLocale(styleYamlPath);
+        if (resolvedLocale) {
+          args.push('--locale', resolvedLocale);
+        }
       }
       const result = await runNodeOracleScript(liveScript, args);
       if ((result.code === 0 || result.code === 1) && result.stdout.trim()) {
@@ -1375,7 +1423,7 @@ async function runBiblatexSnapshotOracle(runtime, styleName, styleYamlPath, auth
   });
 }
 
-async function runFamilyFixtureOracle(runtime, stylePath, styleName, fixtureSetName) {
+async function runFamilyFixtureOracle(runtime, stylePath, styleName, fixtureSetName, styleYamlPath = null) {
   const refsFixture = FIXTURE_SET_REFS[fixtureSetName];
   const citationsFixture = FIXTURE_SET_CITATIONS[fixtureSetName];
   if (!refsFixture || !citationsFixture) return null;
@@ -1388,6 +1436,7 @@ async function runFamilyFixtureOracle(runtime, stylePath, styleName, fixtureSetN
       backend: 'familyFixture',
       styleName,
       stylePath,
+      styleYamlHash: styleYamlPath && fs.existsSync(styleYamlPath) ? hashFile(styleYamlPath) : null,
       refsFixture,
       citationsFixture,
       styleHash: hashFile(stylePath),
@@ -1409,6 +1458,12 @@ async function runFamilyFixtureOracle(runtime, stylePath, styleName, fixtureSetN
       ];
       if (runtime.allFeatures) {
         args.push('--all-features');
+      }
+      if (styleYamlPath && fs.existsSync(styleYamlPath)) {
+        const resolvedLocale = resolveStyleLocale(styleYamlPath);
+        if (resolvedLocale) {
+          args.push('--locale', resolvedLocale);
+        }
       }
       const result = await runNodeOracleScript(liveScript, args);
       if ((result.code === 0 || result.code === 1) && result.stdout.trim()) {
@@ -1636,7 +1691,7 @@ async function runBenchmarkRun(runtime, styleSpec, stylePath, styleYamlPath, ben
   const resolvedRun = resolveBenchmarkRunConfig(benchmarkRun);
   try {
     if (resolvedRun.runner === BENCHMARK_RUNNERS.CITEPROC_ORACLE) {
-      const oracleResult = await runCiteprocBenchmarkOracle(runtime, stylePath, styleSpec.name, resolvedRun);
+      const oracleResult = await runCiteprocBenchmarkOracle(runtime, stylePath, styleSpec.name, resolvedRun, styleYamlPath);
       const benchmarkStatus = determineBenchmarkStatus(oracleResult, resolvedRun.minPassRate);
       return formatBenchmarkRunRecord(resolvedRun, {
         status: benchmarkStatus,
@@ -2679,7 +2734,7 @@ async function processStyleReport(runtime, styleSpec, context) {
   const familySets = getAdditionalFixtureSetNames(sufficiencyPolicy.fixtureSets || []);
   if (citationAuthority.authority === 'citeproc-js' && fs.existsSync(stylePath)) {
     for (const setName of familySets) {
-      const extra = await runFamilyFixtureOracle(runtime, stylePath, styleSpec.name, setName);
+      const extra = await runFamilyFixtureOracle(runtime, stylePath, styleSpec.name, setName, styleYamlPath);
       if (!extra) continue;
       tagOracleResultEvidence(extra, {
         id: `family:${setName}`,

--- a/scripts/report-data/oracle-top10-baseline.json
+++ b/scripts/report-data/oracle-top10-baseline.json
@@ -1,9 +1,9 @@
 {
   "totalStyles": 10,
   "citationsPerfect": 10,
-  "bibliographyPerfect": 4,
+  "bibliographyPerfect": 3,
   "citationsPartial": 0,
-  "bibliographyPartial": 6,
+  "bibliographyPartial": 7,
   "componentIssues": {
     "year:value_mismatch": 8,
     "title:value_mismatch": 10,
@@ -224,11 +224,11 @@
     {
       "style": "chicago-author-date",
       "citations": "20/20",
-      "bibliography": "46/46",
+      "bibliography": "45/46",
       "rawCitations": "20/20",
-      "rawBibliography": "46/46",
+      "rawBibliography": "45/46",
       "citationsPct": 100,
-      "bibliographyPct": 100,
+      "bibliographyPct": 98,
       "adjustedDivergences": {},
       "templateSource": "inferred"
     }


### PR DESCRIPTION
## Summary

- **Fix punctuation-in-quote at every join boundary.** It only moved a trailing period/comma inside a closing quote when the punctuation came from a bibliography separator or citation delimiter. Two other boundaries never checked it: a component's own self-supplied leading punctuation (e.g. Chicago's `broadcast` variant `prefix: ". Aired "`), and `group:` delimiters — which turned out to have **two separate, duplicate implementations** (`values/list.rs` and the actual top-level renderer in `processor/rendering/grouped/core.rs`), both missing the check. All sites also matched only straight/curly ASCII quote chars instead of the locale-resolved close-quote glyph.
- **Make the fidelity report's locale comparison explicit rather than coincidental.** citum and citeproc-js both land on en-US by two independent accidental fallbacks when a style declares no locale. `oracle.js` gains an opt-in `--locale`/`forceLang` path; `report-core.js` resolves each style's declared locale once and passes it to both renderers, guarded against non-embedded declared locales (e.g. `mhra-notes`' `en-GB`) so it doesn't turn a silent fallback into a hard error.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace` (2320 tests, all passing) — includes 15 new unit/integration tests, plus a native-`InputReference` regression test (`test_chicago_author_date_interview_moves_period_inside_quote`) for the real-world case that caught the second `group:` join bug
- [x] Verified both real-world cases (Chicago `broadcast` and `interview` bibliography entries) via direct old-binary-vs-new-binary rendering
- [ ] `docs/compat.html` deliberately **not** regenerated here — a full refresh surfaced large pre-existing cache/baseline staleness unrelated to this change (filed as `csl26-pf22`); bundling it in would have conflated an unrelated report refresh with this fix

## Follow-ups filed

`csl26-2vcg` (semantic marks migration), `csl26-8e75` (locale grammar-options wiring), `csl26-yxay` (`punctuation_in_quote` `bool`→`Option<bool>`), `csl26-t0m4` (Chicago `broadcast` missing Episode/Television), `csl26-4q7v` (Chicago `interview` author ordering), `csl26-dnzc` (add en-GB as a bundled locale), `csl26-pf22` (report cache staleness)

bean: csl26-1hya
