### PR TITLE
refactor(styles): ieee titles via category config

### DIFF
--- a/.beans/csl26-8u5i--styletemplates-is-declared-validated-merged-and-ne.md
+++ b/.beans/csl26-8u5i--styletemplates-is-declared-validated-merged-and-ne.md
@@ -1,0 +1,36 @@
+---
+# csl26-8u5i
+title: Style.templates is declared, validated, merged -- and never resolved
+status: todo
+type: task
+priority: normal
+tags:
+    - schema
+created_at: 2026-08-05T13:52:51Z
+updated_at: 2026-08-05T13:53:02Z
+parent: csl26-ccdt
+---
+
+`Style.templates: Option<HashMap<String, Template>>` (crates/citum-schema-style/src/style/model.rs:36) is documented as **"Named reusable templates"**. It is:
+
+- budget-validated (style/validation.rs:67)
+- merged per-key across style inheritance (style/overlay.rs:150)
+- warned on for unknown enums (citum-engine/src/api/warnings.rs:195)
+- banned in profile overrides (style/validation.rs:115, docs/specs/CONFIG_ONLY_PROFILE_OVERRIDES.md)
+
+**But nothing resolves it.** `TemplateReference` is either a closed built-in `TemplatePreset` enum or a `Uri` (template/reference.rs:42); there is no name-keyed lookup into `style.templates` anywhere in the workspace, and the three embedded styles using `template-ref` all name built-in presets (`numeric-citation`).
+
+## Why it matters
+
+TEMPLATE_V3 §Scope lists "Named templates or Macros (Forbidden)" and "Cross-section references to named reusable template fragments (Forbidden)". A schema field literally called "Named reusable templates" sits badly next to that, whichever way the field is meant to go.
+
+## Decide, do not assume
+
+`delimiter-suppressing-terminal-marks` looked equally inert this session and turned out to be **deliberately reserved** for csl26-zfqr. Check for the same before concluding this one is vestigial.
+
+## Todo
+
+- [ ] Determine whether `templates` is reserved for planned work or vestigial
+- [ ] If reserved: document what will consume it, and add a doc comment at the definition pointing to the bean (the lesson from csl26-zfqr)
+- [ ] If vestigial: remove the field, the validation, the overlay merge, and regenerate schemas; note the breaking schema change
+- [ ] Either way, reconcile TEMPLATE_V3 §Scope wording with what the schema actually carries

--- a/.beans/csl26-q4g5--type-variant-all-selector-shadows-later-variants-1.md
+++ b/.beans/csl26-q4g5--type-variant-all-selector-shadows-later-variants-1.md
@@ -1,0 +1,41 @@
+---
+# csl26-q4g5
+title: 'type-variant ''all'' selector shadows later variants: 16 dead in elsevier-with-titles'
+status: todo
+type: bug
+priority: high
+tags:
+    - engine
+    - style
+    - fidelity
+created_at: 2026-08-05T13:52:35Z
+updated_at: 2026-08-05T13:52:51Z
+parent: csl26-ccdt
+---
+
+`resolve_type_variant` (crates/citum-engine/src/processor/rendering/grouped/component_predicates.rs:25) is `iter().find_map(...)` over an insertion-ordered IndexMap: **first authored match wins, with no specificity ordering anywhere in the engine**. `TypeSelector::matches` treats `all` as matching every reference type (template.rs:442).
+
+## Evidence (2026-08-05)
+
+`elsevier-with-titles-core.yaml` is the only embedded style using `all`. Its own comment states the rule correctly:
+
+> `all` matches every type and is resolved first (engine returns the first matching selector), so any type-specific variant must precede it to take effect.
+
+The file then violates it. `all` is at line 109; **16 type-variant keys are authored after it and are unreachable**: article-magazine, article-newspaper, book, chapter, dataset, interview, legal-case, paper-conference, patent, report, thesis, webpage, [webpage, dataset], [article-newspaper, broadcast], motion-picture, personal-communication.
+
+Confirmed from rendered output, not inferred: ITEM-14 is a book, but renders with the `all` variant's editor-label shape (`(Eds.)` from `prefix: " ("`, `suffix: ")"`, `capitalize-first`) rather than the `book` variant's. Style sits at **27/67 exact parity**.
+
+## Decision needed first
+
+Specificity-based precedence (exact type > multi-type key > `all`) vs. keeping authored-order and just reordering the style file. Spec decision is being made in the TEMPLATE_V3 revision on PR #1142.
+
+## Why this is not a quick fix
+
+Changing precedence makes 16 variants live at once; elsevier-with-titles' 27/67 will move, possibly a lot, in either direction. Needs its own PR and a full embedded sweep, not a fold-in.
+
+## Todo
+
+- [ ] Land the precedence semantics in TEMPLATE_V3 (PR #1142)
+- [ ] Implement specificity ordering in resolve_type_variant, or reorder the style if the decision goes the other way
+- [ ] Lint: flag any type-variant authored after `all` under authored-order semantics
+- [ ] Full embedded sweep before/after; record elsevier-with-titles delta

--- a/.beans/csl26-x8hb--ieee-move-title-rendering-from-template-wrap-to-ti.md
+++ b/.beans/csl26-x8hb--ieee-move-title-rendering-from-template-wrap-to-ti.md
@@ -1,0 +1,44 @@
+---
+# csl26-x8hb
+title: 'ieee: move title rendering from template wrap to titles category config'
+status: in-progress
+type: task
+priority: high
+tags:
+    - schema
+    - style
+    - fidelity
+created_at: 2026-08-05T13:54:29Z
+updated_at: 2026-08-05T13:54:36Z
+parent: csl26-ccdt
+---
+
+`ieee.yaml` encoded a category-level policy (which works get quoted titles) in the template layer: `wrap: { punctuation: quotes }` on the base `title: primary`, applied to every type, then six near-identical type-variants existed purely to take the quotes back off.
+
+Root cause: the style set `titles: humanities`, whose `component` rendering is plain, then compensated in the template. `TitlePreset::Ieee` already exists and quotes component titles.
+
+## Why the template was the wrong layer
+
+The engine keys title rendering by reference type, and the **substitute chain reads the same config** — `resolve_author_substitute` (values/contributor/substitute.rs:879) does not pass the contributor component's `Rendering` into the title branch, by design. A template `wrap:` could never reach a title substituting for a missing author; `options.titles` reaches both paths from one declaration.
+
+## Change
+
+- Replaced `titles: humanities` with explicit category config plus `type-mapping`, derived from the oracle's actual per-type treatment rather than guessed.
+- Deleted `wrap: quotes` from the base template.
+- Deleted four variants that only removed it (broadcast, dataset, report, personal_communication -- the last byte-identical to the base).
+- Converted `book`, `motion-picture`, `entry-encyclopedia` from full templates to diffs; with the wrap gone they differ from base only by additions, which `modify` already expresses.
+
+## Result
+
+**361 -> 233 lines (-170/+42).** ieee exact parity **95/149 unchanged**, fidelity 1.0. Full embedded sweep 1558 -> 1559 (ASME +1 via inheritance; ieee is its direct parent). No regressions, no fidelity movement.
+
+This is the evidence that withdrew the proposed `unset` and `abstract-variants` schema additions from PR #1142: once the rule sits in the right layer, nothing needs to clear an inherited field.
+
+## Todo
+
+- [x] Derive per-type title treatment from the oracle rather than guessing
+- [x] Move rendering policy to options.titles with type-mapping
+- [x] Delete redundant variants; convert the rest to diffs
+- [x] just pre-commit
+- [x] Full embedded sweep vs baseline
+- [ ] CI green

--- a/crates/citum-schema-style/embedded/styles/ieee.yaml
+++ b/crates/citum-schema-style/embedded/styles/ieee.yaml
@@ -28,7 +28,38 @@ options:
     initialize-with: ". "
     demote-non-dropping-particle: sort-only
   dates: short
-  titles: humanities
+  # Title rendering is a category-level policy, not a per-component one: the
+  # engine keys it by reference type, and the substitute chain (a title standing
+  # in for a missing author) reads it too — a template `wrap:` can never reach
+  # that path. Component titles are quoted; standalone works are italicised.
+  titles:
+    # Keys are canonical Citum ref-type names (`Reference::ref_type`), which are
+    # hyphenated — `type-mapping` is looked up verbatim and does not normalise
+    # the CSL underscore spellings.
+    type-mapping:
+      # IEEE quotes theses and reports; the default table treats both as
+      # monographs, which would italicise them instead.
+      thesis: component
+      report: component
+      # Standalone works IEEE italicises but the default table leaves
+      # uncategorised, so they would otherwise pick up `default`'s quotes.
+      legal-case: monograph
+      motion-picture: monograph
+      software: monograph
+      standard: monograph
+      statute: monograph
+    # IEEE quotes the title of the work itself and italicises only standalone
+    # monographs, so `default` quotes rather than falling through to bare.
+    default:
+      quote: true
+    component:
+      quote: true
+    monograph:
+      emph: true
+    periodical:
+      emph: true
+    serial:
+      emph: true
   punctuation-in-quote: true
 citation:
   options:
@@ -64,60 +95,10 @@ bibliography:
             number: pages
           label-form: short
     book:
-    - contributor: author
-      form: long
-      and: text
-      name-order: given-first
-      shorten:
-        min: 7
-        use-first: 1
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: edition
-    - number: volume
-      prefix: ", vol. "
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher-place
-      prefix: ". "
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - date: issued
-      form: year
-    - variable: doi
-      prefix: ", doi: "
-    - variable: url
-    broadcast:
-    - contributor: author
-      form: long
-      and: text
-      name-order: given-first
-      shorten:
-        min: 7
-        use-first: 1
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: edition
-    - number: volume
-      prefix: ", vol. "
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - date: issued
-      form: year
-    - variable: doi
-      prefix: ", doi: "
-    - variable: url
+      modify:
+        - match:
+            variable: publisher-place
+          prefix: ". "
     chapter:
     - contributor: author
       form: long
@@ -150,69 +131,18 @@ bibliography:
       form: year
     - number: pages
       label-form: short
-    dataset:
-    - contributor: author
-      form: long
-      and: text
-      name-order: given-first
-      shorten:
-        min: 7
-        use-first: 1
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: edition
-    - number: volume
-      prefix: ", vol. "
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - date: issued
-      form: year
-    - variable: doi
-      prefix: ", doi: "
-    - variable: url
     entry-encyclopedia:
-      extends: broadcast
       modify:
         - match:
             number: pages
           label-form: short
     motion-picture:
-    - contributor: author
-      form: long
-      and: text
-      name-order: given-first
-      shorten:
-        min: 7
-        use-first: 1
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: edition
-    - number: volume
-      prefix: ", vol. "
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - date: issued
-      form: year
-      wrap:
-        punctuation: parentheses
-      prefix: ", "
-    - variable: doi
-      prefix: ", doi: "
-    - variable: url
+      modify:
+        - match:
+            date: issued
+          prefix: ", "
+          wrap:
+            punctuation: parentheses
     paper-conference:
     - contributor: author
       form: long
@@ -249,62 +179,6 @@ bibliography:
     - number: patent-number
     - date: issued
       form: full
-    personal_communication:
-    - contributor: author
-      form: long
-      and: text
-      name-order: given-first
-      shorten:
-        min: 7
-        use-first: 1
-    - title: primary
-      wrap:
-        punctuation: quotes
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: edition
-    - number: volume
-      prefix: ", vol. "
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - date: issued
-      form: year
-    - variable: doi
-      prefix: ", doi: "
-    - variable: url
-    report:
-    - contributor: author
-      form: long
-      and: text
-      name-order: given-first
-      shorten:
-        min: 7
-        use-first: 1
-    - title: primary
-    - title: parent-monograph
-      emph: true
-    - title: parent-serial
-      emph: true
-    - number: edition
-    - number: volume
-      prefix: ", vol. "
-    - number: issue
-      prefix: ", no. "
-    - variable: publisher-place
-    - variable: publisher
-      prefix: ": "
-    - number: pages
-    - date: issued
-      form: year
-    - variable: doi
-      prefix: ", doi: "
-    - variable: url
     thesis:
     - contributor: author
       form: long
@@ -339,8 +213,6 @@ bibliography:
       min: 7
       use-first: 1
   - title: primary
-    wrap:
-      punctuation: quotes
   - title: parent-monograph
     emph: true
   - title: parent-serial


### PR DESCRIPTION
**Moves a category-level policy out of the template layer, where it never belonged.** `361 → 233` lines, parity-neutral.

## The problem

`ieee.yaml` set `titles: humanities` — a preset whose `component` rendering is **plain** — then compensated by hardcoding `wrap: { punctuation: quotes }` on the base `title: primary`. That applies to *every* reference type, so six near-identical type-variants existed purely to take the quotes back off: `broadcast`, `dataset`, `report`, `motion-picture`, `book`, and `personal_communication` (which was **byte-identical to the base template**).

A `TitlePreset::Ieee` already exists and quotes component titles. The style was using the wrong one.

## Why the template was the wrong layer

The engine keys title rendering by reference type — and the **substitute chain reads the same config**. `resolve_author_substitute` (`values/contributor/substitute.rs:879`) threads the contributor component's `Rendering` into the *contributor* branches, but the title branch deliberately does not. Its own doc comment:

> The substitute chain has no `TemplateTitle` to carry a per-component `text-case:` override, so only the style's category-level `titles:` config applies here.

So a template `wrap:` could **never** reach a title standing in for a missing author. One `titles:` declaration reaches both paths.

## What changed

- `titles: humanities` → explicit category config with `type-mapping`.
- Deleted `wrap: quotes` from the base template.
- Deleted the four variants that existed only to undo it.
- Converted `book`, `motion-picture`, `entry-encyclopedia` from full templates to `modify` diffs — with the wrap gone they differ from the base only by *additions*, which `modify` already expresses.

**Per-type treatment is derived from the oracle, not guessed.** I extracted how citeproc-js renders each type's primary title across the corpus; IEEE quotes nearly everything and italicises only standalone monographs. `type-mapping` records exactly the seven types where that departs from the default table — including that `report` and `thesis` are quoted (the default table calls them monographs) and `motion-picture` is italic.

## Evidence

| | before | after |
|---|---|---|
| ieee exact parity | 95/149 | **95/149** |
| ieee fidelity | 1.0 | **1.0** |
| full embedded sweep | 1558 | **1559** |

Zero regressions. The +1 is `american-society-of-mechanical-engineers` (4/67 → 5/67), whose **direct parent is ieee** — inherited, not incidental.

`just pre-commit`: 2397 tests, 0 failures.

## Why this matters beyond ieee

This is the evidence that **withdrew two proposed schema additions** from #1142. That PR proposed `unset` (let a `modify` clear an inherited rendering field) and `abstract-variants`, justified by ieee's copy-paste. Once the rule sits in the right layer, nothing needs clearing — the remaining diffs are pure additions. Across all 32 embedded styles, the measured demand for `unset` was 5 occurrences of one field, all ieee, all of them this workaround.

## Follow-ups filed, not folded in

- `csl26-q4g5` — the `all` type-variant selector is resolved **first-match-in-authored-order** with no specificity ordering, silently shadowing **16 type-variants** in `elsevier-with-titles-core` (27/67 parity). Confirmed from rendered output.
- `csl26-8u5i` — `Style.templates` ("Named reusable templates") is declared, validated, merged, and **never resolved** by any reference form.

**Also worth a decision, currently undocumented:** `titles.type-mapping` keys are looked up with a plain `HashMap::get` against `Reference::ref_type()`, so an underscore spelling silently never matches — even though the *same* type name works as a `type-variants` key, where `TypeSelector` normalizes it. `validate_type_name` already normalizes and `TitleCategory` is already an enum; `type_mapping` is `HashMap<String, String>` and is validated nowhere. A wrong key or a wrong category value both fail silently. This PR works around it with a comment; the field itself still bypasses both vocabularies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
