### PR TITLE
Specify style-template expressiveness and parity coverage

### DIFF
--- a/.beans/archive/csl26-9zn6--define-template-expressiveness-and-parity-coverage.md
+++ b/.beans/archive/csl26-9zn6--define-template-expressiveness-and-parity-coverage.md
@@ -1,0 +1,44 @@
+---
+# csl26-9zn6
+title: Define style template expressiveness and parity coverage workflow
+status: completed
+type: task
+priority: high
+tags:
+    - docs
+    - architecture
+    - qa
+created_at: 2026-08-09T14:42:00Z
+updated_at: 2026-08-09T14:46:04Z
+---
+
+Produce the docs-only maintainer adjudication for style-template
+expressiveness and parity coverage. The deliverable is a Draft specification,
+not implementation.
+
+Scope:
+
+- decide whether current evidence justifies macros or general conditionals;
+- specify fallback-template diff semantics without carrying pilot code;
+- define coverage state, provenance, denominator, and QA contracts;
+- separate observed pilot facts from inference and preserve unresolved
+  questions;
+- split implementation into the existing fallback bean and a dedicated
+  auditable-packet bean.
+
+Explicitly excluded: generated pilot packets, individual model review records,
+Rust or JavaScript changes, style changes, and workflow control-surface edits.
+
+- [x] Draft and index the specification.
+- [x] Adjudicate the pilot against row and repository evidence.
+- [x] Rescope csl26-4xg9 to the accepted fallback design.
+- [x] Create the auditable and reproducible packet follow-up bean.
+- [x] Keep implementation and workflow changes out of this task.
+
+## Summary of Changes
+
+Published the Draft specification as a docs-only adjudication. It retains
+bounded template reuse, narrows fallback patching to the existing `template`
+field, separates render disposition from comparability, and requires an audit
+manifest before pilot metrics can become baselines. Implementation remains in
+`csl26-4xg9` and `csl26-02yg`.

--- a/.beans/csl26-02yg--make-style-coverage-packets-auditable-and-reproduc.md
+++ b/.beans/csl26-02yg--make-style-coverage-packets-auditable-and-reproduc.md
@@ -1,0 +1,44 @@
+---
+# csl26-02yg
+title: Make style coverage packets auditable and reproducible
+status: todo
+type: task
+priority: high
+tags:
+    - qa
+    - harness
+    - coverage
+created_at: 2026-08-09T14:41:10Z
+updated_at: 2026-08-09T14:41:10Z
+---
+
+Build the coverage packet contract specified by
+docs/specs/STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md. The packet must be
+auditable without trusting aggregate fidelity or an uncommitted working tree.
+
+Required work:
+
+- define a versioned audit manifest with style-chain, fixture, authority, and
+  report hashes;
+- assign a stable observation ID to every style, surface, fixture, reference,
+  type, and field combination;
+- record render disposition separately from comparison eligibility;
+- declare relevant fields and intentional omissions with rationale;
+- join exact-parity evidence by stable identity and reject a supplied report
+  when every exact-match value is null;
+- use deterministic codepoint ordering and emit the complete observation set;
+- add a freshness test that regenerates committed evidence byte for byte;
+- prefer an engine-produced resolved-template trace over a second resolver;
+  if a mirror remains necessary, cover it with shared conformance fixtures.
+
+The 2026-08-09 shortened-notes pilot is motivating evidence, not an accepted
+baseline. Its working-tree provenance, missing row identity, broken parity
+join, and truncated Markdown output must be fixed before its 23/482 parity or
+119 uncovered observations are used as gates.
+
+- [ ] Audit manifest schema and validation are implemented.
+- [ ] Observation identities are stable and unique.
+- [ ] Relevance, intentional omission, and comparability are explicit.
+- [ ] Packet generation is complete, deterministic, and freshness-tested.
+- [ ] Supplied parity evidence produces joined non-null exact-match rows.
+- [ ] Resolver evidence comes from the engine or passes conformance fixtures.

--- a/.beans/csl26-4xg9--proposal-make-style-wide-fallback-templates-patcha.md
+++ b/.beans/csl26-4xg9--proposal-make-style-wide-fallback-templates-patcha.md
@@ -1,6 +1,6 @@
 ---
 # csl26-4xg9
-title: 'Proposal: make style-wide fallback templates patchable like reference-type templates'
+title: Implement inherited fallback-template diffs
 status: todo
 type: feature
 priority: normal
@@ -9,17 +9,35 @@ tags:
     - style
     - chicago
 created_at: 2026-08-07T23:53:13Z
-updated_at: 2026-08-07T23:53:13Z
+updated_at: 2026-08-09T14:48:58Z
 ---
 
-Surfaced in docs/specs/CHICAGO_VARIANT_AXES.md (Gap B) while checking whether Citum's inheritance covers the CSL Chicago family's -no-url variant. Every style has one fallback bibliography template (and one fallback citation template) used for any reference type without a template of its own -- BibliographySpec.template (crates/citum-schema-style/src/style/sections/bibliography.rs:40) and CitationSpec.template (crates/citum-schema-style/src/style/sections/citation.rs:56). Both are a plain Option<Template> (bare component list), not the Full-or-Diff TemplateVariant (crates/citum-schema-style/src/template.rs:653) that reference-type templates in type-variants already use. So modify:/remove:/add: only work per reference type; under extends: the fallback template is whole-replace only (confirmed by test_explicit_null_clears_bibliography_template, crates/citum-schema-style/tests/bdd_inheritance.rs:448). Concretely: chicago-author-date-18th.yaml's own fallback bibliography template renders variable: doi and variable: url unconditionally at its final two components (lines 1041-1043), and a child style cannot remove just those two components -- only copy the entire 41-line template, which then stops tracking the parent's future changes.
+Implement the fallback-template diff contract in
+docs/specs/STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md. This is Gap B from
+docs/specs/CHICAGO_VARIANT_AXES.md.
 
-This looks accidental, not intentional: nothing in STYLE_INHERITANCE.md's merge rules explains why the fallback template should be exempt from the same patch mechanism reference-type templates already have -- it reads as an oversight in how the two fields were typed, not a deliberate constraint.
+BibliographySpec.template and CitationSpec.template are currently
+Option<Template>, while type-specific templates use TemplateVariant. A child
+style therefore has to replace an inherited fallback in full even when it only
+needs to remove or modify one component.
 
-Proposed direction: widen BibliographySpec.template and CitationSpec.template from Option<Template> to Option<TemplateVariant>, reusing the exact Full/Diff resolution already built and tested for reference-type templates (crates/citum-schema-style/src/template/resolution.rs), so a child's Diff patches the parent's already-resolved fallback template the same way it already patches a parent's reference-type template.
+Required direction:
 
-This is a schema and engine change. Per this project's policy, it needs its own docs-first spec PR (with rejected alternatives) before any implementation -- not done as part of the Chicago-axes mapping spec.
+- widen the existing template fields to Option<TemplateVariant> rather than
+  adding a sibling template-variant field;
+- preserve existing YAML sequences as TemplateVariant::Full;
+- resolve the parent's effective fallback, including template-ref, before a
+  child Diff applies;
+- reject a root Diff with no inherited fallback;
+- reject TemplateVariantDiff.extends on fallback templates;
+- reject template-ref plus Diff in the same section;
+- preserve explicit template: null clearing behavior;
+- leave only a concrete Full fallback after style resolution;
+- cover the same cases for citation and bibliography, including selector
+  diagnostics, and regenerate schemas in the implementation commit.
 
-- [ ] Draft a docs/specs/*.md spec proposing the Option<TemplateVariant> widening, including how existing Full-typed fallback templates in shipped styles stay valid (Full is one of the two TemplateVariant cases, so no migration needed) and any interaction with template_ref
-- [ ] Get the spec reviewed and merged as Draft
-- [ ] Implement in a follow-up PR, status flips to Active in that same commit
+- [x] Draft the docs/specs contract, including compatibility and template-ref
+      interaction.
+- [ ] Get the Draft specification reviewed and merged.
+- [ ] Implement the schema and resolver change in a follow-up PR.
+- [ ] Regenerate schemas and pass citation and bibliography conformance tests.

--- a/docs/specs/CHICAGO_FAMILY_STRATEGY.md
+++ b/docs/specs/CHICAGO_FAMILY_STRATEGY.md
@@ -4,7 +4,7 @@
 **Version:** 1.0
 **Date:** 2026-08-07
 **Supersedes:** (none — refines `csl26-40n4`/`csl26-h7oc` execution, does not replace them)
-**Related:** [`docs/architecture/audits/2026-06-30_CHICAGO_FAMILY_AUDIT.md`](../architecture/audits/2026-06-30_CHICAGO_FAMILY_AUDIT.md), [`CHICAGO_18_COVERAGE.md`](./CHICAGO_18_COVERAGE.md), [`CONTRIBUTOR_PHRASE_MESSAGES.md`](./CONTRIBUTOR_PHRASE_MESSAGES.md), [`LOCALE_MESSAGES.md`](./LOCALE_MESSAGES.md), [`CHICAGO_VARIANT_AXES.md`](./CHICAGO_VARIANT_AXES.md), beans `csl26-40n4`, `csl26-h7oc`, `csl26-dfq0`, `csl26-ztl9`
+**Related:** [`docs/architecture/audits/2026-06-30_CHICAGO_FAMILY_AUDIT.md`](../architecture/audits/2026-06-30_CHICAGO_FAMILY_AUDIT.md), [`CHICAGO_18_COVERAGE.md`](./CHICAGO_18_COVERAGE.md), [`CONTRIBUTOR_PHRASE_MESSAGES.md`](./CONTRIBUTOR_PHRASE_MESSAGES.md), [`LOCALE_MESSAGES.md`](./LOCALE_MESSAGES.md), [`CHICAGO_VARIANT_AXES.md`](./CHICAGO_VARIANT_AXES.md), [`STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md`](./STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md), beans `csl26-40n4`, `csl26-h7oc`, `csl26-dfq0`, `csl26-ztl9`
 
 ## Purpose
 

--- a/docs/specs/CHICAGO_VARIANT_AXES.md
+++ b/docs/specs/CHICAGO_VARIANT_AXES.md
@@ -7,6 +7,7 @@
 **Related:** [`CHICAGO_FAMILY_STRATEGY.md`](./CHICAGO_FAMILY_STRATEGY.md),
 [`STYLE_INHERITANCE.md`](./STYLE_INHERITANCE.md),
 [`STYLE_PRESET_ARCHITECTURE.md`](./STYLE_PRESET_ARCHITECTURE.md),
+[`STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md`](./STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md),
 [`NOTE_SHORTENING_POLICY.md`](./NOTE_SHORTENING_POLICY.md),
 beans `csl26-ztl9`, `csl26-adka`, `csl26-cfgw`, `csl26-4xg9`, external:
 [`citation-style-language/style-variant-builder`](https://github.com/citation-style-language/style-variant-builder)

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -192,6 +192,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | [`APA_SQI_ALIGNMENT_AND_PRESET_REFACTOR.md`](./APA_SQI_ALIGNMENT_AND_PRESET_REFACTOR.md) — APA SQI alignment and preset-first cleanup | Active | `bibliography.rs`, `citations.rs` |
 | [`CHICAGO_18_COVERAGE.md`](./CHICAGO_18_COVERAGE.md) — Chicago 18th and APA 8th high-fidelity coverage enhancement | Active | `bibliography.rs`, `citations.rs` |
 | [`CHICAGO_VARIANT_AXES.md`](./CHICAGO_VARIANT_AXES.md) — mapping `style-variant-builder`'s template-diff model onto Citum `extends:`/type-variant inheritance | Draft | `crates/citum-schema-style/tests/bdd_inheritance.rs` |
+| [`STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md`](./STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md) — bounded template reuse, inherited fallback diffs, and auditable field coverage | Draft | — |
 | [`UNIFIED_SCOPED_OPTIONS.md`](./UNIFIED_SCOPED_OPTIONS.md) — typed scoped options replacing flat author-facing contracts | Active | `crates/citum-schema-style/tests/` |
 | [`PER_DOCUMENT_CONFIG_OVERRIDES.md`](./PER_DOCUMENT_CONFIG_OVERRIDES.md) — eligible options and syntax for per-document configuration overrides | Draft | `bibliography.rs::local_overrides` |
 | [`SCHEMA_SPLIT_AND_CONVERT_NAMESPACE.md`](./SCHEMA_SPLIT_AND_CONVERT_NAMESPACE.md) — crate-level schema split and CLI conversion namespace | Active | `crates/citum-schema/tests/` |

--- a/docs/specs/STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md
+++ b/docs/specs/STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md
@@ -1,0 +1,340 @@
+# Style Template Expressiveness and Parity Coverage Specification
+
+**Status:** Draft
+**Version:** 1.0
+**Date:** 2026-08-09
+**Supersedes:** (none)
+**Related:** beans `csl26-9zn6`, `csl26-4xg9`, `csl26-02yg`;
+[`CHICAGO_VARIANT_AXES.md`](./CHICAGO_VARIANT_AXES.md),
+[`TEMPLATE_V3.md`](./TEMPLATE_V3.md),
+[`STYLE_COMPATIBILITY_INHERITANCE_REPORT.md`](./STYLE_COMPATIBILITY_INHERITANCE_REPORT.md),
+[`REPO_LOCAL_HARNESS.md`](./REPO_LOCAL_HARNESS.md)
+
+## Purpose
+
+Define the smallest template and measurement contracts needed to improve a
+style without mistaking aggregate fidelity for correctness. The specification
+settles two related questions: how a child style can patch an inherited
+fallback template, and how a coverage packet proves which relevant fixture
+fields were rendered, intentionally omitted, handled by a fallback, or left
+uncovered.
+
+The shortened-notes pilot motivated this design. Its numerical results remain
+provisional because the packet was generated from uncommitted inputs and its
+row-level parity join failed. This specification preserves the useful findings
+without adopting those numbers as a baseline.
+
+## Scope
+
+In scope:
+
+- the admission rule for new template reuse or conditional features;
+- inherited diffs for citation and bibliography fallback templates;
+- a versioned audit manifest and stable observation identity;
+- field relevance, render disposition, comparison eligibility, and exact
+  parity denominators;
+- reviewer contracts and QA gates for reproducible style evidence;
+- adjudication of the shortened-notes pilot as provisional evidence.
+
+Out of scope:
+
+- adding a general macro or expression language;
+- implementing the fallback diff or coverage tooling in this documentation
+  change;
+- changing a style, converter, rendering engine, fixture, or workflow control
+  surface;
+- committing the pilot packet or individual model review records;
+- treating agreement among models as authority.
+
+## Design
+
+### Bounded expressiveness is the default
+
+Citum already provides six bounded composition mechanisms:
+
+1. `extends` for style-family inheritance;
+2. full or diff-form `type-variants` for reference-type templates;
+3. `render-when` for field-presence conditions;
+4. groups for local composition and affix control;
+5. presets for named configuration reuse; and
+6. locale messages for reusable, reorderable phrases.
+
+No observed shortened-notes residual requires a macro or general conditional.
+The measured defects map to style option values, template content, engine
+behavior, casing, fixtures, or authority pairing. This is a finding about the
+current evidence, not proof that every citation system is expressible. The
+legal, treaty, and hearing templates are too incomplete to test that boundary.
+
+A proposal for a new macro, expression, or conditional feature must include a
+minimum counterexample with all of the following:
+
+- one fixture reference and the expected authority output;
+- the smallest attempted Citum template;
+- an explanation of why `extends`, diffs, `render-when`, groups, presets, and
+  messages cannot express the result;
+- the repetition or maintenance cost that makes a type-specific template
+  inappropriate; and
+- a schema boundary and deterministic evaluation rule.
+
+Until such a counterexample exists, a residual must first be classified as an
+architecture, schema/engine, migration, style-data, fixture, QA, or harness
+finding. Missing template content is not evidence for a new language feature.
+
+### Fallback templates use the existing diff type
+
+`BibliographySpec.template` and `CitationSpec.template` are currently
+`Option<Template>`, while reference-type templates use the untagged
+`TemplateVariant` enum with `Full` and `Diff` cases. This asymmetry makes an
+inherited fallback whole-replace only. A child that needs to remove one URL
+component must copy the rest of the fallback and then track future parent
+changes manually. `CHICAGO_VARIANT_AXES.md`, Gap B, records the concrete
+Chicago example and bean `csl26-4xg9` tracks implementation.
+
+The implementation must widen the existing `template` fields to
+`Option<TemplateVariant>`. It must not add a second sibling field such as
+`template-variant`. Existing YAML sequences continue to deserialize as the
+`Full` case, so authored styles do not need migration.
+
+Resolution follows this contract:
+
+1. Resolve the parent's effective fallback to a concrete template before
+   overlaying the child. This includes resolving a parent `template-ref`.
+2. A child `Full` value replaces the inherited fallback, matching current
+   behavior.
+3. A child `Diff` applies to the captured parent fallback in authored
+   `modify`, `remove`, and `add` order.
+4. A root `Diff` with no inherited fallback is invalid and must name the
+   section and style in its diagnostic.
+5. `TemplateVariantDiff.extends` is invalid for a fallback diff. A fallback
+   has one inherited base and cannot select a reference-type template.
+6. Declaring `template-ref` and a `Diff` in the same section is invalid. A
+   parent reference can be patched after resolution, but a same-section
+   reference must not create a second, implicit base-selection rule.
+7. Existing explicit-null overlay behavior remains unchanged: `template:
+   null` clears an inherited fallback.
+8. Resolution is load-time only. A successfully resolved style exposes a
+   concrete `Full` fallback to the rendering engine and contains no pending
+   diff.
+
+The same conformance cases must cover citation and bibliography sections:
+backward-compatible full YAML, parent full plus child diff, parent
+`template-ref` plus child diff, missing parent, forbidden `extends`, explicit
+null, and selector failures. Schema generation belongs in the implementation
+commit.
+
+### Coverage has three independent dimensions
+
+A populated fixture field is not automatically a style requirement. Coverage
+starts by declaring whether the field is relevant to the style, surface, and
+fixture. Every exclusion needs a manifest rule and a rationale. Fixture
+metadata such as a license or citation key must not inflate the uncovered
+count merely because it is populated.
+
+Each relevant observation then receives exactly one render disposition:
+
+| Disposition | Meaning |
+|---|---|
+| `rendered` | The resolved, non-fallback path consumed the field for this observation. |
+| `fallback` | The resolved style-wide fallback consumed the field. |
+| `suppressed` | The audit manifest declares an intentional omission and its rationale. |
+| `uncovered` | No resolved path consumed the relevant field and no intentional omission applies. |
+
+Comparison eligibility is separate:
+
+| Comparison state | Meaning |
+|---|---|
+| `comparable` | A paired authority observation exists; `exactMatch` is `true` or `false`. |
+| `not-comparable` | No paired authority text exists; `exactMatch` is `null`. |
+
+This replaces the proposed five-value state list. `not-comparable` describes
+authority pairing, not rendering. A field may therefore be `rendered` and
+`not-comparable`, or `uncovered` and `comparable`, without contradiction.
+
+Static component discovery may explain a path, but it cannot prove that a
+conditional component consumed a value at runtime. The target evidence is an
+engine-produced trace of the resolved template and consumed semantic fields.
+If an external tool mirrors resolution, it must run shared conformance
+fixtures against the engine and identify itself as inferred structural
+coverage rather than runtime coverage.
+
+### Audit manifest and observation identity
+
+Every packet is generated from a versioned audit manifest. The manifest must
+record:
+
+- manifest version and packet ID;
+- source revision and whether the worktree was dirty;
+- style ID plus the path and content hash of every style in its inheritance
+  chain;
+- fixture paths and hashes, fixture IDs, reference IDs, and normalized types;
+- generator version or revision and normalized command arguments;
+- authority name, tool version, input hash, output hash, and evidence-run ID;
+- relevant-field rules and intentional omissions with rationales;
+- surfaces, comparison eligibility, and any registered authority conflict;
+- deterministic codepoint ordering and the expected observation count.
+
+An exploratory packet may describe a dirty worktree, but it cannot establish
+or update a gate baseline. Baseline evidence must come from committed inputs
+and must regenerate byte for byte from the recorded manifest.
+
+Each observation has a stable ID derived from:
+
+`style / surface / fixture / reference / normalized type / semantic field /
+occurrence`
+
+The occurrence discriminator is required only when the preceding fields do
+not identify one observation. Anonymous duplicate rows are invalid. Packet
+formats must emit the complete observation set; a human-readable view may
+paginate, but it must not silently truncate.
+
+When a parity report is supplied, rows join by stable evidence identity, not
+array position or display text. The generator must fail if all joined
+`exactMatch` values are null. A freshness test must regenerate committed
+evidence and compare bytes.
+
+### Denominators and gates
+
+Coverage and parity use separate denominators:
+
+- coverage total is the count of relevant observations;
+- coverage dispositions partition that total;
+- excluded populated fields are reported separately with their manifest
+  rationale;
+- exact-parity total is the count of comparable authority observations;
+- `not-comparable` observations are reported but excluded from exact parity.
+
+Fidelity remains a lenient compatibility tripwire. It does not prove field
+coverage or exact text. Exact parity also does not prove coverage because two
+renderers can omit the same relevant field. A completion claim therefore needs
+both coverage accounting and paired exact-parity evidence.
+
+A style or bounded cluster may move no exact observations for a valid reason,
+such as a localization-only change. The result must state its intended effect
+and classify every unchanged residual. A rendering cluster cannot be called
+complete solely because a floor did not regress.
+
+The QA gate for a baseline packet rejects:
+
+- a dirty or incomplete provenance manifest;
+- missing or duplicate observation IDs;
+- relevant fields without a render disposition;
+- suppressed or excluded fields without a rationale;
+- a supplied parity report whose row join produces no non-null exact matches;
+- a mismatched, unstable, or silently truncated denominator;
+- non-deterministic ordering or a stale generated artifact; and
+- a correctness claim based only on aggregate fidelity.
+
+### Review and adjudication
+
+Review packets should be examined from at least three perspectives:
+architecture and schema boundaries, CSL and style semantics, and QA and
+evaluation. Reviewers must label facts and inferences, cite stable observation
+IDs or repository paths, classify findings using the seven categories above,
+and flag missing evidence. Reviews are advisory. A maintainer adjudicates
+conflicts against the packet and authority contract; agreement among models
+does not change the specification.
+
+The repository does not need provider-specific invocation code to enforce this
+contract. Review records may be retained when they add durable evidence, but
+they are not substitutes for the manifest, trace, or maintainer decision.
+
+## Pilot Adjudication
+
+**Verdict:** approve-with-revisions.
+
+The three strongest agreements with the proposal are that bounded reuse is
+sufficient on current evidence, inherited fallback diffs close a concrete
+composition gap, and coverage plus exact parity is stronger than aggregate
+fidelity alone. The three strongest objections are that the packet provenance
+was not reproducible, the five proposed coverage states mixed two dimensions,
+and intentional omission had no auditable declaration channel.
+
+The uncommitted 2026-08-09 shortened-notes pilot reported 23/482 exact parity,
+13 not-comparable authority observations, and 119 uncovered field
+observations. Those are observed generator outputs, not accepted baselines.
+The packet named a Git revision while reading modified inherited styles,
+hashed only the leaf style, referenced a report in `/tmp`, emitted null
+row-level exact matches, and silently limited its Markdown table to 80 of 535
+rows. These facts prevent independent regeneration and row-level attribution.
+
+The pilot still supports the following provisional findings. Zero-based row
+offsets refer to its uncommitted JSON array and are included only to preserve
+the evidence trail until stable observation IDs replace them.
+
+| Classification | Fact or inference | Finding and evidence | Required action |
+|---|---|---|---|
+| architecture | Inference | No observed defect requires a macro or general conditional; legal, treaty, and hearing coverage is too incomplete to close that question. | Require a minimum counterexample before expanding the language. |
+| schema/engine | Fact | Fallback `template` fields are whole-replace while `type-variants` accept `TemplateVariant`; see `BibliographySpec.template`, `CitationSpec.template`, and `CHICAGO_VARIANT_AXES.md` Gap B. | Implement the widening under `csl26-4xg9`. |
+| QA | Inference | Render disposition and comparability were combined, so the five proposed states could not classify both at once. | Store them as independent dimensions. |
+| harness | Fact | The parity join yielded null `exactMatch` values, the Markdown view truncated rows, and provenance omitted dirty inherited inputs. | Implement the manifest and failure gates under `csl26-02yg`. |
+| fixture | Inference | About 37 of 119 uncovered observations were populated metadata such as `citation-key`, `license`, `language`, and `note`, not Chicago render obligations. Examples include pilot row offsets 121, 123-125, 182, and 184-185. | Declare relevance and report exclusions separately. |
+| style-data | Inference | Roughly 39 observations were likely intentional omissions, including bibliography `publisher-place` and fields omitted from shortened citations. Examples include row offsets 76, 143-148, 278-279, and 437-441. | Declare intentional omission with rationale before counting these as suppressed. |
+| style-data | Inference | Roughly 43 observations were likely real template gaps. Journal `issue` appears at offsets 40-45; legal and patent segments at 120, 126, 210, and 253-255; media and interview fields at 164-165, 204-205, and 241-244. | Repair one bounded defect family and remeasure with a valid packet. |
+| schema/engine | Inference | Citation punctuation-in-quote behavior, an authorless leading delimiter, and possible name-suffix ordering explain a material part of the exact drift. The pilot analysis attributed 14 of 38 citation failures solely to punctuation-in-quote. | Test the punctuation boundary as the first single-variable engine experiment. |
+| fixture | Fact | Reference `6188419/SMZBX82P` had divergent title text between compared inputs. | Compare the fixture with the authority input snapshot before assigning fault. |
+| QA | Fact | Thirteen authority observations were unpaired and therefore excluded from the 482 exact-parity denominator. | Preserve `not-comparable` separately and retain evidence-run identity. |
+| migration | Fact | The reviewed style chain was hand-authored, and the pilot identified no converter defect. | Do not assign any residual to migration without new converter evidence. |
+
+The numerical grouping above is a manual interpretation of flawed evidence.
+It explains why 119 is not one kind of defect, but it must not become a gate or
+be presented as an exact causal decomposition. Exact failures often contain
+several overlapping defects.
+
+## Three Smallest High-Leverage Follow-ups
+
+1. Implement the audit manifest, stable row join, complete output, and
+   regeneration test under `csl26-02yg`.
+2. Test and fix punctuation-in-quote at citation assembly, then regenerate the
+   same committed evidence run with an unchanged denominator.
+3. Repair the article-journal issue and year grammar in
+   `chicago-shortened-notes-bibliography-core.yaml`, then measure the inherited
+   effect independently of other residuals.
+
+The recommended next experiment is follow-up 2 on top of follow-up 1. It is a
+single engine variable with a predicted citation effect and exercises the full
+manifest, trace, join, and parity-ratchet path.
+
+## Unresolved Questions
+
+- Once legal, treaty, and hearing templates render their basic fields, does a
+  minimal authority case expose a real conditional gap?
+- Is the `6188419/SMZBX82P` title divergence in the fixture, the authority
+  input, or the pairing?
+- Which engine trace format can expose resolved component and consumed-field
+  identity without coupling the audit to internal renderer types?
+- Should manifest relevance rules live beside fixtures or in a separate
+  versioned audit profile? They must not become hidden style semantics.
+
+## Implementation Notes
+
+- `csl26-4xg9` owns only the schema, resolver, schema-generation, and
+  conformance work for fallback diffs.
+- `csl26-02yg` owns the manifest and packet implementation. It should consume
+  engine resolution evidence where available instead of maintaining a second
+  style resolver.
+- Style and engine fixes discovered by the pilot remain separate changes with
+  their own before-and-after evidence.
+- Workflow control surfaces should be updated only after the packet gates are
+  executable and proven. This Draft does not change contributor policy.
+
+## Acceptance Criteria
+
+- [x] The macro admission rule is tied to a concrete counterexample.
+- [x] Fallback diff syntax, resolution order, error cases, null behavior, and
+      `template-ref` interaction are specified.
+- [x] Relevance, render disposition, comparison eligibility, and exact-parity
+      denominators are defined independently.
+- [x] The pilot findings are separated into facts and inferences without
+      adopting the reported totals as a baseline.
+- [ ] `csl26-4xg9` implements fallback diffs and passes citation and
+      bibliography conformance tests.
+- [ ] `csl26-02yg` implements the manifest, trace or conformance evidence,
+      stable joins, complete output, and byte-regeneration gate.
+- [ ] A committed shortened-notes packet passes the new QA gates and replaces
+      the provisional pilot numbers.
+
+## Changelog
+
+- 2026-08-09: Initial Draft. Adjudicated the shortened-notes pilot, narrowed
+  the fallback design to the existing `template` field, and split coverage
+  disposition from comparison eligibility.


### PR DESCRIPTION
## Summary

- approve bounded reuse on current evidence and require a concrete
  counterexample before adding macros or general conditionals
- specify fallback diffs by widening the existing citation and bibliography
  `template` fields to `TemplateVariant`, including error and `template-ref`
  semantics
- separate field relevance, render disposition, and comparison eligibility,
  backed by a versioned audit manifest and stable observation IDs
- retain the shortened-notes pilot only as provisional evidence because its
  provenance, parity join, and Markdown completeness were not auditable

## Scope

This is one docs-and-beans commit. It intentionally excludes the raw packet,
individual model review records, Rust and JavaScript implementation, style
changes, and workflow control-surface edits.

Bean changes:

- complete and archive `csl26-9zn6` as the docs-only adjudication
- rescope `csl26-4xg9` to implement inherited fallback diffs
- create `csl26-02yg` for reproducible coverage packets

## Validation

- `git diff --check`
- `./scripts/validate-frontmatter.sh --repo-only --copilot-strict` (19 files)
- bean hygiene through the repository skill wrapper; only two unrelated
  advisory stale matches on `main`
- direct existence checks for every new Markdown link target
- pre-commit and pre-push hooks passed; the Rust gate correctly skipped this
  docs-and-beans-only change

`node scripts/check-doc-links.js` still reports nine unchanged broken links in
generated HTML files. None is introduced or touched by this branch.
