### PR TITLE
fix(schema)!: type title category mappings

### DIFF
--- a/.beans/csl26-0h05--type-titlestype-mapping-keys-and-categories.md
+++ b/.beans/csl26-0h05--type-titlestype-mapping-keys-and-categories.md
@@ -8,7 +8,7 @@ tags:
     - schema
     - engine
 created_at: 2026-08-05T15:00:51Z
-updated_at: 2026-08-05T15:02:31Z
+updated_at: 2026-08-05T15:35:08Z
 ---
 
 `titles.type-mapping` currently stores both reference-type keys and title-category values as unchecked strings. Typos silently miss or fall through to default rendering.
@@ -19,8 +19,8 @@ Related: PR #1142 (superseded), PR #1143 (style-layering evidence)
 ## Acceptance Criteria
 
 - [x] Specify typed mapping, normalization, validation, inheritance, and forward-compatibility behavior.
-- [ ] Parse category values through `TitleCategory` and reject invalid values.
-- [ ] Normalize underscore keys and warn for unknown future reference types.
-- [ ] Reject duplicate keys after normalization.
-- [ ] Make engine and migration logic consume typed categories exhaustively.
-- [ ] Regenerate schemas and pass the repository pre-commit gate.
+- [x] Parse category values through `TitleCategory` and reject invalid values.
+- [x] Normalize underscore keys and warn for unknown future reference types.
+- [x] Reject duplicate keys after normalization.
+- [x] Make engine and migration logic consume typed categories exhaustively.
+- [x] Regenerate schemas and pass the repository pre-commit gate.

--- a/crates/citum-engine/src/render/component.rs
+++ b/crates/citum-engine/src/render/component.rs
@@ -468,27 +468,23 @@ pub fn get_title_category_title_rendering(
 ) -> Option<TitleRendering> {
     let titles_config = config.titles.as_ref()?;
 
-    // Use type_mapping if available to resolve category
-    let mapped_category = ref_type.and_then(|rt| {
-        titles_config
-            .type_mapping
-            .as_ref()
-            .and_then(|mapping| mapping.get(rt))
-    });
+    let mapped_category = ref_type.and_then(|rt| titles_config.mapped_category(rt));
 
     use crate::values::type_class::TitleCategory;
 
     let rendering = match title_type {
         TitleType::ContainerTitle => {
             if let Some(cat) = mapped_category {
-                match cat.as_str() {
-                    "periodical" => titles_config.periodical.as_ref(),
-                    "serial" => titles_config.serial.as_ref(),
-                    "monograph" | "collection" => titles_config
+                match cat {
+                    TitleCategory::Periodical => titles_config.periodical.as_ref(),
+                    TitleCategory::Serial => titles_config.serial.as_ref(),
+                    TitleCategory::Monograph | TitleCategory::ContainerMonograph => titles_config
                         .container_monograph
                         .as_ref()
                         .or(titles_config.monograph.as_ref()),
-                    _ => titles_config.default.as_ref(),
+                    TitleCategory::Component | TitleCategory::Default => {
+                        titles_config.default.as_ref()
+                    }
                 }
             } else if let Some(rt) = ref_type {
                 match crate::values::type_class::container_title_category(rt) {
@@ -505,10 +501,13 @@ pub fn get_title_category_title_rendering(
         }
         TitleType::ParentSerial => {
             if let Some(cat) = mapped_category {
-                match cat.as_str() {
-                    "periodical" => titles_config.periodical.as_ref(),
-                    "serial" => titles_config.serial.as_ref(),
-                    _ => titles_config.periodical.as_ref(),
+                match cat {
+                    TitleCategory::Periodical => titles_config.periodical.as_ref(),
+                    TitleCategory::Serial => titles_config.serial.as_ref(),
+                    TitleCategory::Component
+                    | TitleCategory::Monograph
+                    | TitleCategory::ContainerMonograph
+                    | TitleCategory::Default => titles_config.periodical.as_ref(),
                 }
             } else if let Some(rt) = ref_type {
                 match crate::values::type_class::parent_serial_title_category(rt) {
@@ -530,10 +529,13 @@ pub fn get_title_category_title_rendering(
             .or(titles_config.default.as_ref()),
         TitleType::Primary => {
             if let Some(cat) = mapped_category {
-                match cat.as_str() {
-                    "component" => titles_config.component.as_ref(),
-                    "monograph" => titles_config.monograph.as_ref(),
-                    _ => titles_config.default.as_ref(),
+                match cat {
+                    TitleCategory::Component => titles_config.component.as_ref(),
+                    TitleCategory::Monograph => titles_config.monograph.as_ref(),
+                    TitleCategory::Periodical
+                    | TitleCategory::Serial
+                    | TitleCategory::ContainerMonograph
+                    | TitleCategory::Default => titles_config.default.as_ref(),
                 }
             } else if let Some(rt) = ref_type {
                 match crate::values::type_class::title_category(rt) {
@@ -648,5 +650,23 @@ mod tests {
 
         let result = render_component(&component);
         assert_eq!(result, "(\u{201C}Title\u{201D})");
+    }
+
+    #[test]
+    fn underscore_title_mapping_key_matches_canonical_reference_type() {
+        let config: Config = serde_yaml::from_str(
+            "titles:\n  type-mapping:\n    personal_communication: component\n  component:\n    quote: true\n",
+        )
+        .expect("title configuration should parse");
+
+        let rendering = get_title_category_title_rendering(
+            &TitleType::Primary,
+            Some("personal-communication"),
+            None,
+            &config,
+        )
+        .expect("the normalized mapping should select component rendering");
+
+        assert_eq!(rendering.quote, Some(true));
     }
 }

--- a/crates/citum-migrate/src/passes/sqi_refinement.rs
+++ b/crates/citum-migrate/src/passes/sqi_refinement.rs
@@ -408,24 +408,19 @@ fn effective_title_rendering(
         TitleDefaultContext::Unknown => return None,
     };
     let titles = options.titles.as_ref()?;
-    let mapped_category = ref_type.and_then(|rt| {
-        titles
-            .type_mapping
-            .as_ref()
-            .and_then(|mapping| mapping.get(rt))
-    });
+    let mapped_category = ref_type.and_then(|rt| titles.mapped_category(rt));
 
     let rendering = match title_type {
         TitleType::ContainerTitle => {
             if let Some(category) = mapped_category {
-                match category.as_str() {
-                    "periodical" => titles.periodical.as_ref(),
-                    "serial" => titles.serial.as_ref(),
-                    "monograph" | "collection" => titles
+                match category {
+                    TitleCategory::Periodical => titles.periodical.as_ref(),
+                    TitleCategory::Serial => titles.serial.as_ref(),
+                    TitleCategory::Monograph | TitleCategory::ContainerMonograph => titles
                         .container_monograph
                         .as_ref()
                         .or(titles.monograph.as_ref()),
-                    _ => titles.default.as_ref(),
+                    TitleCategory::Component | TitleCategory::Default => titles.default.as_ref(),
                 }
             } else if let Some(ref_type) = ref_type {
                 match container_title_category(ref_type) {
@@ -442,10 +437,13 @@ fn effective_title_rendering(
         }
         TitleType::ParentSerial => {
             if let Some(category) = mapped_category {
-                match category.as_str() {
-                    "periodical" => titles.periodical.as_ref(),
-                    "serial" => titles.serial.as_ref(),
-                    _ => titles.periodical.as_ref(),
+                match category {
+                    TitleCategory::Periodical => titles.periodical.as_ref(),
+                    TitleCategory::Serial => titles.serial.as_ref(),
+                    TitleCategory::Component
+                    | TitleCategory::Monograph
+                    | TitleCategory::ContainerMonograph
+                    | TitleCategory::Default => titles.periodical.as_ref(),
                 }
             } else if let Some(ref_type) = ref_type {
                 match parent_serial_title_category(ref_type) {
@@ -467,10 +465,13 @@ fn effective_title_rendering(
             .or(titles.default.as_ref()),
         TitleType::Primary => {
             if let Some(category) = mapped_category {
-                match category.as_str() {
-                    "component" => titles.component.as_ref(),
-                    "monograph" => titles.monograph.as_ref(),
-                    _ => titles.default.as_ref(),
+                match category {
+                    TitleCategory::Component => titles.component.as_ref(),
+                    TitleCategory::Monograph => titles.monograph.as_ref(),
+                    TitleCategory::Periodical
+                    | TitleCategory::Serial
+                    | TitleCategory::ContainerMonograph
+                    | TitleCategory::Default => titles.default.as_ref(),
                 }
             } else if let Some(ref_type) = ref_type {
                 match title_category(ref_type) {
@@ -617,8 +618,8 @@ mod tests {
     use citum_engine::{Processor, reference::Bibliography};
     use citum_schema::{
         options::{
-            NameForm, RoleOptions, RoleRendering, TextCase, TitleRendering, TitlesConfig,
-            classified_ref_types,
+            NameForm, ReferenceTypeName, RoleOptions, RoleRendering, TextCase, TitleCategory,
+            TitleRendering, TitlesConfig, classified_ref_types,
         },
         template::{
             ContributorForm, ContributorRole, TemplateGroup, TemplateTitle, TemplateVariable,
@@ -989,7 +990,10 @@ mod tests {
             TemplateVariant::Full(vec![container_title(Some(TextCase::SentenceApa))]),
         );
         let mut type_mapping = std::collections::HashMap::new();
-        type_mapping.insert("article-journal".to_string(), "periodical".to_string());
+        type_mapping.insert(
+            ReferenceTypeName::from("article-journal"),
+            TitleCategory::Periodical,
+        );
         let style = Style {
             options: Some(citum_schema::options::Config {
                 titles: Some(TitlesConfig {
@@ -1329,6 +1333,81 @@ mod tests {
                 after, before,
                 "ref_type={ref_type} title_type={title_type:?}"
             );
+        }
+    }
+
+    #[test]
+    fn mapped_title_categories_agree_between_engine_and_migration() {
+        let categories = [
+            TitleCategory::Component,
+            TitleCategory::Monograph,
+            TitleCategory::Periodical,
+            TitleCategory::Serial,
+            TitleCategory::ContainerMonograph,
+            TitleCategory::Default,
+        ];
+        let title_types = [
+            TitleType::Primary,
+            TitleType::ContainerTitle,
+            TitleType::ParentSerial,
+        ];
+
+        for category in categories {
+            let titles = TitlesConfig {
+                type_mapping: Some(std::collections::HashMap::from([(
+                    ReferenceTypeName::from("article-journal"),
+                    category,
+                )])),
+                component: Some(TitleRendering {
+                    text_case: Some(TextCase::Title),
+                    ..TitleRendering::default()
+                }),
+                monograph: Some(TitleRendering {
+                    text_case: Some(TextCase::SentenceApa),
+                    ..TitleRendering::default()
+                }),
+                container_monograph: Some(TitleRendering {
+                    text_case: Some(TextCase::SentenceNlm),
+                    ..TitleRendering::default()
+                }),
+                periodical: Some(TitleRendering {
+                    text_case: Some(TextCase::Uppercase),
+                    ..TitleRendering::default()
+                }),
+                serial: Some(TitleRendering {
+                    text_case: Some(TextCase::Lowercase),
+                    ..TitleRendering::default()
+                }),
+                default: Some(TitleRendering {
+                    text_case: Some(TextCase::CapitalizeFirst),
+                    ..TitleRendering::default()
+                }),
+                ..TitlesConfig::default()
+            };
+            let options = citum_schema::options::Config {
+                titles: Some(titles),
+                ..citum_schema::options::Config::default()
+            };
+
+            for title_type in &title_types {
+                let engine = citum_engine::render::component::get_title_category_title_rendering(
+                    title_type,
+                    Some("article-journal"),
+                    None,
+                    &options,
+                )
+                .map(|rendering| rendering.to_rendering());
+                let migration = effective_title_rendering(
+                    title_type,
+                    TitleDefaultContext::RefType("article-journal"),
+                    &options,
+                );
+
+                assert_eq!(
+                    migration, engine,
+                    "category={category:?} title_type={title_type:?}"
+                );
+            }
         }
     }
 

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -73,7 +73,7 @@ pub use grouping::{
 };
 pub use locale::Locale;
 pub use options::TextCase;
-pub use options::{BibliographyOptions, CitationOptions, Config};
+pub use options::{BibliographyOptions, CitationOptions, Config, ReferenceTypeName, TitleCategory};
 pub use presets::{ContributorPreset, DatePreset, SortPreset, SubstitutePreset, TitlePreset};
 pub use registry::{RegistryEntry, StyleRegistry};
 pub use style::{

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -598,8 +598,8 @@ pub enum PageRangeFormat {
 pub mod titles;
 
 pub use title_class::{
-    TitleCategory, classified_ref_types, container_title_category, parent_serial_title_category,
-    title_category,
+    KNOWN_REFERENCE_TYPE_NAMES, ReferenceTypeName, TitleCategory, classified_ref_types,
+    container_title_category, parent_serial_title_category, title_category,
 };
 pub use titles::{TextCase, TitleRendering, TitlesConfig, TitlesConfigEntry};
 

--- a/crates/citum-schema-style/src/options/title_class.rs
+++ b/crates/citum-schema-style/src/options/title_class.rs
@@ -16,6 +16,121 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! `docs/architecture/audits/2026-07-06_CITUM_MIGRATE_REVIEW.md` (Finding F1)
 //! for why it moved here.
 
+#[cfg(feature = "schema")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::borrow::Borrow;
+
+/// Canonical reference-type names understood by the current style schema.
+///
+/// Unknown names remain valid inputs for forward compatibility, but style
+/// validation warns about them. Template selector keywords such as `all` and
+/// `default` are deliberately excluded because they are not reference types.
+pub const KNOWN_REFERENCE_TYPE_NAMES: &[&str] = &[
+    "book",
+    "manual",
+    "report",
+    "thesis",
+    "webpage",
+    "map",
+    "post",
+    "interview",
+    "manuscript",
+    "personal-communication",
+    "document",
+    "chapter",
+    "entry-dictionary",
+    "paper-conference",
+    "article-journal",
+    "article-magazine",
+    "article-newspaper",
+    "broadcast",
+    "collection",
+    "legal-case",
+    "statute",
+    "treaty",
+    "hearing",
+    "regulation",
+    "brief",
+    "classic",
+    "patent",
+    "dataset",
+    "standard",
+    "software",
+    "motion-picture",
+];
+
+/// A canonical reference-type name used as a style-configuration key.
+///
+/// The vocabulary is intentionally open for forward compatibility. Values
+/// normalize underscores to hyphens so authoring spellings match the
+/// kebab-case strings returned by the reference model.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+pub struct ReferenceTypeName(String);
+
+impl ReferenceTypeName {
+    /// Construct a canonical reference-type name.
+    #[must_use]
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into().replace('_', "-"))
+    }
+
+    /// Return the canonical kebab-case spelling.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Return whether this engine version recognizes the reference type.
+    #[must_use]
+    pub fn is_known(&self) -> bool {
+        KNOWN_REFERENCE_TYPE_NAMES.contains(&self.as_str())
+    }
+}
+
+impl Borrow<str> for ReferenceTypeName {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for ReferenceTypeName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<String> for ReferenceTypeName {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<&str> for ReferenceTypeName {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Serialize for ReferenceTypeName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ReferenceTypeName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer).map(Self::new)
+    }
+}
+
 /// Title-category buckets used to select which `TitlesConfig` rendering
 /// applies to a title component when the style has no explicit
 /// `titles.type_mapping` entry for the reference's type.
@@ -26,7 +141,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 /// (behavior-preserving centralization), not flattened into one shared
 /// table. See `title_category`, `container_title_category`, and
 /// `parent_serial_title_category`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum TitleCategory {
     /// Titles of works contained in a larger work (articles, chapters, entries).
     Component,
@@ -37,9 +153,33 @@ pub enum TitleCategory {
     /// Titles of serials, when distinguished from periodicals proper.
     Serial,
     /// Titles of monographic containers (books containing chapters).
+    #[serde(alias = "collection")]
     ContainerMonograph,
     /// No specific category; use the style's default title rendering.
     Default,
+}
+
+#[cfg(feature = "schema")]
+impl JsonSchema for TitleCategory {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "TitleCategory".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        schemars::json_schema!({
+            "description": "Closed title-rendering category vocabulary. `collection` is accepted as a compatibility alias for `container-monograph`.",
+            "type": "string",
+            "enum": [
+                "component",
+                "monograph",
+                "periodical",
+                "serial",
+                "container-monograph",
+                "collection",
+                "default"
+            ]
+        })
+    }
 }
 
 /// Resolve the default title category for a reference type.

--- a/crates/citum-schema-style/src/options/titles.rs
+++ b/crates/citum-schema-style/src/options/titles.rs
@@ -5,8 +5,11 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 #[cfg(feature = "schema")]
 use schemars::JsonSchema;
+use serde::de::Error as _;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+use super::{ReferenceTypeName, TitleCategory};
 
 /// Text-case transform applied to title-like fields.
 ///
@@ -71,14 +74,20 @@ impl TitlesConfigEntry {
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub struct TitlesConfig {
-    /// Mapping of reference types to title categories.
-    /// Category keys: monograph, periodical, component.
+    /// Mapping of canonical reference types to title categories.
+    ///
+    /// Unknown reference types are retained for forward compatibility and
+    /// reported by style validation. Category values are a closed vocabulary.
     /// Example: { "thesis": "monograph", "article-journal": "periodical" }
     /// `None` means "not configured at this level" and will not override an
     /// inherited value; explicit `type-mapping: ~` clears an inherited
     /// mapping entirely (see `docs/specs/STYLE_INHERITANCE.md`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub type_mapping: Option<HashMap<String, String>>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_type_mapping",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub type_mapping: Option<HashMap<ReferenceTypeName, TitleCategory>>,
     /// Formatting for component titles (articles, chapters).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component: Option<TitleRendering>,
@@ -110,6 +119,62 @@ pub struct TitlesConfig {
     )]
     #[cfg_attr(feature = "schema", schemars(skip))]
     pub unknown_fields: std::collections::BTreeMap<String, serde_yaml::Value>,
+}
+
+impl TitlesConfig {
+    /// Return the authored category for a reference type, using canonical
+    /// underscore-to-hyphen normalization for lookup.
+    #[must_use]
+    pub fn mapped_category(&self, reference_type: &str) -> Option<TitleCategory> {
+        let key = ReferenceTypeName::from(reference_type);
+        self.type_mapping.as_ref()?.get(key.as_str()).copied()
+    }
+}
+
+struct TypeMapping(HashMap<ReferenceTypeName, TitleCategory>);
+
+impl<'de> Deserialize<'de> for TypeMapping {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct TypeMappingVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for TypeMappingVisitor {
+            type Value = TypeMapping;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a reference-type to title-category mapping")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut result = HashMap::with_capacity(map.size_hint().unwrap_or(0));
+                while let Some((raw_key, category)) = map.next_entry::<String, TitleCategory>()? {
+                    let key = ReferenceTypeName::new(raw_key);
+                    if result.insert(key.clone(), category).is_some() {
+                        return Err(A::Error::custom(format!(
+                            "duplicate title type-mapping key `{key}` after normalization"
+                        )));
+                    }
+                }
+                Ok(TypeMapping(result))
+            }
+        }
+
+        deserializer.deserialize_map(TypeMappingVisitor)
+    }
+}
+
+fn deserialize_type_mapping<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<ReferenceTypeName, TitleCategory>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<TypeMapping>::deserialize(deserializer).map(|mapping| mapping.map(|value| value.0))
 }
 
 /// Rendering options for titles.
@@ -221,5 +286,82 @@ mod tests {
     fn test_title_case_preset_name_resolves_through_config_entry() {
         let entry: TitlesConfigEntry = serde_yaml::from_str("title-case").unwrap();
         assert_eq!(entry.resolve(), TitlePreset::TitleCase.config());
+    }
+
+    #[test]
+    fn type_mapping_rejects_invalid_category() {
+        let error = serde_yaml::from_str::<TitlesConfig>(
+            "type-mapping:\n  article-journal: not-a-title-category\n",
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("unknown variant `not-a-title-category`")
+        );
+    }
+
+    #[test]
+    fn type_mapping_normalizes_underscore_keys_for_lookup_and_serialization() {
+        let config: TitlesConfig =
+            serde_yaml::from_str("type-mapping:\n  personal_communication: component\n").unwrap();
+
+        assert_eq!(
+            config.mapped_category("personal-communication"),
+            Some(TitleCategory::Component)
+        );
+        assert_eq!(
+            serde_yaml::to_string(&config).unwrap(),
+            "type-mapping:\n  personal-communication: component\n"
+        );
+    }
+
+    #[test]
+    fn type_mapping_rejects_duplicate_keys_after_normalization() {
+        let error = serde_yaml::from_str::<TitlesConfig>(
+            "type-mapping:\n  article_journal: component\n  article-journal: periodical\n",
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("duplicate title type-mapping key `article-journal` after normalization")
+        );
+    }
+
+    #[test]
+    fn type_mapping_accepts_collection_as_container_monograph_alias() {
+        let config: TitlesConfig =
+            serde_yaml::from_str("type-mapping:\n  chapter: collection\n").unwrap();
+
+        assert_eq!(
+            config.mapped_category("chapter"),
+            Some(TitleCategory::ContainerMonograph)
+        );
+        assert_eq!(
+            serde_yaml::to_string(&config).unwrap(),
+            "type-mapping:\n  chapter: container-monograph\n"
+        );
+    }
+
+    #[cfg(feature = "schema")]
+    #[test]
+    fn title_category_schema_includes_collection_compatibility_alias() {
+        let schema = serde_json::to_value(schemars::schema_for!(TitleCategory)).unwrap();
+
+        assert_eq!(
+            schema.get("enum"),
+            Some(&serde_json::json!([
+                "component",
+                "monograph",
+                "periodical",
+                "serial",
+                "container-monograph",
+                "collection",
+                "default"
+            ]))
+        );
     }
 }

--- a/crates/citum-schema-style/src/style/validation.rs
+++ b/crates/citum-schema-style/src/style/validation.rs
@@ -39,7 +39,7 @@ impl std::fmt::Display for SchemaWarning {
                 write!(
                     f,
                     "unknown reference type \"{name}\" in {location} \
-                     (will silently match nothing; check for typos)"
+                     (may not match a reference; check for typos)"
                 )
             }
         }
@@ -83,7 +83,7 @@ impl Style {
     ///
     /// This method checks for issues that are syntactically valid but
     /// semantically suspect, such as unrecognized reference type names in
-    /// `TypeSelector` values.
+    /// selectors or title mappings.
     ///
     /// Warnings do not prevent rendering; they are informational only.
     pub fn validate(&self) -> Vec<SchemaWarning> {
@@ -94,6 +94,19 @@ impl Style {
 
     /// Collect warnings for all `TypeSelector` values in the style.
     fn collect_type_selector_warnings(&self, warnings: &mut Vec<SchemaWarning>) {
+        if let Some(type_mapping) = self
+            .options
+            .as_ref()
+            .and_then(|options| options.titles.as_ref())
+            .and_then(|titles| titles.type_mapping.as_ref())
+        {
+            for reference_type in type_mapping.keys().filter(|name| !name.is_known()) {
+                warnings.push(SchemaWarning::UnknownTypeName {
+                    name: reference_type.to_string(),
+                    location: "options.titles.type-mapping".to_string(),
+                });
+            }
+        }
         if let Some(bib) = &self.bibliography
             && let Some(type_variants) = &bib.type_variants
         {

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -293,43 +293,9 @@ impl From<WrapPunctuation> for WrapConfig {
 
 /// Canonical reference type names recognized by the Citum engine.
 ///
-/// Used by [`validate_type_name`] to detect likely typos.
-pub const VALID_TYPE_NAMES: &[&str] = &[
-    "book",
-    "manual",
-    "report",
-    "thesis",
-    "webpage",
-    "map",
-    "post",
-    "interview",
-    "manuscript",
-    "personal-communication",
-    "document",
-    "chapter",
-    "entry-dictionary",
-    "paper-conference",
-    "article-journal",
-    "article-magazine",
-    "article-newspaper",
-    "broadcast",
-    "motion-picture",
-    "collection",
-    "legal-case",
-    "statute",
-    "treaty",
-    "hearing",
-    "regulation",
-    "brief",
-    "classic",
-    "patent",
-    "dataset",
-    "standard",
-    "software",
-    // Special keywords
-    "all",
-    "default",
-];
+/// Template-only selector keywords are accepted by [`validate_type_name`] but
+/// are not members of this reference-type vocabulary.
+pub use crate::options::KNOWN_REFERENCE_TYPE_NAMES as VALID_TYPE_NAMES;
 
 /// Returns `true` if `s` is a recognized reference type name.
 ///
@@ -337,8 +303,8 @@ pub const VALID_TYPE_NAMES: &[&str] = &[
 /// `"article_journal"` and `"article-journal"` are accepted.
 /// Returns `false` for unrecognized names (likely typos).
 pub fn validate_type_name(s: &str) -> bool {
-    let normalized = s.replace('_', "-");
-    VALID_TYPE_NAMES.iter().any(|&known| known == normalized)
+    let normalized = crate::options::ReferenceTypeName::from(s);
+    normalized.is_known() || matches!(normalized.as_str(), "all" | "default")
 }
 
 /// Selector for reference types in overrides.

--- a/crates/citum-schema-style/src/tests.rs
+++ b/crates/citum-schema-style/src/tests.rs
@@ -743,6 +743,46 @@ fn style_validate_emits_warning_for_unknown_type_in_bib_type_variants() {
 }
 
 #[test]
+fn style_validate_emits_warning_for_unknown_title_mapping_type() {
+    let style: Style = serde_yaml::from_str(
+        r#"
+info:
+  title: Future type mapping
+options:
+  titles:
+    type-mapping:
+      dance-performance: component
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        style.validate(),
+        vec![SchemaWarning::UnknownTypeName {
+            name: "dance-performance".to_string(),
+            location: "options.titles.type-mapping".to_string(),
+        }]
+    );
+}
+
+#[test]
+fn style_validate_accepts_normalized_known_title_mapping_type() {
+    let style: Style = serde_yaml::from_str(
+        r#"
+info:
+  title: Known type mapping
+options:
+  titles:
+    type-mapping:
+      personal_communication: component
+"#,
+    )
+    .unwrap();
+
+    assert!(style.validate().is_empty());
+}
+
+#[test]
 fn style_validate_no_warnings_for_valid_style() {
     let mut type_variants = IndexMap::new();
     type_variants.insert(

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -5532,13 +5532,13 @@
       "type": "object",
       "properties": {
         "type-mapping": {
-          "description": "Mapping of reference types to title categories.\nCategory keys: monograph, periodical, component.\nExample: { \"thesis\": \"monograph\", \"article-journal\": \"periodical\" }\n`None` means \"not configured at this level\" and will not override an\ninherited value; explicit `type-mapping: ~` clears an inherited\nmapping entirely (see `docs/specs/STYLE_INHERITANCE.md`).",
+          "description": "Mapping of canonical reference types to title categories.\n\nUnknown reference types are retained for forward compatibility and\nreported by style validation. Category values are a closed vocabulary.\nExample: { \"thesis\": \"monograph\", \"article-journal\": \"periodical\" }\n`None` means \"not configured at this level\" and will not override an\ninherited value; explicit `type-mapping: ~` clears an inherited\nmapping entirely (see `docs/specs/STYLE_INHERITANCE.md`).",
           "type": [
             "object",
             "null"
           ],
           "additionalProperties": {
-            "type": "string"
+            "$ref": "#/$defs/TitleCategory"
           }
         },
         "component": {
@@ -5617,6 +5617,19 @@
         }
       },
       "unevaluatedProperties": false
+    },
+    "TitleCategory": {
+      "description": "Closed title-rendering category vocabulary. `collection` is accepted as a compatibility alias for `container-monograph`.",
+      "type": "string",
+      "enum": [
+        "component",
+        "monograph",
+        "periodical",
+        "serial",
+        "container-monograph",
+        "collection",
+        "default"
+      ]
     },
     "TitleRendering": {
       "description": "Rendering options for titles.",

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -130,7 +130,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 |------|--------|-------|
 | [`TYPE_REFACTOR_v3.md`](./TYPE_REFACTOR_v3.md) — unified type system refactor for high-fidelity work modeling | Active | `metadata.rs`, `domain_fixtures.rs` |
 | [`TYPE_SYSTEM_ARCHITECTURE.md`](./TYPE_SYSTEM_ARCHITECTURE.md) — overall type system architecture and classification hierarchy | Draft | `crates/citum-schema/tests/` |
-| [`TYPED_TITLE_MAPPING.md`](./TYPED_TITLE_MAPPING.md) — normalized reference-type keys and closed title-rendering categories | Draft | `crates/citum-schema-style/src/tests.rs`, `citum-engine::render::component` |
+| [`TYPED_TITLE_MAPPING.md`](./TYPED_TITLE_MAPPING.md) — normalized reference-type keys and closed title-rendering categories | Active | `crates/citum-schema-style/src/tests.rs`, `citum-engine::render::component` |
 | [`INPUT_REFERENCE_CLASS_DISCRIMINATOR.md`](./INPUT_REFERENCE_CLASS_DISCRIMINATOR.md) — discriminated union for reference-class dispatch | Active | `crates/citum-schema/tests/` |
 | [`CSL_TYPE_CONVERSION_CONTRACT.md`](./CSL_TYPE_CONVERSION_CONTRACT.md) — CSL 1.0.2 type vocabulary, routing closure, and note-override validation | Active | `crates/citum-schema-data/src/reference/conversion/contract_tests.rs` |
 | [`GENERALIZED_RELATIONAL_CONTAINER_MODEL.md`](./GENERALIZED_RELATIONAL_CONTAINER_MODEL.md) — recursive relational container model replacing flat variables | Active | `metadata.rs` |

--- a/docs/specs/TYPED_TITLE_MAPPING.md
+++ b/docs/specs/TYPED_TITLE_MAPPING.md
@@ -1,6 +1,6 @@
 # Typed Title Mapping Specification
 
-**Status:** Draft
+**Status:** Active
 **Version:** 1.0
 **Date:** 2026-08-05
 **Supersedes:** The `titles.type-mapping` open question in PR #1142
@@ -111,13 +111,19 @@ fallback.
 
 ## Acceptance Criteria
 
-- [ ] Invalid title-category values fail style parsing with the offending value.
-- [ ] Underscore-spelled mapping keys resolve against canonical kebab-case reference types.
-- [ ] Unknown reference-type keys load and produce a location-specific validation warning.
-- [ ] Duplicate keys after normalization fail style parsing.
-- [ ] Valid existing embedded styles render identically before and after the change.
-- [ ] Engine rendering and migration refinement agree for every title category and title position.
+- [x] Invalid title-category values fail style parsing with the offending value.
+- [x] Underscore-spelled mapping keys resolve against canonical kebab-case
+  reference types.
+- [x] Unknown reference-type keys load and produce a location-specific
+  validation warning.
+- [x] Duplicate keys after normalization fail style parsing.
+- [x] Valid existing embedded styles render identically before and after the
+  change.
+- [x] Engine rendering and migration refinement agree for every title category
+  and title position.
 
 ## Changelog
 
 - v1.0 (2026-08-05): Initial specification.
+- v1.0 implementation (2026-08-05): Activated after schema, engine, migration,
+  and embedded-style regression validation.


### PR DESCRIPTION
## Stack

Part 2 of 2 in stack #1146. Depends on the specification in #1144.

## Root cause

`TitlesConfig.type_mapping` used `HashMap<String, String>`. Serde could not
reject an invented category, and both the engine and migration code interpreted
values through string matches with wildcard fallbacks. Reference-type keys were
also compared literally, so underscore spelling and typos could miss silently.

## Fix

- Change the public map to `HashMap<ReferenceTypeName, TitleCategory>`.
- Normalize underscores to hyphens at construction and deserialization.
- Reject invalid categories and duplicate keys after normalization.
- Keep unknown type names loadable, with a location-specific validation warning.
- Preserve `collection` as an input and JSON Schema compatibility alias for
  `container-monograph`.
- Replace engine and migration string matching with exhaustive enum handling.
- Activate the spec and regenerate the checked-in style schema.

This is a deliberate breaking Rust API change. Valid style YAML remains
compatible, and unknown future reference types remain forward-compatible.

## Evidence

- `just schema-gen` passes and records the closed category vocabulary.
- `python3 scripts/audit-rust-review-smells.py --changed` reports no findings.
- `just pre-commit` passes: format, all-feature Clippy with warnings denied, and
  2,405 of 2,405 nextest tests.
- Focused tests prove invalid-category rejection, underscore lookup, unknown-key
  warnings, normalized-duplicate rejection, the `collection` alias, and agreement
  between engine and migration for all six categories at all three title positions.
- The embedded-style quality gate passes for all 35 styles: fidelity 1.0 for all,
  all 19 embedded-core exact-parity floors met, and zero warnings.
- Direct reports at base `05bfcf89` and this commit have byte-identical Citum
  citation and bibliography output payloads across the 35-style corpus.

## Follow-up boundary

#1143 stays separate. It should preferably rebase after this implementation
lands; `all` precedence remains tracked by `csl26-q4g5`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a>.</sub>
