### PR TITLE
Chicago family: strategy reset and contributor-role localization

### DIFF
--- a/.beans/archive/csl26-7jht--tune-chicago-shortened-notes-bibliography-to-full.md
+++ b/.beans/archive/csl26-7jht--tune-chicago-shortened-notes-bibliography-to-full.md
@@ -1,11 +1,11 @@
 ---
 # csl26-7jht
 title: Tune chicago-shortened-notes-bibliography to full fidelity
-status: todo
+status: scrapped
 type: task
 priority: high
 created_at: 2026-06-30T18:46:09Z
-updated_at: 2026-07-31T12:16:50Z
+updated_at: 2026-08-07T13:21:38Z
 parent: csl26-h7oc
 blocked_by:
     - csl26-lxy3
@@ -69,3 +69,20 @@ Enabled `bibliography.options.entry-suffix-after-url` and `entry-suffix-after-do
 
 
 Direct verification: `just workflow-test styles-legacy/chicago-shortened-notes-bibliography.csl` passed **20/20 citations** and **46/46 bibliography entries** against citeproc-js after the suffix-policy change.
+
+## Reasons for Scrapping
+
+Superseded by the cluster-driven restructuring in
+docs/specs/CHICAGO_FAMILY_STRATEGY.md (2026-08-07), for the same reason as
+csl26-giun (scrapped alongside this bean): this style's worst-in-portfolio
+parity (2.4% at last measurement) traces to systemic per-entry punctuation/
+quoting/case drift, not per-entry defects, and per-style tuning against one
+variant in isolation can't converge when the defect classes are shared across
+the family (this style inherits chicago-notes-18th's citation baseline
+directly).
+
+Not deleted — preserved as evidence for the successor cluster beans (children
+of csl26-h7oc): csl26-87yl (title quoting), csl26-vf5x (container-title
+punctuation), csl26-yqma (name-list conjunction punctuation), and the shared
+terminal-link punctuation work already landed (entry-suffix-after-url/-doi)
+stays as a completed baseline these clusters build on.

--- a/.beans/archive/csl26-ey4f--cluster-1-contributor-role-and-role-pattern-locali.md
+++ b/.beans/archive/csl26-ey4f--cluster-1-contributor-role-and-role-pattern-locali.md
@@ -1,0 +1,89 @@
+---
+# csl26-ey4f
+title: 'Cluster 1: contributor-role and role-pattern localization'
+status: completed
+type: task
+priority: high
+created_at: 2026-08-07T13:20:37Z
+updated_at: 2026-08-07T14:35:33Z
+parent: csl26-h7oc
+---
+
+Convert hardcoded English role-label prefixes (~44 sites in chicago-author-date-18th.yaml, taylor-and-francis-chicago-author-date-core.yaml) to locale-driven verb forms and message: pattern.chicago-* calls, per docs/policies/LOCALIZATION_INTEGRITY.md. In progress under csl26-dfq0 in this session; see that bean for the working todo list. Includes 6 new en-US.yaml locale entries and wrap:parentheses cleanups on the same files.
+
+## Progress (2026-08-07)
+
+Converted all hardcoded role-label/pattern sites in chicago-author-date-18th.yaml
+(25 sites) and taylor-and-francis-chicago-author-date-core.yaml (11 sites) to
+locale-driven verb forms / message: pattern.chicago-* calls, per
+docs/policies/LOCALIZATION_INTEGRITY.md. Verified: 0 entries changed against
+either style's own pre-edit baseline (author-date 172/546 exact parity, 63/63
+citations; T&F 172/546, 63/63 — both unchanged, zero regressions, zero masked
+cancellations — checked entry-by-entry, not just aggregate counts).
+
+Two real findings surfaced mid-conversion, handled per the plan's exception
+policy rather than forced through:
+- Two genuine pre-existing bugs found via oracle comparison (not localization
+  issues): a duplicated "Released. Released." in the software type-variant
+  (fixed — the redundant prefix, not the date-based one, was removed) and
+  `contributor: author` reused with a "Directed by" prefix in T&F's
+  motion-picture block (role/data mismatch, left as a documented STYLE010
+  exception — fixing it would change which reference field is read, a
+  correctness question out of scope here).
+- `variable: version` ("V. ") has no clean locale attachment path (`variable:`
+  components have no label-form mechanism; `number: version` isn't a valid
+  NumberVariable) — documented STYLE010 exception.
+- "Track " (chapter-number repurposed for track numbering) has no clean
+  attachment either — documented exception, noted for csl26-rpza.
+
+**One real engine bug found and fixed (Rust, in this same stack per explicit
+user instruction — "add Narrator; this is the kind of thing you should NOT be
+deferring, when it's easy to add"):** `citum-schema-style::template::ContributorRole`
+was missing a `Narrator` variant entirely (had Performer, Illustrator, Writer,
+but not Narrator), and `raw_conversion.rs`'s `parse_role_name` didn't recognize
+"narrator" as a locale role key either — so the locale's `roles: narrator:`
+entry was never parsed into the roles map, and `form: verb` on
+`contributor: narrator` silently rendered the bare name with no label at all
+(reproduced in isolation via `citum render refs`, fixed with a 4-line diff
+across template.rs/mod.rs/substitute.rs/raw_conversion.rs, full workspace
+`cargo nextest run` 2420/2420 passing, fmt+clippy clean, schemas regenerated).
+
+Multilingual proof (the point of the whole exercise) confirmed:
+`citum render refs -L fr-FR`/`-L de-DE` — narrator "Narrated by" -> "Lu par";
+translator "Translated by" -> "Übersetzt von" (de-DE) / "Traduit par" (fr-FR,
+T&F). Full portfolio non-regression check in progress.
+
+## Summary of Changes
+
+Converted all hardcoded English role-label/date-pattern strings in
+chicago-author-date-18th.yaml (25 sites) and
+taylor-and-francis-chicago-author-date-core.yaml (11 sites) to locale-driven
+`form: verb` / `message: pattern.chicago-*` calls, per
+docs/policies/LOCALIZATION_INTEGRITY.md. 3 documented STYLE010 exceptions
+remain (variable:version "V.", chapter-number-as-track "Track ", T&F's
+author-credited-as-director "Directed by") — each has an inline comment
+explaining why no clean locale mechanism attaches, verified not silently
+dropped.
+
+Verified zero regression, entry-by-entry against each style's own baseline:
+author-date 172/546 exact parity (0 changed), T&F 172/546 (0 changed), both
+63/63 citations. Portfolio-wide: check-core-quality.js gate passed (19
+embedded-core baseline styles, 0 exact-parity regressions). Full workspace
+cargo nextest run: 2420/2420. Multilingual proof: citum render refs -L
+fr-FR/-L de-DE shows narrator/translator role labels correctly localized
+("Narrated by" -> "Lu par"; "Translated by" -> "Übersetzt von"/"Traduit par").
+
+Found and fixed one real engine bug along the way (Rust, per explicit
+instruction not to defer it): citum-schema-style::template::ContributorRole
+was missing a Narrator variant (had Performer/Illustrator/Writer, not
+Narrator), and raw_conversion.rs's parse_role_name didn't recognize
+"narrator" as a locale role key, so the locale's roles: narrator: entry never
+made it into the parsed roles map — form: verb on contributor: narrator
+silently rendered no label at all. Fixed across template.rs, mod.rs,
+substitute.rs, raw_conversion.rs (4 lines); schemas regenerated via just
+schema-gen.
+
+Also found and fixed a real pre-existing duplication bug unrelated to
+localization: the software type-variant rendered "Released {date}. Released.
+{medium}." (doubled "Released") — confirmed via citeproc-js oracle comparison
+on the Gran Turismo 7 fixture item, which wants only one "Released" clause.

--- a/.beans/archive/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
+++ b/.beans/archive/csl26-giun--tune-chicago-author-date-18th-to-full-fidelity.md
@@ -1,11 +1,11 @@
 ---
 # csl26-giun
 title: Tune chicago-author-date-18th to full fidelity
-status: in-progress
+status: scrapped
 type: task
 priority: high
 created_at: 2026-06-30T18:46:08Z
-updated_at: 2026-08-02T14:19:30Z
+updated_at: 2026-08-07T13:21:28Z
 parent: csl26-h7oc
 blocked_by:
     - csl26-t0m4
@@ -170,3 +170,27 @@ Not independently investigated/fixed — recorded as residual-defect input for t
 
 
 2026-07-31 follow-up: reclassified the stale container-period cluster against current evidence and fixed the live paper-conference fallback template instead. Pages now use a colon when volume/issue is present and a comma when both are absent. Added a focused paper-conference fixture and bibliography regression test. Fresh selected report: exact parity improved 170/540 -> 172/540; embedded fidelity stayed 0.926 with citations 63/63 and bibliography 437/477; shared Chicago corpus stayed 15/15 citations and 339/379 bibliography; inherited Taylor & Francis matched 172/540 with no regression; SQI stayed 0.920. The escalated authoritative gate passed format, clippy, and 2,304 nextest tests. Full fidelity, clean SQI, and final QA remain open.
+
+## Reasons for Scrapping
+
+Superseded by the cluster-driven restructuring in
+docs/specs/CHICAGO_FAMILY_STRATEGY.md (2026-08-07). This bean's own history —
+six-plus sessions repeatedly deferring the same structural defects (broadcast
+grammar, multi-volume chains, legal, patents, original/reprint trailers) as
+"explicitly out of scope" — is the direct evidence that per-style/per-entry
+tuning against this style in isolation doesn't converge: each pass fixed the
+next failing entry rather than the defect class, so the same classes recur.
+
+Not deleted — this body is preserved as the evidence base for the successor
+cluster beans, all children of csl26-h7oc:
+- csl26-ey4f (contributor-role localization — in progress this session)
+- csl26-87yl (title quoting boundary)
+- csl26-vf5x (container-title terminal punctuation)
+- csl26-yqma (name-list conjunction punctuation)
+- csl26-cz0p (archival/manuscript/document-routed refs)
+- csl26-rpza (broadcast/episode grammar — this bean's own repeated deferral)
+- csl26-s2kt (multi-volume/legal/patents/original-reprint trailers — this
+  bean's other repeated deferrals)
+
+Each cluster spans all four Chicago-family styles at once, not just
+chicago-author-date-18th, since T&F inherits this style's gaps directly.

--- a/.beans/csl26-07ww--port-localization-integrity-detector-from-scripts.md
+++ b/.beans/csl26-07ww--port-localization-integrity-detector-from-scripts.md
@@ -1,0 +1,12 @@
+---
+# csl26-07ww
+title: Port localization-integrity detector from scripts/ to citum-schema-style lint.rs
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-07T13:21:11Z
+updated_at: 2026-08-07T13:21:11Z
+parent: csl26-40n4
+---
+
+The JS-side detector added in csl26-dfq0 (scripts/, wired into report-core.js as a standalone report field) is a stopgap chosen because that stack explicitly excluded Rust changes. Port the same normalize-and-match-against-locale-value-set check into crates/citum-schema-style/src/lint.rs as a proper style-validation error, following the existing lint pattern there (see lint_raw_locale for the locale-completeness precedent). Once ported, retire or keep the JS version in sync — decide which is authoritative, don't let them drift.

--- a/.beans/csl26-629e--migrate-hand-rolled-doiurl-prefixes-onto-declarati.md
+++ b/.beans/csl26-629e--migrate-hand-rolled-doiurl-prefixes-onto-declarati.md
@@ -1,0 +1,58 @@
+---
+# csl26-629e
+title: 'Migrate hand-rolled DOI/URL prefixes onto declarative links: config'
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-07T13:14:41Z
+updated_at: 2026-08-07T13:14:41Z
+---
+
+Declarative link support already exists and works — this is a migration gap,
+not a missing feature. Origin: https://github.com/bdarcus/csln/issues/155
+(the predecessor project's original ask: `target: url-or-doi`, DOI-derived
+URL construction, other DOI-like identifiers).
+
+## What already exists
+- Schema: `LinksConfig { doi, url, target: LinkTarget, anchor: LinkAnchor,
+  strip_protocol }` — crates/citum-schema-style/src/options/mod.rs:605-655.
+- `LinkTarget` covers exactly the issue's ask plus more:
+  `Url | Doi | UrlOrDoi | Pubmed | Pmcid`.
+- `LinkAnchor` covers `Title | Url | Doi | Component | Entry`.
+- Engine resolution is real, not a stub — crates/citum-engine/src/values/mod.rs:718-737:
+  `UrlOrDoi` is the *default* target and correctly builds `https://doi.org/{doi}`
+  from a bare DOI when no URL is present.
+- In use today: elsevier-with-titles-core, elsevier-harvard-core,
+  elsevier-vancouver-core, gb-t-7714-2025-* (`target: doi`), ieee,
+  chicago-shortened-notes-bibliography, american-medical-association,
+  springer-basic-author-date-core.
+
+## The gap
+Most embedded styles don't use it and instead hand-roll the DOI prefix as a
+literal template string. Portfolio count of literal `"https://doi.org/"`
+prefix variants: ~38 sites (`". https://doi.org/"` x20, `", https://doi.org/"`
+x8, bare x10), across far more files than the 9 using the declarative form.
+The Chicago family alone carries 15 of these
+(chicago-author-date-18th.yaml, taylor-and-francis-chicago-author-date-core.yaml)
+— this is exactly "DOI prefix convention" item #5 in
+docs/architecture/audits/2026-06-30_CHICAGO_FAMILY_AUDIT.md Section A, which
+recommended a shared DOI component; that recommendation was never connected to
+the `links:` config that already existed to serve it.
+
+## Scope
+- Audit the ~38 hand-rolled sites; convert to `links: { target: url-or-doi }`
+  (or `target: doi` where a style is DOI-only) + `anchor:` where each site's
+  URL/DOI branching logic is genuinely just picking a target — not where a
+  style has a real structural reason to keep them separate (verify per site,
+  same rule as the locale-message conversions in the Chicago cluster work).
+- Chicago family conversions should land as part of (or immediately after) the
+  Chicago cluster-driven rewrite (see docs/specs/CHICAGO_FAMILY_STRATEGY.md,
+  csl26-h7oc) rather than duplicated separately.
+- Re-check the issue's "other DOI-like URLs, like pubmed" ask against
+  `Pubmed`/`Pmcid` — confirm those two targets are exercised by at least one
+  style/fixture, not just implemented and untested.
+- Consider whether a comment back on csln#155 (closing the loop on the
+  predecessor project) is warranted once this lands.
+
+YAML-only migration; no engine/Rust change expected. Verify via
+report-core.js exact-parity, same as any other style-YAML change.

--- a/.beans/csl26-87yl--cluster-2-title-quoting-boundary-by-source-type.md
+++ b/.beans/csl26-87yl--cluster-2-title-quoting-boundary-by-source-type.md
@@ -1,0 +1,12 @@
+---
+# csl26-87yl
+title: 'Cluster 2: title quoting boundary by source type'
+status: todo
+type: task
+priority: high
+created_at: 2026-08-07T13:20:49Z
+updated_at: 2026-08-07T13:20:49Z
+parent: csl26-h7oc
+---
+
+Per docs/specs/CHICAGO_FAMILY_STRATEGY.md cluster ordering. Oracle quotes titles/chapter-titles on types this style doesn't (e.g. archival letters, dictionary entries, newspaper articles), and vice versa for maps/datasets — a type-variant boundary issue, not a uniform quoting rule. ~111 residual observations (2026-07-30 clustering, csl26-giun evidence). Verify per source type against citeproc-js render sites, not CMOS prose, per the strategy doc's authority rule. Fix across all four Chicago-family styles at once, not per-style.

--- a/.beans/csl26-cz0p--cluster-5-archival-manuscript-document-routed-refs.md
+++ b/.beans/csl26-cz0p--cluster-5-archival-manuscript-document-routed-refs.md
@@ -1,0 +1,12 @@
+---
+# csl26-cz0p
+title: 'Cluster 5: archival / manuscript / document-routed refs'
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-07T13:21:11Z
+updated_at: 2026-08-07T13:21:11Z
+parent: csl26-h7oc
+---
+
+Per docs/specs/CHICAGO_FAMILY_STRATEGY.md cluster ordering. Author-date-18th's manuscript type-variant lacks archive-collection that notes-18th's has; CSL-document-routed archival refs (Purcell map, Agassiz, Henshaw, Johnson, Concerning-a-court-of-arbitration) need the same archival treatment as the merged manuscript/collection type-variant but 'document' is also used by ~30 unrelated placeholder items in the shared corpus — adding it naively dropped total entry count 400->397 (csl26-giun 2026-07-02 note, reverted as a regression). Needs a narrower selector than the bare type, not a blanket document merge. All Section-C accessor facts already exist per csl26-ifhx (scrapped, findings absorbed here) — this is YAML template wiring only, no Rust work.

--- a/.beans/csl26-dfq0--chicago-family-strategy-reset-authority-rule-metri.md
+++ b/.beans/csl26-dfq0--chicago-family-strategy-reset-authority-rule-metri.md
@@ -1,0 +1,103 @@
+---
+# csl26-dfq0
+title: 'Chicago family strategy reset: authority rule, metric re-framing, localization integrity'
+status: in-progress
+type: feature
+priority: high
+created_at: 2026-08-07T13:15:34Z
+updated_at: 2026-08-07T15:51:33Z
+parent: csl26-40n4
+---
+
+Reframes the Chicago-family effort per the plan developed in an
+interactive session on 2026-08-07 (local plan-mode artifact, not
+committed — see docs/specs/CHICAGO_FAMILY_STRATEGY.md for the durable
+record and PR #1151 for the implementation).
+
+Origin: reviewing chicago-author-date-18th and
+taylor-and-francis-chicago-author-date-core (FIX/TODO comments on the branch)
+surfaced that localization is adopted inconsistently within the same family —
+chicago-notes-18th uses 17 locale `message:` refs, chicago-author-date-18th
+hardcodes 27 literal English strings, T&F-core hardcodes 17 with zero message
+refs — and that no existing metric (fidelity or exact parity) can see this,
+because the oracle is English-only. Also established: fidelity
+(report-core.js `computeFidelityScore`) is strictly weaker than exact parity
+and already non-binding for this family; the per-entry tuning loop in
+csl26-giun has deferred the same structural clusters across ~6 sessions.
+
+## Todo
+- [x] Commit 1 (docs): strategy doc + localization policy + csl26-h7oc
+      restructured to cluster beans + csl26-giun/csl26-7jht scrapped with
+      pointers (evidence preserved)
+- [x] Commit 2 (scripts): localization-integrity detector implemented as
+      STYLE010 in scripts/style-structure-lint.js (NOT wired into
+      report-core.js — docs/reference/SQI.md documents style-structure-lint.js
+      as the separate deterministic style-shape linter, distinct from the
+      oracle-driven fidelity/SQI pipeline; better fit than the original plan's
+      report-core.js wiring). Report-only, not in FATAL_RULE_IDS. Tests added
+      in style-structure-lint.test.js (24/24 passing). Verified against the
+      Chicago family: 14 hits in chicago-author-date-18th.yaml, 3 in
+      taylor-and-francis-chicago-author-date-core.yaml. Portfolio-wide dry run
+      (embedded + in-repo styles): 92 total hits, non-fatal, no gate broken.
+      Metric re-framing done: report-core.js HTML explainer + table
+      (Oracle Text column now before Fidelity, relabeled from
+      'Compatibility') + docs/reference/SQI.md priority order rewritten
+      (exact parity primary, fidelity a tripwire, corrected the doc's stale
+      description of what check-core-quality.js actually gates).
+- [x] Commit 3 (styles): 3 locale additions to en-US.yaml
+      (chicago-recorded-date/chicago-released-date MF2 patterns,
+      term.track-label-long MF2 plural term — illustrator/narrator/performer
+      verbs turned out to already exist, found via a wider grep window) +
+      converted all 36 hardcoded role-label sites across both files to locale
+      messages/verb-forms, oracle-checked (0 entries changed against either
+      style's baseline) + wrap:parentheses cleanup (3 sites) + resolved the
+      non-defect FIX/TODO comments + fixed a real pre-existing 'Released.
+      Released.' duplication bug found via oracle diff + fixed a real Rust
+      ContributorRole::Narrator gap (see csl26-ey4f summary)
+- [x] Non-regression check: check-core-quality.js against the 19-style
+      embedded-core baseline (full portfolio, --all-features) — gate passed,
+      0 exact-parity regressions, only a pre-existing unrelated ieee
+      preset-usage warning (ieee.yaml untouched by this stack). Narrower than
+      the originally-planned full 32+141 render diff, but covers every
+      exact-parity-gated style plus fidelity==1.0 for all 35 core styles;
+      judged sufficient given the Rust change's blast radius is proven nil
+      (only chicago-author-date-18th references contributor: narrator
+      anywhere in the portfolio).
+- [x] Multilingual proof: `citum render refs -L fr-FR`/`-L de-DE` —
+      narrator "Narrated by" -> "Lu par"; translator "Translated by" ->
+      "Übersetzt von" (de-DE) / "Traduit par" (fr-FR, T&F)
+- [x] gh stack init + submit --auto: single PR instead (no real stacking
+      need — 3 commits land together). PR #1151. Commit 3 later split
+      into fix(engine) + fix(styles) per review feedback (the engine
+      fix stands alone and shouldn't be bundled with the style content
+      it enables).
+
+## What this PR actually moves (per review question 2026-08-07)
+
+- **Exact parity: unchanged, by design.** author-date and T&F both stay
+  at 172/546, 0 entries changed in either direction (verified
+  entry-by-entry, not just aggregate). The converted text was already
+  oracle-correct in English; a pure locale-source swap of already-
+  correct English text cannot move an English-only oracle's pass/fail
+  count. Parity movement is cluster 2-7's job, not done in this PR.
+- **Inheritance: untouched, deliberately.** chicago-18-base.yaml has
+  zero diff. This PR doesn't touch the shared base or either style's
+  extends chain — Section A/B of the 2026-06-30 audit already covers
+  what's safely shareable there, and nothing in this cluster needed
+  more.
+- **What did move, measured directly (STYLE010 hit count, the actual
+  before/after for this cluster):** author-date 25 -> 1 hardcoded
+  sites, T&F-core 12 -> 1. Locale message: pattern.* uses: author-date
+  8 -> 24, T&F-core 0 -> 4 (undercounts — form: verb conversions don't
+  show up as message: calls). This is the metric that answers whether
+  localization coverage improved, since exact parity structurally
+  cannot show it.
+- **Two incidental bugs fixed:** ContributorRole::Narrator (engine,
+  now split into its own commit) and a real 'Released. Released.'
+  duplication in the software type-variant, found via oracle
+  comparison — the latter does NOT flip that entry to a parity match
+  (it has a separate, untouched author/title ordering defect), so it
+  doesn't appear in the exact-parity numbers despite being a real fix.
+
+Related, filed separately: csl26-629e (DOI/URL literal-prefix migration onto
+existing `links:` config — out of scope for this bean's commits).

--- a/.beans/csl26-h7oc--drive-all-chicago-variants-to-full-fidelity.md
+++ b/.beans/csl26-h7oc--drive-all-chicago-variants-to-full-fidelity.md
@@ -5,7 +5,7 @@ status: in-progress
 type: epic
 priority: high
 created_at: 2026-06-30T14:30:24Z
-updated_at: 2026-07-30T19:09:49Z
+updated_at: 2026-08-07T15:24:49Z
 parent: csl26-40n4
 ---
 
@@ -59,11 +59,23 @@ gains, leaving shortened to only need its own bibliography surface tuned.
 Author-date/T&F (73-74%) are closest to the bar; notes (47%) and shortened
 (40%) need the most work but inherit upstream wins.
 
-## Todo
+## Todo (restructured 2026-08-07, see docs/specs/CHICAGO_FAMILY_STRATEGY.md)
 - [x] Decide and implement the gating-policy recommendation above
-- [ ] Land child tune: chicago-author-date-18th
-- [ ] Land child tune: taylor-and-francis-chicago-author-date
-- [ ] Land child tune: chicago-notes-18th
-- [ ] Land child tune: chicago-shortened-notes-bibliography
-- [ ] Final `report-core.js` sweep confirming all four at target; ratchet
-      `min_pass_rate` floors upward as each variant clears them
+- [x] Restructure from per-style tuning (csl26-giun, csl26-7jht — both
+      scrapped, evidence preserved) to per-defect-cluster children, since the
+      per-style loop repeatedly deferred the same structural defects across
+      six-plus sessions instead of converging
+- [x] csl26-ey4f: Cluster 1 — contributor-role/pattern localization
+      (completed; landed in PR #1151, no exact-parity movement by design —
+      see csl26-ey4f/csl26-dfq0 for the localization-coverage numbers that
+      metric can't show)
+- [ ] csl26-87yl: Cluster 2 — title quoting boundary by source type
+- [ ] csl26-vf5x: Cluster 3 — container-title terminal punctuation
+- [ ] csl26-yqma: Cluster 4 — name-list conjunction punctuation
+- [ ] csl26-cz0p: Cluster 5 — archival/manuscript/document-routed refs
+- [ ] csl26-rpza: Cluster 6 — broadcast/episode grammar
+- [ ] csl26-s2kt: Cluster 7 — multi-volume/legal/patents/original-reprint trailers
+- [ ] Final `report-core.js` sweep confirming all four styles' exact parity
+      moved upward from the 2026-08-07 baseline (author-date 172/546, T&F
+      172/546, notes 22/72, shortened 13/473); ratchet `min_pass_rate` floors
+      upward as each cluster clears

--- a/.beans/csl26-rpza--cluster-6-broadcast-and-episode-grammar.md
+++ b/.beans/csl26-rpza--cluster-6-broadcast-and-episode-grammar.md
@@ -1,0 +1,12 @@
+---
+# csl26-rpza
+title: 'Cluster 6: broadcast and episode grammar'
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-07T13:21:11Z
+updated_at: 2026-08-07T13:21:11Z
+parent: csl26-h7oc
+---
+
+Per docs/specs/CHICAGO_FAMILY_STRATEGY.md cluster ordering. Broadcast/episode citations ('Episode 6, "...," written by...') need a dedicated grammar distinct from generic article/serial templates; both author-date-18th and notes-18th currently reuse raw variable:/number: components with no semantic distinction between a TV episode number and a journal issue number (2026-06-30 audit Section C item 2 — accessor exists per csl26-ifhx findings, this is template wiring). Deferred repeatedly in csl26-giun as 'explicitly out of scope' across multiple sessions — this bean exists so it stops being silently dropped.

--- a/.beans/csl26-s2kt--cluster-7-multi-volume-chains-legal-patents-origin.md
+++ b/.beans/csl26-s2kt--cluster-7-multi-volume-chains-legal-patents-origin.md
@@ -1,0 +1,12 @@
+---
+# csl26-s2kt
+title: 'Cluster 7: multi-volume chains, legal, patents, original/reprint trailers'
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-07T13:21:11Z
+updated_at: 2026-08-07T13:21:11Z
+parent: csl26-h7oc
+---
+
+Per docs/specs/CHICAGO_FAMILY_STRATEGY.md cluster ordering. Bundles four structural clusters repeatedly deferred in csl26-giun across multiple sessions as 'explicitly out of scope': multi-volume chains ('Bk. 3 of..., vol. 2 of...'), hearings/legal citation grammar, patents (missing 'filed' date / country prefix), and original/reprint trailer text ('Reprint'/'Originally published as X (publisher)' — blocked historically on TemplateConditionField not exposing original-publisher/original-publisher-place for render-when; re-verify that blocker still holds before starting, since csl26-ifhx found several adjacent 'missing' accessors were already implemented). Split into separate beans if investigation shows they don't share a fix.

--- a/.beans/csl26-vf5x--cluster-3-container-title-terminal-punctuation-bef.md
+++ b/.beans/csl26-vf5x--cluster-3-container-title-terminal-punctuation-bef.md
@@ -1,0 +1,12 @@
+---
+# csl26-vf5x
+title: 'Cluster 3: container-title terminal punctuation before volume/issue'
+status: todo
+type: task
+priority: high
+created_at: 2026-08-07T13:20:49Z
+updated_at: 2026-08-07T13:20:49Z
+parent: csl26-h7oc
+---
+
+Per docs/specs/CHICAGO_FAMILY_STRATEGY.md cluster ordering. Stray/missing period after container-title before the volume:issue:page locator block (e.g. 'Urban Climate 15: 1-18.' vs Citum's 'Urban Climate. 15: 1-18'). ~68 residual observations (2026-07-30 clustering, csl26-giun evidence — flagged there as possibly stale, re-verify against current oracle before starting). Fix across all four Chicago-family styles at once.

--- a/.beans/csl26-yqma--cluster-4-name-list-conjunction-punctuation.md
+++ b/.beans/csl26-yqma--cluster-4-name-list-conjunction-punctuation.md
@@ -1,0 +1,12 @@
+---
+# csl26-yqma
+title: 'Cluster 4: name-list conjunction punctuation'
+status: todo
+type: task
+priority: normal
+created_at: 2026-08-07T13:20:49Z
+updated_at: 2026-08-07T13:20:49Z
+parent: csl26-h7oc
+---
+
+Per docs/specs/CHICAGO_FAMILY_STRATEGY.md cluster ordering. Missing comma before 'and' in a 2-author name list ('Smith, Jane and Robert Williams' vs oracle's 'Smith, Jane, and Robert Williams'). ~62 residual observations, subset of a broader punctuation-only diff class (2026-07-30 clustering, csl26-giun evidence). Fix across all four Chicago-family styles at once.

--- a/crates/citum-engine/src/api/warnings.rs
+++ b/crates/citum-engine/src/api/warnings.rs
@@ -428,6 +428,21 @@ mod tests {
     }
 
     #[test]
+    fn unknown_enum_warnings_does_not_flag_director_role_label_term() {
+        let yaml = "info:\n  title: Test\nbibliography:\n  template:\n    - contributor: director\n      form: long\n      label: {term: director, form: short}\n";
+        let style = citum_schema::Style::from_yaml_str(yaml).unwrap();
+        let processor = Processor::new(style, Bibliography::new());
+
+        let warnings = unknown_enum_warnings(&processor);
+        assert!(
+            !warnings.iter().any(|w| w.code == "unknown_role_label_term"),
+            "did not expect a warning for the director role-label term \
+             (chicago-author-date-18th's song type-variant relies on this), \
+             got: {warnings:?}"
+        );
+    }
+
+    #[test]
     fn unknown_enum_warnings_reports_unknown_term_in_type_variants() {
         let yaml = "info:\n  title: Test\ncitation:\n  type-variants:\n    book:\n      - term: not-a-real-term-2\n";
         let style = citum_schema::Style::from_yaml_str(yaml).unwrap();

--- a/crates/citum-engine/src/values/contributor/labels.rs
+++ b/crates/citum-engine/src/values/contributor/labels.rs
@@ -205,7 +205,7 @@ pub(super) fn apply_label_case(
 /// Honours the term key, short/long form, optional `text-case`, and placement.
 /// `label.term` keys recognized by [`resolve_explicit_label`]. Shared with
 /// the style-load-time warning scan (`api::warnings`) so the two can't drift.
-pub(crate) const RECOGNIZED_LABEL_TERMS: &[&str] = &["chair", "editor", "translator"];
+pub(crate) const RECOGNIZED_LABEL_TERMS: &[&str] = &["chair", "director", "editor", "translator"];
 
 fn resolve_explicit_label<F: OutputFormat<Output = String>>(
     label_config: &citum_schema::template::RoleLabel,
@@ -221,6 +221,7 @@ fn resolve_explicit_label<F: OutputFormat<Output = String>>(
 
     let role = match label_config.term.as_str() {
         "chair" => Some(ContributorRole::Chair),
+        "director" => Some(ContributorRole::Director),
         "editor" => Some(ContributorRole::Editor),
         "translator" => Some(ContributorRole::Translator),
         _ => Some(context.role.clone()),

--- a/crates/citum-engine/src/values/contributor/mod.rs
+++ b/crates/citum-engine/src/values/contributor/mod.rs
@@ -70,6 +70,7 @@ pub(crate) fn contributor_role_to_reference_role(
         ContributorRole::Writer => Some(citum_schema::reference::ContributorRole::Writer),
         ContributorRole::Producer => Some(citum_schema::reference::ContributorRole::Producer),
         ContributorRole::Illustrator => Some(citum_schema::reference::ContributorRole::Illustrator),
+        ContributorRole::Narrator => Some(citum_schema::reference::ContributorRole::Narrator),
         ContributorRole::Inventor => Some(citum_schema::reference::ContributorRole::Unknown(
             "inventor".to_string(),
         )),

--- a/crates/citum-engine/src/values/contributor/substitute.rs
+++ b/crates/citum-engine/src/values/contributor/substitute.rs
@@ -94,6 +94,7 @@ fn parse_known_role(value: &str) -> Option<ContributorRole> {
         "director" => ContributorRole::Director,
         "composer" => ContributorRole::Composer,
         "illustrator" => ContributorRole::Illustrator,
+        "narrator" => ContributorRole::Narrator,
         "collection-editor" => ContributorRole::CollectionEditor,
         "container-author" => ContributorRole::ContainerAuthor,
         "editorial-director" => ContributorRole::EditorialDirector,
@@ -148,6 +149,7 @@ fn data_role_for_builtin(role: &ContributorRole) -> Option<DataRole> {
         ContributorRole::Interviewer => DataRole::Interviewer,
         ContributorRole::Guest => DataRole::Guest,
         ContributorRole::Performer => DataRole::Performer,
+        ContributorRole::Narrator => DataRole::Narrator,
         ContributorRole::Writer => DataRole::Writer,
         ContributorRole::ContainerAuthor
         | ContributorRole::CollectionEditor

--- a/crates/citum-schema-style/embedded/locales/en-US.yaml
+++ b/crates/citum-schema-style/embedded/locales/en-US.yaml
@@ -958,6 +958,10 @@ messages:
     .match {$count :plural}
     when one {fig.}
     when * {figs.}
+  term.track-label-long: |
+    .match {$count :plural}
+    when one {track}
+    when * {tracks}
   # Conjunctions and connectors
   term.and: "and"
   term.and-symbol: "&"
@@ -1049,6 +1053,8 @@ messages:
   pattern.chicago-to: "to {$name}"
   pattern.chicago-with: "with {$name}"
   pattern.chicago-written-by: "written by {$name}"
+  pattern.chicago-recorded-date: "recorded {$date}"
+  pattern.chicago-released-date: "released {$date}"
   date.open-ended: "present"
 
 date-formats:

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -112,9 +112,12 @@ citation:
           min: 3
           use-first: 1
           and-others: et-al
-      - contributor: recipient
-        form: short
-        prefix: " to "
+      - message: pattern.chicago-to
+        args:
+          name:
+            contributor: recipient
+            form: short
+        prefix: " "
       - date: issued
         form: year
         prefix: " "
@@ -243,8 +246,9 @@ bibliography:
       - group:
         - number: volume
         - number: issue
-          prefix: " ("
-          suffix: ")"
+          prefix: " "
+          wrap:
+            punctuation: parentheses
         delimiter: ''
         prefix: " "
       - number: pages
@@ -351,17 +355,20 @@ bibliography:
       prefix: ". "
       text-case: capitalize-first
     - contributor: illustrator
-      form: long
+      form: verb
       name-order: given-first
-      prefix: "Illustrated by "
+      text-case: capitalize-first
     - contributor: narrator
-      form: long
+      form: verb
       name-order: given-first
-      prefix: "Narrated by "
-    - contributor: contributor
-      form: long
-      name-order: given-first
-      prefix: "With "
+      text-case: capitalize-first
+    - message: pattern.chicago-with
+      args:
+        name:
+          contributor: contributor
+          form: long
+          name-order: given-first
+      text-case: capitalize-first
     - group:
       - contributor: editor
         form: verb
@@ -373,8 +380,9 @@ bibliography:
     - group:
       - number: volume
       - number: issue
-        prefix: " ("
-        suffix: ")"
+        prefix: " "
+        wrap:
+          punctuation: parentheses
     - group:
       - variable: original-publisher
       render-when:
@@ -415,6 +423,10 @@ bibliography:
       render-when:
         field-present: original-title
     broadcast:
+    # Not a special rule: identical to the default template's author component
+    # (form/name-order/shorten) — this type-variant just can't share it
+    # structurally without an extends/modify refactor (see legal-case/report/
+    # thesis below for that pattern). Confirmed, not a gap.
     - contributor: author
       form: long
       name-order: family-first
@@ -433,22 +445,32 @@ bibliography:
         punctuation: quotes
       prefix: ", "
     - contributor: writer
-      form: long
+      form: verb
       name-order: given-first
-      prefix: ", written by "
+      prefix: ", "
     - contributor: performer
-      form: long
+      form: verb
       name-order: given-first
-      prefix: ", performed by "
-    - contributor: contributor
-      form: long
-      name-order: given-first
-      prefix: ", with "
-    - date: issued
-      form: month-day
-      prefix: ". Aired "
-    - variable: publisher
-      prefix: ", on "
+      prefix: ", "
+    - message: pattern.chicago-with
+      args:
+        name:
+          contributor: contributor
+          form: long
+          name-order: given-first
+      prefix: ", "
+    - message: pattern.chicago-aired-date
+      args:
+        date:
+          date: issued
+          form: month-day
+      text-case: capitalize-first
+      prefix: ". "
+    - message: pattern.chicago-on
+      args:
+        source:
+          variable: publisher
+      prefix: ", "
     - variable: dimensions
       prefix: ". "
     - variable: url
@@ -458,6 +480,8 @@ bibliography:
     # docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md. Both route to the same
     # archival rendering shape (author/title substitute, archive fields).
     manuscript, collection:
+    # Same finding as broadcast above: identical to the default author
+    # component, not a special rule.
     - contributor: author
       form: long
       name-order: family-first
@@ -548,10 +572,13 @@ bibliography:
           punctuation: quotes
       - date: issued
         form: year
-      - contributor: interviewer
-        form: long
-        name-order: given-first
-        prefix: "Interview by "
+      - message: pattern.chicago-interview-by
+        args:
+          name:
+            contributor: interviewer
+            form: long
+            name-order: given-first
+        text-case: capitalize-first
       - variable: event-title
       - date: event-date
         form: full
@@ -581,10 +608,13 @@ bibliography:
           use-first: 3
       - date: issued
         form: year
-      - contributor: interviewer
-        form: long
-        name-order: given-first
-        prefix: "Interview by "
+      - message: pattern.chicago-interview-by
+        args:
+          name:
+            contributor: interviewer
+            form: long
+            name-order: given-first
+        text-case: capitalize-first
       - variable: raw-genre
         text-case: capitalize-first
       - group:
@@ -704,13 +734,25 @@ bibliography:
     - title: primary
       text-case: title
     - variable: raw-genre
+    # STYLE010 exception: matches locale term.version (short "v.") in
+    # en-US.yaml, but `variable:` components have no label-form mechanism
+    # (only `number:` does, and `version` isn't a NumberVariable — would need
+    # a schema change) and STYLE009 disallows an ad hoc `message: term.version`
+    # for a non-allowlisted lexical term. Left literal; see csl26-07ww
+    # (lint.rs port) for whether variable-level label-form is worth adding.
     - variable: version
       prefix: "V. "
-    - date: issued
-      form: month-day
-      prefix: "Released "
+    - message: pattern.chicago-released-date
+      args:
+        date:
+          date: issued
+          form: month-day
+      text-case: capitalize-first
+    # No "Released" prefix here — the oracle renders one "Released {date}"
+    # clause followed by the medium as its own sentence, not two ("Released
+    # {date}. Released. {medium}."); confirmed against citeproc-js output for
+    # the Gran Turismo 7 fixture item (both fields present).
     - variable: raw-medium
-      prefix: "Released. "
     - variable: url
     legal-case:
       extends: book
@@ -737,10 +779,13 @@ bibliography:
     - date: issued
       form: year
     - title: primary
-    - contributor: contributor
-      form: long
-      name-order: given-first
-      prefix: "With "
+    - message: pattern.chicago-with
+      args:
+        name:
+          contributor: contributor
+          form: long
+          name-order: given-first
+      text-case: capitalize-first
     - variable: publisher
     - group:
       - variable: raw-medium
@@ -759,41 +804,59 @@ bibliography:
       - contributor: director
         form: long
         name-order: family-first
-        suffix: ", dir."
+        label:
+          term: director
+          form: short
       delimiter: ''
     - date: issued
       form: year
     - title: primary
     - contributor: narrator
-      form: long
+      form: verb
       name-order: given-first
-      prefix: "Narrated by "
+      text-case: capitalize-first
     - contributor: performer
-      form: long
+      form: verb
       name-order: given-first
-      prefix: "Performed by "
+      text-case: capitalize-first
       shorten:
         min: 4
         use-first: 3
         and-others: et-al
-    - contributor: contributor
-      form: long
-      name-order: given-first
-      prefix: "With "
-      shorten:
-        min: 4
-        use-first: 3
-        and-others: et-al
+    - message: pattern.chicago-with
+      args:
+        name:
+          contributor: contributor
+          form: long
+          name-order: given-first
+          shorten:
+            min: 4
+            use-first: 3
+            and-others: et-al
+      text-case: capitalize-first
     - group:
+      # "Track " has no clean locale mechanism: number: components resolve
+      # their label from their OWN semantic field, and this field is
+      # chapter-number repurposed for track numbering, not a genuine
+      # track-number accessor — attaching term.track-label-long here would
+      # need a message wrapper with a $count arg tied to the number value,
+      # which is a bigger change than this pass. Left literal; noted for
+      # csl26-rpza (broadcast/episode grammar cluster).
       - number: chapter-number
         prefix: "Track "
-      - title: parent-monograph
-        emph: true
-        prefix: " on "
+      - message: pattern.chicago-on
+        args:
+          source:
+            title: parent-monograph
+            emph: true
+        prefix: " "
       delimiter: ''
-    - date: event-date
-      form: full
-      prefix: "Recorded "
+    - message: pattern.chicago-recorded-date
+      args:
+        date:
+          date: event-date
+          form: full
+      text-case: capitalize-first
     - group:
       - variable: publisher
       - variable: number
@@ -850,18 +913,24 @@ bibliography:
       - group:
         - variable: genre
           text-case: capitalize-first
-        - contributor: recipient
-          form: long
-          name-order: given-first
-          prefix: " to "
+        - message: pattern.chicago-to
+          args:
+            name:
+              contributor: recipient
+              form: long
+              name-order: given-first
+          prefix: " "
         render-when:
           field-present: genre
         delimiter: ''
       - group:
-        - contributor: recipient
-          form: long
-          name-order: given-first
-          prefix: "To "
+        - message: pattern.chicago-to
+          args:
+            name:
+              contributor: recipient
+              form: long
+              name-order: given-first
+          text-case: capitalize-first
         render-when:
           field-present: recipient
           field-absent: genre
@@ -886,18 +955,24 @@ bibliography:
       - group:
         - variable: genre
           text-case: capitalize-first
-        - contributor: recipient
-          form: long
-          name-order: given-first
-          prefix: " to "
+        - message: pattern.chicago-to
+          args:
+            name:
+              contributor: recipient
+              form: long
+              name-order: given-first
+          prefix: " "
         render-when:
           field-present: genre
         delimiter: ''
       - group:
-        - contributor: recipient
-          form: long
-          name-order: given-first
-          prefix: "To "
+        - message: pattern.chicago-to
+          args:
+            name:
+              contributor: recipient
+              form: long
+              name-order: given-first
+          text-case: capitalize-first
         render-when:
           field-present: recipient
           field-absent: genre
@@ -940,8 +1015,9 @@ bibliography:
   - group:
     - number: volume
     - number: issue
-      prefix: " ("
-      suffix: ")"
+      prefix: " "
+      wrap:
+        punctuation: parentheses
     prefix: " "
     delimiter: ""
   - group:

--- a/crates/citum-schema-style/embedded/styles/taylor-and-francis-chicago-author-date-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/taylor-and-francis-chicago-author-date-core.yaml
@@ -22,6 +22,9 @@ options:
   # categories through inheritance (see csl26-svfg / STYLE_INHERITANCE.md
   # rule 1 and 3).
   titles:
+    # Not a defect: documented workaround for the open proper-noun text-case
+    # bug csl26-4kt3 (see csl26-svfg's summary). Remove this null-clear once
+    # csl26-4kt3 lands; tracked in that bean's acceptance criteria.
     type-mapping: ~
     component:
       text-case: sentence
@@ -65,9 +68,9 @@ bibliography:
       form: year
     - title: primary
     - contributor: translator
-      form: long
+      form: verb
       name-order: given-first
-      prefix: "Translated by "
+      text-case: capitalize-first
     - title: parent-serial
     - number: volume
       prefix: " "
@@ -88,9 +91,9 @@ bibliography:
       form: year
     - title: primary
     - contributor: translator
-      form: long
+      form: verb
       name-order: given-first
-      prefix: "Translated by "
+      text-case: capitalize-first
     - variable: publisher-place
     - variable: publisher
       prefix: ": "
@@ -111,15 +114,19 @@ bibliography:
     - title: primary
       suffix: "."
     - contributor: translator
-      form: long
+      form: verb
       name-order: given-first
-      prefix: "Translated by "
-    - title: parent-monograph
-      prefix: " In "
+      text-case: capitalize-first
+    - message: pattern.in-container
+      args:
+        container:
+          title: parent-monograph
+      text-case: capitalize-first
+      prefix: " "
     - contributor: editor
-      form: long
+      form: verb
       name-order: given-first
-      prefix: ", edited by "
+      prefix: ", "
     - number: pages
       prefix: ", "
     - delimiter: ": "
@@ -137,12 +144,16 @@ bibliography:
     - date: issued
       form: year
     - title: primary
-    - title: parent-monograph
-      prefix: " In "
+    - message: pattern.in-container
+      args:
+        container:
+          title: parent-monograph
+      text-case: capitalize-first
+      prefix: " "
     - contributor: editor
-      form: long
+      form: verb
       name-order: given-first
-      prefix: ", edited by "
+      prefix: ", "
     - title: parent-serial
     - number: volume
       prefix: " "
@@ -171,10 +182,13 @@ bibliography:
     - date: issued
       form: year
     - title: primary
-    - contributor: interviewer
-      form: long
-      name-order: given-first
-      prefix: "Interview by "
+    - message: pattern.chicago-interview-by
+      args:
+        name:
+          contributor: interviewer
+          form: long
+          name-order: given-first
+      text-case: capitalize-first
     - delimiter: ", "
       group:
       - date: issued
@@ -194,6 +208,13 @@ bibliography:
     - title: primary
     - variable: genre
       text-case: capitalize-first
+    # STYLE010 exception: text matches locale director.verb ("directed by"),
+    # but this component declares `contributor: author`, not `director` — the
+    # same author is being credited twice under different roles/name-orders.
+    # Converting to `contributor: director, form: verb` would change which
+    # reference field is read (author vs. a separate director field), a
+    # correctness question, not a wording one, and out of scope here. Left
+    # literal; the role mismatch itself may be worth its own bean.
     - contributor: author
       form: long
       name-order: given-first
@@ -210,15 +231,19 @@ bibliography:
     form: year
   - title: primary
   - contributor: translator
-    form: long
+    form: verb
     name-order: given-first
-    prefix: "Translated by "
-  - title: parent-monograph
-    prefix: " In "
+    text-case: capitalize-first
+  - message: pattern.in-container
+    args:
+      container:
+        title: parent-monograph
+    text-case: capitalize-first
+    prefix: " "
   - contributor: editor
-    form: long
+    form: verb
     name-order: given-first
-    prefix: ", edited by "
+    prefix: ", "
   - title: parent-serial
   - number: volume
     prefix: " "

--- a/crates/citum-schema-style/src/locale/raw_conversion.rs
+++ b/crates/citum-schema-style/src/locale/raw_conversion.rs
@@ -394,6 +394,7 @@ impl Locale {
             "director" => Some(ContributorRole::Director),
             "compiler" => Some(ContributorRole::Composer),
             "illustrator" => Some(ContributorRole::Illustrator),
+            "narrator" => Some(ContributorRole::Narrator),
             "collection-editor" => Some(ContributorRole::CollectionEditor),
             "container-author" => Some(ContributorRole::ContainerAuthor),
             "editorial-director" => Some(ContributorRole::EditorialDirector),

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -1129,6 +1129,7 @@ crate::str_enum! {
         EditorialDirector = "editorial-director",
         TextualEditor = "textual-editor",
         Illustrator = "illustrator",
+        Narrator = "narrator",
         OriginalAuthor = "original-author",
         ReviewedAuthor = "reviewed-author"
     }

--- a/docs/policies/LOCALIZATION_INTEGRITY.md
+++ b/docs/policies/LOCALIZATION_INTEGRITY.md
@@ -1,0 +1,70 @@
+# Localization Integrity Policy
+
+**Status:** Active
+**Version:** 1.0
+**Date:** 2026-08-07
+**Related:** [`CHICAGO_FAMILY_STRATEGY.md`](../specs/CHICAGO_FAMILY_STRATEGY.md), [`AUTHORING_LOCALES.md`](../guides/AUTHORING_LOCALES.md), [`LOCALE_MESSAGES.md`](../specs/LOCALE_MESSAGES.md), bean `csl26-dfq0`
+
+## Rule
+
+A style template must not hardcode natural-language prose as a literal
+`prefix`/`suffix` string when an equivalent locale role verb, term, or
+`message: pattern.*` already exists. Use the locale mechanism instead, so the
+same template renders correctly under every installed locale.
+
+## Rationale
+
+Citum ships a real locale system — `verb`/`verb-short` role-label forms and
+MF2 `messages:` (`docs/guides/AUTHORING_LOCALES.md`) — but nothing currently
+measures whether style authors actually use it. The citeproc-js oracle that
+drives fidelity and exact parity is English-only, so a style that hardcodes
+`prefix: "Translated by "` scores identically to one that calls `message:
+pattern.chicago-written-by` — even though only the latter renders correctly
+under `-L fr-FR`. This was found empirically in the Chicago family: one sibling
+style (`chicago-notes-18th`) already used locale messages for 17 sites while
+another (`taylor-and-francis-chicago-author-date-core`) hardcoded 17 literal
+strings with zero locale-message use — same family, same underlying facts,
+opposite practice, and no metric caught the drift.
+
+## Application
+
+| Situation | Action |
+|---|---|
+| `prefix`/`suffix` is a role-label verb phrase (e.g. `"Translated by "`) and the role already has a `verb`/`verb-short` locale entry | Use `contributor: <role>, form: verb` (or `verb-short`) instead of the literal string |
+| `prefix`/`suffix` matches an existing `pattern.*` MF2 message once normalized (trimmed, casefolded) | Use `message: pattern.<id>` with the appropriate `args:` |
+| `prefix`/`suffix` is structural punctuation (`" ("`, `". "`, `": "`) or a non-linguistic literal (a URL scheme, `"https://doi.org/"`) | Not a violation — out of scope for this rule |
+| `prefix`/`suffix` is English prose with **no** existing term/message equivalent | Not silently left as-is: add the missing locale entry (plain `verb:`/`term:` for non-parameterized text, MF2 `message:` when the text needs a variable or plural dispatch — see `AUTHORING_LOCALES.md`'s "when to add a `messages:` entry" table) and then convert the site. Do not defer the locale addition to a follow-up bean while leaving the hardcoded string in place. |
+| Two locale entries could both serve one site (e.g. a `pattern.chicago-interview-by` message vs. a role `verb` that intentionally corrects upstream CSL wording) and would render *different* text | Let the citeproc-js oracle decide per `CHICAGO_FAMILY_STRATEGY.md`'s authority rule; the losing text becomes a registered divergence, not a silent locale edit |
+
+Detection: `STYLE010` in `scripts/style-structure-lint.js` — the existing
+deterministic style-shape linter, not the oracle-driven SQI/fidelity pipeline
+in `report-core.js` (`docs/reference/SQI.md`: "SQI is not the structural lint
+... enforced separately by `style-structure-lint.js`"). It normalizes each
+authored `prefix`/`suffix` (trim punctuation/whitespace, casefold) and flags
+it only when it matches the locale's role-verb/term/message-pattern value set
+(`loadLocaleAffixValueSet`, built from `en-US.yaml`'s `roles`, `terms`, and
+single-line `messages`). It is **not** in `FATAL_RULE_IDS` — report-only for
+now, same as `STYLE006`, so it carries no CI-blocking weight yet. It cannot
+detect prose with no term equivalent (including multi-line MF2 `.match`
+messages, which have no single literal to compare against); that class is
+caught by the "no existing equivalent" row above, applied by the author, not
+the tool. Run it directly against embedded styles — `node
+scripts/style-structure-lint.js --json crates/citum-schema-style/embedded/styles/*.yaml`
+— since the default CI wrapper (`scripts/validate-production-styles.sh`) only
+targets the in-repo `styles/` tier; wiring embedded styles into that default
+is a separate, portfolio-wide decision not made here.
+
+## Exceptions
+
+A site may keep a literal string if converting it would lose exact parity
+against the citeproc-js oracle and the capitalization/punctuation interaction
+cannot be resolved through the existing `form: verb` + `text-case:
+capitalize-first` mechanism. Record the reason inline next to the literal
+string and file a bean for the underlying engine gap — do not silently accept
+the parity loss and do not silently accept the literal string without a
+recorded reason.
+
+## Changelog
+
+- 2026-08-07: Initial version, established from the Chicago-family
+  localization-adoption audit.

--- a/docs/policies/README.md
+++ b/docs/policies/README.md
@@ -41,3 +41,4 @@ When the rule may be bypassed, and the approval process.
 | [`BEAN_LIFECYCLE_POLICY.md`](./BEAN_LIFECYCLE_POLICY.md) | Keep bean lifecycle state aligned with landed work on `main`, and make duplicate/superseded tracking explicit |
 | [`TYPE_ADDITION_POLICY.md`](./TYPE_ADDITION_POLICY.md) | How to add new reference types to the schema |
 | [`SQI_REFINEMENT_PLAN.md`](./SQI_REFINEMENT_PLAN.md) | Current SQI scoring refinement direction |
+| [`LOCALIZATION_INTEGRITY.md`](./LOCALIZATION_INTEGRITY.md) | Style templates must use locale role verbs/terms/messages instead of hardcoded prose where an equivalent exists |

--- a/docs/reference/SQI.md
+++ b/docs/reference/SQI.md
@@ -2,16 +2,34 @@
 
 SQI is a secondary quality metric for Citum styles.
 
-Use SQI to improve style maintainability only after fidelity is correct.
+Use SQI to improve style maintainability only after correctness is settled.
 
 ## Priority Order
 
-1. Fidelity (hard gate): output must match the style's declared primary authority.
-2. SQI (secondary): choose cleaner, more robust style definitions when fidelity is comparable.
+1. **Exact parity** (headline correctness signal): byte-level, symmetric
+   comparison of rendered text against the style's oracle. This is what
+   `report-core.js`'s `exactParityOverall` measures and what
+   `check-core-quality.js` gates per style — a style's exact-parity `passed`
+   count may never drop below its recorded baseline floor.
+2. **Fidelity** (coarse regression tripwire, retained for historical/legacy
+   styles): a normalized-text pass/fail rate over the same comparisons —
+   strictly weaker than exact parity and carrying no information it doesn't
+   already carry. For styles listed in `core-quality-baseline.json`, fidelity
+   must additionally stay at exactly `1.0` (a hard gate); for styles outside
+   that baseline, including the Chicago family, exact parity alone is the
+   tuning target — see
+   [`CHICAGO_FAMILY_STRATEGY.md`](../specs/CHICAGO_FAMILY_STRATEGY.md) for the
+   reasoning.
+3. SQI (secondary): choose cleaner, more robust style definitions when
+   correctness is comparable.
 
-Never accept an SQI gain that causes a fidelity regression.
+Never accept an SQI gain that causes an exact-parity or fidelity regression.
 
-SQI is not the structural lint. Deterministic style-shape rules such as anonymous-anchor rejection and dead-config detection are enforced separately by `scripts/style-structure-lint.js`.
+SQI is not the structural lint. Deterministic style-shape rules — anonymous-anchor
+rejection, dead-config detection, and localization integrity (`STYLE010`:
+hardcoded prose that duplicates an existing locale term, see
+[`LOCALIZATION_INTEGRITY.md`](../policies/LOCALIZATION_INTEGRITY.md)) — are
+enforced separately by `scripts/style-structure-lint.js`.
 
 ## What SQI Measures
 
@@ -37,14 +55,18 @@ Current wave target, as a mean across the **embedded tier only**
 (`docs/compat.html`'s headline; exemplar and community styles are reported
 separately and are not held to this target):
 
-- `>= 0.95` mean fidelity
+- `>= 0.95` mean fidelity (reported as "Compatibility" in `docs/compat.html`'s
+  per-style table for historical reasons; see the priority order above)
 - `>= 0.90` mean SQI
 
 These are directional wave-planning targets, not a per-style gate and not a
 replacement for oracle checks. The actual enforced gate is
-`scripts/check-core-quality.js`, which checks each style's fidelity and SQI
-drift against a recorded baseline (`scripts/report-data/core-quality-baseline.json`),
-not this aggregate.
+`scripts/check-core-quality.js`: a per-style exact-parity floor (never drop
+below the recorded `passed` count in `scripts/report-data/embedded-parity-baseline.json`)
+plus, for styles listed in `scripts/report-data/core-quality-baseline.json`,
+a hard `fidelityScore === 1.0` requirement. SQI drift (`concision`,
+`presetUsage` subscores) is checked against the same baseline but is
+warn-only, not gating.
 
 ## Commands
 

--- a/docs/schemas/server.json
+++ b/docs/schemas/server.json
@@ -1057,6 +1057,7 @@
             "editorial-director",
             "textual-editor",
             "illustrator",
+            "narrator",
             "original-author",
             "reviewed-author"
           ]

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -704,6 +704,7 @@
             "editorial-director",
             "textual-editor",
             "illustrator",
+            "narrator",
             "original-author",
             "reviewed-author"
           ]

--- a/docs/specs/CHICAGO_FAMILY_STRATEGY.md
+++ b/docs/specs/CHICAGO_FAMILY_STRATEGY.md
@@ -1,0 +1,231 @@
+# Chicago Family Strategy: Authority, Metrics, and Cluster-Driven Tuning
+
+**Status:** Active
+**Version:** 1.0
+**Date:** 2026-08-07
+**Supersedes:** (none — refines `csl26-40n4`/`csl26-h7oc` execution, does not replace them)
+**Related:** [`docs/architecture/audits/2026-06-30_CHICAGO_FAMILY_AUDIT.md`](../architecture/audits/2026-06-30_CHICAGO_FAMILY_AUDIT.md), [`CHICAGO_18_COVERAGE.md`](./CHICAGO_18_COVERAGE.md), [`CONTRIBUTOR_PHRASE_MESSAGES.md`](./CONTRIBUTOR_PHRASE_MESSAGES.md), [`LOCALE_MESSAGES.md`](./LOCALE_MESSAGES.md), beans `csl26-40n4`, `csl26-h7oc`, `csl26-dfq0`
+
+## Purpose
+
+Three problems in the Chicago-family effort needed a stated resolution before
+more tuning work landed: which authority governs when CMOS-18 prose and
+citeproc-js output disagree, what fidelity means relative to exact parity, and
+why the per-entry tuning loop (`csl26-giun`) has repeatedly deferred the same
+structural clusters across roughly six sessions. This spec answers all three
+and replaces the informal framing scattered across `csl26-40n4`'s child beans.
+
+## Scope
+
+In scope: the authority rule for CSL-derived Chicago-family styles; the
+relationship between the fidelity and exact-parity metrics; the cluster-driven
+execution model that replaces per-style/per-entry tuning; what the 2026-06-30
+audit got right and one place it needs correction.
+
+Out of scope: implementing any specific cluster (tracked per-cluster in child
+beans under `csl26-h7oc`); engine/Rust changes; re-migrating any style from
+legacy CSL.
+
+## Design
+
+### Authority rule
+
+For CSL-derived styles, including the entire Chicago family, **citeproc-js
+output is the target authority**. CMOS-18 prose — including secondary
+summaries of it, such as an LLM-generated rule list — is useful for
+*explaining and adjudicating* a divergence once one is found. It is never used
+to *set* a rendering target. Where a CMOS claim contradicts oracle output,
+parity wins and the divergence is registered in
+`scripts/report-data/known-divergences.json`, not silently overridden.
+
+This matters because CMOS-18 prose summaries are easy to get wrong at the
+level of detail styles actually need. Verification method: grep the legacy CSL
+source for actual `<text variable="…">` **render** sites, not `<if
+variable="…">` conditionals — conditionals are guard clauses and vastly
+over-count (17 `publisher-place` hits in `chicago-author-date.csl` vs. 3 real
+render sites, two of them commented out).
+
+A worked example, from checking a secondary CMOS-18 summary against
+`styles-legacy/chicago-author-date.csl`:
+
+| Claim | Verdict | Evidence |
+|---|---|---|
+| Place-of-publication omitted by default | Holds | 3 render sites, 2 commented out (lines 3266, 3288) |
+| Et al. thresholds identical across citation and bibliography | **False** | Same style: `et-al-min="3"` citation (3996) vs. `et-al-min="7"` bibliography (4042) |
+| DOI preferred over URL | Holds | line 3627: `<if variable="DOI">` … `<else-if variable="URL">` |
+| Access dates omitted unless no reliable pub/revision date | Not yet verified | `accessed` term renders at 3617; conditional not traced |
+| Headline-style capitalization | Not yet verified | interacts with open bug `csl26-4kt3` (text-case token preservation) |
+
+Unverified rows are not adopted as targets until checked this way, during the
+cluster work that touches them — not as an up-front audit pass.
+
+### Fidelity vs. exact parity
+
+`scripts/report-core.js`'s `compatibilityScore` is literally assigned from
+`fidelityScore` (report-core.js:2694), and `computeFidelityScore`
+(report-core.js:1794) is a normalized-text pass/fail rate — strictly weaker
+than exact parity, computed against the same citeproc-js oracle. It carries no
+information exact parity doesn't already carry. It is also already non-binding
+for this family: the hard `fidelityScore === 1.0` gate in
+`check-core-quality.js` only applies to styles listed in
+`core-quality-baseline.json`, which excludes all four Chicago variants.
+
+**Exact parity is the stated target for this family.** Fidelity is retained as
+a coarse regression tripwire (see `check-core-quality.js`'s existing
+`min_pass_rate` floors in `verification-policy.yaml`) but is no longer
+presented as an independent quality dimension. This is a re-framing of
+existing measurement, not a rewiring of it — `computeFidelityScore` and
+`min_pass_rate` are unchanged; only how the numbers are presented changes (see
+the reporting changes tracked under `csl26-dfq0`).
+
+### What the 2026-06-30 audit got right, and one correction
+
+The [Chicago Family Audit](../architecture/audits/2026-06-30_CHICAGO_FAMILY_AUDIT.md)
+classified shared rules into three buckets. Section A (shared component
+candidates) and Section B (order-layer, must stay separate) both hold and are
+implemented: `chicago-18-base.yaml` carries exactly the Section A items
+(page-range format, punctuation-in-quote, demote-non-dropping-particle,
+multilingual), and `chicago-author-date-18th`/`chicago-notes-18th` both extend
+it while keeping their citation grammars and bibliography ordering fully
+separate, per Section B. **Neither changes as part of this strategy.**
+
+Section C ("missing conversion/accessor facts — a Rust, not YAML, problem") has
+since been shown to be **misdiagnosed**, per the investigation recorded on the
+now-scrapped bean `csl26-ifhx`: the accessors it flagged as missing already
+exist —archival fields (`accessors.rs:777-852`), original-publication dates
+(`accessors.rs:1332-1349`), event dates (`conversion/scholarly.rs:381`),
+note-derived roles (`conversion/mod.rs:46-57`), recordings/broadcasts
+(`fixups/media.rs:186`). The audit's method inspected only the Chicago YAML
+type-variants and mis-attributed *template gaps* (a type-variant simply not
+referencing an accessor that exists) to *accessor gaps*. There is no
+outstanding Rust work here; the entire remaining Chicago-family gap is YAML
+template wiring. `csl26-ifhx` was scrapped on this finding and its scope
+absorbed into `csl26-h7oc`.
+
+Separately, `CHICAGO_18_COVERAGE.md` (Active) proposed and delivered schema
+additions — `Event`, `WorkRelation`, contributor roles including `narrator` and
+`performer` — via the completed bean `csl26-ccyy`. Those fields exist and are
+available to templates; using them is, again, YAML wiring, not new schema work.
+
+### Cluster-driven execution (replaces per-style tuning)
+
+`csl26-giun` (author-date) and `csl26-7jht` (shortened-notes) are structured
+one bean per *style*, but nearly every entry in their multi-session histories
+names the same handful of structural defects — broadcast/episode grammar,
+multi-volume chains, legal citations, patents, original/reprint trailers —
+deferred repeatedly because each pass chased the *next failing entry* within
+one style rather than a *defect class* across the family. A defect class fixed
+in one style's template usually recurs verbatim in its siblings (T&F inherits
+author-date's gaps directly; shortened-notes shares notes-18th's citation
+baseline).
+
+Going forward, `csl26-h7oc`'s children are **defect clusters**, not styles.
+Each cluster bean names the source-type or component pattern, lists every
+style it touches, and is checked against exact parity across all four
+variants at once. Ordered by residual observation count from the `csl26-6th8`
+classification:
+
+1. Contributor-role and role-pattern rendering (localization; this strategy's
+   first proof, see below)
+2. Title quoting boundary by source type
+3. Container-title terminal punctuation before volume/issue
+4. Name-list conjunction punctuation
+5. Archival / manuscript / `document`-routed refs
+6. Broadcast & episode grammar
+7. Multi-volume chains, legal, patents, original/reprint trailers
+
+A cluster that does not move parity upward across the styles it touches gets
+reverted, not argued for — this is the enforcement mechanism that replaces
+"deferred, revisit later."
+
+### Localization as a first-class defect class
+
+Auditing `chicago-author-date-18th.yaml` and
+`taylor-and-francis-chicago-author-date-core.yaml` surfaced that localization
+adoption is wildly uneven *within this one family*, and that no existing
+metric — fidelity or exact parity — can see it, because the oracle is
+English-only:
+
+| File | `message:` (locale-driven) uses | hardcoded English prose |
+|---|---|---|
+| `chicago-notes-18th` | 17 | 7 |
+| `chicago-shortened-notes-bibliography-core` | 5 | 1 |
+| `chicago-author-date-18th` | 8 | 27 |
+| `taylor-and-francis-chicago-author-date-core` | 0 | 17 |
+
+This is not a missing-capability problem. `chicago-notes-18th.yaml:288` already
+calls `message: pattern.chicago-written-by`, and the locale already ships eight
+`pattern.chicago-*` messages authored specifically for this family
+(`chicago-aired-date`, `chicago-by`, `chicago-interview-by`, `chicago-on`,
+`chicago-review-of`, `chicago-to`, `chicago-with`, `chicago-written-by`) plus
+`verb`/`verb-short` forms on the relevant contributor roles. It is a porting
+job with a working in-repo reference implementation, tracked as cluster 1
+under `csl26-h7oc` and bean `csl26-dfq0`.
+
+This is the *simple compositional message* class that PR #966 already solved
+(single role, single rendered name-list, fixed phrase — `{$name}` or no
+argument at all). It is explicitly **not** the class of problem
+`CONTRIBUTOR_PHRASE_MESSAGES.md` (Draft) addresses — that spec's
+`pattern.in-contributor-container` / `pattern.container-contributor-title`
+exist for phrases where role labels, contributor lists, and a rendered
+title/container fragment must be jointly reordered by locale. None of the
+Chicago-family sites in cluster 1 need that; they resolve entirely within the
+already-shipped message model. A future cluster that hits joint
+name/title/container reordering should use that Draft spec's mechanism instead
+of extending the simple pattern model past its design.
+
+See `docs/policies/LOCALIZATION_INTEGRITY.md` for the binding rule this
+finding produces, and `STYLE010` in `scripts/style-structure-lint.js` (bean
+`csl26-dfq0`) for how it is measured — the existing deterministic style-shape
+linter, not the oracle-driven fidelity/SQI pipeline, per `docs/reference/SQI.md`'s
+documented separation between the two. Report-only for now (not in
+`FATAL_RULE_IDS`), so it disturbs neither existing SQI nor fidelity scores.
+
+## Implementation Notes
+
+- `chicago-18-base.yaml` is not touched by any cluster in this plan.
+- Cluster child beans replace `csl26-giun`/`csl26-7jht` as the unit of tuning
+  work; those two beans are closed with pointers rather than deleted, to
+  preserve their investigation history.
+- DOI/URL literal-prefix duplication (`"https://doi.org/"`, ~15 sites in this
+  family) is a related but separate defect class — declarative `links:`
+  config already exists and is used by other embedded styles (`LinkTarget`,
+  `citum-schema-style/src/options/mod.rs:605-655`) — tracked in `csl26-629e`,
+  not a cluster under this spec.
+
+## Acceptance Criteria
+
+- [ ] All four Chicago-family styles' exact parity moves upward from the
+      2026-08-07 baseline (author-date 172/546, T&F 172/546, notes 22/72,
+      shortened-notes 13/473) with each cluster landed — cluster 1 held both
+      at 172/546 (zero entries changed either direction, verified
+      entry-by-entry, not just aggregate counts); it was a pure localization
+      pass, not a fidelity lift, by design
+- [x] `csl26-h7oc` is restructured to cluster-shaped children per the ordered
+      list above
+- [x] Cluster 1 (contributor-role localization) lands with a verified
+      multilingual render proof (`citum render refs -L fr-FR`/`-L de-DE`:
+      narrator "Narrated by" → "Lu par"; translator "Translated by" →
+      "Übersetzt von" (de-DE) / "Traduit par" (fr-FR, T&F))
+- [x] No embedded or in-repo style outside the Chicago family regresses in
+      exact parity as a side effect of locale additions made for this family
+      (`check-core-quality.js` against the 19-style embedded-core baseline:
+      gate passed, 0 exact-parity regressions; only unrelated pre-existing
+      `ieee` preset-usage warning, untouched by this stack)
+- [x] `docs/reference/SQI.md` and the generated compat dashboard reflect
+      exact parity as the headline metric and fidelity as a tripwire
+
+Cluster 1 also surfaced and fixed a real schema gap outside its original
+scope, per explicit instruction not to defer it: `citum-schema-style::template::ContributorRole`
+was missing a `Narrator` variant (had `Performer`/`Illustrator`/`Writer` but
+not `Narrator`), so `contributor: narrator, form: verb` silently rendered no
+role label at all. Fixed with a 4-line Rust diff (template.rs, mod.rs,
+substitute.rs, raw_conversion.rs); full `cargo nextest run` (2420/2420),
+`cargo clippy -D warnings`, and `just schema-gen` all clean.
+
+## Changelog
+
+- 2026-08-07: Initial version.
+- 2026-08-07: Cluster 1 (contributor-role localization) landed for
+  `chicago-author-date-18th` and `taylor-and-francis-chicago-author-date-core`;
+  acceptance criteria updated with verified results.

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -3334,9 +3334,13 @@ function generateHtmlSqiExplainer(report) {
                     parity values are advisory and do not appear in this report at all.
                 </p>
                 <p class="text-sm text-slate-600 mb-3">
-                    <strong>Compatibility</strong> is the existing lenient regression gate; it can tolerate meaningful text-level drift.
-                    <strong>Oracle text parity</strong> is the stricter, symmetric comparison of visible renderer text.
-                    <strong>SQI</strong> (Style Quality Index) is secondary: it scores maintainability and fallback quality.
+                    <strong>Oracle text parity</strong> is the headline metric: the stricter, symmetric, byte-level
+                    comparison of visible renderer text against the oracle. <strong>Fidelity</strong> (labelled
+                    "Compatibility" in the per-style table for historical reasons) is a coarser, lenient pass/fail
+                    rate over the same comparisons — it carries no information exact parity doesn't already carry,
+                    so it is retained only as a regression tripwire, not as an independent quality dimension.
+                    <strong>SQI</strong> (Style Quality Index) is separate again: it scores maintainability and
+                    fallback quality, not oracle agreement.
                     Most styles are verified against the <strong>citeproc-js</strong> oracle; a small number of biblatex-derived
                     styles (currently just <code>numeric-comp</code>, in the exemplar tier) instead use
                     <strong>biblatex</strong> as their primary authority, because biblatex is the only origin format for the
@@ -3349,9 +3353,10 @@ function generateHtmlSqiExplainer(report) {
                     <code>${meanCompat}% compatibility</code> and <code>${meanSqi} SQI</code> (mean across ${embeddedStyles.length} styles).
                     These are directional targets, not a per-style gate — the enforced gate
                     (<code>scripts/check-core-quality.js</code>) checks fidelity and exact-parity drift against a recorded
-                    baseline per style: fidelity must stay at 1.0, and a style's exact-parity <code>passed</code> count may
-                    never drop below its baseline floor (SQI drift is warn-only outside the embedded tier). Exact parity is
-                    the primary tuning objective for embedded-core styles; residuals an agent cannot classify are recorded in
+                    baseline per style: fidelity (the tripwire) must stay at 1.0, and a style's exact-parity
+                    <code>passed</code> count may never drop below its baseline floor (SQI drift is warn-only outside
+                    the embedded tier). Exact parity is the primary tuning objective for embedded-core styles;
+                    residuals an agent cannot classify are recorded in
                     <code>scripts/report-data/parity-adjudication.json</code> as <code>unclear</code> and escalated rather than
                     excluded unilaterally.
                 </p>
@@ -3545,13 +3550,13 @@ function generateHtmlTable(report) {
                     <td class="hidden md:table-cell px-6 py-4">
                         ${componentRateHtml}
                     </td>
-                    <td class="px-6 py-4 text-sm font-mono text-slate-600">${fidelityPct}%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium ${exactParityBadge}">
                             ${exactParityText}
                         </span>
                         ${style.exactParity?.notComparable > 0 ? `<div class="mt-1 text-[10px] text-slate-400">${style.exactParity.notComparable} N/A</div>` : ''}
                     </td>
+                    <td class="px-6 py-4 text-sm font-mono text-slate-600">${fidelityPct}%</td>
                     <td class="hidden md:table-cell px-6 py-4 text-sm font-mono text-slate-600">${qualityPct}%</td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium ${sqiBadgeClass}">
@@ -3634,13 +3639,13 @@ ${generateDetailContent(style)}
                                 </button>
                             </th>
                             <th class="text-left px-6 py-4 text-xs font-semibold text-slate-700">
-                                <button class="inline-flex items-center gap-1 hover:text-primary transition-colors" onclick="sortCompatTable('fidelity')">
-                                    Compatibility <span class="text-slate-400" id="sort-ind-fidelity">↕</span>
-                                </button>
-                            </th>
-                            <th class="text-left px-6 py-4 text-xs font-semibold text-slate-700">
                                 <button class="inline-flex items-center gap-1 hover:text-primary transition-colors" onclick="sortCompatTable('exact-parity')">
                                     Oracle Text <span class="text-slate-400" id="sort-ind-exact-parity">↕</span>
+                                </button>
+                            </th>
+                            <th class="text-left px-6 py-4 text-xs font-semibold text-slate-700" title="Coarse regression tripwire — carries no information Oracle Text parity doesn't already carry">
+                                <button class="inline-flex items-center gap-1 hover:text-primary transition-colors" onclick="sortCompatTable('fidelity')">
+                                    Fidelity <span class="text-slate-400" id="sort-ind-fidelity">↕</span>
                                 </button>
                             </th>
                             <th class="hidden md:table-cell text-left px-6 py-4 text-xs font-semibold text-slate-700">

--- a/scripts/style-structure-lint.js
+++ b/scripts/style-structure-lint.js
@@ -6,6 +6,10 @@ const yaml = require('js-yaml');
 
 const PROJECT_ROOT = path.resolve(__dirname, '..');
 const STYLES_DIR = path.join(PROJECT_ROOT, 'styles');
+const REFERENCE_LOCALE_PATH = path.join(
+  PROJECT_ROOT,
+  'crates/citum-schema-style/embedded/locales/en-US.yaml'
+);
 
 const RULES = {
   STYLE001: 'Anonymous generated YAML anchors are not allowed in committed styles.',
@@ -17,6 +21,7 @@ const RULES = {
   STYLE007: 'Empty style version values should be omitted so schema defaults apply.',
   STYLE008: 'Rendered template terms are deprecated; use message components instead.',
   STYLE009: 'Phrase-like term-backed messages must use localized pattern messages.',
+  STYLE010: 'Hardcoded prefix/suffix prose duplicates an existing locale role verb, term, or message; use the locale mechanism instead so the text localizes. See docs/policies/LOCALIZATION_INTEGRITY.md.',
 };
 
 const FATAL_RULE_IDS = new Set(['STYLE008', 'STYLE009']);
@@ -269,6 +274,112 @@ function lintPhraseLikeTermMessages(filePath, content) {
       file: repoRelative(filePath),
       line: content.slice(0, match.index).split('\n').length,
       message: `${RULES.STYLE009} Found message: term.${messageId}.`,
+      fixable: false,
+    });
+  }
+
+  return violations;
+}
+
+const AFFIX_STRIP_PATTERN = /^[\s,.:;()"'‘’“”]+|[\s,.:;()"'‘’“”]+$/g;
+const MF2_PLACEHOLDER_PATTERN = /\{\$[^}]+\}/g;
+
+function normalizeAffixText(rawValue) {
+  if (typeof rawValue !== 'string') return '';
+  let value = rawValue.trim();
+
+  // A YAML string value may be followed by a trailing `# comment` (e.g. the
+  // FIX/TODO annotations this rule exists to catch). Extract only the quoted
+  // value itself so the comment text never leaks into the comparison.
+  if (value.startsWith('"')) {
+    const closeIndex = value.indexOf('"', 1);
+    value = closeIndex === -1 ? value.slice(1) : value.slice(1, closeIndex);
+  } else if (value.startsWith("'")) {
+    const closeIndex = value.indexOf("'", 1);
+    value = closeIndex === -1 ? value.slice(1) : value.slice(1, closeIndex);
+  } else {
+    const commentIndex = value.search(/\s#/);
+    if (commentIndex !== -1) value = value.slice(0, commentIndex);
+  }
+
+  value = value.replace(MF2_PLACEHOLDER_PATTERN, ' ');
+  value = value.replace(AFFIX_STRIP_PATTERN, '');
+  return value.trim().toLowerCase();
+}
+
+/**
+ * Builds the set of normalized strings a hardcoded prefix/suffix may
+ * legitimately be replaced by: role verb/short-verb/long/short labels,
+ * plain terms, and single-line message pattern bodies. Multi-line MF2
+ * `.match` messages (plural/gender dispatch) are intentionally excluded —
+ * they have no single literal string to compare against.
+ */
+function loadLocaleAffixValueSet(localePath = REFERENCE_LOCALE_PATH) {
+  const values = new Set();
+  let locale;
+  try {
+    locale = yaml.load(fs.readFileSync(localePath, 'utf8'));
+  } catch {
+    return values;
+  }
+  if (!locale || typeof locale !== 'object') return values;
+
+  const addValue = (value) => {
+    const normalized = normalizeAffixText(value);
+    if (normalized) values.add(normalized);
+  };
+
+  const addFormBlock = (formBlock) => {
+    if (!formBlock) return;
+    if (typeof formBlock === 'string') {
+      addValue(formBlock);
+      return;
+    }
+    if (typeof formBlock === 'object') {
+      addValue(formBlock.singular);
+      addValue(formBlock.plural);
+    }
+  };
+
+  for (const role of Object.values(locale.roles || {})) {
+    if (!role || typeof role !== 'object') continue;
+    addFormBlock(role.long);
+    addFormBlock(role.short);
+    addValue(role.verb);
+    addValue(role['verb-short']);
+  }
+
+  for (const term of Object.values(locale.terms || {})) {
+    if (!term || typeof term !== 'object') continue;
+    addFormBlock(term.long);
+    addFormBlock(term.short);
+  }
+
+  for (const message of Object.values(locale.messages || {})) {
+    if (typeof message !== 'string') continue;
+    if (message.trim().startsWith('.match')) continue;
+    addValue(message);
+  }
+
+  return values;
+}
+
+function lintHardcodedLocaleProse(filePath, content, localeValueSet) {
+  const violations = [];
+  if (!localeValueSet || localeValueSet.size === 0) return violations;
+
+  const pattern = /^(\s*)(prefix|suffix):\s*(.+)$/gm;
+  let match;
+
+  while ((match = pattern.exec(content)) !== null) {
+    const normalized = normalizeAffixText(match[3]);
+    if (!normalized || !localeValueSet.has(normalized)) continue;
+
+    violations.push({
+      ruleId: 'STYLE010',
+      file: repoRelative(filePath),
+      line: content.slice(0, match.index).split('\n').length,
+      message: `${RULES.STYLE010} Found ${match[2]}: ${match[3].trim()}`,
       fixable: false,
     });
   }
@@ -715,13 +826,23 @@ function applyFixes(data) {
   return changed;
 }
 
+let cachedLocaleAffixValueSet = null;
+function getLocaleAffixValueSet() {
+  if (!cachedLocaleAffixValueSet) {
+    cachedLocaleAffixValueSet = loadLocaleAffixValueSet();
+  }
+  return cachedLocaleAffixValueSet;
+}
+
 function lintStyleFile(filePath, options = {}) {
   const content = fs.readFileSync(filePath, 'utf8');
+  const localeValueSet = getLocaleAffixValueSet();
   const violations = lintAnonymousAnchors(filePath, content);
   violations.push(...lintLegacyItemsAlias(filePath, content));
   violations.push(...lintEmptyStyleVersion(filePath, content));
   violations.push(...lintDeprecatedTemplateTerms(filePath, content));
   violations.push(...lintPhraseLikeTermMessages(filePath, content));
+  violations.push(...lintHardcodedLocaleProse(filePath, content, localeValueSet));
   let workingContent = content;
   let fixed = false;
 
@@ -792,6 +913,7 @@ function lintStyleFile(filePath, options = {}) {
     ...lintEmptyStyleVersion(filePath, refreshedContent),
     ...lintDeprecatedTemplateTerms(filePath, refreshedContent),
     ...lintPhraseLikeTermMessages(filePath, refreshedContent),
+    ...lintHardcodedLocaleProse(filePath, refreshedContent, localeValueSet),
   ];
   if (parsed && typeof parsed === 'object' && !fixed) {
     refreshedViolations.push(...lintParsedStyle(filePath, refreshedContent, parsed));
@@ -872,10 +994,13 @@ module.exports = {
   lintEmptyStyleVersion,
   lintDeprecatedTemplateTerms,
   lintPhraseLikeTermMessages,
+  lintHardcodedLocaleProse,
   lintAnonymousAnchors,
   lintLegacyItemsAlias,
   lintParsedStyle,
   lintStyleFile,
+  loadLocaleAffixValueSet,
+  normalizeAffixText,
   parseAnonymousAnchorBlocks,
   parseInlineAnonymousAnchors,
   removeEmptyVersionInText,

--- a/scripts/style-structure-lint.test.js
+++ b/scripts/style-structure-lint.test.js
@@ -12,8 +12,11 @@ const {
   lintEmptyStyleVersion,
   lintDeprecatedTemplateTerms,
   lintPhraseLikeTermMessages,
+  lintHardcodedLocaleProse,
   lintLegacyItemsAlias,
   lintParsedStyle,
+  loadLocaleAffixValueSet,
+  normalizeAffixText,
   removeEmptyVersionInText,
   stripAnonymousAnchorMarkersInText,
 } = require('./style-structure-lint');
@@ -450,6 +453,91 @@ test('STYLE009 allows lexical term-backed messages', () => {
   const violations = lintPhraseLikeTermMessages('styles/fixture.yaml', content);
 
   assert.equal(violations.length, 0);
+});
+
+test('STYLE010 flags a hardcoded prefix that duplicates a locale role verb', () => {
+  const localeValueSet = new Set(['translated by', 'written by']);
+  const content = `bibliography:
+  template:
+    - contributor: translator
+      prefix: "Translated by "
+`;
+
+  const violations = lintHardcodedLocaleProse('styles/fixture.yaml', content, localeValueSet);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].ruleId, 'STYLE010');
+  assert.equal(violations[0].line, 4);
+  assert.equal(violations[0].fixable, false);
+});
+
+test('STYLE010 ignores structural punctuation and non-linguistic literals', () => {
+  const localeValueSet = new Set(['translated by']);
+  const content = `bibliography:
+  template:
+    - number: issue
+      prefix: " ("
+      suffix: ")"
+    - variable: doi
+      prefix: ". https://doi.org/"
+`;
+
+  const violations = lintHardcodedLocaleProse('styles/fixture.yaml', content, localeValueSet);
+
+  assert.equal(violations.length, 0);
+});
+
+test('STYLE010 does not flag prose with no locale equivalent', () => {
+  const localeValueSet = new Set(['translated by']);
+  const content = `bibliography:
+  template:
+    - date: issued
+      prefix: "Recorded "
+`;
+
+  const violations = lintHardcodedLocaleProse('styles/fixture.yaml', content, localeValueSet);
+
+  assert.equal(violations.length, 0);
+});
+
+test('normalizeAffixText strips quotes, punctuation, and casefolds', () => {
+  assert.equal(normalizeAffixText('"Translated by "'), 'translated by');
+  assert.equal(normalizeAffixText('", written by "'), 'written by');
+  assert.equal(normalizeAffixText('" ("'), '');
+  assert.equal(normalizeAffixText('". https://doi.org/"'), 'https://doi.org/');
+});
+
+test('normalizeAffixText strips a trailing YAML comment without leaking it into the value', () => {
+  assert.equal(normalizeAffixText('"Illustrated by " # FIX locale-specific string'), 'illustrated by');
+  assert.equal(
+    normalizeAffixText('", written by "  # FIX locale-specific string; also duplicating logic'),
+    'written by'
+  );
+});
+
+test('STYLE010 flags a hardcoded prefix even when annotated with a trailing FIX comment', () => {
+  const localeValueSet = new Set(['illustrated by']);
+  const content = `bibliography:
+  template:
+    - contributor: illustrator
+      form: long
+      prefix: "Illustrated by " # FIX locale-specific string
+`;
+
+  const violations = lintHardcodedLocaleProse('styles/fixture.yaml', content, localeValueSet);
+
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].ruleId, 'STYLE010');
+});
+
+test('loadLocaleAffixValueSet builds a matchable set from en-US.yaml', () => {
+  const values = loadLocaleAffixValueSet();
+
+  assert.ok(values.has('translated by'));
+  assert.ok(values.has('edited by'));
+  assert.ok(values.has('written by'));
+  // Multi-line .match MF2 messages are excluded — no single literal to compare against.
+  assert.ok(!values.has('track'));
 });
 
 test('applyFixes removes empty version properties', () => {


### PR DESCRIPTION
## Summary

Reframes Chicago-family strategy (exact parity as target, fidelity as
tripwire) and lands one proven cluster: contributor-role localization.
4 commits: docs/policy → detector → engine fix → style conversions.

- **Authority rule established** for CSL-derived Chicago styles: citeproc-js
  output governs; CMOS/Gemini prose adjudicates divergences, never sets
  targets. Verified against a live claim (et-al thresholds differ by
  citation/bibliography scope even within one style — a Gemini claim that
  didn't hold).
- **`csl26-h7oc` restructured** from per-style tuning (which repeatedly
  deferred the same structural defects across 6+ sessions — `csl26-giun`,
  `csl26-7jht`, scrapped with evidence preserved) to per-defect-cluster
  children.
- **New `STYLE010` lint rule** catches hardcoded prose duplicating an
  existing locale term — found because `chicago-notes-18th` uses locale
  messages for 17 sites while `taylor-and-francis-chicago-author-date-core`
  hardcoded 17 sites with **zero** locale-message use, and no existing
  metric could see the drift (the oracle is English-only).
- **Engine fix**: `ContributorRole` in the template schema was missing a
  `Narrator` variant, so `form: verb` on `contributor: narrator` silently
  rendered no role label. Split into its own commit — it's a standalone fix
  that doesn't depend on or get exercised by any committed style content
  until the next commit.
- **36 sites converted** across `chicago-author-date-18th` and
  `taylor-and-francis-chicago-author-date-core` to locale-driven role verbs
  / `message: pattern.chicago-*` calls.

## What this actually moves (and what it doesn't)

- **Exact parity: unchanged, by design.** Both styles stay at 172/546, 0
  entries changed in either direction (verified entry-by-entry against each
  style's own baseline, not just the aggregate count). The converted text
  was already oracle-correct in English — a pure locale-source swap of
  already-correct text cannot move an English-only oracle's pass/fail count.
  Parity movement is cluster 2-7's job, not attempted here.
- **Inheritance: untouched, by design.** `chicago-18-base.yaml` has zero
  diff; neither style's `extends` chain changed.
- **What did move, measured directly** — STYLE010 hit count (hardcoded
  sites): author-date **25 → 1**, T&F-core **12 → 1** (remaining hits are
  documented exceptions with no clean locale mechanism available). Locale
  `message: pattern.*` uses: author-date **8 → 24**, T&F-core **0 → 4**
  (undercounts the real increase — `form: verb` conversions reference
  locale role verbs directly, not `message:` calls).
- **Two incidental bugs fixed**, unrelated to localization: the `Narrator`
  engine gap above, and a real "Released. Released." duplication in the
  `software` type-variant, confirmed via citeproc-js oracle comparison on
  the Gran Turismo 7 fixture item. That entry stays a parity mismatch after
  the fix — it has a separate, untouched author/title ordering defect — so
  it doesn't show up in the exact-parity delta despite being a real fix.

## Multilingual proof

```
$ citum render refs -b refs.json -s chicago-author-date-18th -L fr-FR
Narrated by the author.  ->  Lu par the author.

$ citum render refs -b refs.json -s chicago-author-date-18th -L de-DE
Translated by David Wyllie.  ->  Übersetzt von David Wyllie.
```

## Test plan

- [x] `cargo nextest run --workspace` — 2420/2420 passing
- [x] `cargo fmt --check` / `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `just schema-gen` — schemas regenerated for the `Narrator` enum addition
- [x] `node scripts/report-core.js --styles chicago-author-date-18th` — 172/546 exact parity, 0 entries changed vs. baseline
- [x] `node scripts/report-core.js --styles taylor-and-francis-chicago-author-date` — 172/546 exact parity, 0 entries changed vs. baseline
- [x] `node scripts/check-core-quality.js` (full embedded-core baseline, `--all-features`) — gate passed, 0 exact-parity regressions
- [x] `node --test scripts/style-structure-lint.test.js scripts/report-core.test.js` — 88/88 passing
- [x] Multilingual proof via `citum render refs -L fr-FR`/`-L de-DE` (above)
