### PR TITLE
docs(spec): specify variant unset and locale vocab

### DIFF
--- a/.beans/csl26-zaxo--schema-design-variant-field-unset-abstract-variant.md
+++ b/.beans/csl26-zaxo--schema-design-variant-field-unset-abstract-variant.md
@@ -1,0 +1,52 @@
+---
+# csl26-zaxo
+title: 'Schema design: variant field unset, abstract variants, locale vocab override'
+status: in-progress
+type: feature
+priority: high
+tags:
+    - schema
+    - style
+    - engine
+created_at: 2026-08-05T12:35:20Z
+updated_at: 2026-08-05T12:38:53Z
+parent: csl26-ccdt
+---
+
+Docs-only design PR covering three schema gaps found while measuring ieee exact parity (88/149). Review gate before any implementation.
+
+G1 -- `modify` cannot unset an inherited rendering field. `Rendering::merge` goes through `merge_options!` (citum-schema-style/src/macros.rs:109), which assigns only when the source is Some. Dropping the base template's `wrap: quotes` in a type-variant is unexpressible, so authors must `remove` + `add` and restate component position. Direct cause of ieee.yaml's copy-pasted variants (personal_communication is byte-identical to the base template; broadcast/dataset/report are identical to each other).
+
+G2 -- no name for an intermediate variant. `resolve_variant_parent_template` (template/resolution.rs:213) resolves `extends` via `original.contains_key`, so a parent must be a concrete reference type. entry-encyclopedia currently says `extends: broadcast`, which is semantically arbitrary.
+
+G3 -- `LocaleOverride` carries no `vocab`. types.rs:748, raw.rs:596, raw_conversion.rs:795 handle messages/grammar-options/legacy-term-aliases/dates but not vocab.genre or vocab.medium. Blocks a per-style genre vocabulary (IEEE's published examples use "Ph.D. dissertation", not en-US's generic "PhD thesis").
+
+Scope: docs only. No Rust, no schema regen. Implementation lands after review, stacked.
+
+## Todo
+
+- [x] TEMPLATE_V3.md section for G1 + G2 (syntax, resolution semantics, JSON-schema shape, migrate impact, what stays forbidden)
+- [x] G3 spec placement decided and written
+- [x] Worked ieee.yaml before/after showing the duplication collapse
+- [x] Resolve the three open syntax questions rather than assume
+- [x] Doc link check
+- [ ] CI green
+
+## Decisions taken (for review)
+
+- **G1** -> `unset: [wrap, prefix]` on a modify op. Rejected explicit YAML `null`:
+  serde cannot tell an absent key from an explicit null on `Option<T>` without
+  lifting every `Rendering` field to `Option<Option<T>>` or hand-writing a
+  deserializer for the most-touched struct in the schema. `unset` is additive
+  and leaves `Rendering` untouched. Spec: TEMPLATE_V3.md 5.1.
+- **G2** -> sibling `abstract-variants:` map. Rejected a reserved sigil inside
+  the `type-variants` key space: it makes `TypeSelector` mean two things by
+  leading character and needs a carve-out in `matches`, `unknown_type_names`,
+  validation, lint, and the JSON schema. Spec: TEMPLATE_V3.md 5.2.
+- **G3** -> `vocab` on `LocaleOverride`, merged key-by-key like `messages` and
+  `dates` (not whole-replace like `grammar-options`). Spec: LOCALE_MESSAGES.md 4.1.
+
+Also specified: `citum-migrate` should *not* start emitting the new forms on
+this change -- converter output is compared against a pinned corpus, so a shape
+change would move migration-fidelity numbers for reasons unrelated to converter
+quality.

--- a/docs/specs/LOCALE_MESSAGES.md
+++ b/docs/specs/LOCALE_MESSAGES.md
@@ -1,10 +1,11 @@
 # Locale Messages Specification
 
 **Status:** Active
-**Version:** 1.7
-**Date:** 2026-06-26
+**Version:** 1.8
+**Date:** 2026-08-05
 **Supersedes:** (none)
-**Related:** bean `csl26-qrpo` (ICU4X upgrade), bean `csl26-v6ok`
+**Related:** bean `csl26-zaxo` (locale vocab override), bean `csl26-qrpo`
+(ICU4X upgrade), bean `csl26-v6ok`
 (locale-authored date patterns), bean `csl26-fdzc` (style phrase migration),
 bean `csl26-eh5c` (contributor phrase messages),
 [`CONTRIBUTOR_PHRASE_MESSAGES.md`](./CONTRIBUTOR_PHRASE_MESSAGES.md)
@@ -722,11 +723,63 @@ locale for a specific style or document. It lives in `locales/overrides/`.
 | `dateFormats` | `map` | Partial — only keys to override. |
 | `grammarOptions` | `map` | Partial — only keys to override. |
 | `dates` | `object` | Partial month/season name overrides, keyed by EDTF sub-year code — see [`LOCALE_DATE_NAME_KEYING.md`](./LOCALE_DATE_NAME_KEYING.md). |
+| `vocab` | `object` | Partial `genre` / `medium` display-name overrides — see §4.1. |
 
 **Merge semantics:** shallow key-level replacement. For each map
-(`messages`, `dateFormats`, `grammarOptions`, `dates`), keys present in the
-override replace matching keys in the base. Keys absent from the override
-retain their base values. There is no deep-merge or list-append behavior.
+(`messages`, `dateFormats`, `grammarOptions`, `dates`, `vocab`), keys present
+in the override replace matching keys in the base. Keys absent from the
+override retain their base values. There is no deep-merge or list-append
+behavior.
+
+#### 4.1 `vocab` — per-style genre and medium names
+
+`LocalePreset` carries a `vocab` block mapping canonical genre and medium keys
+to display text, resolved through `Locale::lookup_genre` /
+`Locale::lookup_medium`, with a kebab-to-display fallback for unknown keys.
+`LocaleOverride` cannot reach it, so display text for these keys is currently
+global to a base locale.
+
+That is too coarse. The canonical key is style-neutral by design — a reference
+records `genre: phd-thesis` — but its rendered form is a house-style decision.
+IEEE's published examples use `Ph.D. dissertation`, while en-US ships the
+generic `PhD thesis`. Today the only ways to render IEEE's form are to change
+the shared en-US locale (wrong for every other style) or to author a complete
+replacement locale (defeats the point of sparse overrides).
+
+`LocaleOverride` therefore gains a `vocab` block with the same shape as
+`LocalePreset.vocab`:
+
+```yaml
+# locales/overrides/en-US-ieee.yaml
+id: en-US-ieee
+base-locale: en-US
+
+vocab:
+  genre:
+    phd-thesis: "Ph.D. dissertation"
+```
+
+Semantics:
+
+- Merge is key-by-key within each of `vocab.genre` and `vocab.medium`,
+  matching `messages` and `dates` rather than `grammar-options`. Overriding one
+  genre key MUST NOT drop the base locale's remaining genre or medium entries.
+  A whole-block replacement would force every override to restate the full
+  vocabulary to change one entry, which is the shape
+  [`LOCALE_DATE_NAME_KEYING.md`](./LOCALE_DATE_NAME_KEYING.md) already rejected
+  for month names.
+- `genre` and `medium` merge independently; supplying one leaves the other at
+  its base values.
+- Keys are canonical kebab-case keys, not display strings. An override keyed by
+  display text (`"PhD thesis": …`) silently never matches; linters SHOULD warn
+  on a key that is absent from the base locale's vocabulary, since that is
+  almost always this mistake rather than a deliberate new key.
+- The unknown-key fallback is unchanged: a key in neither the base nor the
+  override still renders through kebab-to-display.
+
+Structurally this mirrors what `dates` already does, in the same three places:
+the `LocaleOverride` type, its raw deserialization mirror, and `apply_override`.
+No new resolution stage, and no change to `LocalePreset`.
 
 **Example — Chicago English:**
 
@@ -1141,6 +1194,9 @@ Engine behavior by `localeSchemaVersion`:
 
 ## Changelog
 
+- v1.8 (2026-08-05): Add `vocab` to `LocaleOverride` (§4.1) so a style can
+  override individual genre or medium display names on top of a base locale,
+  merged key-by-key like `messages` and `dates`.
 - v1.7 (2026-06-26): Link the dedicated contributor phrase message spec and
   replace the earlier deferred placeholder with the initial
   `pattern.in-contributor-container` and `pattern.container-contributor-title`

--- a/docs/specs/TEMPLATE_V3.md
+++ b/docs/specs/TEMPLATE_V3.md
@@ -1,10 +1,10 @@
 # Template Schema v3 Specification
 
 **Status:** Active
-**Version:** 0.5
-**Date:** 2026-06-24
+**Version:** 0.6
+**Date:** 2026-08-05
 **Supersedes:** `docs/specs/TEMPLATE_V2.md`
-**Related:** csl26-t3v1, `docs/specs/DISTRIBUTED_RESOLVER.md`
+**Related:** csl26-t3v1, csl26-zaxo, `docs/specs/DISTRIBUTED_RESOLVER.md`
 
 ## Purpose
 
@@ -273,7 +273,7 @@ The engine MUST process each operation list (`modify`, `remove`, `add`) in the o
     *   If no component matches, the operation MUST be ignored or treated as a validation error (implementation-defined, but validators SHOULD treat this as an error).
     *   If multiple components match, engines MUST treat this as a validation error or select the first match deterministically; style authors SHOULD avoid ambiguous `match` selectors.
 2.  **Apply Operation:**
-    *   `modify`: Overwrites rendering hints. If a `modify` operation attempts to change the component’s kind or primary value (e.g., `contributor: author` to `contributor: editor` or `variable: publisher` to `variable: url`), the style is invalid and must be rejected by validators or ignored by non-validating engines (implementation-defined).
+    *   `modify`: Overwrites rendering hints, and MAY clear inherited ones via `unset` (§5.1). If a `modify` operation attempts to change the component’s kind or primary value (e.g., `contributor: author` to `contributor: editor` or `variable: publisher` to `variable: url`), the style is invalid and must be rejected by validators or ignored by non-validating engines (implementation-defined).
     *   `remove`: Deletes the anchor from the list.
     *   `add`: Inserts a new component `before` or `after` the anchor. An `add` operation MAY specify either `before` or `after`, but not both. If both are present, the style is invalid. If the anchor in `before`/`after` does not match any component, the engine MUST append the new component to the end of the list.
 
@@ -302,12 +302,219 @@ bibliography:
 
 Engines SHOULD treat unreachable or invalid parent URIs as resolution errors; style authors MUST NOT assume offline resolution if remote parents are unavailable.
 
+### §5 — Variant Reuse Without Duplication
+
+§1–§4 give a diff model but leave two shapes inexpressible, and authors have
+been paying for both by pasting whole templates. This section closes them
+**without** relaxing the macro prohibition: neither addition introduces a named
+fragment that a template can call, and neither is reachable from a template
+body. They act only on the variant-resolution graph, which already exists.
+
+#### 5.1 Clearing an inherited field (`unset`)
+
+A `modify` operation can set a rendering field but not clear one. `Rendering`
+fields are all `Option`, and the merge assigns only where the incoming value is
+`Some`, so there is no value an author can write that means "the parent set
+this; I don't want it."
+
+The practical consequence is severe. A base template whose `title: primary`
+carries `wrap: { punctuation: quotes }` cannot be specialized into a variant
+that renders the title bare. The author's only recourse is `remove` + `add`,
+which restates the component *and its position* — reintroducing exactly the
+fragility the diff model exists to remove, because a later change to the base
+template's ordering silently stops flowing through.
+
+A `modify` operation MAY therefore carry `unset`, a list of rendering field
+names to clear on the anchor:
+
+```yaml
+type-variants:
+  book:
+    modify:
+      - match: { title: primary }
+        unset: [wrap]
+```
+
+Semantics:
+
+- Field names use the schema's kebab-case rendering vocabulary: `text-case`,
+  `emph`, `quote`, `strong`, `small-caps`, `vertical-align`, `prefix`,
+  `suffix`, `wrap`, `suppress`, `initialize-with`, `name-form`,
+  `strip-periods`, and `label-form` (the last valid only on a `number:`
+  anchor, matching where `modify` already accepts it).
+- An unrecognized field name is a validation error. It MUST NOT be silently
+  ignored: a typo that quietly leaves inherited quotes in place is precisely
+  the failure this operation exists to prevent.
+- Clearing a field the parent never set is a **no-op, not an error**. A diff
+  must stay valid when an upstream parent stops setting a field.
+- Within one operation, `unset` applies **before** that operation's own
+  rendering merge. `{ unset: [wrap], wrap: { punctuation: parentheses } }` is
+  therefore a replace, not a self-cancelling no-op. Ordering across separate
+  operations remains authored order, per §3.
+- `unset` MUST NOT change the component's kind or primary value; the §3
+  `modify` rule applies unchanged. `unset: [title]` is invalid.
+
+Alternative considered and rejected: an explicit YAML `null` (`wrap: null`).
+Serde cannot distinguish an absent key from an explicit null on `Option<T>`
+without lifting every field to `Option<Option<T>>` or hand-writing a
+deserializer for `Rendering` — a large, invasive change to the most-touched
+struct in the schema, in exchange for a spelling that reads as ambiguous
+(`prefix: null` vs `prefix: ""`). `unset` is self-describing, additive, costs
+one new field on the modify operation, and leaves `Rendering` untouched.
+
+#### 5.2 Abstract variants (`abstract-variants`)
+
+`extends` can only name something that is itself a reference type. When several
+types share a specialization, the author must either repeat it or pick one
+arbitrary type as the donor. `ieee.yaml` does the latter today —
+`entry-encyclopedia` extends `broadcast`, which asserts a relationship between
+encyclopedia entries and broadcasts that does not exist. Nothing in the file
+records that both are really "a standalone work, whose title is not quoted."
+
+A section MAY therefore declare `abstract-variants`, a sibling map to
+`type-variants` holding named, non-type bases:
+
+```yaml
+bibliography:
+  abstract-variants:
+    standalone-work:
+      modify:
+        - match: { title: primary }
+          unset: [wrap]
+
+  type-variants:
+    [broadcast, dataset, report]:
+      extends: standalone-work
+    book:
+      extends: standalone-work
+      modify:
+        - match: { variable: publisher-place }
+          prefix: ". "
+```
+
+Semantics:
+
+- An `abstract-variants` entry has the same value shape as a `type-variants`
+  entry: a full template or a diff. Omitting `extends` implicitly extends the
+  section's base `template`, exactly as in §1.
+- Its key is a **name, not a type selector**. It is never compared against a
+  reference type, so it can never be selected for rendering. Type-name
+  validation (`unknown reference type "…"`) MUST NOT fire for these keys.
+- `extends: X` resolves in order: local `type-variants[X]`, local
+  `abstract-variants[X]`, inherited `type-variants[X]`, inherited
+  `abstract-variants[X]`. A name defined in both local maps is a validation
+  error rather than a silent precedence win.
+- An abstract variant MAY extend another abstract variant. Cycles are detected
+  by the same mechanism as type-variant cycles and are a resolution error.
+- Abstract variants are a **resolution-time construct only**. A fully resolved
+  style contains concrete `type-variants` and no `abstract-variants`; the
+  renderer never sees them.
+- An abstract variant that nothing extends is dead weight, not an error.
+  Linters SHOULD warn.
+- Under §4, a child style MAY extend a remote parent's abstract variant, and
+  abstract variants merge by name on the same terms as type-variants.
+
+Alternative considered and rejected: a reserved sigil inside the existing
+`type-variants` key space (`_standalone-work`). It keeps one map but forces
+`TypeSelector` to mean two different things depending on a leading character,
+and every consumer — `matches`, `unknown_type_names`, validation, lint, the
+JSON schema — needs a carve-out. A separate map keeps `TypeSelector` meaning
+"reference type" and requires no carve-outs.
+
+#### 5.3 Worked example
+
+`ieee.yaml` today spells out six near-identical bibliography variants. Measured
+against its own base `template`, `personal_communication` is byte-identical;
+`broadcast`, `dataset`, and `report` are identical to each other and differ from
+the base only in dropping the title's quote wrap; `book` and `motion-picture`
+add one field each on top of that. Roughly 150 lines encode about four real
+decisions.
+
+Before (abridged — this shape repeats six times):
+
+```yaml
+type-variants:
+  broadcast:
+  - contributor: author
+    form: long
+    and: text
+    name-order: given-first
+    shorten: { min: 7, use-first: 1 }
+  - title: primary
+  - title: parent-monograph
+    emph: true
+  # … nine more components, copied verbatim from the base template …
+```
+
+After:
+
+```yaml
+abstract-variants:
+  standalone-work:
+    modify:
+      - match: { title: primary }
+        unset: [wrap]
+
+type-variants:
+  [broadcast, dataset, report]:
+    extends: standalone-work
+  book:
+    extends: standalone-work
+    modify:
+      - match: { variable: publisher-place }
+        prefix: ". "
+  entry-encyclopedia:
+    extends: standalone-work
+    modify:
+      - match: { number: pages }
+        label-form: short
+  # `personal_communication` is deleted: it was the base template.
+```
+
+Each variant now states its one real difference, and a change to the base
+template flows into all of them.
+
+#### 5.4 What remains forbidden
+
+This section MUST NOT be read as reopening macros. Unchanged from §"Scope":
+
+- There is still no named fragment a **template body** can invoke. Both
+  additions act on the variant graph; neither is reachable from a component
+  list.
+- `abstract-variants` entries are diffs over one section's base template, not
+  reusable component sequences. They cannot be shared across `citation` and
+  `bibliography`, and they take no arguments.
+- Resolution stays total and static: every variant is still derivable to a
+  concrete template before rendering, with no runtime dispatch.
+
+#### 5.5 Schema and tooling impact
+
+- `TemplateModifyOperation` gains `unset: Vec<RenderingField>`, defaulting to
+  empty and skipped when empty on serialize. `Rendering` is unchanged.
+- Each template section gains
+  `abstract-variants: Option<IndexMap<String, TemplateVariant>>`, skipped when
+  absent. `TypeSelector` is unchanged.
+- `just schema-gen` regenerates `docs/schemas/style.json`; `unset` surfaces as
+  an enum-constrained string array, `abstract-variants` as an object with
+  free-form keys and the existing `TemplateVariant` value schema.
+- Both fields are additive. Existing styles parse and resolve unchanged, so no
+  style migration is required.
+- `citum-migrate` SHOULD NOT start emitting either form on this change.
+  Converter output is compared against a pinned corpus, and changing its shape
+  would move migration-fidelity numbers for reasons unrelated to converter
+  quality. Teaching the converter to factor shared specializations out is
+  separate work, worth its own bean once hand-authored styles have exercised
+  the syntax.
+
 ---
 
 ## Acceptance Criteria
 
 - [x] Macros are absent from the spec.
 - [ ] `type-variants` schema supports `extends`, `modify`, `add`, and `remove` with defined matching and ordering semantics.
+- [ ] A `modify` operation can clear an inherited rendering field without restating the component's position (§5.1).
+- [ ] Several reference types can share one specialization through a named non-type base, without one of them being designated the arbitrary donor (§5.2).
+- [ ] A fully resolved style contains no `abstract-variants`, and abstract names never reach reference-type validation.
 - [ ] Style-level `options` expanded to handle contributor and date formatting policies, with clear precedence rules vs local component hints.
 - [ ] Engine resolution logic supports cross-URI template diffing, including recursive parent chains and error handling for missing parents.
 
@@ -315,6 +522,9 @@ Engines SHOULD treat unreachable or invalid parent URIs as resolution errors; st
 
 ## Changelog
 
+- v0.6 (2026-08-05): Add §5 — `unset` on `modify` for clearing an inherited
+  rendering field, and `abstract-variants` for named non-type bases. Both act
+  on the variant graph only; the macro prohibition is restated in §5.4.
 - v0.5 (2026-07-15): Clarify family inheritance, forbid named cross-section
   fragments, define authoritative date-fallback omission semantics, and allow
   narrowly scoped style-owned MF2 messages for textual classification.


### PR DESCRIPTION
**Docs only — this is the review gate before any schema code.** No Rust, no `schema-gen`, no style changes.

## Why

Measuring `ieee.yaml` for exact parity turned up a bigger question than the parity rows: *CSL encodes shared logic once with macros — does Citum force duplication instead?*

Mostly no. `TEMPLATE_V3.md` already answers it with structural diffs and explicitly forbids macros, and `ieee.yaml` simply never migrated off V2's full-replacement variants. Diffed against its own base `template`:

| variant | difference from the base template |
|---|---|
| `personal_communication` | **none — byte-identical** |
| `broadcast`, `dataset`, `report` | **identical to each other**; only the title's quote wrap is dropped |
| `book` | as above, plus one prefix |
| `motion-picture` | as above, plus a parenthesised date |

~150 lines encoding about four real decisions. But two of those four **cannot** be written as diffs today, which is *why* the file is pasted. That's a real gap, and this PR specifies it rather than working around it.

## What's specified

**G1 — `unset` on a `modify` operation** (`TEMPLATE_V3.md` §5.1). `Rendering::merge` goes through `merge_options!`, which assigns only where the source is `Some`, so no value means "the parent set this; I don't want it." A variant that wants the base's `title: primary` *without* its quote wrap must `remove` + `add`, restating the component's position — the exact fragility the diff model exists to remove.

> Rejected: explicit YAML `null`. Serde cannot distinguish an absent key from an explicit null on `Option<T>` without lifting every `Rendering` field to `Option<Option<T>>` or hand-writing a deserializer for the most-touched struct in the schema — and `prefix: null` vs `prefix: ""` reads ambiguously. `unset` is additive and leaves `Rendering` untouched.

**G2 — `abstract-variants`** (`TEMPLATE_V3.md` §5.2). `extends` can only name something that is itself a reference type, so shared specializations need an arbitrary donor. `ieee.yaml` has `entry-encyclopedia extends broadcast` today, asserting a relationship that doesn't exist; nothing records that both are really "a standalone work, whose title is not quoted."

> Rejected: a reserved sigil inside the `type-variants` key space. It makes `TypeSelector` mean two different things by leading character and needs a carve-out in `matches`, `unknown_type_names`, validation, lint, and the JSON schema.

**G3 — `vocab` on `LocaleOverride`** (`LOCALE_MESSAGES.md` §4.1). The override struct carries `messages`, `grammar-options`, `legacy-term-aliases`, and now `dates` — but not `vocab`, so genre/medium display text is global to a base locale. The canonical key is style-neutral by design (`genre: phd-thesis`); its rendered form is a house-style decision. IEEE's published examples use `Ph.D. dissertation` where en-US ships the generic `PhD thesis`, and today the only options are to change shared en-US or author a whole replacement locale. Merges key-by-key, matching `dates`.

## Worth reviewing closely

- **§5.4 "What remains forbidden"** — the load-bearing paragraph. Both additions act only on the variant-resolution graph; neither is reachable from a template body, neither takes arguments, neither crosses sections. If this reads as reopening macros, that's the thing to push back on.
- **§5.1 ordering rule** — within one operation `unset` applies *before* that operation's own merge, so `{ unset: [wrap], wrap: {...} }` is a replace, not a no-op.
- **§5.2 name resolution order** — local `type-variants` → local `abstract-variants` → inherited, with a name in both local maps a validation error rather than a silent precedence win.
- **Migrate impact** — specified as *no change*: `citum-migrate` should not start emitting the new forms here, since converter output is compared against a pinned corpus and a shape change would move migration-fidelity numbers for reasons unrelated to converter quality.

## Next session

Implementation lands after this is approved, stacked on this branch. Then PR3 rewrites `ieee.yaml` as V3 diffs and adds an `en-US-ieee` locale override (month abbreviations, `day-zero-pad`, `vocab.genre`, and the missing `Accessed: … [Online]. Available: …` tail).

Two content decisions are flagged in the plan and deliberately **not** assumed: the exact `Ph.D. dissertation` spelling, and whether to add a `masters-thesis` fixture — the corpus has no such reference today, so `M.S. thesis` cannot currently be verified.

Predecessor: #1140 (engine separator fix, +12 exact-parity rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
