### PR TITLE
feat(styles): add acta psychologica bilingual overlay

### DIFF
--- a/.beans/csl26-30o1--add-declarative-multilingual-entry-mode-rendering.md
+++ b/.beans/csl26-30o1--add-declarative-multilingual-entry-mode-rendering.md
@@ -1,0 +1,38 @@
+---
+# csl26-30o1
+title: Add declarative multilingual entry-mode rendering
+status: todo
+type: feature
+priority: normal
+tags:
+    - multilingual
+    - schema
+    - engine
+    - rendering
+created_at: 2026-08-03T15:30:45Z
+updated_at: 2026-08-03T15:30:45Z
+parent: csl26-0ugp
+---
+
+Add a declarative entry-level multilingual rendering mode for bilingual bibliographies.
+
+Proposed style shape:
+
+```yaml
+options:
+  multilingual:
+    entry-mode:
+      pattern:
+        - view: translated
+        - view: original-script
+          wrap: brackets
+```
+
+Checklist:
+
+- [ ] Add `entry-mode` to `MultilingualConfig` and generated schemas.
+- [ ] Define bibliography-only projection and precedence semantics with field-level multilingual modes.
+- [ ] Render translated/original entry bodies without duplicating citation numbers, type labels, URLs, or entry suffixes.
+- [ ] Preserve punctuation, rich-text markup, missing-translation fallback, and simple English deduplication.
+- [ ] Add multilingual engine and inheritance regression coverage.
+- [ ] Enable the Acta Psychologica Sinica overlay to use the entry-level mode once supported.

--- a/examples/acta-psychologica-sinica-refs.yaml
+++ b/examples/acta-psychologica-sinica-refs.yaml
@@ -1,0 +1,113 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/bib.json
+#
+# Focused structured-multilingual fixture for styles/acta-psychologica-sinica.yaml.
+# The style exercises translated-first rendering for titles and container
+# titles, translated-first name configuration with Latin fallback data, a
+# simple English control, and missing-translation fallbacks.
+
+info:
+  description: Acta Psychologica Sinica bilingual numeric overlay examples
+
+references:
+  - id: chinese-psychology-article
+    class: serial-component
+    type: article
+    language: zh
+    title:
+      original: 中国心理学的过去与未来
+      lang: zh
+      translations:
+        en: The past and future of Chinese psychology
+    author:
+      - original:
+          family: 张
+          given: 三
+        lang: zh
+        transliterations:
+          zh-Latn-pinyin:
+            family: Zhang
+            given: S.
+        translations:
+          en:
+            family: Zhang
+            given: S.
+    issued: "2008"
+    volume: "40"
+    pages: "210-215"
+    container:
+      class: serial
+      type: academic-journal
+      title:
+        original: 心理学报
+        lang: zh
+        translations:
+          en: Acta Psychologica Sinica
+
+  - id: chinese-psychology-book
+    class: monograph
+    type: book
+    language: zh
+    title:
+      original: 现代汉语频率词典
+      lang: zh
+      translations:
+        en: Modern Chinese Frequency Dictionary
+    author:
+      - original:
+          family: 王
+          given: 五
+        lang: zh
+        transliterations:
+          zh-Latn-pinyin:
+            family: Wang
+            given: W.
+        translations:
+          en:
+            family: Wang
+            given: W.
+    issued: "1986"
+    publisher:
+      name:
+        original: 北京语言学院出版社
+        lang: zh
+        translations:
+          en: Beijing Language and Culture University Press
+      place: 北京
+
+  - id: chinese-missing-translation
+    class: serial-component
+    type: article
+    language: zh
+    title:
+      original: 没有英文翻译的中文题名
+      lang: zh
+    author:
+      - original:
+          family: 李
+          given: 四
+        lang: zh
+        transliterations:
+          zh-Latn-pinyin:
+            family: Li
+            given: S.
+    issued: "2010"
+    container:
+      class: serial
+      type: academic-journal
+      title: 中文期刊
+
+  - id: english-control
+    class: serial-component
+    type: article
+    language: en
+    title: A control article with ordinary English metadata
+    author:
+      - family: Smith
+        given: J.
+    issued: "2020"
+    volume: "12"
+    pages: "1-10"
+    container:
+      class: serial
+      type: academic-journal
+      title: Journal of Citation Testing

--- a/styles/acta-psychologica-sinica.yaml
+++ b/styles/acta-psychologica-sinica.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
+#
+# Numeric bilingual overlay for Acta Psychologica Sinica (心理学报).
+# The journal's convention puts translated English metadata first and appends
+# the original Chinese metadata in brackets for Chinese-language references.
+
+extends: gb-t-7714-2025-numeric
+
+info:
+  id: https://zotero-chinese.com/styles/心理学报
+  title: 心理学报 (Acta Psychologica Sinica) — GB/T numeric bilingual
+  description: >-
+    A GB/T 7714—2025 numeric overlay for Acta Psychologica Sinica that
+    renders structured multilingual names and titles as translated English
+    followed by the original Chinese in brackets.
+  fields:
+    - psychology
+  default-locale: en-US
+  source:
+    csl-id: https://zotero-chinese.com/styles/心理学报
+    license: http://creativecommons.org/licenses/by-sa/3.0/
+    original-authors:
+      - name: Zeping Lee
+    links:
+      - href: https://zotero-chinese.com/styles/心理学报
+        rel: self
+      - href: https://journal.psych.ac.cn/xlxb/fileup/0439-755X/ITEM/20220223114333.pdf
+        rel: documentation
+
+options:
+  multilingual:
+    preferred-script: Latn
+    title-mode:
+      pattern:
+        - view: translated
+        - view: original-script
+          wrap: brackets
+    name-mode:
+      pattern:
+        - view: translated
+        - view: original-script
+          wrap: brackets


### PR DESCRIPTION
## Summary

Add a dependent GB/T 7714—2025 numeric overlay for Acta Psychologica Sinica (心理学报), with structured multilingual fixture coverage.

## Scope

- Add `styles/acta-psychologica-sinica.yaml`.
- Add `examples/acta-psychologica-sinica-refs.yaml`.
- Preserve inherited GB/T numeric citations, sorting, punctuation, and bibliography templates.
- Track the processor follow-up as bean `csl26-30o1`: declarative entry-level multilingual rendering.

## Validation

- `cargo run --bin citum -- check -s styles/acta-psychologica-sinica.yaml`
- Rendered the focused fixture with `citum render refs`.
- `node scripts/style-structure-lint.js styles/acta-psychologica-sinica.yaml`
- `cargo nextest run -p citum-engine --test i18n` — 46 passed.
- `cargo nextest run -p citum-schema-style --test bdd_inheritance` — 18 passed.
- `python scripts/audit-coverage.py` — completed successfully.

## Boundary

The overlay provides a supported field-level approximation: translated titles/container titles and multilingual contributor configuration render before bracketed originals. Exact whole-record bilingual duplication with source-style punctuation still requires the entry-level `options.multilingual.entry-mode` feature tracked in bean `csl26-30o1`. Publisher-place translation and legacy `original-*` metadata remain separate follow-ups.
