### PR TITLE
fix(engine): bare numeric labels leak a separator

### DIFF
--- a/.beans/archive/csl26-j7uc--engine-gap-bibliography-numeric-label-rendering-fo.md
+++ b/.beans/archive/csl26-j7uc--engine-gap-bibliography-numeric-label-rendering-fo.md
@@ -5,7 +5,7 @@ status: completed
 type: task
 priority: normal
 created_at: 2026-07-30T14:28:57Z
-updated_at: 2026-07-30T15:50:31Z
+updated_at: 2026-08-02T12:28:42Z
 parent: csl26-arly
 ---
 
@@ -37,3 +37,15 @@ Mechanized the same transform via a small text-based Python script (finds the ty
 - nature: fidelity 0.966 (unchanged), citations/bibliography unchanged, **exactParity unchanged at 40/149 (26.8%)** despite the fix working correctly (direct render confirms every entry now carries its number, byte-identical to oracle on that boundary). Nearly all of nature's 101 originally-attributed 'class A' mismatches are actually COMPOUND defects -- number missing AND a second, independent defect (name-list '&' vs ',' conjunction, container-title trailing punctuation) on the same entry. Fixing only the number doesn't flip these to exact match. This means the original taxonomy's per-class counts overstate what a single-class fix buys when defects co-occur -- worth remembering for future wave planning.
 
 All three: citum check OK, node --test scripts/oracle.test.js 53/53 passing, no .rs touched.
+
+## Follow-up verification (2026-08-02, from csl26-unyu's ieee tuning wave)
+
+Checked whether the ieee wave's engine fix (`ProcTemplateComponent.label_only`, commit `12865760` on `style/ieee-exact-parity-wave`) retroactively improved these four styles for free, since they use the identical `delimiter: "" + group: [number: citation-number, <first component>]` pattern hand-authored here, and this bean's own summary notes "no .rs touched" -- meaning the engine-level separator bug this session found and fixed was never addressed for these styles.
+
+Result, one style at a time via `node scripts/report-core.js --style <name> --all-features --json`:
+- **american-medical-association (embedded-core, gated): 48/67 -> 49/67. Confirmed free win** -- verified against the checked-in `scripts/report-data/embedded-parity-baseline.json` (48/67), not just this bean's recorded number, so the +1 is cleanly attributable to the engine fix and nothing else touched this code path since.
+- american-medical-association-alphabetical (exemplar): passed count unchanged (33), but total shifted 67 -> 65 -- unrelated fixture/pairing drift, not a parity change, not investigated further here.
+- nature (exemplar): unchanged, 40/149. Consistent with this bean's own note that nature's remaining defects are compound (number-fix alone doesn't flip entries that also carry a second, independent defect).
+- american-chemical-society (exemplar): unchanged, 30/82.
+
+Not reopening this bean (its own scope is complete); recording here since the improvement is a direct consequence of work this bean did, surfaced by unrelated follow-up work rather than anything further needed here.

--- a/.beans/archive/csl26-unyu--tune-ieee-to-exact-parity-floor-audit-probe-wave.md
+++ b/.beans/archive/csl26-unyu--tune-ieee-to-exact-parity-floor-audit-probe-wave.md
@@ -1,0 +1,26 @@
+---
+# csl26-unyu
+title: Tune ieee to exact-parity floor (audit probe wave)
+status: completed
+type: task
+priority: high
+tags:
+    - migrate
+    - engine
+    - fidelity
+    - style
+created_at: 2026-08-01T20:25:14Z
+updated_at: 2026-08-02T13:17:42Z
+---
+
+Ran the ieee tuning wave the interpretation audit (csl26-2jls) called for: parity-targeted tuning on ieee, cost recorded, decision rule fixed in advance (90%+ at sane cost = translation is fine; stalling in the 50s-60s = justifies scoping a CSL interpreter).
+
+Result: 84/149 -> 88/149 exact parity (56.4% -> 59.1%), fidelity 100% throughout. Landed as commit 12865760 on style/ieee-exact-parity-wave.
+
+What shipped: a general engine bug fix (bibliography numeric labels wrongly counted as content when their sibling is empty -- affects every numeric-processing style, not just ieee) plus three small ieee.yaml fixes (motion-picture date parens, patent number, removed a redundant label component).
+
+What was tried and reverted: a shared role-label preset fix that helped ieee but silently regressed chicago-author-date-18th and american-medical-association -- caught before landing, filed as csl26-g6bi with the regression evidence attached.
+
+Verdict: 59.1% is inside the "stall" band the decision rule named, but one general bug fix improving multiple styles for free complicates a simple yes/no read -- see the audit addendum (docs/architecture/audits/2026-08-01_CSL_DIRECT_INTERPRETATION_ANALYSIS.md) for the full discussion.
+
+Follow-ups, all under csl26-ccdt: csl26-ww77 (start here), csl26-g6bi, csl26-y49d, csl26-3az5, csl26-lhrl.

--- a/.beans/csl26-3az5--localeoverride-needs-per-style-month-abbreviation.md
+++ b/.beans/csl26-3az5--localeoverride-needs-per-style-month-abbreviation.md
@@ -1,0 +1,21 @@
+---
+# csl26-3az5
+title: LocaleOverride needs per-style month-abbreviation override + date engine needs day-zero-pad
+status: todo
+type: feature
+priority: normal
+tags:
+    - style
+    - schema
+    - engine
+created_at: 2026-08-02T00:09:33Z
+updated_at: 2026-08-02T13:16:38Z
+---
+
+Add two small date-formatting capabilities ieee needs and no style currently has:
+- A way for a style to override specific month abbreviations (ieee wants "Jul."/"Jun."/"Sep.", not the engine defaults "July"/"June"/"Sept.").
+- Zero-padded days ("Feb. 07" not "Feb. 7").
+
+Example currently wrong: a patent entry renders "July 13, 2021" instead of "Jul. 13, 2021".
+
+Both are schema+engine changes (LocaleOverride has no month-override field; the date formatter has no day-zero-pad option), reusable by any future style with the same need -- not ieee-specific. Regenerate schemas per CLAUDE.md if types change.

--- a/.beans/csl26-ccdt--embedded-tier-non-chicago-parity-successor-to-csl2.md
+++ b/.beans/csl26-ccdt--embedded-tier-non-chicago-parity-successor-to-csl2.md
@@ -1,0 +1,18 @@
+---
+# csl26-ccdt
+title: Embedded-tier non-Chicago parity (successor to csl26-arly)
+status: in-progress
+type: epic
+priority: high
+tags:
+    - engine
+    - fidelity
+    - style
+created_at: 2026-08-02T12:57:29Z
+updated_at: 2026-08-02T13:17:02Z
+parent: csl26-w0hf
+---
+
+Container for embedded-tier parity work outside the Chicago family (csl26-40n4), replacing csl26-arly, which closed its own scope on 2026-07-30.
+
+Start here: csl26-ww77 (check the 37% unclassified residual bucket for more engine bugs). Also open: csl26-g6bi (shared-preset punctuation fix, has known regression risk -- read it before touching), csl26-waly (low-priority reporting bug, carried over from csl26-arly).

--- a/.beans/csl26-g6bi--fix-edstrans-role-label-trailing-punctuation-witho.md
+++ b/.beans/csl26-g6bi--fix-edstrans-role-label-trailing-punctuation-witho.md
@@ -1,0 +1,20 @@
+---
+# csl26-g6bi
+title: Fix Eds./Trans. role-label trailing punctuation without regressing shared styles
+status: todo
+type: bug
+priority: normal
+tags:
+    - engine
+    - style
+    - fidelity
+created_at: 2026-08-02T00:09:00Z
+updated_at: 2026-08-02T13:16:07Z
+parent: csl26-ccdt
+---
+
+Fix ieee's "Eds."/"Trans." punctuation -- it renders "Eds. The Handbook" instead of "Eds., The Handbook" (missing comma before the next field).
+
+- Already tried the obvious fix (add a comma to the shared role-label preset) -- it corrected ieee but silently broke chicago-author-date-18th (172->164/540 exact parity) and american-medical-association (49->48/67), since the preset is shared identically across all three styles. Reverted.
+- Don't patch the shared preset again. Needs either a per-style override, or separator logic that tells an abbreviation-ending period ("Eds.") apart from a sentence-ending one.
+- Before landing any fix here, run report-core.js --all-features across every embedded-core style, not a guessed subset -- that's exactly how the last attempt caught its regression.

--- a/.beans/csl26-lhrl--ieee-raw-phd-thesis-enum-leak-and-one-fabricated-n.md
+++ b/.beans/csl26-lhrl--ieee-raw-phd-thesis-enum-leak-and-one-fabricated-n.md
@@ -1,0 +1,17 @@
+---
+# csl26-lhrl
+title: 'ieee: raw phd-thesis enum leak and one fabricated ''no. 1'''
+status: todo
+type: bug
+priority: low
+tags:
+    - style
+    - fidelity
+created_at: 2026-08-02T00:09:51Z
+updated_at: 2026-08-02T13:16:50Z
+---
+
+Two small, unrelated ieee bugs, neither investigated yet:
+
+- "phd-thesis" renders literally instead of "PhD thesis". Check whether VocabMap (citum-schema-style/src/locale/types.rs) is the right fix, or something else is needed.
+- One entry (Sagan, "The Universe in a Nutshell") gets a fabricated "no. 1" that isn't in the source data at all. Trace which component is populating it.

--- a/.beans/csl26-w0hf--embedded-tier-oracle-parity-to-100.md
+++ b/.beans/csl26-w0hf--embedded-tier-oracle-parity-to-100.md
@@ -5,7 +5,7 @@ status: in-progress
 type: milestone
 priority: high
 created_at: 2026-07-30T19:09:35Z
-updated_at: 2026-07-30T19:09:41Z
+updated_at: 2026-08-02T12:57:45Z
 ---
 
 Reach 100% oracle text parity (byte-for-byte match with citeproc-js for
@@ -51,3 +51,9 @@ parent):
 Re-derive this list with:
 `beans query '{ bean(id: "csl26-40n4") { children { id title status blockedBy { id status } } } }'`
 and recurse into any in-progress children.
+
+## Update (2026-08-02)
+
+A second active child now exists alongside csl26-40n4 (Chicago): **csl26-ccdt** ("Embedded-tier non-Chicago parity", successor to the now-completed csl26-arly). csl26-ccdt is where the ieee tuning wave's findings live and where the next concrete action is: **csl26-ww77** (check the 37%-unclassified residual bucket from csl26-arly's taxonomy for more general engine bugs like the one this wave found).
+
+The 'Next actions (as of 2026-07-30)' list above is Chicago-only and still accurate for that thread, but is no longer the complete picture -- check csl26-ccdt's children for non-Chicago work.

--- a/.beans/csl26-waly--report-bug-rsc-oracle-parity-evidence-indices-dont.md
+++ b/.beans/csl26-waly--report-bug-rsc-oracle-parity-evidence-indices-dont.md
@@ -5,8 +5,8 @@ status: todo
 type: bug
 priority: low
 created_at: 2026-07-30T14:28:57Z
-updated_at: 2026-07-30T14:28:57Z
-parent: csl26-arly
+updated_at: 2026-08-02T12:57:36Z
+parent: csl26-ccdt
 ---
 
 royal-society-of-chemistry's oracleDetail entries show a Citum-side bibliography number present on some entries and absent on others, all tagged evidenceRunId: baseline (looks like within-run inconsistency). Direct CLI rendering (citum render refs -s styles/royal-society-of-chemistry.yaml --mode bib, and --mode both with a citations fixture) produces zero numbered entries, consistently, for every reference -- the numbered oracleDetail entries don't correspond to what the style actually renders against references-expanded.json. Likely an evidence-index mislabeling/merging bug in report-core.js's benchmark-run assembly, not a rendering defect. Not root-caused; time-boxed out of the 2026-07-30 class-A spike. See docs/architecture/audits/2026-07-30_EMBEDDED_PARITY_CLASS_A.md finding 3.

--- a/.beans/csl26-ww77--check-the-z-unclassified-residual-bucket-for-more.md
+++ b/.beans/csl26-ww77--check-the-z-unclassified-residual-bucket-for-more.md
@@ -1,0 +1,20 @@
+---
+# csl26-ww77
+title: Check the Z-unclassified residual bucket for more label_only-shaped engine bugs
+status: todo
+type: task
+priority: normal
+tags:
+    - engine
+    - fidelity
+    - research
+created_at: 2026-08-02T12:34:31Z
+updated_at: 2026-08-02T13:15:49Z
+parent: csl26-ccdt
+---
+
+Check the 37% "unclassified" bucket from the 2026-07-30 parity audit (925 of 2,501 mismatches) for more bugs shaped like the one this wave just fixed in ieee: a bibliography number wrongly treated as real content, causing a stray separator before the next field.
+
+- That bug was tagged "unclassified" because it didn't match any known defect pattern -- there may be more like it hiding the same way.
+- Run the oracle-parity report, filter to unclassified mismatches, sample a chunk by hand for the same signature (stray punctuation right after a bibliography number).
+- Investigation only -- file a new bean for anything found, don't fix inline.

--- a/.beans/csl26-y49d--ieee-missing-type-variants-legal-case-treaty-gover.md
+++ b/.beans/csl26-y49d--ieee-missing-type-variants-legal-case-treaty-gover.md
@@ -1,0 +1,20 @@
+---
+# csl26-y49d
+title: 'ieee missing type-variants: legal_case, treaty, government-act, apparatus'
+status: todo
+type: task
+priority: normal
+tags:
+    - migrate
+    - style
+    - fidelity
+created_at: 2026-08-02T00:09:16Z
+updated_at: 2026-08-02T13:16:20Z
+---
+
+Hand-author the missing ieee bibliography type-variants: legal_case, treaty, government-act (bill/legislation), and apparatus/equipment. Right now they fall back to the generic monograph template, which gets title quoting, container title, and field order all wrong for these types.
+
+- The source (ieee.csl) has real, distinct rules for each -- this is copying them over, not designing new behavior.
+- Examples currently wrong: "Brown v. Board of Education", "Every Student Succeeds Act", the Tactile Labs apparatus entry.
+- Likely the single biggest remaining piece of ieee's exact-parity gap.
+- Before starting: check whether other numeric/engineering CSL styles need the same branches -- worth building once if so, not per-style each time.

--- a/crates/citum-engine/src/processor/rendering/grouped/component_predicates.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/component_predicates.rs
@@ -67,6 +67,17 @@ pub(super) fn is_term_only_component(component: &TemplateComponent) -> bool {
     }
 }
 
+/// True for the bibliography numeric-label component (`update_label_mode`'s
+/// injected `number: citation-number` node), the one piece of "content" a
+/// bibliography entry always carries regardless of whether its sibling in
+/// the synthetic `[label, following]` group has any data.
+pub(super) fn is_citation_number_component(component: &TemplateComponent) -> bool {
+    matches!(
+        component,
+        TemplateComponent::Number(number) if matches!(number.number, NumberVariable::CitationNumber)
+    )
+}
+
 pub(super) fn is_primary_title_component(component: &TemplateComponent) -> bool {
     matches!(
         component,

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -10,7 +10,8 @@ use super::super::{
     strip_leading_group_affixes,
 };
 use super::component_predicates::{
-    is_term_only_component, resolve_localized_type_variant, resolve_type_variant,
+    is_citation_number_component, is_term_only_component, resolve_localized_type_variant,
+    resolve_type_variant,
 };
 use super::group_citation_items_by_author;
 use crate::error::ProcessorError;
@@ -1173,6 +1174,7 @@ impl Renderer<'_> {
             quote_marks: crate::render::format::QuoteMarks::from(ctx.options.locale),
             sentence_initial: false,
             pre_formatted: values.pre_formatted,
+            label_only: false,
         })
     }
 
@@ -1198,7 +1200,8 @@ impl Renderer<'_> {
 
         let fmt = F::default();
         let mut group_tracker = tracker.clone();
-        let values = self.render_group_child_values(&fmt, ctx, group, &mut group_tracker)?;
+        let (values, label_only) =
+            self.render_group_child_values(&fmt, ctx, group, &mut group_tracker)?;
         let default_delimiter = citum_schema::template::DelimiterPunctuation::Comma;
         let punctuation = group.delimiter.as_ref().unwrap_or(&default_delimiter);
         let (script, realization) = crate::values::punctuation_realization_context(
@@ -1250,25 +1253,33 @@ impl Renderer<'_> {
             quote_marks: crate::render::format::QuoteMarks::from(ctx.options.locale),
             sentence_initial: false,
             pre_formatted: true,
+            label_only,
         })
     }
 
     /// Render the children of a template group into rendered strings, dropping
     /// empty values. Returns `None` when no child carries meaningful content
-    /// (i.e. only term-only siblings produced output). Borrows the parent
-    /// `fmt` so a stateful `OutputFormat` sees a single instance for both
-    /// child rendering and the final `join` in the caller.
+    /// (i.e. only term-only siblings produced output) — except for the
+    /// bibliography numeric-label pattern (`update_label_mode`'s injected
+    /// `[label, following]` group), where the label alone is still real
+    /// content that must render even when `following` is empty (e.g. no
+    /// author); the second element of the returned tuple flags that case so
+    /// the caller can mark the resulting component `label_only` instead of
+    /// treating it as ordinary preceding content for separator purposes.
+    /// Borrows the parent `fmt` so a stateful `OutputFormat` sees a single
+    /// instance for both child rendering and the final `join` in the caller.
     fn render_group_child_values<F>(
         &self,
         fmt: &F,
         ctx: &TemplateRenderContext<'_>,
         group: &citum_schema::template::TemplateGroup,
         tracker: &mut TemplateComponentTracker,
-    ) -> Option<Vec<String>>
+    ) -> Option<(Vec<String>, bool)>
     where
         F: crate::render::format::OutputFormat<Output = String>,
     {
         let mut has_meaningful_content = false;
+        let mut has_citation_number_label = false;
         let mut values = Vec::with_capacity(group.group.len());
 
         for item in &group.group {
@@ -1285,13 +1296,18 @@ impl Renderer<'_> {
             if rendered_str.trim().is_empty() {
                 continue;
             }
-            if !is_term_only_component(item) {
+            if is_citation_number_component(item) {
+                has_citation_number_label = true;
+            } else if !is_term_only_component(item) {
                 has_meaningful_content = true;
             }
             values.push(rendered_str);
         }
 
-        (has_meaningful_content && !values.is_empty()).then_some(values)
+        if values.is_empty() || !(has_meaningful_content || has_citation_number_label) {
+            return None;
+        }
+        Some((values, !has_meaningful_content && has_citation_number_label))
     }
 
     fn apply_issued_no_date_fallback(

--- a/crates/citum-engine/src/render/bibliography.rs
+++ b/crates/citum-engine/src/render/bibliography.rs
@@ -167,6 +167,62 @@ pub fn render_entry_body_with_format<F: OutputFormat<Output = String>>(
     render_entry_body_components_with_format::<F>(&entry.template)
 }
 
+/// Append `rendered` to `entry_output`, either via the normal separator logic
+/// or, when `suppress` is set, as a raw append with no separator at all.
+///
+/// `suppress` is set when the *previous* flush was a bare bibliography
+/// numeric label (`ProcTemplateComponent::label_only`) — see its docs for
+/// why such a label must never engage normal inter-component separator
+/// logic with whatever comes next.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "threads shared per-entry punctuation state"
+)]
+fn append_or_suppress<F: OutputFormat<Output = String>>(
+    entry_output: &mut String,
+    rendered: &str,
+    suppress: bool,
+    default_separator: &RealizedPunctuation<'_>,
+    punctuation_in_quote: bool,
+    strong_terminal_comma_policy: citum_schema::options::StrongTerminalCommaPolicy,
+    close_quote: &str,
+) {
+    if suppress {
+        entry_output.push_str(rendered);
+    } else {
+        append_rendered_component::<F>(
+            entry_output,
+            rendered,
+            default_separator,
+            punctuation_in_quote,
+            strong_terminal_comma_policy,
+            close_quote,
+        );
+    }
+}
+
+/// Re-render `last_component` with its own suffix (and any wrap inner-suffix)
+/// stripped, when trailing template components after it were all empty — a
+/// component's suffix implies "there is more to come," which stops being
+/// true once nothing after it actually rendered.
+fn trim_trailing_only_suffix<F: OutputFormat<Output = String>>(
+    last_component: &ProcTemplateComponent,
+    rendered: String,
+    is_truly_last: bool,
+) -> String {
+    if is_truly_last {
+        return rendered;
+    }
+    let mut trimmed_component = last_component.clone();
+    let rendering = trimmed_component.template_component.rendering_mut();
+    rendering.suffix = None;
+    if let Some(ref mut wrap_config) = rendering.wrap {
+        wrap_config.inner_suffix = None;
+    }
+    trimmed_component.suffix = None;
+    render_component_with_format::<F>(&trimmed_component)
+}
+
 /// Render processed bibliography components without outer entry/bibliography wrappers.
 #[must_use]
 pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = String>>(
@@ -205,40 +261,47 @@ pub(crate) fn render_entry_body_components_with_format<F: OutputFormat<Output = 
         PunctuationPosition::Separator,
     );
 
+    // Bibliography numeric labels (`update_label_mode`'s injected
+    // `[label, following]` group with `following` empty, e.g. no author)
+    // render real, non-empty text but must attach directly to whatever
+    // content actually opens the entry — no separator, exactly as if the
+    // label were not there. Tracks whether the item just written to
+    // `entry_output` was such a label, so the *next* flush skips normal
+    // separator logic instead of treating the label as preceding content.
+    let mut suppress_next_separator = false;
+
     for (index, component) in proc_template.iter().enumerate() {
         let rendered = render_component_with_format::<F>(component);
         if rendered.is_empty() {
             continue;
         }
 
-        if let Some((_, _, previous)) = pending_component.replace((index, component, rendered)) {
-            append_rendered_component::<F>(
+        if let Some((_, previous_component, previous)) =
+            pending_component.replace((index, component, rendered))
+        {
+            append_or_suppress::<F>(
                 &mut entry_output,
                 &previous,
+                suppress_next_separator,
                 &default_separator,
                 punctuation_in_quote,
                 strong_terminal_comma_policy,
                 close_quote,
             );
+            suppress_next_separator = previous_component.label_only;
         }
     }
 
     if let Some((last_index, last_component, rendered)) = pending_component {
-        let final_rendered = if last_index + 1 < proc_template.len() {
-            let mut trimmed_component = last_component.clone();
-            let rendering = trimmed_component.template_component.rendering_mut();
-            rendering.suffix = None;
-            if let Some(ref mut wrap_config) = rendering.wrap {
-                wrap_config.inner_suffix = None;
-            }
-            trimmed_component.suffix = None;
-            render_component_with_format::<F>(&trimmed_component)
-        } else {
-            rendered
-        };
-        append_rendered_component::<F>(
+        let final_rendered = trim_trailing_only_suffix::<F>(
+            last_component,
+            rendered,
+            last_index + 1 == proc_template.len(),
+        );
+        append_or_suppress::<F>(
             &mut entry_output,
             &final_rendered,
+            suppress_next_separator,
             &default_separator,
             punctuation_in_quote,
             strong_terminal_comma_policy,
@@ -710,6 +773,7 @@ mod tests {
             quote_marks: Default::default(),
             sentence_initial: false,
             pre_formatted: false,
+            label_only: false,
         };
 
         let c2 = ProcTemplateComponent {
@@ -735,6 +799,7 @@ mod tests {
             quote_marks: Default::default(),
             sentence_initial: false,
             pre_formatted: false,
+            label_only: false,
         };
 
         let entries = vec![ProcEntry {
@@ -744,6 +809,79 @@ mod tests {
         }];
         let result = refs_to_string(entries);
         assert_eq!(result, "Publisher1. Place");
+    }
+
+    #[rstest]
+    #[case::label_only_component_suppresses_the_separator(true, "[15]Title Text")]
+    #[case::ordinary_first_component_keeps_the_separator(false, "[15]. Title Text")]
+    fn given_a_leading_component_when_label_only_flag_varies_then_separator_follows_it(
+        #[case] label_only: bool,
+        #[case] expected: &str,
+    ) {
+        // A bibliography numeric-label component (`update_label_mode`'s
+        // synthetic `[label, following]` group with `following` empty --
+        // e.g. no author) renders real, non-empty text ("[15]") but must
+        // never engage normal separator logic with whatever comes next.
+        // Contrasted against an ordinary component of otherwise identical
+        // shape, which *does* get the normal separator.
+        use citum_schema::options::{BibliographyConfig, Config};
+
+        let config = Config::default();
+        let bibliography_config = BibliographyConfig {
+            separator: Some(". ".into()),
+            entry_suffix: Some(String::new().into()),
+            ..Default::default()
+        };
+
+        let label = ProcTemplateComponent {
+            template_component: TemplateComponent::Number(citum_schema::template::TemplateNumber {
+                number: citum_schema::template::NumberVariable::CitationNumber,
+                rendering: Rendering::default(),
+                ..Default::default()
+            }),
+            template_index: None,
+            value: "[15]".to_string(),
+            prefix: None,
+            suffix: None,
+            ref_type: None,
+            config: Some(config.clone().into()),
+            bibliography_config: Some(bibliography_config.clone().into()),
+            url: None,
+            item_language: None,
+            quote_marks: Default::default(),
+            sentence_initial: false,
+            pre_formatted: true,
+            label_only,
+        };
+
+        let content = ProcTemplateComponent {
+            template_component: TemplateComponent::Title(citum_schema::template::TemplateTitle {
+                title: citum_schema::template::TitleType::Primary,
+                rendering: Rendering::default(),
+                ..Default::default()
+            }),
+            template_index: None,
+            value: "Title Text".to_string(),
+            prefix: None,
+            suffix: None,
+            ref_type: None,
+            config: Some(config.into()),
+            bibliography_config: Some(bibliography_config.into()),
+            url: None,
+            item_language: None,
+            quote_marks: Default::default(),
+            sentence_initial: false,
+            pre_formatted: false,
+            label_only: false,
+        };
+
+        let entries = vec![ProcEntry {
+            id: "id1".to_string(),
+            template: vec![label, content],
+            metadata: crate::render::format::ProcEntryMetadata::default(),
+        }];
+        let result = refs_to_string(entries);
+        assert_eq!(result, expected);
     }
 
     #[test]
@@ -784,6 +922,7 @@ mod tests {
             quote_marks: Default::default(),
             sentence_initial: false,
             pre_formatted: false,
+            label_only: false,
         };
 
         let c2 = ProcTemplateComponent {
@@ -804,6 +943,7 @@ mod tests {
             quote_marks: Default::default(),
             sentence_initial: false,
             pre_formatted: false,
+            label_only: false,
         };
 
         let entries = vec![ProcEntry {
@@ -1038,6 +1178,7 @@ mod tests {
             quote_marks: Default::default(),
             sentence_initial: false,
             pre_formatted: false,
+            label_only: false,
         };
 
         let c2 = ProcTemplateComponent {
@@ -1061,6 +1202,7 @@ mod tests {
             quote_marks: Default::default(),
             sentence_initial: false,
             pre_formatted: false,
+            label_only: false,
         };
 
         let entries = vec![ProcEntry {
@@ -1105,6 +1247,7 @@ mod tests {
             quote_marks: Default::default(),
             sentence_initial: false,
             pre_formatted: false,
+            label_only: false,
         };
 
         let pages = ProcTemplateComponent {
@@ -1125,6 +1268,7 @@ mod tests {
             quote_marks: Default::default(),
             sentence_initial: false,
             pre_formatted: false,
+            label_only: false,
         };
 
         let result = refs_to_string(vec![ProcEntry {
@@ -1178,6 +1322,7 @@ mod tests {
             quote_marks: Default::default(),
             sentence_initial: false,
             pre_formatted: false,
+            label_only: false,
         };
 
         let pages = ProcTemplateComponent {
@@ -1202,6 +1347,7 @@ mod tests {
             quote_marks: Default::default(),
             sentence_initial: false,
             pre_formatted: false,
+            label_only: false,
         };
 
         let doi = ProcTemplateComponent {
@@ -1225,6 +1371,7 @@ mod tests {
             quote_marks: Default::default(),
             sentence_initial: false,
             pre_formatted: false,
+            label_only: false,
         };
 
         let result = refs_to_string_with_format::<Html>(
@@ -1278,6 +1425,7 @@ mod tests {
                 quote_marks: Default::default(),
                 sentence_initial: false,
                 pre_formatted: false,
+                label_only: false,
             }],
             metadata: crate::render::format::ProcEntryMetadata::default(),
         }

--- a/crates/citum-engine/src/render/citation.rs
+++ b/crates/citum-engine/src/render/citation.rs
@@ -243,6 +243,7 @@ mod tests {
                 quote_marks: Default::default(),
                 sentence_initial: false,
                 pre_formatted: false,
+                label_only: false,
             },
             ProcTemplateComponent {
                 template_component: TemplateComponent::Date(TemplateDate {
@@ -263,6 +264,7 @@ mod tests {
                 quote_marks: Default::default(),
                 sentence_initial: false,
                 pre_formatted: false,
+                label_only: false,
             },
         ];
 
@@ -304,6 +306,7 @@ mod tests {
                 quote_marks: Default::default(),
                 sentence_initial: false,
                 pre_formatted: false,
+                label_only: false,
             },
             ProcTemplateComponent {
                 template_component: TemplateComponent::Date(TemplateDate {
@@ -324,6 +327,7 @@ mod tests {
                 quote_marks: Default::default(),
                 sentence_initial: false,
                 pre_formatted: false,
+                label_only: false,
             },
         ];
 
@@ -639,6 +643,7 @@ ENDING IN COMMA
                 quote_marks: Default::default(),
                 sentence_initial: false,
                 pre_formatted: false,
+                label_only: false,
             },
             ProcTemplateComponent {
                 template_component: TemplateComponent::Date(TemplateDate {
@@ -666,6 +671,7 @@ ENDING IN COMMA
                 quote_marks: Default::default(),
                 sentence_initial: false,
                 pre_formatted: false,
+                label_only: false,
             },
         ]
     }

--- a/crates/citum-engine/src/render/component.rs
+++ b/crates/citum-engine/src/render/component.rs
@@ -41,6 +41,14 @@ pub struct ProcTemplateComponent {
     pub sentence_initial: bool,
     /// Whether the value is already pre-formatted (e.g. from a List or substitution).
     pub pre_formatted: bool,
+    /// True when this component's rendered text is *only* a bibliography
+    /// numeric label (`update_label_mode`'s synthetic `[label, following]`
+    /// group with an empty `following`, e.g. no author). Bibliography
+    /// assembly must still write the label text, but must not treat it as
+    /// real preceding content for the *next* component's separator decision
+    /// — the label attaches directly to whatever content actually opens the
+    /// entry, exactly as if the label were not there.
+    pub label_only: bool,
 }
 
 /// A processed template (list of rendered components).

--- a/crates/citum-engine/src/values/list.rs
+++ b/crates/citum-engine/src/values/list.rs
@@ -53,6 +53,7 @@ impl ComponentValues for TemplateGroup {
                 quote_marks: crate::render::format::QuoteMarks::from(options.locale),
                 sentence_initial: false,
                 pre_formatted: v.pre_formatted,
+                label_only: false,
             };
 
             let rendered = crate::render::render_component_with_format_and_renderer::<F>(

--- a/crates/citum-engine/src/values/message.rs
+++ b/crates/citum-engine/src/values/message.rs
@@ -122,6 +122,7 @@ fn render_message_arg<F: crate::render::format::OutputFormat<Output = String>>(
         quote_marks: crate::render::format::QuoteMarks::from(options.locale),
         sentence_initial: false,
         pre_formatted: values.pre_formatted,
+        label_only: false,
     };
 
     let rendered = crate::render::render_component_with_format_and_renderer::<F>(

--- a/crates/citum-schema-style/embedded/styles/ieee.yaml
+++ b/crates/citum-schema-style/embedded/styles/ieee.yaml
@@ -206,6 +206,9 @@ bibliography:
     - number: pages
     - date: issued
       form: year
+      wrap:
+        punctuation: parentheses
+      prefix: ", "
     - variable: doi
       prefix: ", doi: "
     - variable: url
@@ -230,9 +233,6 @@ bibliography:
     - number: pages
       label-form: short
     patent:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
     - contributor: author
       form: long
       shorten:
@@ -245,6 +245,7 @@ bibliography:
       quote: true
       wrap:
         punctuation: quotes
+    - number: patent-number
     - date: issued
       form: full
     personal_communication:
@@ -320,9 +321,6 @@ bibliography:
     - date: issued
       form: year
     standard:
-    - number: citation-number
-      wrap:
-        punctuation: brackets
     - title: primary
     - variable: standard-number
     - variable: publisher-place


### PR DESCRIPTION
## Summary

- **Fixes a general engine bug, not ieee-specific:** `update_label_mode`'s synthetic `[label, following]` group renders label-only text when `following` (e.g. the author) is empty, but the entry assembly loop treated that as real preceding content and inserted a spurious separator before whatever came next — `[15], "Title..."` instead of `[15]"Title..."`. Adds `ProcTemplateComponent.label_only`; the assembly loop now suppresses the next separator when it's set. Any numeric-processing style hits this whenever the first template component can be empty.
- **Three `ieee.yaml` fixes** surfaced while tracing the above: motion-picture release dates now parenthesized, patent entries no longer drop the patent number, and the `patent`/`standard` type-variants no longer declare a redundant `citation-number` component duplicating the global bibliography label (that redundancy was the proximate trigger for the bug in those two type-variants).
- **Result:** `ieee` exact parity 84/149 → 88/149 (56.4% → 59.1%), fidelity 100% throughout, **zero regressions** on `chicago-author-date-18th` and `american-medical-association` (both share the affected engine paths, explicitly cross-checked).
- Companion doc: [PR #1127](https://github.com/citum/citum-core/pull/1127) addendum records the full tuning-wave results, including a shared-preset fix that was tried, found to regress those same two styles, and reverted — filed as follow-up `csl26-g6bi` rather than landed here.

## Test plan

- [x] `node scripts/oracle.js styles-legacy/ieee.csl --json` — 100% fidelity, unchanged
- [x] `node scripts/report-core.js --style ieee --all-features --json` — 88/149 exact parity (was 84/149)
- [x] Same check re-run for `chicago-author-date-18th` (172/540, unchanged) and `american-medical-association` (49/67, unchanged) — no regression
- [x] `just pre-commit` (fmt, clippy -D warnings, full nextest — 2331 tests) passes
- [x] Bean `csl26-unyu` closed with full results; four follow-up beans filed for the remaining residual classes
