### PR TITLE
docs(spec): define typed title mappings

### DIFF
--- a/.beans/csl26-0h05--type-titlestype-mapping-keys-and-categories.md
+++ b/.beans/csl26-0h05--type-titlestype-mapping-keys-and-categories.md
@@ -1,0 +1,26 @@
+---
+# csl26-0h05
+title: Type titles.type-mapping keys and categories
+status: in-progress
+type: bug
+priority: high
+tags:
+    - schema
+    - engine
+created_at: 2026-08-05T15:00:51Z
+updated_at: 2026-08-05T15:02:31Z
+---
+
+`titles.type-mapping` currently stores both reference-type keys and title-category values as unchecked strings. Typos silently miss or fall through to default rendering.
+
+Spec: `docs/specs/TYPED_TITLE_MAPPING.md`
+Related: PR #1142 (superseded), PR #1143 (style-layering evidence)
+
+## Acceptance Criteria
+
+- [x] Specify typed mapping, normalization, validation, inheritance, and forward-compatibility behavior.
+- [ ] Parse category values through `TitleCategory` and reject invalid values.
+- [ ] Normalize underscore keys and warn for unknown future reference types.
+- [ ] Reject duplicate keys after normalization.
+- [ ] Make engine and migration logic consume typed categories exhaustively.
+- [ ] Regenerate schemas and pass the repository pre-commit gate.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -130,6 +130,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 |------|--------|-------|
 | [`TYPE_REFACTOR_v3.md`](./TYPE_REFACTOR_v3.md) — unified type system refactor for high-fidelity work modeling | Active | `metadata.rs`, `domain_fixtures.rs` |
 | [`TYPE_SYSTEM_ARCHITECTURE.md`](./TYPE_SYSTEM_ARCHITECTURE.md) — overall type system architecture and classification hierarchy | Draft | `crates/citum-schema/tests/` |
+| [`TYPED_TITLE_MAPPING.md`](./TYPED_TITLE_MAPPING.md) — normalized reference-type keys and closed title-rendering categories | Draft | `crates/citum-schema-style/src/tests.rs`, `citum-engine::render::component` |
 | [`INPUT_REFERENCE_CLASS_DISCRIMINATOR.md`](./INPUT_REFERENCE_CLASS_DISCRIMINATOR.md) — discriminated union for reference-class dispatch | Active | `crates/citum-schema/tests/` |
 | [`CSL_TYPE_CONVERSION_CONTRACT.md`](./CSL_TYPE_CONVERSION_CONTRACT.md) — CSL 1.0.2 type vocabulary, routing closure, and note-override validation | Active | `crates/citum-schema-data/src/reference/conversion/contract_tests.rs` |
 | [`GENERALIZED_RELATIONAL_CONTAINER_MODEL.md`](./GENERALIZED_RELATIONAL_CONTAINER_MODEL.md) — recursive relational container model replacing flat variables | Active | `metadata.rs` |

--- a/docs/specs/TEMPLATE_V3.md
+++ b/docs/specs/TEMPLATE_V3.md
@@ -1,8 +1,8 @@
 # Template Schema v3 Specification
 
 **Status:** Active
-**Version:** 0.5
-**Date:** 2026-06-24
+**Version:** 0.6
+**Date:** 2026-08-05
 **Supersedes:** `docs/specs/TEMPLATE_V2.md`
 **Related:** csl26-t3v1, `docs/specs/DISTRIBUTED_RESOLVER.md`
 
@@ -302,12 +302,39 @@ bibliography:
 
 Engines SHOULD treat unreachable or invalid parent URIs as resolution errors; style authors MUST NOT assume offline resolution if remote parents are unavailable.
 
+### §5 — Templates Own Structure; Options Own Rendering Policy
+
+Templates own which components appear and in what order. Rendering policy that
+varies by what kind of work a reference is, especially title quoting, emphasis,
+and text case, belongs in `options.titles`, keyed by reference type through
+`type-mapping`.
+
+This is a behavioral boundary, not an authoring preference. When a title
+substitutes for a missing contributor, there is no `TemplateTitle` from which
+to inherit component-local rendering. The substitute path therefore resolves
+title rendering from `options.titles`. A template-level quote wrapper can make
+the ordinary title look correct while leaving the substituted title wrong.
+
+```yaml
+options:
+  titles:
+    type-mapping: { thesis: component, report: component }
+    component: { quote: true }
+    monograph: { emph: true }
+```
+
+Style authors SHOULD use template rendering only for policy local to that
+specific template position. See
+[`TYPED_TITLE_MAPPING.md`](./TYPED_TITLE_MAPPING.md) for the mapping's typed
+contract.
+
 ---
 
 ## Acceptance Criteria
 
 - [x] Macros are absent from the spec.
 - [ ] `type-variants` schema supports `extends`, `modify`, `add`, and `remove` with defined matching and ordering semantics.
+- [ ] Title quoting, emphasis, and text case are expressible once in `options.titles` for every reference type.
 - [ ] Style-level `options` expanded to handle contributor and date formatting policies, with clear precedence rules vs local component hints.
 - [ ] Engine resolution logic supports cross-URI template diffing, including recursive parent chains and error handling for missing parents.
 
@@ -315,6 +342,8 @@ Engines SHOULD treat unreachable or invalid parent URIs as resolution errors; st
 
 ## Changelog
 
+- v0.6 (2026-08-05): State the boundary between structural templates and
+  category-level title rendering policy.
 - v0.5 (2026-07-15): Clarify family inheritance, forbid named cross-section
   fragments, define authoritative date-fallback omission semantics, and allow
   narrowly scoped style-owned MF2 messages for textual classification.

--- a/docs/specs/TYPED_TITLE_MAPPING.md
+++ b/docs/specs/TYPED_TITLE_MAPPING.md
@@ -1,0 +1,123 @@
+# Typed Title Mapping Specification
+
+**Status:** Draft
+**Version:** 1.0
+**Date:** 2026-08-05
+**Supersedes:** The `titles.type-mapping` open question in PR #1142
+**Related:** bean `csl26-0h05`, PR #1143,
+[`TYPE_CLASSIFICATION_CENTRALIZATION.md`](./TYPE_CLASSIFICATION_CENTRALIZATION.md),
+[`FORWARD_COMPATIBILITY.md`](./FORWARD_COMPATIBILITY.md)
+
+## Purpose
+
+Make `options.titles.type-mapping` a checked boundary between reference types
+and title-rendering categories. The current `HashMap<String, String>` accepts
+misspelled keys and values, then silently either misses the lookup or falls
+back to default rendering. The mapping began as a mechanical replacement for
+processor hardcoding before `TitleCategory` existed; that historical shape is
+not an extensibility contract.
+
+## Scope
+
+In scope:
+
+- A normalized reference-type key that preserves forward-compatible unknown
+  types while making lookup spelling consistent.
+- A closed `TitleCategory` value vocabulary.
+- Validation, inheritance, and serialization behavior for the mapping.
+- Shared typed consumption by the engine and migration refinement.
+
+Out of scope:
+
+- Changing the default reference-type classification tables.
+- Changing rendered output for valid existing styles.
+- Template type-variant precedence, locale vocabulary overrides, or new title
+  categories.
+
+## Design
+
+### Typed shape
+
+`TitlesConfig.type_mapping` has this public Rust shape:
+
+```rust
+Option<HashMap<ReferenceTypeName, TitleCategory>>
+```
+
+`ReferenceTypeName` is an owned string newtype because reference inputs can
+carry classes introduced by a newer schema. It normalizes `_` to `-` during
+construction and deserialization, exposes its canonical spelling for lookup,
+and serializes in canonical kebab-case. It is not a closed enum.
+
+`TitleCategory` is the closed rendering-policy vocabulary:
+
+- `component`
+- `monograph`
+- `periodical`
+- `serial`
+- `container-monograph`
+- `default`
+
+The legacy input spelling `collection` deserializes as
+`container-monograph`; serialization always emits `container-monograph`.
+Any other category value is a parse error rather than a silent fallback.
+
+### Key validation and lookup
+
+Known reference-type names share one authoritative vocabulary with template
+type-selector validation. `all` and `default` remain selector keywords and are
+not reference-type names.
+
+Unknown canonical keys remain loadable for forward compatibility, but
+`Style::validate` emits `SchemaWarning::UnknownTypeName` at
+`options.titles.type-mapping`. This distinguishes an intentional future type
+from a likely typo without preventing an older engine from loading the style.
+
+Lookup compares canonical spellings. Consequently, an authored
+`personal_communication` key matches the engine's
+`personal-communication` reference type. Two keys in one authored mapping
+that normalize to the same spelling are a parse error; authored order must not
+silently choose a winner.
+
+### Inheritance
+
+Existing `TitlesConfig` inheritance is unchanged:
+
+- omission leaves the inherited mapping untouched;
+- `type-mapping: ~` clears it;
+- a non-null child mapping merges by canonical reference-type key, with child
+  values replacing matching parent values.
+
+Normalization occurs before merge, so underscore and kebab spellings cannot
+create two effective entries for one reference type.
+
+### Rendering and migration
+
+The engine and `citum-migrate` consume `TitleCategory` values directly and
+match them exhaustively. They must not convert the value back to a string.
+Existing per-title-position fallback behavior remains unchanged: a category
+that does not apply to the current title position uses that position's current
+fallback.
+
+## Implementation Notes
+
+- Place `ReferenceTypeName` and the shared known-name vocabulary in
+  `citum-schema-style`; re-export the type through the `citum-schema` facade.
+- Keep `TypeSelector`'s public shape unchanged, but route its validation and
+  normalization through the same helpers.
+- Use a custom map deserializer so normalization collisions are detected before
+  a `HashMap` overwrites an earlier entry.
+- Regenerate the checked-in style schemas in the implementation commit.
+
+## Acceptance Criteria
+
+- [ ] Invalid title-category values fail style parsing with the offending value.
+- [ ] Underscore-spelled mapping keys resolve against canonical kebab-case reference types.
+- [ ] Unknown reference-type keys load and produce a location-specific validation warning.
+- [ ] Duplicate keys after normalization fail style parsing.
+- [ ] Valid existing embedded styles render identically before and after the change.
+- [ ] Engine rendering and migration refinement agree for every title category and title position.
+
+## Changelog
+
+- v1.0 (2026-08-05): Initial specification.


### PR DESCRIPTION
## Stack

Part 1 of 2 in stack #1146. The implementation is #1145.

## Why

PR #1142 correctly identified `titles.type-mapping` as a style-owned policy
layer, but mixed that point with broader precedence, locale, and authoring
questions. This PR keeps the useful layering rationale and gives the actual
type-safety bug a focused contract.

The current public Rust shape is `HashMap<String, String>`. Category values are
therefore accepted by Serde without validation, while misspelled keys silently
miss lookup. That is accidental permissiveness, not an extensibility contract.

## What this layer specifies

- Open, normalized `ReferenceTypeName` keys for forward compatibility.
- Closed `TitleCategory` values with `collection` as a compatibility alias.
- Warnings for unknown future type names and errors for invalid categories or
  duplicate keys after normalization.
- Existing inheritance and per-title-position fallback behavior.
- Typed, exhaustive consumption by the engine and migration refinement.

The bug is tracked by bean `csl26-0h05`. The focused boundary note in the
Template V3 spec explains why title classification belongs here without
expanding this PR into a general precedence redesign.

## Deliberately excluded

- `all` precedence, which remains under `csl26-q4g5` and #1143.
- Locale vocabulary overrides.
- Presets-versus-macros material.
- Unrelated bean changes from #1142.

## Validation

- Repository bean hygiene passes; two unrelated soft-stale advisories remain.
- `git diff --check` passes.
- The implementation layer activates every acceptance criterion in #1145.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>.</sub>
