### PR TITLE
docs(spec): remove all type-selector keyword

### DIFF
--- a/.beans/archive/csl26-g6bi--fix-edstrans-role-label-trailing-punctuation-witho.md
+++ b/.beans/archive/csl26-g6bi--fix-edstrans-role-label-trailing-punctuation-witho.md
@@ -1,7 +1,7 @@
 ---
 # csl26-g6bi
 title: Fix Eds./Trans. role-label trailing punctuation without regressing shared styles
-status: in-progress
+status: completed
 type: bug
 priority: normal
 tags:
@@ -9,7 +9,7 @@ tags:
     - style
     - fidelity
 created_at: 2026-08-02T00:09:00Z
-updated_at: 2026-08-05T12:30:25Z
+updated_at: 2026-08-05T17:32:21Z
 parent: csl26-ccdt
 ---
 
@@ -49,7 +49,7 @@ Plan: docs/../plans -- PR1 of three (engine -> schema docs -> style).
 - [x] Regression cases: "Title." + ". " unchanged; "Title!" + ", " unchanged under both StrongTerminalCommaPolicy values
 - [x] just pre-commit
 - [x] Full embedded sweep vs baseline: chicago-author-date-18th 172/540 and american-medical-association 49/67 unmoved
-- [ ] CI green
+- [x] CI green
 
 ## Result
 

--- a/docs/guides/style-author-guide.md
+++ b/docs/guides/style-author-guide.md
@@ -741,7 +741,10 @@ References use a `class` (top-level discriminator) and `type` (subtype). In styl
 > [!TIP]
 > **Using Type Values in type-variants**
 > - Use the `type` value (e.g., `article-journal`, `book`) in `type-variants:`.
-> - Special keywords `default` and `all` also work.
+> - The special keyword `default` also works.
+> - There is no wildcard selector. A type with no entry renders the section
+>   `template:`, which is also the implicit parent of every variant that omits
+>   `extends`.
 > - For components, parents are embedded under the `parent:` key.
 
 ## [code] Complete Examples

--- a/docs/specs/TEMPLATE_V3.md
+++ b/docs/specs/TEMPLATE_V3.md
@@ -328,6 +328,37 @@ specific template position. See
 [`TYPED_TITLE_MAPPING.md`](./TYPED_TITLE_MAPPING.md) for the mapping's typed
 contract.
 
+### §6 — The Section Template Is the Only Wildcard
+
+A section's `template` is what a reference renders when no `type-variants` key
+matches it, and it is the implicit parent of every variant that omits `extends`
+(§1). It is therefore already the style's wildcard, and it is the only one.
+
+The `all` selector keyword is **removed**. It matched every reference type, so
+in a resolver that returns the first matching selector it could only ever
+shadow: any type-specific variant authored after it became unreachable, and a
+variant authored before it made `all` a partial default whose coverage depended
+on authoring order rather than on anything the author declared. Neither reading
+adds expressiveness the section template does not already provide.
+
+`default` is retained. It is not a wildcard — it names the entry rendered for
+the `default` reference type, and matches only that.
+
+A style that still authors `all:` is not a load error. The name simply leaves
+the reference-type vocabulary, so it flows through the existing
+`SchemaWarning::UnknownTypeName` path and matches nothing at render time.
+Rejecting it outright is the published schema's job, not the engine's: the
+`type-variants` key vocabulary becomes a `propertyNames` enum that no longer
+contains `all`. See [`TYPED_TITLE_MAPPING.md`](./TYPED_TITLE_MAPPING.md) for
+that contract and for why the enum is hyphenated only.
+
+**Migration.** Authors move the `all` body into the section `template` when the
+style has no other default, or delete it when the section template already
+expresses the same shape. The one embedded style that used `all`
+(`elsevier-with-titles-core`) was the second case: its `all` body differed from
+its section template only by contributor initialization that the style's own
+`options.contributors` preset already supplied.
+
 ---
 
 ## Acceptance Criteria
@@ -342,6 +373,8 @@ contract.
 
 ## Changelog
 
+- v0.7 (2026-08-05): Remove the `all` selector keyword; the section template is
+  the only wildcard. Retain `default`.
 - v0.6 (2026-08-05): State the boundary between structural templates and
   category-level title rendering policy.
 - v0.5 (2026-07-15): Clarify family inheritance, forbid named cross-section

--- a/docs/specs/TYPED_TITLE_MAPPING.md
+++ b/docs/specs/TYPED_TITLE_MAPPING.md
@@ -65,13 +65,60 @@ Any other category value is a parse error rather than a silent fallback.
 ### Key validation and lookup
 
 Known reference-type names share one authoritative vocabulary with template
-type-selector validation. `all` and `default` remain selector keywords and are
-not reference-type names.
+type-selector validation. `default` remains a selector keyword and is not a
+reference-type name. `all` was also such a keyword and is removed; see
+[`TEMPLATE_V3.md`](./TEMPLATE_V3.md) §6.
 
 Unknown canonical keys remain loadable for forward compatibility, but
 `Style::validate` emits `SchemaWarning::UnknownTypeName` at
 `options.titles.type-mapping`. This distinguishes an intentional future type
 from a likely typo without preventing an older engine from loading the style.
+
+#### The key vocabulary belongs in the published schema
+
+The paragraph above is a statement about the **engine**: an unknown name loads,
+warns, and matches nothing. That tolerance is deliberate, and it is not a reason
+for `docs/schemas/style.json` to be silent about the vocabulary — but silent is
+what it has been. `type-mapping` is `HashMap<ReferenceTypeName, TitleCategory>`,
+and the published schema constrains only the value half. schemars generates
+`additionalProperties` for map types and discards the key type, so the key half —
+a validated, normalizing Rust type — reaches the schema as a free string.
+
+This is not specific to `type-mapping`. `propertyNames` appears **nowhere** in
+any of the eight published schemas, so every map-keyed vocabulary in Citum is an
+open string space to a schema consumer.
+
+The rule, stated once: **the published schema is the authoring contract and
+carries the key vocabulary; the engine is the runtime and stays
+forward-compatible.** A style using a reference type Citum does not yet know
+fails schema validation in an editor and still renders correctly.
+
+Applied to reference types, which are a closed vocabulary:
+
+```json
+"type-variants": {
+  "type": "object",
+  "propertyNames": { "enum": ["article-journal", "book", "…", "default"] },
+  "additionalProperties": { "$ref": "#/$defs/TemplateVariant" }
+}
+```
+
+The enum is **hyphenated only**. Authored underscore spellings are dropped
+rather than enumerated alongside their canonical forms: normalizing the
+authored side let two spellings of one name coexist, which is the ambiguity the
+duplicate-key rule below already rejects within a single mapping. Normalization
+of *incoming reference data* is unaffected — that is input tolerance, not an
+authoring surface, and a hyphenated selector still matches a reference whose
+type arrives with underscores.
+
+Vocabularies that are genuinely open-ended — locale codes, message keys, field
+names — take `propertyNames: { "pattern": … }` rather than an enum, so a typo is
+caught without freezing an extensible namespace.
+
+Scope note: this spec change lands the four reference-type maps
+(`type-mapping` plus the three `type-variants` sites). The remaining nine
+vocabularies are tracked separately; they span locales, messages, and
+contributor roles and want their own review.
 
 Lookup compares canonical spellings. Consequently, an authored
 `personal_communication` key matches the engine's


### PR DESCRIPTION
**Docs only.** Spec + guide for removing the `all` type-selector. Implementation is stacked in the next PR.

## What changed

**`all` is removed.** It matched every reference type, so in a resolver that returns the first matching selector it could only shadow. A section's `template` is already the wildcard — it renders for unmatched types and is the implicit parent of every variant omitting `extends` — so `all` added no expressiveness. `default` is retained: it names a reference type rather than matching all of them.

**Found while checking how to reject the removed name:** `propertyNames` appears **nowhere** in any of the eight published schemas. Every map-keyed vocabulary in Citum is an open string space to a schema consumer. That includes `titles.type-mapping`, whose *value* half #1145 typed while schemars silently discarded the key type.

`TYPED_TITLE_MAPPING.md` now states the rule: **the published schema is the authoring contract and carries the key vocabulary; the engine is the runtime and stays forward-compatible.** Reference-type enums are hyphenated only — authored underscore spellings go away rather than being enumerated twice.

## Files

- `docs/specs/TEMPLATE_V3.md` — new §6, v0.7 changelog
- `docs/specs/TYPED_TITLE_MAPPING.md` — corrects the "`all` remains a keyword" line from #1144
- `docs/guides/style-author-guide.md` — drops `all` from the keyword tip

Also completes `csl26-g6bi`, stale since #1140 merged green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
