### PR TITLE
Support inherited fallback-template diffs

### DIFF
--- a/.beans/csl26-4xg9--proposal-make-style-wide-fallback-templates-patcha.md
+++ b/.beans/csl26-4xg9--proposal-make-style-wide-fallback-templates-patcha.md
@@ -1,7 +1,7 @@
 ---
 # csl26-4xg9
 title: Implement inherited fallback-template diffs
-status: todo
+status: in-progress
 type: feature
 priority: normal
 tags:
@@ -9,7 +9,7 @@ tags:
     - style
     - chicago
 created_at: 2026-08-07T23:53:13Z
-updated_at: 2026-08-09T14:48:58Z
+updated_at: 2026-08-09T15:51:43Z
 ---
 
 Implement the fallback-template diff contract in
@@ -39,5 +39,5 @@ Required direction:
 - [x] Draft the docs/specs contract, including compatibility and template-ref
       interaction.
 - [ ] Get the Draft specification reviewed and merged.
-- [ ] Implement the schema and resolver change in a follow-up PR.
-- [ ] Regenerate schemas and pass citation and bibliography conformance tests.
+- [x] Implement the schema and resolver change in a follow-up PR.
+- [x] Regenerate schemas and pass citation and bibliography conformance tests.

--- a/crates/citum-analyze/src/batch_test.rs
+++ b/crates/citum-analyze/src/batch_test.rs
@@ -131,7 +131,7 @@ fn test_style(path: &Path) -> TestResult {
             template: if output.bibliography.is_empty() {
                 None
             } else {
-                Some(output.bibliography)
+                Some(output.bibliography.into())
             },
             ..Default::default()
         }),
@@ -139,7 +139,7 @@ fn test_style(path: &Path) -> TestResult {
             template: if output.citation.is_empty() {
                 None
             } else {
-                Some(output.citation)
+                Some(output.citation.into())
             },
             ..Default::default()
         }),

--- a/crates/citum-analyze/src/semantic.rs
+++ b/crates/citum-analyze/src/semantic.rs
@@ -15,7 +15,8 @@ use std::collections::HashSet;
 use citum_schema::StyleBase;
 use citum_schema::locale::GeneralTerm;
 use citum_schema::template::{
-    ContributorRole, DateVariable, NumberVariable, SimpleVariable, TemplateComponent, TitleType,
+    ContributorRole, DateVariable, NumberVariable, SimpleVariable, TemplateComponent,
+    TemplateVariant, TitleType,
 };
 
 /// A simplified semantic representation of a compiled template component.
@@ -160,23 +161,28 @@ pub fn collect_base_semantic_sets()
                 .bibliography
                 .as_ref()
                 .and_then(|b| b.template.as_ref())
-                .map(|t| template_to_set(t))
+                .and_then(TemplateVariant::as_template)
+                .map(template_to_set)
                 .unwrap_or_default();
 
             let mut cit_sets = Vec::new();
             if let Some(cit) = &style.citation {
-                if let Some(t) = &cit.template {
-                    cit_sets.push(template_to_set(t));
+                if let Some(t) = &cit.template
+                    && let Some(template) = t.as_template()
+                {
+                    cit_sets.push(template_to_set(template));
                 }
                 if let Some(i) = &cit.integral
                     && let Some(t) = &i.template
+                    && let Some(template) = t.as_template()
                 {
-                    cit_sets.push(template_to_set(t));
+                    cit_sets.push(template_to_set(template));
                 }
                 if let Some(ni) = &cit.non_integral
                     && let Some(t) = &ni.template
+                    && let Some(template) = t.as_template()
                 {
-                    cit_sets.push(template_to_set(t));
+                    cit_sets.push(template_to_set(template));
                 }
             }
             (base.clone(), bib_set, cit_sets)

--- a/crates/citum-bindings/src/lib.rs
+++ b/crates/citum-bindings/src/lib.rs
@@ -154,7 +154,7 @@ pub fn ensure_style_has_templates(style: &mut Style) {
                 },
                 ..Default::default()
             }));
-            citation.template = Some(template);
+            citation.template = Some(template.into());
             citation.template_ref = None;
         }
     }

--- a/crates/citum-engine/benches/rendering.rs
+++ b/crates/citum-engine/benches/rendering.rs
@@ -709,15 +709,18 @@ fn build_type_variant_bench_style() -> Style {
                 }),
                 ..Default::default()
             }),
-            template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                title: TitleType::Primary,
-                form: None,
-                rendering: Rendering {
-                    prefix: Some("DEFAULT ".into()),
+            template: Some(
+                vec![TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    form: None,
+                    rendering: Rendering {
+                        prefix: Some("DEFAULT ".into()),
+                        ..Default::default()
+                    },
                     ..Default::default()
-                },
-                ..Default::default()
-            })]),
+                })]
+                .into(),
+            ),
             type_variants: Some(IndexMap::from([(
                 "article-journal"
                     .parse()
@@ -812,22 +815,25 @@ fn build_compound_bench_style() -> Style {
                 }),
                 ..Default::default()
             }),
-            template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: citum_schema::template::ContributorForm::Long,
-                    ..Default::default()
-                }),
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    form: None,
-                    rendering: Rendering {
-                        prefix: Some(". ".into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: citum_schema::template::ContributorForm::Long,
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        form: None,
+                        rendering: Rendering {
+                            prefix: Some(". ".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -622,20 +622,23 @@ mod tests {
                 ..Default::default()
             }),
             citation: Some(CitationSpec {
-                template: Some(vec![
-                    TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author.into(),
-                        form: ContributorForm::Short,
-                        rendering: Rendering::default(),
-                        ..Default::default()
-                    }),
-                    TemplateComponent::Date(TemplateDate {
-                        date: TemplateDateVariable::Issued,
-                        form: DateForm::Year,
-                        rendering: Rendering::default(),
-                        ..Default::default()
-                    }),
-                ]),
+                template: Some(
+                    vec![
+                        TemplateComponent::Contributor(TemplateContributor {
+                            contributor: ContributorRole::Author.into(),
+                            form: ContributorForm::Short,
+                            rendering: Rendering::default(),
+                            ..Default::default()
+                        }),
+                        TemplateComponent::Date(TemplateDate {
+                            date: TemplateDateVariable::Issued,
+                            form: DateForm::Year,
+                            rendering: Rendering::default(),
+                            ..Default::default()
+                        }),
+                    ]
+                    .into(),
+                ),
                 wrap: Some(WrapPunctuation::Parentheses.into()),
                 ..Default::default()
             }),
@@ -701,10 +704,13 @@ mod tests {
     fn format_document_html_bibliography_entries_preserve_inline_markup() {
         let mut style = make_test_style();
         style.bibliography = Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                title: TitleType::Primary,
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         });
 
@@ -1007,23 +1013,26 @@ mod tests {
                 ..Default::default()
             }),
             citation: Some(CitationSpec {
-                template: Some(vec![
-                    TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author.into(),
-                        form: ContributorForm::Short,
-                        rendering: Rendering::default(),
-                        ..Default::default()
-                    }),
-                    TemplateComponent::Date(TemplateDate {
-                        date: TemplateDateVariable::Issued,
-                        form: DateForm::Year,
-                        rendering: Rendering {
-                            prefix: Some(", ".into()),
+                template: Some(
+                    vec![
+                        TemplateComponent::Contributor(TemplateContributor {
+                            contributor: ContributorRole::Author.into(),
+                            form: ContributorForm::Short,
+                            rendering: Rendering::default(),
                             ..Default::default()
-                        },
-                        ..Default::default()
-                    }),
-                ]),
+                        }),
+                        TemplateComponent::Date(TemplateDate {
+                            date: TemplateDateVariable::Issued,
+                            form: DateForm::Year,
+                            rendering: Rendering {
+                                prefix: Some(", ".into()),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        }),
+                    ]
+                    .into(),
+                ),
                 wrap: Some(WrapPunctuation::Parentheses.into()),
                 ..Default::default()
             }),
@@ -1204,28 +1213,34 @@ mod tests {
             }),
             citation: Some(CitationSpec {
                 integral: Some(Box::new(CitationSpec {
-                    template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author.into(),
-                        form: ContributorForm::Long,
-                        rendering: Rendering::default(),
-                        ..Default::default()
-                    })]),
+                    template: Some(
+                        vec![TemplateComponent::Contributor(TemplateContributor {
+                            contributor: ContributorRole::Author.into(),
+                            form: ContributorForm::Long,
+                            rendering: Rendering::default(),
+                            ..Default::default()
+                        })]
+                        .into(),
+                    ),
                     ..Default::default()
                 })),
-                template: Some(vec![
-                    TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author.into(),
-                        form: ContributorForm::Short,
-                        rendering: Rendering::default(),
-                        ..Default::default()
-                    }),
-                    TemplateComponent::Date(TemplateDate {
-                        date: TemplateDateVariable::Issued,
-                        form: DateForm::Year,
-                        rendering: Rendering::default(),
-                        ..Default::default()
-                    }),
-                ]),
+                template: Some(
+                    vec![
+                        TemplateComponent::Contributor(TemplateContributor {
+                            contributor: ContributorRole::Author.into(),
+                            form: ContributorForm::Short,
+                            rendering: Rendering::default(),
+                            ..Default::default()
+                        }),
+                        TemplateComponent::Date(TemplateDate {
+                            date: TemplateDateVariable::Issued,
+                            form: DateForm::Year,
+                            rendering: Rendering::default(),
+                            ..Default::default()
+                        }),
+                    ]
+                    .into(),
+                ),
                 wrap: Some(WrapPunctuation::Parentheses.into()),
                 ..Default::default()
             }),
@@ -1402,10 +1417,13 @@ mod tests {
 
         let mut style = make_test_style();
         style.bibliography = Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                title: TitleType::Primary,
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         });
         let mut refs = Bibliography::new();
@@ -1479,10 +1497,13 @@ mod tests {
         let mut style = make_test_style();
         // A bibliography template is required for entries to be produced.
         style.bibliography = Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                title: TitleType::Primary,
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         });
         let refs = make_test_bibliography(); // contains "smith2020"
@@ -1570,10 +1591,13 @@ mod tests {
     fn nocite_ref_sorts_alongside_cited_ref() {
         let mut style = make_test_style();
         style.bibliography = Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                title: TitleType::Primary,
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         });
 

--- a/crates/citum-engine/src/api/session.rs
+++ b/crates/citum-engine/src/api/session.rs
@@ -702,23 +702,26 @@ mod tests {
                 ..Default::default()
             }),
             citation: Some(CitationSpec {
-                template: Some(vec![
-                    TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author.into(),
-                        form: ContributorForm::Short,
-                        rendering: Rendering::default(),
-                        ..Default::default()
-                    }),
-                    TemplateComponent::Date(TemplateDate {
-                        date: TemplateDateVariable::Issued,
-                        form: DateForm::Year,
-                        rendering: Rendering {
-                            prefix: Some(", ".into()),
+                template: Some(
+                    vec![
+                        TemplateComponent::Contributor(TemplateContributor {
+                            contributor: ContributorRole::Author.into(),
+                            form: ContributorForm::Short,
+                            rendering: Rendering::default(),
                             ..Default::default()
-                        },
-                        ..Default::default()
-                    }),
-                ]),
+                        }),
+                        TemplateComponent::Date(TemplateDate {
+                            date: TemplateDateVariable::Issued,
+                            form: DateForm::Year,
+                            rendering: Rendering {
+                                prefix: Some(", ".into()),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        }),
+                    ]
+                    .into(),
+                ),
                 wrap: Some(WrapPunctuation::Parentheses.into()),
                 ..Default::default()
             }),
@@ -1047,31 +1050,37 @@ mod tests {
             }),
             citation: Some(CitationSpec {
                 integral: Some(Box::new(CitationSpec {
-                    template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author.into(),
-                        form: ContributorForm::Long,
-                        rendering: Rendering::default(),
-                        ..Default::default()
-                    })]),
+                    template: Some(
+                        vec![TemplateComponent::Contributor(TemplateContributor {
+                            contributor: ContributorRole::Author.into(),
+                            form: ContributorForm::Long,
+                            rendering: Rendering::default(),
+                            ..Default::default()
+                        })]
+                        .into(),
+                    ),
                     ..Default::default()
                 })),
-                template: Some(vec![
-                    TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author.into(),
-                        form: ContributorForm::Short,
-                        rendering: Rendering::default(),
-                        ..Default::default()
-                    }),
-                    TemplateComponent::Date(TemplateDate {
-                        date: TemplateDateVariable::Issued,
-                        form: DateForm::Year,
-                        rendering: Rendering {
-                            prefix: Some(", ".into()),
+                template: Some(
+                    vec![
+                        TemplateComponent::Contributor(TemplateContributor {
+                            contributor: ContributorRole::Author.into(),
+                            form: ContributorForm::Short,
+                            rendering: Rendering::default(),
                             ..Default::default()
-                        },
-                        ..Default::default()
-                    }),
-                ]),
+                        }),
+                        TemplateComponent::Date(TemplateDate {
+                            date: TemplateDateVariable::Issued,
+                            form: DateForm::Year,
+                            rendering: Rendering {
+                                prefix: Some(", ".into()),
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        }),
+                    ]
+                    .into(),
+                ),
                 wrap: Some(WrapPunctuation::Parentheses.into()),
                 ..Default::default()
             }),
@@ -1268,10 +1277,13 @@ mod tests {
     fn style_with_bibliography() -> Style {
         let mut s = style();
         s.bibliography = Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                title: TitleType::Primary,
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         });
         s

--- a/crates/citum-engine/src/api/warnings.rs
+++ b/crates/citum-engine/src/api/warnings.rs
@@ -202,7 +202,7 @@ pub fn unknown_enum_warnings(processor: &Processor) -> Vec<Warning> {
     }
     if let Some(bib) = &processor.style.bibliography {
         if let Some(template) = &bib.template {
-            scan_template_for_unknowns(template, "bibliography layout", &mut warnings);
+            scan_template_variant_for_unknowns(template, "bibliography layout", &mut warnings);
         }
         if let Some(type_variants) = &bib.type_variants {
             for variant in type_variants.values() {
@@ -277,7 +277,7 @@ fn scan_citation_spec_for_unknowns(
     warnings: &mut Vec<Warning>,
 ) {
     if let Some(template) = &spec.template {
-        scan_template_for_unknowns(template, location, warnings);
+        scan_template_variant_for_unknowns(template, location, warnings);
     }
     if let Some(type_variants) = &spec.type_variants {
         for variant in type_variants.values() {
@@ -303,6 +303,27 @@ fn scan_citation_spec_for_unknowns(
     }
     if let Some(child) = &spec.ibid {
         scan_citation_spec_for_unknowns(child, &format!("{location} (ibid)"), warnings);
+    }
+}
+
+fn scan_template_variant_for_unknowns(
+    variant: &citum_schema::template::TemplateVariant,
+    location: &str,
+    warnings: &mut Vec<Warning>,
+) {
+    match variant {
+        citum_schema::template::TemplateVariant::Full(template) => {
+            scan_template_for_unknowns(template, location, warnings);
+        }
+        citum_schema::template::TemplateVariant::Diff(diff) => {
+            for add in &diff.add {
+                scan_template_for_unknowns(
+                    std::slice::from_ref(&add.component),
+                    location,
+                    warnings,
+                );
+            }
+        }
     }
 }
 

--- a/crates/citum-engine/src/lib.rs
+++ b/crates/citum-engine/src/lib.rs
@@ -54,7 +54,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //!                 rendering: Rendering::default(),
 //!                 ..Default::default()
 //!             }),
-//!         ]),
+//!         ].into()),
 //!         wrap: Some(WrapPunctuation::Parentheses.into()),
 //!         ..Default::default()
 //!     }),

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -220,7 +220,7 @@ impl Processor {
         if let Some(group_template) = &group.template {
             let mut local_style = self.style.clone();
             if let Some(bibliography) = local_style.bibliography.as_mut() {
-                bibliography.template = Some(group_template.clone());
+                bibliography.template = Some(group_template.clone().into());
             }
             Cow::Owned(local_style)
         } else {

--- a/crates/citum-engine/src/processor/bibliography/tests.rs
+++ b/crates/citum-engine/src/processor/bibliography/tests.rs
@@ -89,21 +89,24 @@ fn author_date_style() -> Style {
                 subsequent_author_substitute: Some("———".to_string()),
                 ..Default::default()
             }),
-            template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Long,
-                    ..Default::default()
-                }),
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    rendering: Rendering {
-                        prefix: Some(", ".into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Long,
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        rendering: Rendering {
+                            prefix: Some(", ".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -124,21 +127,24 @@ fn numeric_style() -> Style {
     options.label_mode = Some(citum_schema::options::BibliographyLabelMode::Numeric);
     options.label_wrap = Some(citum_schema::options::BibliographyLabelWrap::Brackets);
     options.label_separator = Some(" ".to_string());
-    bibliography.template = Some(vec![
-        TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author.into(),
-            form: ContributorForm::Long,
-            ..Default::default()
-        }),
-        TemplateComponent::Title(TemplateTitle {
-            title: TitleType::Primary,
-            rendering: Rendering {
-                prefix: Some(", ".into()),
+    bibliography.template = Some(
+        vec![
+            TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author.into(),
+                form: ContributorForm::Long,
                 ..Default::default()
-            },
-            ..Default::default()
-        }),
-    ]);
+            }),
+            TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                rendering: Rendering {
+                    prefix: Some(", ".into()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+        ]
+        .into(),
+    );
     style
 }
 

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -1274,21 +1274,27 @@ mod tests {
             },
             options: Some(config),
             citation: Some(CitationSpec {
-                template: Some(vec![
-                    citum_schema::tc_contributor!(Author, Short),
-                    citum_schema::tc_date!(Issued, Year, prefix = ", "),
-                ]),
+                template: Some(
+                    vec![
+                        citum_schema::tc_contributor!(Author, Short),
+                        citum_schema::tc_date!(Issued, Year, prefix = ", "),
+                    ]
+                    .into(),
+                ),
                 wrap: Some(WrapPunctuation::Parentheses.into()),
                 ..Default::default()
             }),
             bibliography: Some(BibliographySpec {
                 sort: bibliography_sort.map(citum_schema::grouping::GroupSortEntry::Explicit),
-                template: Some(vec![TemplateComponent::Title(
-                    citum_schema::template::TemplateTitle {
-                        title: citum_schema::template::TitleType::Primary,
-                        ..Default::default()
-                    },
-                )]),
+                template: Some(
+                    vec![TemplateComponent::Title(
+                        citum_schema::template::TemplateTitle {
+                            title: citum_schema::template::TitleType::Primary,
+                            ..Default::default()
+                        },
+                    )]
+                    .into(),
+                ),
                 ..Default::default()
             }),
             ..Default::default()

--- a/crates/citum-engine/src/processor/document/tests.rs
+++ b/crates/citum-engine/src/processor/document/tests.rs
@@ -55,40 +55,46 @@ fn make_test_bib() -> Bibliography {
 fn make_author_date_style() -> Style {
     Style {
         citation: Some(CitationSpec {
-            template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Short,
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: DateVariable::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering::default(),
-                    ..Default::default()
-                }),
-            ]),
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Short,
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: DateVariable::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             wrap: Some(WrapPunctuation::Parentheses.into()),
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Long,
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: DateVariable::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering {
-                        prefix: Some(" (".into()),
-                        suffix: Some(")".into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Long,
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: DateVariable::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering {
+                            prefix: Some(" (".into()),
+                            suffix: Some(")".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -102,54 +108,66 @@ fn make_note_style() -> Style {
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                title: TitleType::Primary,
-                rendering: Rendering::default(),
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    rendering: Rendering::default(),
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             suffix: Some(".".into()),
             subsequent: Some(Box::new(CitationSpec {
-                template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    rendering: Rendering {
-                        prefix: Some("sub: ".into()),
+                template: Some(
+                    vec![TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        rendering: Rendering {
+                            prefix: Some("sub: ".into()),
+                            ..Default::default()
+                        },
                         ..Default::default()
-                    },
-                    ..Default::default()
-                })]),
+                    })]
+                    .into(),
+                ),
                 suffix: Some(".".into()),
                 ..Default::default()
             })),
             ibid: Some(Box::new(CitationSpec {
                 note_start_text_case: Some(NoteStartTextCase::CapitalizeFirst),
-                template: Some(vec![TemplateComponent::Term(TemplateTerm {
-                    term: citum_schema::locale::GeneralTerm::Ibid,
-                    form: None,
-                    gender: None,
-                    rendering: Rendering::default(),
-                    custom: None,
-                })]),
+                template: Some(
+                    vec![TemplateComponent::Term(TemplateTerm {
+                        term: citum_schema::locale::GeneralTerm::Ibid,
+                        form: None,
+                        gender: None,
+                        rendering: Rendering::default(),
+                        custom: None,
+                    })]
+                    .into(),
+                ),
                 suffix: Some(".".into()),
                 ..Default::default()
             })),
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Long,
-                    ..Default::default()
-                }),
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    rendering: Rendering {
-                        prefix: Some(". ".into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Long,
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        rendering: Rendering {
+                            prefix: Some(". ".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -179,48 +197,57 @@ fn make_integral_name_style(scope: IntegralNameScope, contexts: IntegralNameCont
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Short,
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: DateVariable::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering::default(),
-                    ..Default::default()
-                }),
-            ]),
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Short,
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: DateVariable::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             integral: Some(Box::new(CitationSpec {
-                template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Long,
-                    ..Default::default()
-                })]),
+                template: Some(
+                    vec![TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Long,
+                        ..Default::default()
+                    })]
+                    .into(),
+                ),
                 ..Default::default()
             })),
             wrap: Some(WrapPunctuation::Parentheses.into()),
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Long,
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: DateVariable::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering {
-                        prefix: Some(" (".into()),
-                        suffix: Some(")".into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Long,
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: DateVariable::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering {
+                            prefix: Some(" (".into()),
+                            suffix: Some(")".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -505,42 +532,48 @@ fn test_repro_djot_parsing() {
 fn test_repro_djot_rendering() {
     let style = Style {
         citation: Some(CitationSpec {
-            template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Short,
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: DateVariable::Issued,
-                    form: DateForm::Year,
-                    ..Default::default()
-                }),
-            ]),
-            delimiter: Some(", ".into()),
-            wrap: Some(WrapPunctuation::Parentheses.into()),
-            integral: Some(Box::new(citum_schema::CitationSpec {
-                template: Some(vec![
+            template: Some(
+                vec![
                     TemplateComponent::Contributor(TemplateContributor {
                         contributor: ContributorRole::Author.into(),
                         form: ContributorForm::Short,
                         ..Default::default()
                     }),
-                    TemplateComponent::Group(TemplateGroup {
-                        group: vec![TemplateComponent::Date(TemplateDate {
-                            date: DateVariable::Issued,
-                            form: DateForm::Year,
-                            ..Default::default()
-                        })],
-                        rendering: Rendering {
-                            wrap: Some(WrapPunctuation::Parentheses.into()),
-                            ..Default::default()
-                        },
-                        delimiter: None,
-                        render_when: None,
-                        custom: None,
+                    TemplateComponent::Date(TemplateDate {
+                        date: DateVariable::Issued,
+                        form: DateForm::Year,
+                        ..Default::default()
                     }),
-                ]),
+                ]
+                .into(),
+            ),
+            delimiter: Some(", ".into()),
+            wrap: Some(WrapPunctuation::Parentheses.into()),
+            integral: Some(Box::new(citum_schema::CitationSpec {
+                template: Some(
+                    vec![
+                        TemplateComponent::Contributor(TemplateContributor {
+                            contributor: ContributorRole::Author.into(),
+                            form: ContributorForm::Short,
+                            ..Default::default()
+                        }),
+                        TemplateComponent::Group(TemplateGroup {
+                            group: vec![TemplateComponent::Date(TemplateDate {
+                                date: DateVariable::Issued,
+                                form: DateForm::Year,
+                                ..Default::default()
+                            })],
+                            rendering: Rendering {
+                                wrap: Some(WrapPunctuation::Parentheses.into()),
+                                ..Default::default()
+                            },
+                            delimiter: None,
+                            render_when: None,
+                            custom: None,
+                        }),
+                    ]
+                    .into(),
+                ),
                 delimiter: Some(" ".into()),
                 ..Default::default()
             })),

--- a/crates/citum-engine/src/processor/rendering/tests.rs
+++ b/crates/citum-engine/src/processor/rendering/tests.rs
@@ -46,23 +46,26 @@ fn grouped_author_date_style() -> Style {
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Short,
-                    rendering: Rendering::default(),
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: citum_schema::template::DateVariable::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering {
-                        prefix: Some(", ".into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Short,
+                        rendering: Rendering::default(),
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: citum_schema::template::DateVariable::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering {
+                            prefix: Some(", ".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             wrap: Some(WrapPunctuation::Parentheses.into()),
             ..Default::default()
         }),
@@ -83,36 +86,39 @@ fn explicit_author_year_group_style() -> Style {
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![
-                TemplateComponent::Group(TemplateGroup {
-                    group: vec![
-                        TemplateComponent::Contributor(TemplateContributor {
-                            contributor: ContributorRole::Author.into(),
-                            form: ContributorForm::Short,
-                            rendering: Rendering::default(),
+            template: Some(
+                vec![
+                    TemplateComponent::Group(TemplateGroup {
+                        group: vec![
+                            TemplateComponent::Contributor(TemplateContributor {
+                                contributor: ContributorRole::Author.into(),
+                                form: ContributorForm::Short,
+                                rendering: Rendering::default(),
+                                ..Default::default()
+                            }),
+                            TemplateComponent::Date(TemplateDate {
+                                date: citum_schema::template::DateVariable::Issued,
+                                form: DateForm::Year,
+                                rendering: Rendering::default(),
+                                ..Default::default()
+                            }),
+                        ],
+                        delimiter: Some(DelimiterPunctuation::Space),
+                        rendering: Rendering::default(),
+                        render_when: None,
+                        custom: None,
+                    }),
+                    TemplateComponent::Variable(TemplateVariable {
+                        variable: SimpleVariable::Locator,
+                        rendering: Rendering {
+                            prefix: Some(", ".into()),
                             ..Default::default()
-                        }),
-                        TemplateComponent::Date(TemplateDate {
-                            date: citum_schema::template::DateVariable::Issued,
-                            form: DateForm::Year,
-                            rendering: Rendering::default(),
-                            ..Default::default()
-                        }),
-                    ],
-                    delimiter: Some(DelimiterPunctuation::Space),
-                    rendering: Rendering::default(),
-                    render_when: None,
-                    custom: None,
-                }),
-                TemplateComponent::Variable(TemplateVariable {
-                    variable: SimpleVariable::Locator,
-                    rendering: Rendering {
-                        prefix: Some(", ".into()),
+                        },
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                ]
+                .into(),
+            ),
             wrap: Some(WrapPunctuation::Parentheses.into()),
             delimiter: Some("".into()),
             ..Default::default()
@@ -133,33 +139,36 @@ fn explicit_author_year_group_with_locator_delimiter_style() -> Style {
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![
-                TemplateComponent::Group(TemplateGroup {
-                    group: vec![
-                        TemplateComponent::Contributor(TemplateContributor {
-                            contributor: ContributorRole::Author.into(),
-                            form: ContributorForm::Short,
-                            rendering: Rendering::default(),
-                            ..Default::default()
-                        }),
-                        TemplateComponent::Date(TemplateDate {
-                            date: citum_schema::template::DateVariable::Issued,
-                            form: DateForm::Year,
-                            rendering: Rendering::default(),
-                            ..Default::default()
-                        }),
-                    ],
-                    delimiter: Some(DelimiterPunctuation::Space),
-                    rendering: Rendering::default(),
-                    render_when: None,
-                    custom: None,
-                }),
-                TemplateComponent::Variable(TemplateVariable {
-                    variable: SimpleVariable::Locator,
-                    rendering: Rendering::default(),
-                    ..Default::default()
-                }),
-            ]),
+            template: Some(
+                vec![
+                    TemplateComponent::Group(TemplateGroup {
+                        group: vec![
+                            TemplateComponent::Contributor(TemplateContributor {
+                                contributor: ContributorRole::Author.into(),
+                                form: ContributorForm::Short,
+                                rendering: Rendering::default(),
+                                ..Default::default()
+                            }),
+                            TemplateComponent::Date(TemplateDate {
+                                date: citum_schema::template::DateVariable::Issued,
+                                form: DateForm::Year,
+                                rendering: Rendering::default(),
+                                ..Default::default()
+                            }),
+                        ],
+                        delimiter: Some(DelimiterPunctuation::Space),
+                        rendering: Rendering::default(),
+                        render_when: None,
+                        custom: None,
+                    }),
+                    TemplateComponent::Variable(TemplateVariable {
+                        variable: SimpleVariable::Locator,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             wrap: Some(WrapPunctuation::Parentheses.into()),
             delimiter: Some(", ".into()),
             ..Default::default()
@@ -187,31 +196,37 @@ fn integral_name_style() -> Style {
         }),
         citation: Some(CitationSpec {
             integral: Some(Box::new(CitationSpec {
-                template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Long,
-                    rendering: Rendering::default(),
-                    ..Default::default()
-                })]),
+                template: Some(
+                    vec![TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Long,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    })]
+                    .into(),
+                ),
                 ..Default::default()
             })),
-            template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Short,
-                    rendering: Rendering::default(),
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: citum_schema::template::DateVariable::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering {
-                        wrap: Some(WrapPunctuation::Parentheses.into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Short,
+                        rendering: Rendering::default(),
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: citum_schema::template::DateVariable::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering {
+                            wrap: Some(WrapPunctuation::Parentheses.into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -230,23 +245,26 @@ fn legal_case_style() -> Style {
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    form: None,
-                    rendering: Rendering::default(),
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: citum_schema::template::DateVariable::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering {
-                        prefix: Some(", ".into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        form: None,
+                        rendering: Rendering::default(),
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: citum_schema::template::DateVariable::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering {
+                            prefix: Some(", ".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             wrap: Some(WrapPunctuation::Parentheses.into()),
             multi_cite_delimiter: Some("; ".into()),
             ..Default::default()
@@ -848,12 +866,15 @@ fn test_type_specific_rendering() {
         }),
         citation: Some(CitationSpec {
             type_variants: Some(type_variants),
-            template: Some(vec![TemplateComponent::Variable(TemplateVariable {
-                variable: SimpleVariable::Locator,
-                rendering: Rendering::default(),
-                links: None,
-                custom: None,
-            })]),
+            template: Some(
+                vec![TemplateComponent::Variable(TemplateVariable {
+                    variable: SimpleVariable::Locator,
+                    rendering: Rendering::default(),
+                    links: None,
+                    custom: None,
+                })]
+                .into(),
+            ),
             wrap: Some(WrapPunctuation::Parentheses.into()),
             ..Default::default()
         }),
@@ -1031,7 +1052,7 @@ fn test_bibliography_type_specific_rendering() {
         },
         bibliography: Some(BibliographySpec {
             type_variants: Some(type_variants),
-            template: Some(vec![TemplateComponent::Title(TemplateTitle::default())]),
+            template: Some(vec![TemplateComponent::Title(TemplateTitle::default())].into()),
             ..Default::default()
         }),
         ..Default::default()
@@ -1105,7 +1126,7 @@ fn bibliography_style_with_template(template: Vec<TemplateComponent>) -> Style {
             ..Default::default()
         },
         bibliography: Some(citum_schema::BibliographySpec {
-            template: Some(template),
+            template: Some(template.into()),
             ..Default::default()
         }),
         ..Default::default()

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -44,57 +44,63 @@ fn make_style() -> Style {
         }),
         citation: Some(CitationSpec {
             options: None,
-            template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Short,
-                    name_order: None,
-                    delimiter: None,
-                    rendering: Rendering::default(),
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: TDateVar::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering::default(),
-                    ..Default::default()
-                }),
-            ]),
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Short,
+                        name_order: None,
+                        delimiter: None,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: TDateVar::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             wrap: Some(WrapPunctuation::Parentheses.into()),
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
             options: None,
-            template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Long,
-                    name_order: None,
-                    delimiter: None,
-                    and: None,
-                    rendering: Default::default(),
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: TDateVar::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering {
-                        wrap: Some(WrapPunctuation::Parentheses.into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Long,
+                        name_order: None,
+                        delimiter: None,
+                        and: None,
+                        rendering: Default::default(),
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    form: None,
-                    rendering: Rendering {
-                        prefix: Some(". ".into()),
-                        emph: Some(true),
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: TDateVar::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering {
+                            wrap: Some(WrapPunctuation::Parentheses.into()),
+                            ..Default::default()
+                        },
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        form: None,
+                        rendering: Rendering {
+                            prefix: Some(". ".into()),
+                            emph: Some(true),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         templates: None,
@@ -193,7 +199,7 @@ fn render_consumption_template(template: Vec<TemplateComponent>) -> String {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(template),
+            template: Some(template.into()),
             ..Default::default()
         }),
         ..Default::default()
@@ -326,26 +332,29 @@ fn make_grouped_compound_selection_style() -> Style {
                 }),
                 ..Default::default()
             }),
-            template: Some(vec![
-                TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Long,
-                    name_order: None,
-                    delimiter: None,
-                    and: None,
-                    rendering: Rendering::default(),
-                    ..Default::default()
-                }),
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    form: None,
-                    rendering: Rendering {
-                        prefix: Some(". ".into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Long,
+                        name_order: None,
+                        delimiter: None,
+                        and: None,
+                        rendering: Rendering::default(),
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        form: None,
+                        rendering: Rendering {
+                            prefix: Some(". ".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             groups: Some(vec![make_selected_bibliography_group()]),
             ..Default::default()
         }),
@@ -662,18 +671,21 @@ fn test_process_citations_batch_api() {
 fn test_process_citation_treats_trimmed_none_delimiter_as_empty() {
     let mut style = make_style();
     style.citation = Some(CitationSpec {
-        template: Some(vec![
-            TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author.into(),
-                form: ContributorForm::Short,
-                ..Default::default()
-            }),
-            TemplateComponent::Date(TemplateDate {
-                date: TDateVar::Issued,
-                form: DateForm::Year,
-                ..Default::default()
-            }),
-        ]),
+        template: Some(
+            vec![
+                TemplateComponent::Contributor(TemplateContributor {
+                    contributor: ContributorRole::Author.into(),
+                    form: ContributorForm::Short,
+                    ..Default::default()
+                }),
+                TemplateComponent::Date(TemplateDate {
+                    date: TDateVar::Issued,
+                    form: DateForm::Year,
+                    ..Default::default()
+                }),
+            ]
+            .into(),
+        ),
         wrap: Some(WrapPunctuation::Parentheses.into()),
         delimiter: Some(DelimiterPunctuation::from_csl_string(" none ")),
         ..Default::default()
@@ -702,24 +714,29 @@ fn test_process_citation_treats_trimmed_none_delimiter_as_empty() {
 fn test_citation_locator_label_renders_term() {
     let mut style = make_style();
     style.citation = Some(citum_schema::CitationSpec {
-        template: Some(vec![
-            citum_schema::TemplateComponent::Contributor(
-                citum_schema::template::TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Short,
+        template: Some(
+            vec![
+                citum_schema::TemplateComponent::Contributor(
+                    citum_schema::template::TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Short,
+                        ..Default::default()
+                    },
+                ),
+                citum_schema::TemplateComponent::Date(citum_schema::template::TemplateDate {
+                    date: TDateVar::Issued,
+                    form: DateForm::Year,
                     ..Default::default()
-                },
-            ),
-            citum_schema::TemplateComponent::Date(citum_schema::template::TemplateDate {
-                date: TDateVar::Issued,
-                form: DateForm::Year,
-                ..Default::default()
-            }),
-            citum_schema::TemplateComponent::Variable(citum_schema::template::TemplateVariable {
-                variable: citum_schema::template::SimpleVariable::Locator,
-                ..Default::default()
-            }),
-        ]),
+                }),
+                citum_schema::TemplateComponent::Variable(
+                    citum_schema::template::TemplateVariable {
+                        variable: citum_schema::template::SimpleVariable::Locator,
+                        ..Default::default()
+                    },
+                ),
+            ]
+            .into(),
+        ),
         wrap: Some(WrapPunctuation::Parentheses.into()),
         delimiter: Some(", ".into()),
         ..Default::default()
@@ -753,24 +770,29 @@ fn test_citation_locator_label_renders_term_with_loaded_locale() {
 
     let mut style = make_style();
     style.citation = Some(citum_schema::CitationSpec {
-        template: Some(vec![
-            citum_schema::TemplateComponent::Contributor(
-                citum_schema::template::TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Short,
+        template: Some(
+            vec![
+                citum_schema::TemplateComponent::Contributor(
+                    citum_schema::template::TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Short,
+                        ..Default::default()
+                    },
+                ),
+                citum_schema::TemplateComponent::Date(citum_schema::template::TemplateDate {
+                    date: TDateVar::Issued,
+                    form: DateForm::Year,
                     ..Default::default()
-                },
-            ),
-            citum_schema::TemplateComponent::Date(citum_schema::template::TemplateDate {
-                date: TDateVar::Issued,
-                form: DateForm::Year,
-                ..Default::default()
-            }),
-            citum_schema::TemplateComponent::Variable(citum_schema::template::TemplateVariable {
-                variable: citum_schema::template::SimpleVariable::Locator,
-                ..Default::default()
-            }),
-        ]),
+                }),
+                citum_schema::TemplateComponent::Variable(
+                    citum_schema::template::TemplateVariable {
+                        variable: citum_schema::template::SimpleVariable::Locator,
+                        ..Default::default()
+                    },
+                ),
+            ]
+            .into(),
+        ),
         wrap: Some(WrapPunctuation::Parentheses.into()),
         delimiter: Some(", ".into()),
         ..Default::default()
@@ -807,24 +829,29 @@ fn test_citation_locator_can_suppress_label() {
         });
     }
     style.citation = Some(citum_schema::CitationSpec {
-        template: Some(vec![
-            citum_schema::TemplateComponent::Contributor(
-                citum_schema::template::TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Short,
+        template: Some(
+            vec![
+                citum_schema::TemplateComponent::Contributor(
+                    citum_schema::template::TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Short,
+                        ..Default::default()
+                    },
+                ),
+                citum_schema::TemplateComponent::Date(citum_schema::template::TemplateDate {
+                    date: TDateVar::Issued,
+                    form: DateForm::Year,
                     ..Default::default()
-                },
-            ),
-            citum_schema::TemplateComponent::Date(citum_schema::template::TemplateDate {
-                date: TDateVar::Issued,
-                form: DateForm::Year,
-                ..Default::default()
-            }),
-            citum_schema::TemplateComponent::Variable(citum_schema::template::TemplateVariable {
-                variable: citum_schema::template::SimpleVariable::Locator,
-                ..Default::default()
-            }),
-        ]),
+                }),
+                citum_schema::TemplateComponent::Variable(
+                    citum_schema::template::TemplateVariable {
+                        variable: citum_schema::template::SimpleVariable::Locator,
+                        ..Default::default()
+                    },
+                ),
+            ]
+            .into(),
+        ),
         wrap: Some(WrapPunctuation::Parentheses.into()),
         delimiter: Some(", ".into()),
         ..Default::default()
@@ -868,24 +895,29 @@ fn test_citation_locator_can_strip_label_periods() {
         });
     }
     style.citation = Some(citum_schema::CitationSpec {
-        template: Some(vec![
-            citum_schema::TemplateComponent::Contributor(
-                citum_schema::template::TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Short,
+        template: Some(
+            vec![
+                citum_schema::TemplateComponent::Contributor(
+                    citum_schema::template::TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Short,
+                        ..Default::default()
+                    },
+                ),
+                citum_schema::TemplateComponent::Date(citum_schema::template::TemplateDate {
+                    date: TDateVar::Issued,
+                    form: DateForm::Year,
                     ..Default::default()
-                },
-            ),
-            citum_schema::TemplateComponent::Date(citum_schema::template::TemplateDate {
-                date: TDateVar::Issued,
-                form: DateForm::Year,
-                ..Default::default()
-            }),
-            citum_schema::TemplateComponent::Variable(citum_schema::template::TemplateVariable {
-                variable: citum_schema::template::SimpleVariable::Locator,
-                ..Default::default()
-            }),
-        ]),
+                }),
+                citum_schema::TemplateComponent::Variable(
+                    citum_schema::template::TemplateVariable {
+                        variable: citum_schema::template::SimpleVariable::Locator,
+                        ..Default::default()
+                    },
+                ),
+            ]
+            .into(),
+        ),
         wrap: Some(WrapPunctuation::Parentheses.into()),
         delimiter: Some(", ".into()),
         ..Default::default()
@@ -1644,7 +1676,7 @@ fn test_apa_titles_config() {
     let style = Style {
         options: Some(config),
         bibliography: Some(citum_schema::BibliographySpec {
-            template: Some(bib_template),
+            template: Some(bib_template.into()),
             ..Default::default()
         }),
         ..Default::default()
@@ -2248,10 +2280,13 @@ fn test_inline_title_link_takes_precedence_over_global_title_link_html() {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                title: TitleType::Primary,
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -2291,10 +2326,13 @@ fn test_chicago_title_preset_preserves_djot_markup_html() {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                title: TitleType::Primary,
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -2508,7 +2546,7 @@ fn test_declarative_numeric_citation_label_collapses_before_wrap() {
             label_wrap: Some(citum_schema::options::LabelWrap::Brackets),
             ..Default::default()
         }),
-        template: Some(Vec::new()),
+        template: Some(Vec::new().into()),
         multi_cite_delimiter: Some(",".into()),
         collapse: Some(citum_schema::CitationCollapse::CitationNumber),
         ..Default::default()
@@ -2580,16 +2618,19 @@ fn test_declarative_numeric_citation_label_with_locator() {
             label_wrap: Some(citum_schema::options::LabelWrap::Brackets),
             ..Default::default()
         }),
-        template: Some(vec![TemplateComponent::Variable(
-            citum_schema::template::TemplateVariable {
-                variable: citum_schema::template::SimpleVariable::Locator,
-                rendering: Rendering {
-                    prefix: Some(", ".into()),
+        template: Some(
+            vec![TemplateComponent::Variable(
+                citum_schema::template::TemplateVariable {
+                    variable: citum_schema::template::SimpleVariable::Locator,
+                    rendering: Rendering {
+                        prefix: Some(", ".into()),
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
-                ..Default::default()
-            },
-        )]),
+            )]
+            .into(),
+        ),
         delimiter: Some("".into()),
         ..Default::default()
     });
@@ -2645,16 +2686,19 @@ fn test_wrap_scope_decides_where_the_bracket_sits(
             item_wrap,
             ..Default::default()
         }),
-        template: Some(vec![TemplateComponent::Variable(
-            citum_schema::template::TemplateVariable {
-                variable: citum_schema::template::SimpleVariable::Locator,
-                rendering: Rendering {
-                    prefix: Some(", ".into()),
+        template: Some(
+            vec![TemplateComponent::Variable(
+                citum_schema::template::TemplateVariable {
+                    variable: citum_schema::template::SimpleVariable::Locator,
+                    rendering: Rendering {
+                        prefix: Some(", ".into()),
+                        ..Default::default()
+                    },
                     ..Default::default()
                 },
-                ..Default::default()
-            },
-        )]),
+            )]
+            .into(),
+        ),
         delimiter: Some("".into()),
         ..Default::default()
     });
@@ -2696,13 +2740,16 @@ fn test_declarative_numeric_integral_label_follows_authored_content() {
         }),
         integral: Some(Box::new(citum_schema::CitationSpec {
             delimiter: Some(" ".into()),
-            template: Some(vec![TemplateComponent::Contributor(
-                citum_schema::template::TemplateContributor {
-                    contributor: citum_schema::template::ContributorRole::Author.into(),
-                    form: citum_schema::template::ContributorForm::Short,
-                    ..Default::default()
-                },
-            )]),
+            template: Some(
+                vec![TemplateComponent::Contributor(
+                    citum_schema::template::TemplateContributor {
+                        contributor: citum_schema::template::ContributorRole::Author.into(),
+                        form: citum_schema::template::ContributorForm::Short,
+                        ..Default::default()
+                    },
+                )]
+                .into(),
+            ),
             ..Default::default()
         })),
         ..Default::default()
@@ -2989,14 +3036,17 @@ fn test_label_integral_citation_uses_author_text() {
     });
     // Citation template now includes both author and label
     style.citation = Some(citum_schema::CitationSpec {
-        template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author.into(),
-            form: ContributorForm::Short,
-            name_order: None,
-            delimiter: None,
-            rendering: Rendering::default(),
-            ..Default::default()
-        })]),
+        template: Some(
+            vec![TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author.into(),
+                form: ContributorForm::Short,
+                name_order: None,
+                delimiter: None,
+                rendering: Rendering::default(),
+                ..Default::default()
+            })]
+            .into(),
+        ),
         options: Some(citum_schema::CitationOptions {
             label_mode: Some(citum_schema::options::CitationLabelMode::Alphabetic),
             ..Default::default()
@@ -3121,28 +3171,31 @@ fn test_same_author_integral_multi_cite_collapses_to_grouped_years() {
     base_citation.multi_cite_delimiter = Some("; ".into());
     base_citation.integral = Some(Box::new(CitationSpec {
         delimiter: Some(" ".into()),
-        template: Some(vec![
-            TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author.into(),
-                form: ContributorForm::Short,
-                rendering: Rendering::default(),
-                ..Default::default()
-            }),
-            TemplateComponent::Group(TemplateGroup {
-                group: vec![TemplateComponent::Date(TemplateDate {
-                    date: TDateVar::Issued,
-                    form: DateForm::Year,
+        template: Some(
+            vec![
+                TemplateComponent::Contributor(TemplateContributor {
+                    contributor: ContributorRole::Author.into(),
+                    form: ContributorForm::Short,
                     rendering: Rendering::default(),
                     ..Default::default()
-                })],
-                rendering: Rendering {
-                    prefix: Some(", ".into()),
-                    wrap: Some(WrapPunctuation::Parentheses.into()),
+                }),
+                TemplateComponent::Group(TemplateGroup {
+                    group: vec![TemplateComponent::Date(TemplateDate {
+                        date: TDateVar::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    })],
+                    rendering: Rendering {
+                        prefix: Some(", ".into()),
+                        wrap: Some(WrapPunctuation::Parentheses.into()),
+                        ..Default::default()
+                    },
                     ..Default::default()
-                },
-                ..Default::default()
-            }),
-        ]),
+                }),
+            ]
+            .into(),
+        ),
         ..Default::default()
     }));
     style.citation = Some(base_citation);
@@ -3193,23 +3246,26 @@ fn test_same_author_non_integral_multi_cite_collapses_to_grouped_years() {
     let mut style = make_style();
     // Flat non-integral template: [author, date] with cluster-level parentheses wrap.
     style.citation = Some(CitationSpec {
-        template: Some(vec![
-            TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author.into(),
-                form: ContributorForm::Short,
-                rendering: Rendering::default(),
-                ..Default::default()
-            }),
-            TemplateComponent::Date(TemplateDate {
-                date: TDateVar::Issued,
-                form: DateForm::Year,
-                rendering: Rendering {
-                    prefix: Some(", ".into()),
+        template: Some(
+            vec![
+                TemplateComponent::Contributor(TemplateContributor {
+                    contributor: ContributorRole::Author.into(),
+                    form: ContributorForm::Short,
+                    rendering: Rendering::default(),
                     ..Default::default()
-                },
-                ..Default::default()
-            }),
-        ]),
+                }),
+                TemplateComponent::Date(TemplateDate {
+                    date: TDateVar::Issued,
+                    form: DateForm::Year,
+                    rendering: Rendering {
+                        prefix: Some(", ".into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+            ]
+            .into(),
+        ),
         wrap: Some(WrapPunctuation::Parentheses.into()),
         multi_cite_delimiter: Some("; ".into()),
         ..Default::default()
@@ -3264,28 +3320,31 @@ fn test_same_author_integral_multi_cite_respects_bracket_wrap() {
     base_citation.multi_cite_delimiter = Some("; ".into());
     base_citation.integral = Some(Box::new(CitationSpec {
         delimiter: Some(" ".into()),
-        template: Some(vec![
-            TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author.into(),
-                form: ContributorForm::Short,
-                rendering: Rendering::default(),
-                ..Default::default()
-            }),
-            TemplateComponent::Group(TemplateGroup {
-                group: vec![TemplateComponent::Date(TemplateDate {
-                    date: TDateVar::Issued,
-                    form: DateForm::Year,
+        template: Some(
+            vec![
+                TemplateComponent::Contributor(TemplateContributor {
+                    contributor: ContributorRole::Author.into(),
+                    form: ContributorForm::Short,
                     rendering: Rendering::default(),
                     ..Default::default()
-                })],
-                rendering: Rendering {
-                    prefix: Some(", ".into()),
-                    wrap: Some(WrapPunctuation::Brackets.into()),
+                }),
+                TemplateComponent::Group(TemplateGroup {
+                    group: vec![TemplateComponent::Date(TemplateDate {
+                        date: TDateVar::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    })],
+                    rendering: Rendering {
+                        prefix: Some(", ".into()),
+                        wrap: Some(WrapPunctuation::Brackets.into()),
+                        ..Default::default()
+                    },
                     ..Default::default()
-                },
-                ..Default::default()
-            }),
-        ]),
+                }),
+            ]
+            .into(),
+        ),
         ..Default::default()
     }));
     style.citation = Some(base_citation);
@@ -3333,31 +3392,34 @@ fn test_same_author_integral_multi_cite_respects_bracket_wrap() {
 fn test_integral_locator_does_not_duplicate_group_delimiter() {
     let mut style = make_style();
     style.citation = Some(CitationSpec {
-        template: Some(vec![
-            TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author.into(),
-                form: ContributorForm::Short,
-                rendering: Rendering::default(),
-                ..Default::default()
-            }),
-            TemplateComponent::Date(TemplateDate {
-                date: TDateVar::Issued,
-                form: DateForm::Year,
-                rendering: Rendering {
-                    prefix: Some(", ".into()),
+        template: Some(
+            vec![
+                TemplateComponent::Contributor(TemplateContributor {
+                    contributor: ContributorRole::Author.into(),
+                    form: ContributorForm::Short,
+                    rendering: Rendering::default(),
                     ..Default::default()
-                },
-                ..Default::default()
-            }),
-            TemplateComponent::Variable(TemplateVariable {
-                variable: SimpleVariable::Locator,
-                rendering: Rendering {
-                    prefix: Some(", ".into()),
+                }),
+                TemplateComponent::Date(TemplateDate {
+                    date: TDateVar::Issued,
+                    form: DateForm::Year,
+                    rendering: Rendering {
+                        prefix: Some(", ".into()),
+                        ..Default::default()
+                    },
                     ..Default::default()
-                },
-                ..Default::default()
-            }),
-        ]),
+                }),
+                TemplateComponent::Variable(TemplateVariable {
+                    variable: SimpleVariable::Locator,
+                    rendering: Rendering {
+                        prefix: Some(", ".into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+            ]
+            .into(),
+        ),
         wrap: Some(WrapPunctuation::Parentheses.into()),
         integral: Some(Box::new(CitationSpec {
             wrap: None,
@@ -3553,7 +3615,7 @@ fn test_grouped_numeric_bibliography_rerender_preserves_numbers_and_substitution
             subsequent_author_substitute: Some("———".to_string()),
             ..Default::default()
         }),
-        template: Some(group_template.clone()),
+        template: Some(group_template.clone().into()),
         groups: Some(vec![BibliographyGroup {
             id: "grouped".to_string(),
             heading: Some(GroupHeading::Literal {
@@ -5682,26 +5744,8 @@ fn test_grouped_integral_citation_renders_all_items() {
     let mut style = make_style();
     // Add an explicit integral template for author-date styles
     style.citation = Some(CitationSpec {
-        template: Some(vec![
-            TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author.into(),
-                form: ContributorForm::Short,
-                name_order: None,
-                delimiter: None,
-                rendering: Rendering::default(),
-                ..Default::default()
-            }),
-            TemplateComponent::Date(TemplateDate {
-                date: TDateVar::Issued,
-                form: DateForm::Year,
-                rendering: Rendering::default(),
-                ..Default::default()
-            }),
-        ]),
-        wrap: Some(WrapPunctuation::Parentheses.into()),
-        // Explicit integral template (should be used for grouped cites in integral mode)
-        integral: Some(Box::new(CitationSpec {
-            template: Some(vec![
+        template: Some(
+            vec![
                 TemplateComponent::Contributor(TemplateContributor {
                     contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
@@ -5716,7 +5760,31 @@ fn test_grouped_integral_citation_renders_all_items() {
                     rendering: Rendering::default(),
                     ..Default::default()
                 }),
-            ]),
+            ]
+            .into(),
+        ),
+        wrap: Some(WrapPunctuation::Parentheses.into()),
+        // Explicit integral template (should be used for grouped cites in integral mode)
+        integral: Some(Box::new(CitationSpec {
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Short,
+                        name_order: None,
+                        delimiter: None,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: TDateVar::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         })),
         ..Default::default()
@@ -5768,24 +5836,8 @@ fn test_grouped_integral_citation_preserves_later_item_prefixes() {
 
     let mut style = make_style();
     style.citation = Some(CitationSpec {
-        template: Some(vec![
-            TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author.into(),
-                form: ContributorForm::Short,
-                name_order: None,
-                delimiter: None,
-                rendering: Rendering::default(),
-                ..Default::default()
-            }),
-            TemplateComponent::Date(TemplateDate {
-                date: TDateVar::Issued,
-                form: DateForm::Year,
-                rendering: Rendering::default(),
-                ..Default::default()
-            }),
-        ]),
-        integral: Some(Box::new(CitationSpec {
-            template: Some(vec![
+        template: Some(
+            vec![
                 TemplateComponent::Contributor(TemplateContributor {
                     contributor: ContributorRole::Author.into(),
                     form: ContributorForm::Short,
@@ -5800,7 +5852,29 @@ fn test_grouped_integral_citation_preserves_later_item_prefixes() {
                     rendering: Rendering::default(),
                     ..Default::default()
                 }),
-            ]),
+            ]
+            .into(),
+        ),
+        integral: Some(Box::new(CitationSpec {
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Short,
+                        name_order: None,
+                        delimiter: None,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: TDateVar::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering::default(),
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         })),
         ..Default::default()
@@ -5860,14 +5934,17 @@ fn test_label_integral_citation_includes_label() {
     });
     // Citation template with citation label
     style.citation = Some(CitationSpec {
-        template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-            contributor: ContributorRole::Author.into(),
-            form: ContributorForm::Short,
-            name_order: None,
-            delimiter: None,
-            rendering: Rendering::default(),
-            ..Default::default()
-        })]),
+        template: Some(
+            vec![TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author.into(),
+                form: ContributorForm::Short,
+                name_order: None,
+                delimiter: None,
+                rendering: Rendering::default(),
+                ..Default::default()
+            })]
+            .into(),
+        ),
         options: Some(citum_schema::CitationOptions {
             label_mode: Some(citum_schema::options::CitationLabelMode::Alphabetic),
             ..Default::default()

--- a/crates/citum-engine/src/sorting.rs
+++ b/crates/citum-engine/src/sorting.rs
@@ -667,7 +667,8 @@ fn variants_may_have_list_primary(variants: &citum_schema::template::TemplateVar
 /// forms) declares a merged-list primary contributor component.
 pub(crate) fn citation_may_have_list_primary(spec: &citum_schema::CitationSpec) -> bool {
     spec.template
-        .as_deref()
+        .as_ref()
+        .and_then(citum_schema::template::TemplateVariant::as_template)
         .is_some_and(template_has_list_primary)
         || spec
             .template_ref
@@ -704,7 +705,8 @@ pub(crate) fn citation_may_have_list_primary(spec: &citum_schema::CitationSpec) 
 
 fn bibliography_may_have_list_primary(spec: &citum_schema::BibliographySpec) -> bool {
     spec.template
-        .as_deref()
+        .as_ref()
+        .and_then(citum_schema::template::TemplateVariant::as_template)
         .is_some_and(template_has_list_primary)
         || spec
             .template_ref

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -82,10 +82,13 @@ fn build_numeric_style() -> Style {
                 label_separator: Some(". ".to_string()),
                 ..Default::default()
             }),
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Long),
-                citum_schema::tc_date!(Issued, Year, prefix = " (", suffix = ")"),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    citum_schema::tc_date!(Issued, Year, prefix = " (", suffix = ")"),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -136,10 +139,13 @@ fn build_sorted_style(sort: Vec<SortSpec>) -> Style {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Long),
-                citum_schema::tc_date!(Issued, Year, prefix = " "),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    citum_schema::tc_date!(Issued, Year, prefix = " "),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -189,11 +195,14 @@ fn build_title_year_sorted_style(sort: Vec<SortSpec>) -> Style {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Long),
-                citum_schema::tc_title!(Primary, prefix = ". "),
-                citum_schema::tc_date!(Issued, Year, prefix = " "),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    citum_schema::tc_title!(Primary, prefix = ". "),
+                    citum_schema::tc_date!(Issued, Year, prefix = " "),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -396,10 +405,13 @@ fn language_partition_substitute_style() -> Style {
         .bibliography
         .as_mut()
         .expect("partition substitute style should have bibliography")
-        .template = Some(vec![
-        citum_schema::tc_contributor!(Author, Long),
-        citum_schema::tc_title!(Primary, prefix = ". "),
-    ]);
+        .template = Some(
+        vec![
+            citum_schema::tc_contributor!(Author, Long),
+            citum_schema::tc_title!(Primary, prefix = ". "),
+        ]
+        .into(),
+    );
     style
 }
 
@@ -536,7 +548,7 @@ fn given_romanized_sorting_with_explicit_script_partitioning_then_romanized_orde
                 }),
                 ..Default::default()
             }),
-            template: Some(vec![citum_schema::tc_title!(Primary)]),
+            template: Some(vec![citum_schema::tc_title!(Primary)].into()),
             ..Default::default()
         }),
         ..Default::default()
@@ -787,26 +799,29 @@ fn build_container_title_short_style(title_type: TitleType) -> Style {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Group(TemplateGroup {
-                group: vec![
-                    TemplateComponent::Variable(TemplateVariable {
-                        variable: SimpleVariable::ContainerTitleShort,
-                        ..Default::default()
-                    }),
-                    TemplateComponent::Title(TemplateTitle {
-                        title: title_type.clone(),
-                        form: Some(TitleForm::Short),
-                        ..Default::default()
-                    }),
-                    TemplateComponent::Title(TemplateTitle {
-                        title: title_type,
-                        form: Some(TitleForm::Long),
-                        ..Default::default()
-                    }),
-                ],
-                delimiter: Some(DelimiterPunctuation::Slash),
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Group(TemplateGroup {
+                    group: vec![
+                        TemplateComponent::Variable(TemplateVariable {
+                            variable: SimpleVariable::ContainerTitleShort,
+                            ..Default::default()
+                        }),
+                        TemplateComponent::Title(TemplateTitle {
+                            title: title_type.clone(),
+                            form: Some(TitleForm::Short),
+                            ..Default::default()
+                        }),
+                        TemplateComponent::Title(TemplateTitle {
+                            title: title_type,
+                            form: Some(TitleForm::Long),
+                            ..Default::default()
+                        }),
+                    ],
+                    delimiter: Some(DelimiterPunctuation::Slash),
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -821,24 +836,27 @@ fn build_group_with_suppressed_child_style() -> Style {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Group(TemplateGroup {
-                group: vec![
-                    TemplateComponent::Variable(TemplateVariable {
-                        variable: SimpleVariable::Url,
-                        rendering: Rendering {
-                            suppress: Some(true),
+            template: Some(
+                vec![TemplateComponent::Group(TemplateGroup {
+                    group: vec![
+                        TemplateComponent::Variable(TemplateVariable {
+                            variable: SimpleVariable::Url,
+                            rendering: Rendering {
+                                suppress: Some(true),
+                                ..Default::default()
+                            },
                             ..Default::default()
-                        },
-                        ..Default::default()
-                    }),
-                    TemplateComponent::Title(TemplateTitle {
-                        title: TitleType::Primary,
-                        ..Default::default()
-                    }),
-                ],
-                delimiter: Some(DelimiterPunctuation::Slash),
-                ..Default::default()
-            })]),
+                        }),
+                        TemplateComponent::Title(TemplateTitle {
+                            title: TitleType::Primary,
+                            ..Default::default()
+                        }),
+                    ],
+                    delimiter: Some(DelimiterPunctuation::Slash),
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -853,20 +871,23 @@ fn build_status_bibliography_style() -> Style {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    ..Default::default()
-                }),
-                TemplateComponent::Variable(TemplateVariable {
-                    variable: SimpleVariable::Status,
-                    rendering: Rendering {
-                        prefix: Some(". ".into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Variable(TemplateVariable {
+                        variable: SimpleVariable::Status,
+                        rendering: Rendering {
+                            prefix: Some(". ".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -890,52 +911,55 @@ fn build_article_journal_no_page_fallback_style() -> Style {
                 separator: Some(", ".into()),
                 ..Default::default()
             }),
-            template: Some(vec![
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::ParentSerial,
-                    ..Default::default()
-                }),
-                TemplateComponent::Group(TemplateGroup {
-                    group: vec![
-                        TemplateComponent::Date(TemplateDate {
-                            date: DateVariable::Issued,
-                            form: DateForm::Year,
-                            ..Default::default()
-                        }),
-                        TemplateComponent::Number(TemplateNumber {
-                            number: NumberVariable::Volume,
-                            ..Default::default()
-                        }),
-                        TemplateComponent::Number(TemplateNumber {
-                            number: NumberVariable::Issue,
-                            rendering: Rendering {
-                                prefix: Some("(".into()),
-                                suffix: Some(")".into()),
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }),
-                        TemplateComponent::Number(TemplateNumber {
-                            number: NumberVariable::Pages,
-                            rendering: Rendering {
-                                prefix: Some("pp. ".into()),
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }),
-                    ],
-                    delimiter: Some(DelimiterPunctuation::Comma),
-                    ..Default::default()
-                }),
-                TemplateComponent::Variable(TemplateVariable {
-                    variable: SimpleVariable::Doi,
-                    rendering: Rendering {
-                        prefix: Some("DOI:".into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::ParentSerial,
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Group(TemplateGroup {
+                        group: vec![
+                            TemplateComponent::Date(TemplateDate {
+                                date: DateVariable::Issued,
+                                form: DateForm::Year,
+                                ..Default::default()
+                            }),
+                            TemplateComponent::Number(TemplateNumber {
+                                number: NumberVariable::Volume,
+                                ..Default::default()
+                            }),
+                            TemplateComponent::Number(TemplateNumber {
+                                number: NumberVariable::Issue,
+                                rendering: Rendering {
+                                    prefix: Some("(".into()),
+                                    suffix: Some(")".into()),
+                                    ..Default::default()
+                                },
+                                ..Default::default()
+                            }),
+                            TemplateComponent::Number(TemplateNumber {
+                                number: NumberVariable::Pages,
+                                rendering: Rendering {
+                                    prefix: Some("pp. ".into()),
+                                    ..Default::default()
+                                },
+                                ..Default::default()
+                            }),
+                        ],
+                        delimiter: Some(DelimiterPunctuation::Comma),
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Variable(TemplateVariable {
+                        variable: SimpleVariable::Doi,
+                        rendering: Rendering {
+                            prefix: Some("DOI:".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -994,7 +1018,7 @@ fn build_bibliography_entry_link_style() -> Style {
                 }),
                 ..Default::default()
             }),
-            template: Some(vec![citum_schema::tc_title!(Primary)]),
+            template: Some(vec![citum_schema::tc_title!(Primary)].into()),
             ..Default::default()
         }),
         ..Default::default()
@@ -1019,11 +1043,14 @@ fn build_bibliography_local_note_sort_style() -> Style {
                 label_separator: Some(". ".to_string()),
                 ..Default::default()
             }),
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Long),
-                citum_schema::tc_title!(Primary, prefix = ". "),
-                citum_schema::tc_date!(Issued, Year, prefix = " "),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    citum_schema::tc_title!(Primary, prefix = ". "),
+                    citum_schema::tc_date!(Issued, Year, prefix = " "),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1048,7 +1075,7 @@ fn build_bibliography_local_numeric_style() -> Style {
                 label_separator: Some(". ".to_string()),
                 ..Default::default()
             }),
-            template: Some(vec![citum_schema::tc_contributor!(Author, Long)]),
+            template: Some(vec![citum_schema::tc_contributor!(Author, Long)].into()),
             ..Default::default()
         }),
         ..Default::default()
@@ -1081,10 +1108,13 @@ fn build_numeric_citation_style_with_bibliography_local_note_sort() -> Style {
                 label_separator: Some(". ".to_string()),
                 ..Default::default()
             }),
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Long),
-                citum_schema::tc_title!(Primary, prefix = ". "),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    citum_schema::tc_title!(Primary, prefix = ". "),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1099,33 +1129,34 @@ fn build_inline_article_journal_detail_group_style() -> Style {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                TemplateComponent::Contributor(citum_schema::template::TemplateContributor {
-                    contributor: citum_schema::template::ContributorRole::Author.into(),
-                    form: citum_schema::template::ContributorForm::Long,
-                    rendering: Rendering {
-                        suffix: Some(". ".into()),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::ParentSerial,
-                    rendering: Rendering {
-                        emph: Some(true),
-                        suffix: Some(". ".into()),
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-                TemplateComponent::Group(TemplateGroup {
-                    group: vec![
-                        TemplateComponent::Number(TemplateNumber {
-                            number: NumberVariable::Volume,
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(citum_schema::template::TemplateContributor {
+                        contributor: citum_schema::template::ContributorRole::Author.into(),
+                        form: citum_schema::template::ContributorForm::Long,
+                        rendering: Rendering {
+                            suffix: Some(". ".into()),
                             ..Default::default()
-                        }),
-                        TemplateComponent::Group(TemplateGroup {
-                            group: vec![
+                        },
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::ParentSerial,
+                        rendering: Rendering {
+                            emph: Some(true),
+                            suffix: Some(". ".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Group(TemplateGroup {
+                        group: vec![
+                            TemplateComponent::Number(TemplateNumber {
+                                number: NumberVariable::Volume,
+                                ..Default::default()
+                            }),
+                            TemplateComponent::Group(TemplateGroup {
+                                group: vec![
                                 TemplateComponent::Number(TemplateNumber {
                                     number: NumberVariable::Issue,
                                     ..Default::default()
@@ -1143,22 +1174,24 @@ fn build_inline_article_journal_detail_group_style() -> Style {
                                     ..Default::default()
                                 }),
                             ],
-                            delimiter: Some(DelimiterPunctuation::Space),
-                            ..Default::default()
-                        }),
-                        TemplateComponent::Number(TemplateNumber {
-                            number: NumberVariable::Pages,
-                            rendering: Rendering {
-                                prefix: Some("pp. ".into()),
+                                delimiter: Some(DelimiterPunctuation::Space),
                                 ..Default::default()
-                            },
-                            ..Default::default()
-                        }),
-                    ],
-                    delimiter: Some(DelimiterPunctuation::Comma),
-                    ..Default::default()
-                }),
-            ]),
+                            }),
+                            TemplateComponent::Number(TemplateNumber {
+                                number: NumberVariable::Pages,
+                                rendering: Rendering {
+                                    prefix: Some("pp. ".into()),
+                                    ..Default::default()
+                                },
+                                ..Default::default()
+                            }),
+                        ],
+                        delimiter: Some(DelimiterPunctuation::Comma),
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1173,22 +1206,25 @@ fn build_archive_eprint_style() -> Style {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                citum_schema::tc_title!(Primary, suffix = ". "),
-                variable_component(SimpleVariable::ArchiveName, None, None),
-                variable_component(SimpleVariable::ArchiveCollection, Some(", "), None),
-                variable_component(SimpleVariable::ArchiveCollectionId, Some(", "), None),
-                variable_component(SimpleVariable::ArchiveSeries, Some(", Series "), None),
-                variable_component(SimpleVariable::ArchiveBox, Some(", Box "), None),
-                variable_component(SimpleVariable::ArchiveFolder, Some(", Folder "), None),
-                variable_component(SimpleVariable::ArchiveItem, Some(", Item "), None),
-                variable_component(SimpleVariable::ArchiveLocation, Some(", "), None),
-                variable_component(SimpleVariable::ArchivePlace, Some(", "), None),
-                variable_component(SimpleVariable::ArchiveUrl, Some(", "), None),
-                variable_component(SimpleVariable::EprintServer, Some(", "), None),
-                variable_component(SimpleVariable::EprintId, Some(":"), None),
-                variable_component(SimpleVariable::EprintClass, Some(" ["), Some("]")),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_title!(Primary, suffix = ". "),
+                    variable_component(SimpleVariable::ArchiveName, None, None),
+                    variable_component(SimpleVariable::ArchiveCollection, Some(", "), None),
+                    variable_component(SimpleVariable::ArchiveCollectionId, Some(", "), None),
+                    variable_component(SimpleVariable::ArchiveSeries, Some(", Series "), None),
+                    variable_component(SimpleVariable::ArchiveBox, Some(", Box "), None),
+                    variable_component(SimpleVariable::ArchiveFolder, Some(", Folder "), None),
+                    variable_component(SimpleVariable::ArchiveItem, Some(", Item "), None),
+                    variable_component(SimpleVariable::ArchiveLocation, Some(", "), None),
+                    variable_component(SimpleVariable::ArchivePlace, Some(", "), None),
+                    variable_component(SimpleVariable::ArchiveUrl, Some(", "), None),
+                    variable_component(SimpleVariable::EprintServer, Some(", "), None),
+                    variable_component(SimpleVariable::EprintId, Some(":"), None),
+                    variable_component(SimpleVariable::EprintClass, Some(" ["), Some("]")),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1203,17 +1239,20 @@ fn build_archive_location_fallback_style() -> Style {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                citum_schema::tc_title!(Primary, suffix = ". "),
-                variable_component(SimpleVariable::ArchiveName, None, None),
-                variable_component(SimpleVariable::ArchiveCollection, Some(", "), None),
-                variable_component(SimpleVariable::ArchiveLocation, Some(", "), None),
-                variable_component(SimpleVariable::ArchivePlace, Some(", "), None),
-                variable_component(SimpleVariable::ArchiveUrl, Some(", "), None),
-                variable_component(SimpleVariable::EprintServer, Some(", "), None),
-                variable_component(SimpleVariable::EprintId, Some(":"), None),
-                variable_component(SimpleVariable::EprintClass, Some(" ["), Some("]")),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_title!(Primary, suffix = ". "),
+                    variable_component(SimpleVariable::ArchiveName, None, None),
+                    variable_component(SimpleVariable::ArchiveCollection, Some(", "), None),
+                    variable_component(SimpleVariable::ArchiveLocation, Some(", "), None),
+                    variable_component(SimpleVariable::ArchivePlace, Some(", "), None),
+                    variable_component(SimpleVariable::ArchiveUrl, Some(", "), None),
+                    variable_component(SimpleVariable::EprintServer, Some(", "), None),
+                    variable_component(SimpleVariable::EprintId, Some(":"), None),
+                    variable_component(SimpleVariable::EprintClass, Some(" ["), Some("]")),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1252,10 +1291,13 @@ fn build_multilingual_archive_name_style() -> Style {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Variable(TemplateVariable {
-                variable: SimpleVariable::ArchiveName,
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Variable(TemplateVariable {
+                    variable: SimpleVariable::ArchiveName,
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1646,11 +1688,14 @@ fn build_processing_style(processing: Processing) -> Style {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Long),
-                citum_schema::tc_date!(Issued, Year, prefix = " "),
-                citum_schema::tc_title!(Primary, prefix = ". "),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    citum_schema::tc_date!(Issued, Year, prefix = " "),
+                    citum_schema::tc_title!(Primary, prefix = ". "),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1680,10 +1725,13 @@ fn make_style_with_substitute(substitute: Option<String>) -> Style {
                 entry_suffix: Some(".".into()),
                 ..Default::default()
             }),
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Long),
-                citum_schema::tc_date!(Issued, Year),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    citum_schema::tc_date!(Issued, Year),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1846,10 +1894,13 @@ fn build_editor_verb_prefix_style(title_suffix: Option<&str>) -> Style {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                citum_schema::tc_title!(Primary, suffix = title_suffix.unwrap_or("")),
-                citum_schema::tc_contributor!(Editor, Long),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_title!(Primary, suffix = title_suffix.unwrap_or("")),
+                    citum_schema::tc_contributor!(Editor, Long),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1868,7 +1919,7 @@ fn build_bare_long_form_editor_style(role: Option<ContributorConfig>) -> Style {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![citum_schema::tc_contributor!(Editor, Long)]),
+            template: Some(vec![citum_schema::tc_contributor!(Editor, Long)].into()),
             ..Default::default()
         }),
         ..Default::default()
@@ -1991,17 +2042,20 @@ fn build_sentence_initial_emph_group_style() -> Style {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Group(TemplateGroup {
-                group: vec![TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    rendering: Rendering {
-                        emph: Some(true),
+            template: Some(
+                vec![TemplateComponent::Group(TemplateGroup {
+                    group: vec![TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        rendering: Rendering {
+                            emph: Some(true),
+                            ..Default::default()
+                        },
                         ..Default::default()
-                    },
+                    })],
                     ..Default::default()
-                })],
-                ..Default::default()
-            })]),
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -2054,7 +2108,7 @@ fn make_name_particle_style(display_as_sort: DisplayAsSort) -> Style {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![citum_schema::tc_contributor!(Author, Long)]),
+            template: Some(vec![citum_schema::tc_contributor!(Author, Long)].into()),
             ..Default::default()
         }),
         ..Default::default()
@@ -2206,10 +2260,13 @@ fn collection_title_component_renders_parent_series_title() {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                title: TitleType::CollectionTitle,
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::CollectionTitle,
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -2240,10 +2297,13 @@ fn container_title_component_renders_monograph_or_serial_parent_title() {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                title: TitleType::ContainerTitle,
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::ContainerTitle,
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -2284,24 +2344,27 @@ fn legal_case_parent_serial_uses_reporter_as_container_title() {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Group(TemplateGroup {
-                group: vec![
-                    TemplateComponent::Title(TemplateTitle {
-                        title: TitleType::ParentSerial,
-                        ..Default::default()
-                    }),
-                    TemplateComponent::Number(TemplateNumber {
-                        number: NumberVariable::Volume,
-                        ..Default::default()
-                    }),
-                    TemplateComponent::Number(TemplateNumber {
-                        number: NumberVariable::Pages,
-                        ..Default::default()
-                    }),
-                ],
-                delimiter: Some(DelimiterPunctuation::Slash),
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Group(TemplateGroup {
+                    group: vec![
+                        TemplateComponent::Title(TemplateTitle {
+                            title: TitleType::ParentSerial,
+                            ..Default::default()
+                        }),
+                        TemplateComponent::Number(TemplateNumber {
+                            number: NumberVariable::Volume,
+                            ..Default::default()
+                        }),
+                        TemplateComponent::Number(TemplateNumber {
+                            number: NumberVariable::Pages,
+                            ..Default::default()
+                        }),
+                    ],
+                    delimiter: Some(DelimiterPunctuation::Slash),
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -2506,11 +2569,14 @@ fn magic_subsequent_author_substitute_reuses_the_full_author_group() {
                 subsequent_author_substitute: Some("———".to_string()),
                 ..Default::default()
             }),
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Long),
-                citum_schema::tc_title!(Primary, prefix = ", "),
-                citum_schema::tc_date!(Issued, Year, prefix = " (", suffix = ")"),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    citum_schema::tc_title!(Primary, prefix = ", "),
+                    citum_schema::tc_date!(Issued, Year, prefix = " (", suffix = ")"),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -2595,14 +2661,17 @@ fn make_two_author_and_style(
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Contributor(
-                citum_schema::template::TemplateContributor {
-                    contributor: citum_schema::template::ContributorRole::Author.into(),
-                    form: citum_schema::template::ContributorForm::Long,
-                    name_order,
-                    ..Default::default()
-                },
-            )]),
+            template: Some(
+                vec![TemplateComponent::Contributor(
+                    citum_schema::template::TemplateContributor {
+                        contributor: citum_schema::template::ContributorRole::Author.into(),
+                        form: citum_schema::template::ContributorForm::Long,
+                        name_order,
+                        ..Default::default()
+                    },
+                )]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -4126,28 +4195,31 @@ fn original_published_date_variable_renders_when_reference_has_original_date() {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                TemplateComponent::Date(TemplateDate {
-                    date: DateVariable::OriginalPublished,
-                    form: DateForm::Year,
-                    rendering: Rendering {
-                        prefix: Some("(".into()),
-                        suffix: Some(") ".into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Date(TemplateDate {
+                        date: DateVariable::OriginalPublished,
+                        form: DateForm::Year,
+                        rendering: Rendering {
+                            prefix: Some("(".into()),
+                            suffix: Some(") ".into()),
+                            ..Default::default()
+                        },
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: DateVariable::Issued,
-                    form: DateForm::Year,
-                    ..Default::default()
-                }),
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    form: Some(TitleForm::Long),
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: DateVariable::Issued,
+                        form: DateForm::Year,
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        form: Some(TitleForm::Long),
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -4185,28 +4257,31 @@ fn original_published_date_variable_renders_for_patent_references() {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                TemplateComponent::Date(TemplateDate {
-                    date: DateVariable::OriginalPublished,
-                    form: DateForm::Year,
-                    rendering: Rendering {
-                        prefix: Some("(".into()),
-                        suffix: Some(") ".into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Date(TemplateDate {
+                        date: DateVariable::OriginalPublished,
+                        form: DateForm::Year,
+                        rendering: Rendering {
+                            prefix: Some("(".into()),
+                            suffix: Some(") ".into()),
+                            ..Default::default()
+                        },
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: DateVariable::Issued,
-                    form: DateForm::Year,
-                    ..Default::default()
-                }),
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    form: Some(TitleForm::Long),
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: DateVariable::Issued,
+                        form: DateForm::Year,
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        form: Some(TitleForm::Long),
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -4287,30 +4362,33 @@ fn given_original_publication_fields_when_a_bibliography_group_checks_field_pres
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                TemplateComponent::Group(TemplateGroup {
-                    group: vec![TemplateComponent::Variable(TemplateVariable {
-                        variable: SimpleVariable::Doi,
+            template: Some(
+                vec![
+                    TemplateComponent::Group(TemplateGroup {
+                        group: vec![TemplateComponent::Variable(TemplateVariable {
+                            variable: SimpleVariable::Doi,
+                            ..Default::default()
+                        })],
+                        render_when: Some(TemplateGroupCondition {
+                            field_present: Some(TemplateConditionField::OriginalPublisher),
+                            field_absent: None,
+                        }),
                         ..Default::default()
-                    })],
-                    render_when: Some(TemplateGroupCondition {
-                        field_present: Some(TemplateConditionField::OriginalPublisher),
-                        field_absent: None,
                     }),
-                    ..Default::default()
-                }),
-                TemplateComponent::Group(TemplateGroup {
-                    group: vec![TemplateComponent::Variable(TemplateVariable {
-                        variable: SimpleVariable::Url,
+                    TemplateComponent::Group(TemplateGroup {
+                        group: vec![TemplateComponent::Variable(TemplateVariable {
+                            variable: SimpleVariable::Url,
+                            ..Default::default()
+                        })],
+                        render_when: Some(TemplateGroupCondition {
+                            field_present: Some(TemplateConditionField::OriginalPublisherPlace),
+                            field_absent: Some(TemplateConditionField::OriginalPublisher),
+                        }),
                         ..Default::default()
-                    })],
-                    render_when: Some(TemplateGroupCondition {
-                        field_present: Some(TemplateConditionField::OriginalPublisherPlace),
-                        field_absent: Some(TemplateConditionField::OriginalPublisher),
                     }),
-                    ..Default::default()
-                }),
-            ]),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -4353,17 +4431,20 @@ fn given_a_field_absent_only_condition_when_the_probed_field_is_present_or_absen
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Group(TemplateGroup {
-                group: vec![TemplateComponent::Variable(TemplateVariable {
-                    variable: SimpleVariable::Doi,
+            template: Some(
+                vec![TemplateComponent::Group(TemplateGroup {
+                    group: vec![TemplateComponent::Variable(TemplateVariable {
+                        variable: SimpleVariable::Doi,
+                        ..Default::default()
+                    })],
+                    render_when: Some(TemplateGroupCondition {
+                        field_present: None,
+                        field_absent: Some(TemplateConditionField::OriginalPublished),
+                    }),
                     ..Default::default()
-                })],
-                render_when: Some(TemplateGroupCondition {
-                    field_present: None,
-                    field_absent: Some(TemplateConditionField::OriginalPublished),
-                }),
-                ..Default::default()
-            })]),
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -4428,30 +4509,33 @@ fn given_nested_render_when_conditions_when_outer_and_inner_fields_vary_then_eac
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Group(TemplateGroup {
-                group: vec![
-                    TemplateComponent::Variable(TemplateVariable {
-                        variable: SimpleVariable::Doi,
-                        ..Default::default()
-                    }),
-                    TemplateComponent::Group(TemplateGroup {
-                        group: vec![TemplateComponent::Variable(TemplateVariable {
-                            variable: SimpleVariable::OriginalPublisherPlace,
+            template: Some(
+                vec![TemplateComponent::Group(TemplateGroup {
+                    group: vec![
+                        TemplateComponent::Variable(TemplateVariable {
+                            variable: SimpleVariable::Doi,
                             ..Default::default()
-                        })],
-                        render_when: Some(TemplateGroupCondition {
-                            field_present: None,
-                            field_absent: Some(TemplateConditionField::OriginalPublisher),
                         }),
-                        ..Default::default()
+                        TemplateComponent::Group(TemplateGroup {
+                            group: vec![TemplateComponent::Variable(TemplateVariable {
+                                variable: SimpleVariable::OriginalPublisherPlace,
+                                ..Default::default()
+                            })],
+                            render_when: Some(TemplateGroupCondition {
+                                field_present: None,
+                                field_absent: Some(TemplateConditionField::OriginalPublisher),
+                            }),
+                            ..Default::default()
+                        }),
+                    ],
+                    render_when: Some(TemplateGroupCondition {
+                        field_present: Some(TemplateConditionField::OriginalTitle),
+                        field_absent: None,
                     }),
-                ],
-                render_when: Some(TemplateGroupCondition {
-                    field_present: Some(TemplateConditionField::OriginalTitle),
-                    field_absent: None,
-                }),
-                ..Default::default()
-            })]),
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -4496,22 +4580,25 @@ fn original_title_variable_renders_the_original_language_title() {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    form: Some(TitleForm::Long),
-                    ..Default::default()
-                }),
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Original,
-                    form: Some(TitleForm::Long),
-                    rendering: Rendering {
-                        prefix: Some(" / ".into()),
+            template: Some(
+                vec![
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        form: Some(TitleForm::Long),
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Original,
+                        form: Some(TitleForm::Long),
+                        rendering: Rendering {
+                            prefix: Some(" / ".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -4563,14 +4650,17 @@ fn given_a_number_component_with_free_text_when_a_text_case_override_is_set_then
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Number(TemplateNumber {
-                number: NumberVariable::Edition,
-                rendering: Rendering {
-                    text_case,
+            template: Some(
+                vec![TemplateComponent::Number(TemplateNumber {
+                    number: NumberVariable::Edition,
+                    rendering: Rendering {
+                        text_case,
+                        ..Default::default()
+                    },
                     ..Default::default()
-                },
-                ..Default::default()
-            })]),
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -4639,16 +4729,19 @@ fn archive_hierarchy_assembled_when_location_absent() {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    ..Default::default()
-                }),
-                TemplateComponent::Variable(TemplateVariable {
-                    variable: SimpleVariable::ArchiveLocation,
-                    ..Default::default()
-                }),
-            ]),
+            template: Some(
+                vec![
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Variable(TemplateVariable {
+                        variable: SimpleVariable::ArchiveLocation,
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -4692,16 +4785,19 @@ fn archive_location_string_bypasses_assembly() {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    ..Default::default()
-                }),
-                TemplateComponent::Variable(TemplateVariable {
-                    variable: SimpleVariable::ArchiveLocation,
-                    ..Default::default()
-                }),
-            ]),
+            template: Some(
+                vec![
+                    TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Variable(TemplateVariable {
+                        variable: SimpleVariable::ArchiveLocation,
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -4765,7 +4861,7 @@ fn processor_renders_bibliography_annotations() {
             ..Default::default()
         },
         bibliography: Some(citum_schema::BibliographySpec {
-            template: Some(vec![citum_schema::tc_title!(Primary)]),
+            template: Some(vec![citum_schema::tc_title!(Primary)].into()),
             ..Default::default()
         }),
         ..Default::default()
@@ -5006,14 +5102,17 @@ fn quoted_title_style(grouped: bool) -> Style {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                title: TitleType::Primary,
-                rendering: Rendering {
-                    quote: Some(true),
+            template: Some(
+                vec![TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    rendering: Rendering {
+                        quote: Some(true),
+                        ..Default::default()
+                    },
                     ..Default::default()
-                },
-                ..Default::default()
-            })]),
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -5117,10 +5216,13 @@ fn given_multilingual_ref_when_rendering_html_then_data_attrs_match_displayed_fo
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                title: TitleType::Primary,
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Title(TemplateTitle {
+                    title: TitleType::Primary,
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             groups: Some(vec![citum_schema::grouping::BibliographyGroup {
                 id: "all".to_string(),
                 heading: None,
@@ -5270,11 +5372,14 @@ fn given_numeric_label_mode_when_label_wrap_varies_then_label_renders_flush_agai
                 separator: Some(". ".into()),
                 ..Default::default()
             }),
-            template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author.into(),
-                form: ContributorForm::Long,
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Contributor(TemplateContributor {
+                    contributor: ContributorRole::Author.into(),
+                    form: ContributorForm::Long,
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -83,10 +83,13 @@ fn build_title_year_citation_style(sort: Vec<GroupSortKey>) -> Style {
                 ..Default::default()
             }),
             sort: Some(GroupSortEntry::Explicit(GroupSort { template: sort })),
-            template: Some(vec![
-                citum_schema::tc_title!(Primary),
-                citum_schema::tc_date!(Issued, Year),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_title!(Primary),
+                    citum_schema::tc_date!(Issued, Year),
+                ]
+                .into(),
+            ),
             delimiter: Some(" ".into()),
             multi_cite_delimiter: Some("; ".into()),
             ..Default::default()
@@ -114,17 +117,20 @@ fn build_integral_name_style() -> Style {
         }),
         citation: Some(CitationSpec {
             integral: Some(Box::new(CitationSpec {
-                template: Some(vec![citum_schema::tc_contributor!(Author, Long)]),
+                template: Some(vec![citum_schema::tc_contributor!(Author, Long)].into()),
                 ..Default::default()
             })),
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Short),
-                citum_schema::tc_date!(
-                    Issued,
-                    Year,
-                    wrap = citum_schema::template::WrapPunctuation::Parentheses
-                ),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Short),
+                    citum_schema::tc_date!(
+                        Issued,
+                        Year,
+                        wrap = citum_schema::template::WrapPunctuation::Parentheses
+                    ),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -249,7 +255,7 @@ fn two_names_citation_never_uses_delimiter_even_when_always_is_declared() {
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![citum_schema::tc_contributor!(Author, Long)]),
+            template: Some(vec![citum_schema::tc_contributor!(Author, Long)].into()),
             ..Default::default()
         }),
         ..Default::default()
@@ -304,7 +310,7 @@ fn substitute_title_style(title_quote: Option<SubstituteTitleQuoteMode>) -> Styl
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![citum_schema::tc_contributor!(Author, Long)]),
+            template: Some(vec![citum_schema::tc_contributor!(Author, Long)].into()),
             ..Default::default()
         }),
         ..Default::default()
@@ -500,14 +506,17 @@ fn disambiguation_two_level_author_collisions_get_distinct_suffixes() {
             .citation
             .as_ref()
             .and_then(|spec| spec.sort.clone()),
-        template: Some(vec![
-            citum_schema::tc_contributor!(Author, Short),
-            citum_schema::tc_date!(
-                Issued,
-                Year,
-                wrap = citum_schema::template::WrapPunctuation::Parentheses
-            ),
-        ]),
+        template: Some(
+            vec![
+                citum_schema::tc_contributor!(Author, Short),
+                citum_schema::tc_date!(
+                    Issued,
+                    Year,
+                    wrap = citum_schema::template::WrapPunctuation::Parentheses
+                ),
+            ]
+            .into(),
+        ),
         delimiter: Some(" ".into()),
         multi_cite_delimiter: Some("; ".into()),
         ..Default::default()
@@ -1042,14 +1051,17 @@ fn subsequent_et_al_thresholds_shorten_the_repeat_citation() {
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Short),
-                citum_schema::tc_date!(
-                    Issued,
-                    Year,
-                    wrap = citum_schema::template::WrapPunctuation::Parentheses
-                ),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Short),
+                    citum_schema::tc_date!(
+                        Issued,
+                        Year,
+                        wrap = citum_schema::template::WrapPunctuation::Parentheses
+                    ),
+                ]
+                .into(),
+            ),
             multi_cite_delimiter: Some("; ".into()),
             ..Default::default()
         }),
@@ -1172,7 +1184,7 @@ fn citation_scoped_contributor_shorten_applies_without_component_override() {
                 }),
                 ..Default::default()
             }),
-            template: Some(vec![citum_schema::tc_contributor!(Author, Long)]),
+            template: Some(vec![citum_schema::tc_contributor!(Author, Long)].into()),
             ..Default::default()
         }),
         ..Default::default()
@@ -1874,9 +1886,9 @@ fn note_styles_without_ibid_overrides_fall_back_to_subsequent() {
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![citum_schema::tc_contributor!(Author, Long)]),
+            template: Some(vec![citum_schema::tc_contributor!(Author, Long)].into()),
             subsequent: Some(Box::new(CitationSpec {
-                template: Some(vec![citum_schema::tc_contributor!(Author, Short)]),
+                template: Some(vec![citum_schema::tc_contributor!(Author, Short)].into()),
                 ..Default::default()
             })),
             ..Default::default()
@@ -2699,22 +2711,25 @@ fn test_personal_communication_citation_rendering_is_style_driven() {
             ..Default::default()
         },
         citation: Some(CitationSpec {
-            template: Some(vec![
-                citum_schema::template::TemplateComponent::Contributor(
-                    citum_schema::template::TemplateContributor {
-                        contributor: citum_schema::template::ContributorRole::Author.into(),
-                        form: citum_schema::template::ContributorForm::Long,
-                        name_order: Some(citum_schema::template::NameOrder::GivenFirst),
-                        rendering: citum_schema::template::Rendering {
-                            name_form: Some(NameForm::Initials),
+            template: Some(
+                vec![
+                    citum_schema::template::TemplateComponent::Contributor(
+                        citum_schema::template::TemplateContributor {
+                            contributor: citum_schema::template::ContributorRole::Author.into(),
+                            form: citum_schema::template::ContributorForm::Long,
+                            name_order: Some(citum_schema::template::NameOrder::GivenFirst),
+                            rendering: citum_schema::template::Rendering {
+                                name_form: Some(NameForm::Initials),
+                                ..Default::default()
+                            },
                             ..Default::default()
                         },
-                        ..Default::default()
-                    },
-                ),
-                citum_schema::tc_term!(PersonalCommunication),
-                citum_schema::tc_date!(Issued, Full),
-            ]),
+                    ),
+                    citum_schema::tc_term!(PersonalCommunication),
+                    citum_schema::tc_date!(Issued, Full),
+                ]
+                .into(),
+            ),
             delimiter: Some(", ".into()),
             wrap: Some(citum_schema::template::WrapPunctuation::Parentheses.into()),
             ..Default::default()
@@ -3044,7 +3059,7 @@ fn role_label_defaults_bundle_never_fires_in_citation_context() {
                 label_mode: Some(CitationLabelMode::None),
                 ..Default::default()
             }),
-            template: Some(vec![citum_schema::tc_contributor!(Editor, Long)]),
+            template: Some(vec![citum_schema::tc_contributor!(Editor, Long)].into()),
             ..Default::default()
         }),
         ..Default::default()
@@ -3093,7 +3108,7 @@ fn leading_non_author_contributor_renders_once_in_grouped_citation() {
             ..Default::default()
         },
         citation: Some(CitationSpec {
-            template: Some(vec![citum_schema::tc_contributor!(Translator, Long)]),
+            template: Some(vec![citum_schema::tc_contributor!(Translator, Long)].into()),
             ..Default::default()
         }),
         ..Default::default()
@@ -3187,19 +3202,22 @@ fn given_a_tied_bibliography_sort_when_citing_then_year_suffixes_follow_registra
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Short),
-                citum_schema::tc_date!(
-                    Issued,
-                    Year,
-                    wrap = citum_schema::template::WrapPunctuation::Parentheses
-                ),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Short),
+                    citum_schema::tc_date!(
+                        Issued,
+                        Year,
+                        wrap = citum_schema::template::WrapPunctuation::Parentheses
+                    ),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         bibliography: Some(citum_schema::BibliographySpec {
             sort: Some(bibliography_sort),
-            template: Some(vec![citum_schema::tc_title!(Primary)]),
+            template: Some(vec![citum_schema::tc_title!(Primary)].into()),
             ..Default::default()
         }),
         ..Default::default()

--- a/crates/citum-engine/tests/common/mod.rs
+++ b/crates/citum-engine/tests/common/mod.rs
@@ -397,7 +397,7 @@ pub fn build_author_date_style(
                     ],
                 },
             )),
-            template: Some(citation_template),
+            template: Some(citation_template.into()),
             multi_cite_delimiter: Some("; ".into()),
             ..Default::default()
         }),

--- a/crates/citum-engine/tests/date_annotations.rs
+++ b/crates/citum-engine/tests/date_annotations.rs
@@ -143,19 +143,22 @@ fn style_with_duplicated_issued_date() -> Style {
                 }),
                 ..Default::default()
             }),
-            template: Some(vec![
-                TemplateComponent::Date(TemplateDate {
-                    date: DateVariable::Issued,
-                    form: DateForm::Year,
-                    ..Default::default()
-                }),
-                TemplateComponent::Date(TemplateDate {
-                    date: DateVariable::Issued,
-                    form: DateForm::Year,
-                    suppress_note: Some(true),
-                    ..Default::default()
-                }),
-            ]),
+            template: Some(
+                vec![
+                    TemplateComponent::Date(TemplateDate {
+                        date: DateVariable::Issued,
+                        form: DateForm::Year,
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Date(TemplateDate {
+                        date: DateVariable::Issued,
+                        form: DateForm::Year,
+                        suppress_note: Some(true),
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()

--- a/crates/citum-engine/tests/document.rs
+++ b/crates/citum-engine/tests/document.rs
@@ -115,10 +115,13 @@ fn given_simple_author_date_document_when_rendered_as_html_then_a_bibliography_h
                 entry_suffix: Some(".".into()),
                 ..Default::default()
             }),
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Long),
-                citum_schema::tc_date!(Issued, Year),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    citum_schema::tc_date!(Issued, Year),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -187,10 +190,13 @@ fn given_simple_author_date_document_when_rendered_as_djot_then_html_tags_are_no
                 entry_suffix: Some(".".into()),
                 ..Default::default()
             }),
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Long),
-                citum_schema::tc_date!(Issued, Year),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    citum_schema::tc_date!(Issued, Year),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1584,12 +1590,15 @@ fn djot_note_preserves_italic_markup_in_html_bibliography() {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![citum_schema::template::TemplateComponent::Variable(
-                TemplateVariable {
-                    variable: SimpleVariable::Note,
-                    ..Default::default()
-                },
-            )]),
+            template: Some(
+                vec![citum_schema::template::TemplateComponent::Variable(
+                    TemplateVariable {
+                        variable: SimpleVariable::Note,
+                        ..Default::default()
+                    },
+                )]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1633,14 +1642,17 @@ fn djot_note_sentence_case_does_not_restart_across_markup_boundaries() {
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![TemplateComponent::Variable(TemplateVariable {
-                variable: SimpleVariable::Note,
-                rendering: Rendering {
-                    text_case: Some(TextCase::Sentence),
+            template: Some(
+                vec![TemplateComponent::Variable(TemplateVariable {
+                    variable: SimpleVariable::Note,
+                    rendering: Rendering {
+                        text_case: Some(TextCase::Sentence),
+                        ..Default::default()
+                    },
                     ..Default::default()
-                },
-                ..Default::default()
-            })]),
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1797,10 +1809,13 @@ fn given_a_large_library_and_a_small_cited_subset_when_rendering_a_flat_document
                 entry_suffix: Some(".".into()),
                 ..Default::default()
             }),
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Long),
-                citum_schema::tc_title!(Primary, prefix = ". "),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    citum_schema::tc_title!(Primary, prefix = ". "),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1879,10 +1894,13 @@ fn given_an_uncited_reference_between_two_same_author_cited_entries_when_renderi
                 subsequent_author_substitute: Some("———".to_string()),
                 ..Default::default()
             }),
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Long),
-                citum_schema::tc_title!(Primary, prefix = ". "),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    citum_schema::tc_title!(Primary, prefix = ". "),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1955,10 +1973,13 @@ fn given_sort_partitioned_sections_and_subsequent_author_substitution_when_rende
                 }),
                 ..Default::default()
             }),
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Long),
-                citum_schema::tc_title!(Primary, prefix = ". "),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    citum_schema::tc_title!(Primary, prefix = ". "),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -2056,10 +2077,13 @@ fn given_groups_enabled_false_with_groups_still_configured_when_rendering_a_docu
                 template: None,
                 disambiguate: None,
             }]),
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Long),
-                citum_schema::tc_title!(Primary, prefix = ". "),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    citum_schema::tc_title!(Primary, prefix = ". "),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()

--- a/crates/citum-engine/tests/forward_compatibility.rs
+++ b/crates/citum-engine/tests/forward_compatibility.rs
@@ -98,13 +98,13 @@ fn style_has_unknowns(style: &Style) -> bool {
     // catches Unknown variants captured by the tolerant deserializer.
     if let Some(citation) = &style.citation
         && let Some(template) = &citation.template
-        && template_has_unknowns(template)
+        && template.as_template().is_some_and(template_has_unknowns)
     {
         return true;
     }
     if let Some(bib) = &style.bibliography
         && let Some(template) = &bib.template
-        && template_has_unknowns(template)
+        && template.as_template().is_some_and(template_has_unknowns)
     {
         return true;
     }

--- a/crates/citum-engine/tests/i18n.rs
+++ b/crates/citum-engine/tests/i18n.rs
@@ -378,10 +378,13 @@ fn build_ml_style(name_mode: MultilingualMode, preferred_script: Option<String>)
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![
-                citum_schema::tc_contributor!(Author, Short),
-                citum_schema::tc_date!(Issued, Year),
-            ]),
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Short),
+                    citum_schema::tc_date!(Issued, Year),
+                ]
+                .into(),
+            ),
             delimiter: Some(", ".into()),
             ..Default::default()
         }),
@@ -415,37 +418,40 @@ fn make_german_translator_role_style() -> Style {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                citum_schema::template::TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Author.into(),
-                    form: ContributorForm::Long,
-                    ..Default::default()
-                }),
-                citum_schema::template::TemplateComponent::Date(TemplateDate {
-                    date: citum_schema::template::DateVariable::Issued,
-                    form: DateForm::Year,
-                    rendering: Rendering {
-                        suffix: Some(". ".into()),
+            template: Some(
+                vec![
+                    citum_schema::template::TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Author.into(),
+                        form: ContributorForm::Long,
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-                citum_schema::template::TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    rendering: Rendering {
-                        emph: Some(true),
-                        suffix: Some(". ".into()),
+                    }),
+                    citum_schema::template::TemplateComponent::Date(TemplateDate {
+                        date: citum_schema::template::DateVariable::Issued,
+                        form: DateForm::Year,
+                        rendering: Rendering {
+                            suffix: Some(". ".into()),
+                            ..Default::default()
+                        },
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-                citum_schema::template::TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Translator.into(),
-                    form: ContributorForm::Long,
-                    name_order: Some(NameOrder::GivenFirst),
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    citum_schema::template::TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        rendering: Rendering {
+                            emph: Some(true),
+                            suffix: Some(". ".into()),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    }),
+                    citum_schema::template::TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Translator.into(),
+                        form: ContributorForm::Long,
+                        name_order: Some(NameOrder::GivenFirst),
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -975,7 +981,7 @@ fn given_translated_numeric_integral_citations_when_rendered_then_the_translated
     let mut style = build_ml_style(MultilingualMode::Translated, None);
     style.options.as_mut().unwrap().processing = Some(Processing::Numeric);
     style.citation.as_mut().unwrap().template =
-        Some(vec![citum_schema::tc_contributor!(Author, Short)]);
+        Some(vec![citum_schema::tc_contributor!(Author, Short)].into());
 
     let mut bib = indexmap::IndexMap::new();
     let mut translations = HashMap::new();
@@ -1095,7 +1101,7 @@ fn given_localized_citation_templates_when_the_item_language_matches_then_the_lo
             ..Default::default()
         },
         citation: Some(CitationSpec {
-            template: Some(vec![citum_schema::tc_variable!(Note)]),
+            template: Some(vec![citum_schema::tc_variable!(Note)].into()),
             locales: Some(vec![
                 LocalizedTemplateSpec {
                     locale: Some(vec!["de".to_string()]),
@@ -1218,7 +1224,7 @@ fn given_localized_bibliography_templates_when_only_the_multilingual_title_has_a
             ..Default::default()
         },
         bibliography: Some(BibliographySpec {
-            template: Some(vec![citum_schema::tc_variable!(Note)]),
+            template: Some(vec![citum_schema::tc_variable!(Note)].into()),
             locales: Some(vec![
                 LocalizedTemplateSpec {
                     locale: Some(vec!["ja".to_string()]),
@@ -1325,10 +1331,10 @@ fn given_mixed_language_titles_when_rendering_the_bibliography_then_field_langua
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
+            template: Some(citum_schema::TemplateVariant::Full(vec![
                 citum_schema::tc_title!(Primary),
                 citum_schema::tc_title!(ParentMonograph),
-            ]),
+            ])),
             ..Default::default()
         }),
         ..Default::default()
@@ -1409,20 +1415,23 @@ fn given_apa_multilingual_title_mode_when_rendering_a_japanese_article_then_titl
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![
-                citum_schema::template::TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::Primary,
-                    rendering: Rendering {
-                        suffix: Some(". ".into()),
+            template: Some(
+                vec![
+                    citum_schema::template::TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::Primary,
+                        rendering: Rendering {
+                            suffix: Some(". ".into()),
+                            ..Default::default()
+                        },
                         ..Default::default()
-                    },
-                    ..Default::default()
-                }),
-                citum_schema::template::TemplateComponent::Title(TemplateTitle {
-                    title: TitleType::ParentSerial,
-                    ..Default::default()
-                }),
-            ]),
+                    }),
+                    citum_schema::template::TemplateComponent::Title(TemplateTitle {
+                        title: TitleType::ParentSerial,
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1517,16 +1526,19 @@ fn chicago_pattern_renders_three_way_japanese_title() {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![citum_schema::template::TemplateComponent::Title(
-                TemplateTitle {
-                    title: TitleType::Primary,
-                    rendering: Rendering {
-                        suffix: Some(". ".into()),
+            template: Some(
+                vec![citum_schema::template::TemplateComponent::Title(
+                    TemplateTitle {
+                        title: TitleType::Primary,
+                        rendering: Rendering {
+                            suffix: Some(". ".into()),
+                            ..Default::default()
+                        },
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
-            )]),
+                )]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -1598,16 +1610,19 @@ fn mla_pattern_renders_original_and_translation_chinese_title() {
             ..Default::default()
         }),
         bibliography: Some(BibliographySpec {
-            template: Some(vec![citum_schema::template::TemplateComponent::Title(
-                TemplateTitle {
-                    title: TitleType::Primary,
-                    rendering: Rendering {
-                        suffix: Some(". ".into()),
+            template: Some(
+                vec![citum_schema::template::TemplateComponent::Title(
+                    TemplateTitle {
+                        title: TitleType::Primary,
+                        rendering: Rendering {
+                            suffix: Some(". ".into()),
+                            ..Default::default()
+                        },
                         ..Default::default()
                     },
-                    ..Default::default()
-                },
-            )]),
+                )]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()

--- a/crates/citum-engine/tests/metadata.rs
+++ b/crates/citum-engine/tests/metadata.rs
@@ -58,11 +58,14 @@ fn build_name_style(form: ContributorForm, shorten: Option<ShortenListOptions>) 
                 label_mode: Some(CitationLabelMode::None),
                 ..Default::default()
             }),
-            template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-                contributor: ContributorRole::Author.into(),
-                form,
-                ..Default::default()
-            })]),
+            template: Some(
+                vec![TemplateComponent::Contributor(TemplateContributor {
+                    contributor: ContributorRole::Author.into(),
+                    form,
+                    ..Default::default()
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()
@@ -85,16 +88,19 @@ fn build_date_style(form: DateForm) -> Style {
                 label_mode: Some(CitationLabelMode::None),
                 ..Default::default()
             }),
-            template: Some(vec![TemplateComponent::Date(TemplateDate {
-                date: TDateVar::Issued,
-                form,
-                fallback: Some(vec![TemplateComponent::Term(TemplateTerm {
-                    term: GeneralTerm::NoDate,
-                    form: Some(TermForm::Short),
+            template: Some(
+                vec![TemplateComponent::Date(TemplateDate {
+                    date: TDateVar::Issued,
+                    form,
+                    fallback: Some(vec![TemplateComponent::Term(TemplateTerm {
+                        term: GeneralTerm::NoDate,
+                        form: Some(TermForm::Short),
+                        ..Default::default()
+                    })]),
                     ..Default::default()
-                })]),
-                ..Default::default()
-            })]),
+                })]
+                .into(),
+            ),
             ..Default::default()
         }),
         ..Default::default()

--- a/crates/citum-engine/tests/name_form_initialization.rs
+++ b/crates/citum-engine/tests/name_form_initialization.rs
@@ -52,7 +52,7 @@ fn build_name_form_test_style(
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(vec![citum_schema::tc_contributor!(Author, Long)]),
+            template: Some(vec![citum_schema::tc_contributor!(Author, Long)].into()),
             ..Default::default()
         }),
         ..Default::default()

--- a/crates/citum-engine/tests/sort_oracle.rs
+++ b/crates/citum-engine/tests/sort_oracle.rs
@@ -122,7 +122,7 @@ fn test_numeric_sort_by_citation_order() {
                     label_separator: Some(". ".to_string()),
                     ..Default::default()
                 }),
-                template: Some(vec![citum_schema::tc_contributor!(Author, Long)]),
+                template: Some(vec![citum_schema::tc_contributor!(Author, Long)].into()),
                 ..Default::default()
             }),
             ..Default::default()

--- a/crates/citum-engine/tests/term_locale.rs
+++ b/crates/citum-engine/tests/term_locale.rs
@@ -102,11 +102,11 @@ fn style_with_bibliography_term_locale_item() -> Style {
                 }),
                 ..Default::default()
             }),
-            template: Some(term_locale_probe_template()),
+            template: Some(term_locale_probe_template().into()),
             ..Default::default()
         }),
         citation: Some(CitationSpec {
-            template: Some(term_locale_probe_template()),
+            template: Some(term_locale_probe_template().into()),
             ..Default::default()
         }),
         ..Default::default()

--- a/crates/citum-migrate/src/assembly.rs
+++ b/crates/citum-migrate/src/assembly.rs
@@ -321,7 +321,7 @@ fn build_final_style(legacy_style: &csl_legacy::model::Style, mut c: CompiledOut
         .filter(|t| t != &c.new_cit)
         .map(|t| {
             Box::new(CitationSpec {
-                template: Some(t),
+                template: Some(t.into()),
                 ..Default::default()
             })
         });
@@ -331,7 +331,7 @@ fn build_final_style(legacy_style: &csl_legacy::model::Style, mut c: CompiledOut
         .filter(|t| t != &c.new_cit)
         .map(|t| {
             Box::new(CitationSpec {
-                template: Some(t),
+                template: Some(t.into()),
                 ..Default::default()
             })
         });
@@ -348,7 +348,7 @@ fn build_final_style(legacy_style: &csl_legacy::model::Style, mut c: CompiledOut
         citation: Some(CitationSpec {
             options: citation_scope_options,
             template_ref: None,
-            template: Some(c.new_cit),
+            template: Some(c.new_cit.into()),
             locales: c.citation_locales,
             collapse: extract_citation_collapse(&legacy_style.citation),
             wrap: c.citation_wrap.map(Into::into),
@@ -368,7 +368,7 @@ fn build_final_style(legacy_style: &csl_legacy::model::Style, mut c: CompiledOut
         bibliography: Some(BibliographySpec {
             options: bibliography_scope_options,
             template_ref: None,
-            template: Some(new_bib),
+            template: Some(new_bib.into()),
             locales: c.bibliography_locales,
             type_variants,
             sort: bibliography_sort,
@@ -730,10 +730,13 @@ mod tests {
                 ..CitationSpec::default()
             }),
             bibliography: Some(BibliographySpec {
-                template: Some(vec![TemplateComponent::Variable(TemplateVariable {
-                    variable: SimpleVariable::Url,
-                    ..TemplateVariable::default()
-                })]),
+                template: Some(
+                    vec![TemplateComponent::Variable(TemplateVariable {
+                        variable: SimpleVariable::Url,
+                        ..TemplateVariable::default()
+                    })]
+                    .into(),
+                ),
                 ..BibliographySpec::default()
             }),
             ..Style::default()
@@ -744,10 +747,13 @@ mod tests {
                 ..CitationSpec::default()
             }),
             bibliography: Some(BibliographySpec {
-                template: Some(vec![TemplateComponent::Variable(TemplateVariable {
-                    variable: SimpleVariable::Doi,
-                    ..TemplateVariable::default()
-                })]),
+                template: Some(
+                    vec![TemplateComponent::Variable(TemplateVariable {
+                        variable: SimpleVariable::Doi,
+                        ..TemplateVariable::default()
+                    })]
+                    .into(),
+                ),
                 ..BibliographySpec::default()
             }),
             ..Style::default()
@@ -910,6 +916,7 @@ mod tests {
             .citation
             .as_ref()
             .and_then(|citation| citation.template.as_ref())
+            .and_then(TemplateVariant::as_template)
             .expect("citation template should be present");
         let TemplateComponent::Contributor(author) = citation_template
             .first()

--- a/crates/citum-migrate/src/lineage.rs
+++ b/crates/citum-migrate/src/lineage.rs
@@ -970,32 +970,38 @@ mod tests {
                 ..Default::default()
             },
             citation: Some(citum_schema::CitationSpec {
-                template: Some(vec![
-                    TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author.into(),
-                        form: ContributorForm::Short,
-                        ..Default::default()
-                    }),
-                    TemplateComponent::Date(TemplateDate {
-                        date: DateVariable::Issued,
-                        form: DateForm::Year,
-                        ..Default::default()
-                    }),
-                ]),
+                template: Some(
+                    vec![
+                        TemplateComponent::Contributor(TemplateContributor {
+                            contributor: ContributorRole::Author.into(),
+                            form: ContributorForm::Short,
+                            ..Default::default()
+                        }),
+                        TemplateComponent::Date(TemplateDate {
+                            date: DateVariable::Issued,
+                            form: DateForm::Year,
+                            ..Default::default()
+                        }),
+                    ]
+                    .into(),
+                ),
                 ..Default::default()
             }),
             bibliography: Some(citum_schema::BibliographySpec {
-                template: Some(vec![
-                    TemplateComponent::Contributor(TemplateContributor {
-                        contributor: ContributorRole::Author.into(),
-                        form: ContributorForm::Long,
-                        ..Default::default()
-                    }),
-                    TemplateComponent::Variable(TemplateVariable {
-                        variable: SimpleVariable::Doi,
-                        ..Default::default()
-                    }),
-                ]),
+                template: Some(
+                    vec![
+                        TemplateComponent::Contributor(TemplateContributor {
+                            contributor: ContributorRole::Author.into(),
+                            form: ContributorForm::Long,
+                            ..Default::default()
+                        }),
+                        TemplateComponent::Variable(TemplateVariable {
+                            variable: SimpleVariable::Doi,
+                            ..Default::default()
+                        }),
+                    ]
+                    .into(),
+                ),
                 ..Default::default()
             }),
             ..Default::default()

--- a/crates/citum-migrate/src/main_tests.rs
+++ b/crates/citum-migrate/src/main_tests.rs
@@ -66,7 +66,7 @@ fn compile_from_xml_emits_ordered_localized_templates_with_default() {
         Some(true)
     );
     let citation = citum_schema::CitationSpec {
-        template: Some(output.citation.clone()),
+        template: Some(output.citation.clone().into()),
         locales: Some(citation_locales),
         ..Default::default()
     };

--- a/crates/citum-migrate/src/measured_citation.rs
+++ b/crates/citum-migrate/src/measured_citation.rs
@@ -667,7 +667,8 @@ fn citation_style_contains_primary_title(style: &Style) -> bool {
 fn citation_spec_contains_primary_title(spec: &citum_schema::CitationSpec) -> bool {
     spec.template
         .as_ref()
-        .is_some_and(|template| template_contains_primary_title(template))
+        .and_then(TemplateVariant::as_template)
+        .is_some_and(template_contains_primary_title)
         || spec.type_variants.as_ref().is_some_and(|type_variants| {
             type_variants.values().any(|variant| {
                 variant
@@ -723,7 +724,11 @@ where
     F: Fn(&mut [TemplateComponent]) -> bool,
 {
     let mut changed = false;
-    if let Some(template) = spec.template.as_mut() {
+    if let Some(template) = spec
+        .template
+        .as_mut()
+        .and_then(TemplateVariant::as_template_mut)
+    {
         changed |= mutator(template);
     }
     if let Some(type_variants) = spec.type_variants.as_mut() {
@@ -1024,7 +1029,11 @@ where
     let mut style = style.clone();
     let bibliography = style.bibliography.as_mut()?;
     let mut changed = false;
-    if let Some(template) = bibliography.template.as_mut() {
+    if let Some(template) = bibliography
+        .template
+        .as_mut()
+        .and_then(TemplateVariant::as_template_mut)
+    {
         changed |= mutator(template);
     }
     if let Some(type_variants) = bibliography.type_variants.as_mut() {
@@ -1041,7 +1050,9 @@ fn apply_type_local_default(style: &Style, ref_type: &str) -> Option<Style> {
     let template = style
         .bibliography
         .as_ref()
-        .and_then(|bibliography| bibliography.template.clone())?;
+        .and_then(|bibliography| bibliography.template.as_ref())
+        .and_then(TemplateVariant::as_template)
+        .map(<[_]>::to_vec)?;
     let mut style = style.clone();
     let bibliography = style.bibliography.as_mut()?;
     bibliography
@@ -1116,7 +1127,11 @@ fn bibliography_template_for_type(style: &Style, ref_type: &str) -> Option<Vec<T
             }
         }
     }
-    bibliography.template.clone()
+    bibliography
+        .template
+        .as_ref()
+        .and_then(TemplateVariant::as_template)
+        .map(<[_]>::to_vec)
 }
 
 fn suppress_matching_components<F>(

--- a/crates/citum-migrate/src/passes/sqi_refinement.rs
+++ b/crates/citum-migrate/src/passes/sqi_refinement.rs
@@ -77,7 +77,11 @@ fn collect_citation_templates<'a>(
     let Some(spec) = spec else {
         return;
     };
-    if let Some(template) = spec.template.as_ref() {
+    if let Some(template) = spec
+        .template
+        .as_ref()
+        .and_then(TemplateVariant::as_template)
+    {
         templates.push(template);
     }
     if let Some(type_variants) = spec.type_variants.as_ref() {
@@ -96,7 +100,11 @@ fn collect_bibliography_templates<'a>(
     let Some(spec) = spec else {
         return;
     };
-    if let Some(template) = spec.template.as_ref() {
+    if let Some(template) = spec
+        .template
+        .as_ref()
+        .and_then(TemplateVariant::as_template)
+    {
         templates.push(template);
     }
     if let Some(type_variants) = spec.type_variants.as_ref() {
@@ -160,7 +168,11 @@ fn encode_bibliography_type_variants(style: &mut Style) {
     let Some(bibliography) = style.bibliography.as_mut() else {
         return;
     };
-    let Some(base_template) = bibliography.template.as_ref() else {
+    let Some(base_template) = bibliography
+        .template
+        .as_ref()
+        .and_then(TemplateVariant::as_template)
+    else {
         return;
     };
     let Some(type_variants) = bibliography.type_variants.as_ref() else {
@@ -185,7 +197,7 @@ fn encode_bibliography_type_variants(style: &mut Style) {
         let TemplateVariant::Full(template) = variant else {
             continue;
         };
-        if template.as_slice() != base_template.as_slice() {
+        if template.as_slice() != base_template {
             type_templates.insert(selector, template);
         }
     }
@@ -264,7 +276,11 @@ fn prune_style_against_options(style: &mut Style) {
             || global_options.clone(),
             |options| options.merged_with(&global_options),
         );
-        if let Some(template) = bibliography.template.as_mut() {
+        if let Some(template) = bibliography
+            .template
+            .as_mut()
+            .and_then(TemplateVariant::as_template_mut)
+        {
             normalize_templates_against_options(
                 template,
                 TitleDefaultContext::Default,
@@ -280,7 +296,11 @@ fn prune_citation_spec(spec: &mut CitationSpec, inherited_options: &citum_schema
         || inherited_options.clone(),
         |options| options.merged_with(inherited_options),
     );
-    if let Some(template) = spec.template.as_mut() {
+    if let Some(template) = spec
+        .template
+        .as_mut()
+        .and_then(TemplateVariant::as_template_mut)
+    {
         normalize_templates_against_options(
             template,
             TitleDefaultContext::Default,
@@ -547,7 +567,11 @@ fn normalize_serialized_suppress_markers(style: &mut Style) {
         normalize_citation_suppress(citation);
     }
     if let Some(bibliography) = style.bibliography.as_mut() {
-        if let Some(template) = bibliography.template.as_mut() {
+        if let Some(template) = bibliography
+            .template
+            .as_mut()
+            .and_then(TemplateVariant::as_template_mut)
+        {
             normalize_visible_suppress(template);
         }
         normalize_variant_suppress(bibliography.type_variants.as_mut());
@@ -555,7 +579,11 @@ fn normalize_serialized_suppress_markers(style: &mut Style) {
 }
 
 fn normalize_citation_suppress(spec: &mut CitationSpec) {
-    if let Some(template) = spec.template.as_mut() {
+    if let Some(template) = spec
+        .template
+        .as_mut()
+        .and_then(TemplateVariant::as_template_mut)
+    {
         normalize_visible_suppress(template);
     }
     normalize_variant_suppress(spec.type_variants.as_mut());
@@ -699,11 +727,11 @@ mod tests {
     fn common_contributor_and_is_hoisted_to_global_options() {
         let style = Style {
             citation: Some(CitationSpec {
-                template: Some(vec![author(Some(AndOptions::Text))]),
+                template: Some(vec![author(Some(AndOptions::Text))].into()),
                 ..CitationSpec::default()
             }),
             bibliography: Some(BibliographySpec {
-                template: Some(vec![author(Some(AndOptions::Text))]),
+                template: Some(vec![author(Some(AndOptions::Text))].into()),
                 ..BibliographySpec::default()
             }),
             ..Style::default()
@@ -723,6 +751,7 @@ mod tests {
             .citation
             .as_ref()
             .and_then(|citation| citation.template.as_ref())
+            .and_then(TemplateVariant::as_template)
             .expect("citation template should exist");
         let TemplateComponent::Contributor(author) = &citation_template[0] else {
             panic!("citation component should be author");
@@ -734,11 +763,11 @@ mod tests {
     fn scope_contributor_and_is_hoisted_without_global_match() {
         let style = Style {
             citation: Some(CitationSpec {
-                template: Some(vec![author(Some(AndOptions::Symbol))]),
+                template: Some(vec![author(Some(AndOptions::Symbol))].into()),
                 ..CitationSpec::default()
             }),
             bibliography: Some(BibliographySpec {
-                template: Some(vec![primary_title(None)]),
+                template: Some(vec![primary_title(None)].into()),
                 ..BibliographySpec::default()
             }),
             ..Style::default()
@@ -776,11 +805,11 @@ mod tests {
                 ..citum_schema::options::Config::default()
             }),
             citation: Some(CitationSpec {
-                template: Some(vec![author(Some(AndOptions::Text))]),
+                template: Some(vec![author(Some(AndOptions::Text))].into()),
                 ..CitationSpec::default()
             }),
             bibliography: Some(BibliographySpec {
-                template: Some(vec![author(Some(AndOptions::Text))]),
+                template: Some(vec![author(Some(AndOptions::Text))].into()),
                 ..BibliographySpec::default()
             }),
             ..Style::default()
@@ -810,6 +839,7 @@ mod tests {
             .citation
             .as_ref()
             .and_then(|citation| citation.template.as_ref())
+            .and_then(TemplateVariant::as_template)
             .and_then(|template| template.first())
             .expect("citation author exists");
         let TemplateComponent::Contributor(citation_author) = citation_author else {
@@ -823,16 +853,19 @@ mod tests {
         let style = Style {
             options: Some(style_options()),
             citation: Some(CitationSpec {
-                template: Some(vec![
-                    author_with_name_options(),
-                    primary_title(Some(TextCase::SentenceApa)),
-                ]),
+                template: Some(
+                    vec![
+                        author_with_name_options(),
+                        primary_title(Some(TextCase::SentenceApa)),
+                    ]
+                    .into(),
+                ),
                 subsequent: Some(Box::new(CitationSpec {
-                    template: Some(vec![author_with_name_options()]),
+                    template: Some(vec![author_with_name_options()].into()),
                     ..CitationSpec::default()
                 })),
                 ibid: Some(Box::new(CitationSpec {
-                    template: Some(vec![author(Some(AndOptions::Text))]),
+                    template: Some(vec![author(Some(AndOptions::Text))].into()),
                     ..CitationSpec::default()
                 })),
                 ..CitationSpec::default()
@@ -842,7 +875,11 @@ mod tests {
 
         let refined = refine_style(style);
         let citation = refined.citation.as_ref().expect("citation should exist");
-        let template = citation.template.as_ref().expect("template should exist");
+        let template = citation
+            .template
+            .as_ref()
+            .and_then(TemplateVariant::as_template)
+            .expect("template should exist");
         let TemplateComponent::Contributor(author) = &template[0] else {
             panic!("first component should be contributor");
         };
@@ -858,6 +895,7 @@ mod tests {
             .subsequent
             .as_ref()
             .and_then(|spec| spec.template.as_ref())
+            .and_then(TemplateVariant::as_template)
             .expect("subsequent template should exist");
         let TemplateComponent::Contributor(subsequent_author) = &subsequent[0] else {
             panic!("subsequent component should be contributor");
@@ -869,6 +907,7 @@ mod tests {
             .ibid
             .as_ref()
             .and_then(|spec| spec.template.as_ref())
+            .and_then(TemplateVariant::as_template)
             .expect("ibid template should exist");
         let TemplateComponent::Contributor(ibid_author) = &ibid[0] else {
             panic!("ibid component should be contributor");
@@ -916,7 +955,7 @@ mod tests {
         let style = Style {
             options: Some(options),
             bibliography: Some(BibliographySpec {
-                template: Some(vec![merged]),
+                template: Some(vec![merged].into()),
                 ..BibliographySpec::default()
             }),
             ..Style::default()
@@ -927,6 +966,7 @@ mod tests {
             .bibliography
             .as_ref()
             .and_then(|bibliography| bibliography.template.as_ref())
+            .and_then(TemplateVariant::as_template)
             .expect("bibliography template should exist");
         let TemplateComponent::Contributor(contributor) = &template[0] else {
             panic!("component should be contributor");
@@ -958,7 +998,7 @@ mod tests {
                 ..citum_schema::options::Config::default()
             }),
             bibliography: Some(BibliographySpec {
-                template: Some(vec![author(Some(AndOptions::Text))]),
+                template: Some(vec![author(Some(AndOptions::Text))].into()),
                 type_variants: Some(type_variants),
                 ..BibliographySpec::default()
             }),
@@ -1007,7 +1047,7 @@ mod tests {
                 ..citum_schema::options::Config::default()
             }),
             bibliography: Some(BibliographySpec {
-                template: Some(vec![primary_title(None)]),
+                template: Some(vec![primary_title(None)].into()),
                 type_variants: Some(type_variants),
                 ..BibliographySpec::default()
             }),
@@ -1046,7 +1086,7 @@ mod tests {
                 ..citum_schema::options::Config::default()
             }),
             bibliography: Some(BibliographySpec {
-                template: Some(vec![primary_title(None)]),
+                template: Some(vec![primary_title(None)].into()),
                 type_variants: Some(type_variants),
                 ..BibliographySpec::default()
             }),
@@ -1083,7 +1123,7 @@ mod tests {
         );
         let style = Style {
             bibliography: Some(BibliographySpec {
-                template: Some(vec![visible_author]),
+                template: Some(vec![visible_author].into()),
                 type_variants: Some(type_variants),
                 ..BibliographySpec::default()
             }),
@@ -1096,6 +1136,7 @@ mod tests {
             bibliography
                 .template
                 .as_ref()
+                .and_then(TemplateVariant::as_template)
                 .and_then(|template| template[0].rendering().suppress),
             None
         );
@@ -1124,7 +1165,7 @@ mod tests {
         );
         let style = Style {
             bibliography: Some(BibliographySpec {
-                template: Some(vec![base_title]),
+                template: Some(vec![base_title].into()),
                 type_variants: Some(type_variants),
                 ..BibliographySpec::default()
             }),
@@ -1151,7 +1192,7 @@ mod tests {
         let style = Style {
             citation: Some(CitationSpec {
                 non_integral: Some(Box::new(CitationSpec {
-                    template: Some(vec![visible_author]),
+                    template: Some(vec![visible_author].into()),
                     ..CitationSpec::default()
                 })),
                 ..CitationSpec::default()
@@ -1165,6 +1206,7 @@ mod tests {
             .as_ref()
             .and_then(|citation| citation.non_integral.as_ref())
             .and_then(|spec| spec.template.as_ref())
+            .and_then(TemplateVariant::as_template)
             .expect("non-integral template exists");
         assert_eq!(non_integral[0].rendering().suppress, None);
     }
@@ -1188,10 +1230,13 @@ mod tests {
                 ..citum_schema::options::Config::default()
             }),
             bibliography: Some(BibliographySpec {
-                template: Some(vec![
-                    author_with_name_options(),
-                    primary_title(Some(TextCase::SentenceApa)),
-                ]),
+                template: Some(
+                    vec![
+                        author_with_name_options(),
+                        primary_title(Some(TextCase::SentenceApa)),
+                    ]
+                    .into(),
+                ),
                 ..BibliographySpec::default()
             }),
             ..Style::default()
@@ -1315,11 +1360,14 @@ mod tests {
                     ..citum_schema::options::Config::default()
                 }),
                 bibliography: Some(BibliographySpec {
-                    template: Some(vec![TemplateComponent::Title(TemplateTitle {
-                        title: title_type.clone(),
-                        rendering: rendering.to_rendering(),
-                        ..TemplateTitle::default()
-                    })]),
+                    template: Some(
+                        vec![TemplateComponent::Title(TemplateTitle {
+                            title: title_type.clone(),
+                            rendering: rendering.to_rendering(),
+                            ..TemplateTitle::default()
+                        })]
+                        .into(),
+                    ),
                     ..BibliographySpec::default()
                 }),
                 ..Style::default()
@@ -1415,13 +1463,16 @@ mod tests {
     fn contributor_without_explicit_and_blocks_hoist() {
         let style = Style {
             citation: Some(CitationSpec {
-                template: Some(vec![
-                    author(Some(AndOptions::Text)),
-                    TemplateComponent::Group(TemplateGroup {
-                        group: vec![author(None)],
-                        ..TemplateGroup::default()
-                    }),
-                ]),
+                template: Some(
+                    vec![
+                        author(Some(AndOptions::Text)),
+                        TemplateComponent::Group(TemplateGroup {
+                            group: vec![author(None)],
+                            ..TemplateGroup::default()
+                        }),
+                    ]
+                    .into(),
+                ),
                 ..CitationSpec::default()
             }),
             ..Style::default()
@@ -1442,6 +1493,7 @@ mod tests {
             .citation
             .as_ref()
             .and_then(|citation| citation.template.as_ref())
+            .and_then(TemplateVariant::as_template)
             .expect("citation template exists");
         let TemplateComponent::Contributor(author) = &template[0] else {
             panic!("first component should be contributor");

--- a/crates/citum-migrate/src/synthesis/bibliography.rs
+++ b/crates/citum-migrate/src/synthesis/bibliography.rs
@@ -116,15 +116,10 @@ pub(crate) fn synthesize_bibliography_rounds(
             score: seed.seed_score,
         },
         &score_fn,
-        &|style: &Style| {
-            style
-                .bibliography
-                .as_ref()
-                .and_then(|bibliography| bibliography.template.clone())
-        },
+        &full_bibliography_template,
         &|style: &Style, template: Template| {
             let mut mutated = style.clone();
-            mutated.bibliography.as_mut()?.template = Some(template);
+            mutated.bibliography.as_mut()?.template = Some(template.into());
             Some(mutated)
         },
         &context,
@@ -169,6 +164,15 @@ pub(crate) fn synthesize_bibliography_rounds(
         synthesis_rounds: accepted_mutations.len(),
         accepted_mutations,
     })
+}
+
+fn full_bibliography_template(style: &Style) -> Option<Template> {
+    style
+        .bibliography
+        .as_ref()
+        .and_then(|bibliography| bibliography.template.as_ref())
+        .and_then(citum_schema::TemplateVariant::as_template)
+        .map(<[_]>::to_vec)
 }
 
 /// Print per-candidate seed-stage scores for bibliography selection debug.

--- a/crates/citum-migrate/src/synthesis/citation.rs
+++ b/crates/citum-migrate/src/synthesis/citation.rs
@@ -121,11 +121,13 @@ pub(crate) fn synthesize_citation_rounds(
             style
                 .citation
                 .as_ref()
-                .and_then(|citation| citation.template.clone())
+                .and_then(|citation| citation.template.as_ref())
+                .and_then(citum_schema::TemplateVariant::as_template)
+                .map(<[_]>::to_vec)
         },
         &|style: &Style, template: Template| {
             let mut mutated = style.clone();
-            mutated.citation.as_mut()?.template = Some(template);
+            mutated.citation.as_mut()?.template = Some(template.into());
             Some(mutated)
         },
         &context,

--- a/crates/citum-migrate/src/synthesis/core.rs
+++ b/crates/citum-migrate/src/synthesis/core.rs
@@ -282,7 +282,7 @@ mod tests {
     fn style_with_citation_template(template: Template) -> Style {
         Style {
             citation: Some(citum_schema::CitationSpec {
-                template: Some(template),
+                template: Some(template.into()),
                 ..Default::default()
             }),
             ..Default::default()
@@ -293,12 +293,14 @@ mod tests {
         style
             .citation
             .as_ref()
-            .and_then(|citation| citation.template.clone())
+            .and_then(|citation| citation.template.as_ref())
+            .and_then(citum_schema::TemplateVariant::as_template)
+            .map(<[_]>::to_vec)
     }
 
     fn with_citation_template(style: &Style, template: Template) -> Option<Style> {
         let mut mutated = style.clone();
-        mutated.citation.as_mut()?.template = Some(template);
+        mutated.citation.as_mut()?.template = Some(template.into());
         Some(mutated)
     }
 

--- a/crates/citum-migrate/src/template_diff.rs
+++ b/crates/citum-migrate/src/template_diff.rs
@@ -72,7 +72,7 @@ pub(crate) fn engine_validate_variants(
     // constraint — so try_into_resolved() only runs resolve_style_template_variants.
     let probe = Style {
         bibliography: Some(BibliographySpec {
-            template: Some(default_template.to_vec()),
+            template: Some(default_template.to_vec().into()),
             type_variants: Some(variants.clone()),
             ..Default::default()
         }),

--- a/crates/citum-migrate/src/template_resolver.rs
+++ b/crates/citum-migrate/src/template_resolver.rs
@@ -237,8 +237,14 @@ fn load_hand_authored_sections(path: &Path) -> Option<HandAuthoredTemplates> {
     let style: citum_schema::Style = serde_yaml::from_str(&text).ok()?;
     Some(HandAuthoredTemplates {
         path: path.to_path_buf(),
-        bibliography: style.bibliography.and_then(|b| b.template),
-        citation: style.citation.and_then(|c| c.template),
+        bibliography: style
+            .bibliography
+            .and_then(|b| b.template)
+            .and_then(citum_schema::TemplateVariant::into_template),
+        citation: style
+            .citation
+            .and_then(|c| c.template)
+            .and_then(citum_schema::TemplateVariant::into_template),
     })
 }
 

--- a/crates/citum-resolver-api/src/error.rs
+++ b/crates/citum-resolver-api/src/error.rs
@@ -140,6 +140,14 @@ pub enum ResolutionError {
         /// Human-readable location hint.
         location: String,
     },
+    /// A fallback-template diff violates its inheritance contract.
+    #[error("invalid fallback-template diff in `{location}`: {reason}")]
+    InvalidFallbackTemplateDiff {
+        /// Style-aware location of the invalid fallback template.
+        location: String,
+        /// Reason the fallback diff cannot be resolved.
+        reason: String,
+    },
     /// The fetched parent style's content did not hash to the value declared
     /// in `extends-pin`.
     #[error("extends-pin integrity check failed for `{uri}`: expected {expected}, got {actual}")]

--- a/crates/citum-schema-style/src/lint.rs
+++ b/crates/citum-schema-style/src/lint.rs
@@ -1048,11 +1048,14 @@ mod tests {
     fn test_lint_style_against_locale_warns_for_missing_general_term() {
         let style = Style {
             citation: Some(CitationSpec {
-                template: Some(vec![TemplateComponent::Term(TemplateTerm {
-                    term: GeneralTerm::NoDate,
-                    form: Some(TermForm::Short),
-                    ..Default::default()
-                })]),
+                template: Some(
+                    vec![TemplateComponent::Term(TemplateTerm {
+                        term: GeneralTerm::NoDate,
+                        form: Some(TermForm::Short),
+                        ..Default::default()
+                    })]
+                    .into(),
+                ),
                 ..Default::default()
             }),
             ..Default::default()
@@ -1073,10 +1076,13 @@ mod tests {
     fn test_lint_style_against_locale_errors_for_missing_message_id() {
         let style = Style {
             citation: Some(CitationSpec {
-                template: Some(vec![TemplateComponent::Message(TemplateMessage {
-                    message: "pattern.missing".into(),
-                    ..Default::default()
-                })]),
+                template: Some(
+                    vec![TemplateComponent::Message(TemplateMessage {
+                        message: "pattern.missing".into(),
+                        ..Default::default()
+                    })]
+                    .into(),
+                ),
                 ..Default::default()
             }),
             ..Default::default()
@@ -1097,11 +1103,14 @@ mod tests {
     fn test_lint_style_against_locale_accepts_term_backed_message_id() {
         let style = Style {
             citation: Some(CitationSpec {
-                template: Some(vec![TemplateComponent::Message(TemplateMessage {
-                    message: "term.edition".into(),
-                    form: Some(TermForm::Short),
-                    ..Default::default()
-                })]),
+                template: Some(
+                    vec![TemplateComponent::Message(TemplateMessage {
+                        message: "term.edition".into(),
+                        form: Some(TermForm::Short),
+                        ..Default::default()
+                    })]
+                    .into(),
+                ),
                 ..Default::default()
             }),
             ..Default::default()
@@ -1118,10 +1127,13 @@ mod tests {
     fn test_lint_style_against_locale_errors_for_missing_message_arg() {
         let style = Style {
             citation: Some(CitationSpec {
-                template: Some(vec![TemplateComponent::Message(TemplateMessage {
-                    message: "pattern.accessed-date".into(),
-                    ..Default::default()
-                })]),
+                template: Some(
+                    vec![TemplateComponent::Message(TemplateMessage {
+                        message: "pattern.accessed-date".into(),
+                        ..Default::default()
+                    })]
+                    .into(),
+                ),
                 ..Default::default()
             }),
             ..Default::default()
@@ -1145,11 +1157,14 @@ mod tests {
     fn test_lint_style_against_locale_warns_for_missing_role_term() {
         let style = Style {
             citation: Some(CitationSpec {
-                template: Some(vec![TemplateComponent::Contributor(TemplateContributor {
-                    contributor: ContributorRole::Editor.into(),
-                    form: ContributorForm::Verb,
-                    ..Default::default()
-                })]),
+                template: Some(
+                    vec![TemplateComponent::Contributor(TemplateContributor {
+                        contributor: ContributorRole::Editor.into(),
+                        form: ContributorForm::Verb,
+                        ..Default::default()
+                    })]
+                    .into(),
+                ),
                 ..Default::default()
             }),
             ..Default::default()
@@ -1170,11 +1185,14 @@ mod tests {
     fn test_lint_style_against_locale_accepts_custom_locator_when_locale_defines_it() {
         let style = Style {
             citation: Some(CitationSpec {
-                template: Some(vec![TemplateComponent::Number(TemplateNumber {
-                    number: NumberVariable::Custom("reel".to_string()),
-                    label_form: Some(TemplateLabelForm::Short),
-                    ..Default::default()
-                })]),
+                template: Some(
+                    vec![TemplateComponent::Number(TemplateNumber {
+                        number: NumberVariable::Custom("reel".to_string()),
+                        label_form: Some(TemplateLabelForm::Short),
+                        ..Default::default()
+                    })]
+                    .into(),
+                ),
                 ..Default::default()
             }),
             ..Default::default()
@@ -1204,11 +1222,14 @@ locators:
     fn test_lint_style_against_locale_warns_for_missing_custom_locator_term() {
         let style = Style {
             citation: Some(CitationSpec {
-                template: Some(vec![TemplateComponent::Number(TemplateNumber {
-                    number: NumberVariable::Custom("reel".to_string()),
-                    label_form: Some(TemplateLabelForm::Short),
-                    ..Default::default()
-                })]),
+                template: Some(
+                    vec![TemplateComponent::Number(TemplateNumber {
+                        number: NumberVariable::Custom("reel".to_string()),
+                        label_form: Some(TemplateLabelForm::Short),
+                        ..Default::default()
+                    })]
+                    .into(),
+                ),
                 ..Default::default()
             }),
             ..Default::default()

--- a/crates/citum-schema-style/src/options/scoped.rs
+++ b/crates/citum-schema-style/src/options/scoped.rs
@@ -224,7 +224,7 @@ fn apply_bibliography_options(bibliography: &mut BibliographySpec) {
 
     let needs_template = options.date_position.is_some() || options.title_terminator.is_some();
     if needs_template && bibliography.template.is_none() && bibliography.template_ref.is_some() {
-        bibliography.template = bibliography.resolve_template();
+        bibliography.template = bibliography.resolve_template().map(Into::into);
     }
 
     if let Some(position) = options.date_position {
@@ -239,7 +239,13 @@ fn apply_bibliography_options(bibliography: &mut BibliographySpec) {
 }
 
 fn apply_date_position(bibliography: &mut BibliographySpec, position: DatePosition) {
-    reposition_date(bibliography.template.as_mut(), position);
+    reposition_date(
+        bibliography
+            .template
+            .as_mut()
+            .and_then(crate::template::TemplateVariant::as_template_mut),
+        position,
+    );
     if let Some(variants) = bibliography.type_variants.as_mut() {
         for variant in variants.values_mut() {
             reposition_date(variant.as_template_mut(), position);
@@ -248,7 +254,13 @@ fn apply_date_position(bibliography: &mut BibliographySpec, position: DatePositi
 }
 
 fn apply_title_terminator(bibliography: &mut BibliographySpec, terminator: TitleTerminator) {
-    update_title_terminator(bibliography.template.as_mut(), terminator);
+    update_title_terminator(
+        bibliography
+            .template
+            .as_mut()
+            .and_then(crate::template::TemplateVariant::as_template_mut),
+        terminator,
+    );
     if let Some(variants) = bibliography.type_variants.as_mut() {
         for variant in variants.values_mut() {
             update_title_terminator(variant.as_template_mut(), terminator);

--- a/crates/citum-schema-style/src/style/diagnostics.rs
+++ b/crates/citum-schema-style/src/style/diagnostics.rs
@@ -129,7 +129,12 @@ fn validate_bibliography_spec(value: &Value, path: &str) -> Result<(), String> {
 
 fn validate_common_section_templates(map: &serde_yaml::Mapping, path: &str) -> Result<(), String> {
     if let Some(template) = child(map, "template") {
-        validate_template(template, &format!("{path}.template"))?;
+        let template_path = format!("{path}.template");
+        if template.as_sequence().is_some() {
+            validate_template(template, &template_path)?;
+        } else if let Some(diff) = template.as_mapping() {
+            validate_diff(diff, &template_path)?;
+        }
     }
     if let Some(locales) = child(map, "locales")
         && let Some(locale_values) = locales.as_sequence()

--- a/crates/citum-schema-style/src/style/resolution.rs
+++ b/crates/citum-schema-style/src/style/resolution.rs
@@ -181,14 +181,15 @@ impl Style {
         merge_style_overlay(&mut effective, &self);
         effective.scoped_raw_options =
             std::mem::take(&mut effective.scoped_raw_options).merged_with_child(&self);
+        crate::template::resolve_style_template_variants_with_overlay(
+            &mut effective,
+            inherited_variants.as_ref(),
+            &self,
+        )?;
         effective.version = self.version;
         effective.extends = self.extends;
         effective.extends_pin = self.extends_pin;
         effective.raw_yaml = self.raw_yaml;
-        crate::template::resolve_style_template_variants(
-            &mut effective,
-            inherited_variants.as_ref(),
-        )?;
         options::scoped::apply_scoped_style_options(&mut effective);
         if is_profile {
             effective.extends = None;

--- a/crates/citum-schema-style/src/style/sections/bibliography.rs
+++ b/crates/citum-schema-style/src/style/sections/bibliography.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::grouping;
 use crate::options::BibliographyOptions;
 use crate::template::{
-    LocalizedTemplateSpec, ResolvedLocalizedTemplate, Template, TemplateReference,
+    LocalizedTemplateSpec, ResolvedLocalizedTemplate, Template, TemplateReference, TemplateVariant,
     TemplateVariants, matched_localized_template,
 };
 
@@ -32,12 +32,14 @@ pub struct BibliographySpec {
     pub options: Option<BibliographyOptions>,
     /// Reference to an embedded template preset or external template.
     ///
-    /// If both `template-ref` and `template` are present, `template` takes precedence.
+    /// A complete `template` takes precedence. Pairing `template-ref` with a
+    /// template diff in the same section is invalid.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template_ref: Option<TemplateReference>,
-    /// Default template for entries when no localized override is selected.
+    /// Default template or inherited template diff when no localized override is selected.
+    /// Diffs are materialized as complete templates during style resolution.
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub template: Option<Template>,
+    pub template: Option<TemplateVariant>,
     /// Locale-specific template overrides checked before the default template.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub locales: Option<Vec<LocalizedTemplateSpec>>,
@@ -110,14 +112,18 @@ impl Default for BibliographySpec {
 impl BibliographySpec {
     /// Resolve the effective template for this bibliography.
     ///
-    /// Returns the explicit `template` if present, otherwise resolves `template-ref`.
-    /// Returns `None` if neither is specified.
+    /// Returns the explicit resolved template if present, otherwise resolves
+    /// `template-ref`. A pending diff is not exposed as a concrete template.
     pub fn resolve_template(&self) -> Option<Template> {
-        self.template.clone().or_else(|| {
-            self.template_ref
-                .as_ref()
-                .and_then(TemplateReference::bibliography_template)
-        })
+        self.template
+            .as_ref()
+            .and_then(TemplateVariant::as_template)
+            .map(<[_]>::to_vec)
+            .or_else(|| {
+                self.template_ref
+                    .as_ref()
+                    .and_then(TemplateReference::bibliography_template)
+            })
     }
 
     /// Resolve a template and the locale selected by its localized branch.

--- a/crates/citum-schema-style/src/style/sections/citation.rs
+++ b/crates/citum-schema-style/src/style/sections/citation.rs
@@ -15,7 +15,7 @@ use crate::grouping;
 use crate::options::CitationOptions;
 use crate::template::{
     DelimiterPunctuation, LocalizedTemplateSpec, ResolvedLocalizedTemplate, Template,
-    TemplateReference, TemplateVariants, matched_localized_template,
+    TemplateReference, TemplateVariant, TemplateVariants, matched_localized_template,
 };
 
 /// Citation collapse behavior for multi-item citations.
@@ -48,12 +48,14 @@ pub struct CitationSpec {
     pub options: Option<CitationOptions>,
     /// Reference to an embedded template preset or external template.
     ///
-    /// If both `template-ref` and `template` are present, `template` takes precedence.
+    /// A complete `template` takes precedence. Pairing `template-ref` with a
+    /// template diff in the same section is invalid.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub template_ref: Option<TemplateReference>,
-    /// Default template when no localized override is selected.
+    /// Default template or inherited template diff when no localized override is selected.
+    /// Diffs are materialized as complete templates during style resolution.
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub template: Option<Template>,
+    pub template: Option<TemplateVariant>,
     /// Locale-specific template overrides checked before the default template.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub locales: Option<Vec<LocalizedTemplateSpec>>,
@@ -142,14 +144,18 @@ pub struct CitationSpec {
 impl CitationSpec {
     /// Resolve the effective template for this citation.
     ///
-    /// Returns the explicit `template` if present, otherwise resolves `template-ref`.
-    /// Returns `None` if neither is specified.
+    /// Returns the explicit resolved template if present, otherwise resolves
+    /// `template-ref`. A pending diff is not exposed as a concrete template.
     pub fn resolve_template(&self) -> Option<Template> {
-        self.template.clone().or_else(|| {
-            self.template_ref
-                .as_ref()
-                .and_then(TemplateReference::citation_template)
-        })
+        self.template
+            .as_ref()
+            .and_then(TemplateVariant::as_template)
+            .map(<[_]>::to_vec)
+            .or_else(|| {
+                self.template_ref
+                    .as_ref()
+                    .and_then(TemplateReference::citation_template)
+            })
     }
 
     /// Resolve a template and the locale selected by its localized branch.

--- a/crates/citum-schema-style/src/style/validation.rs
+++ b/crates/citum-schema-style/src/style/validation.rs
@@ -459,7 +459,7 @@ impl TemplateResourceBudget {
             validate_substitute_candidates(substitute, &format!("{location}.options.substitute"))?;
         }
         if let Some(template) = &spec.template {
-            self.check_template(template, &format!("{location}.template"), depth)?;
+            self.check_variant(template, &format!("{location}.template"), depth)?;
         }
         if let Some(locales) = &spec.locales {
             self.check_locales(locales, &format!("{location}.locales"), depth)?;
@@ -495,7 +495,7 @@ impl TemplateResourceBudget {
             validate_substitute_candidates(substitute, &format!("{location}.options.substitute"))?;
         }
         if let Some(template) = &spec.template {
-            self.check_template(template, &format!("{location}.template"), depth)?;
+            self.check_variant(template, &format!("{location}.template"), depth)?;
         }
         if let Some(locales) = &spec.locales {
             self.check_locales(locales, &format!("{location}.locales"), depth)?;
@@ -537,7 +537,7 @@ mod security_resource_tests {
     fn validate_resource_limits_rejects_deeply_nested_templates() {
         let style = Style {
             bibliography: Some(BibliographySpec {
-                template: Some(vec![nested_group(MAX_TEMPLATE_NESTING_DEPTH + 1)]),
+                template: Some(vec![nested_group(MAX_TEMPLATE_NESTING_DEPTH + 1)].into()),
                 ..BibliographySpec::default()
             }),
             ..Style::default()
@@ -554,10 +554,9 @@ mod security_resource_tests {
     fn validate_resource_limits_rejects_too_many_components() {
         let style = Style {
             bibliography: Some(BibliographySpec {
-                template: Some(vec![
-                    TemplateComponent::default();
-                    MAX_TEMPLATE_COMPONENTS + 1
-                ]),
+                template: Some(
+                    vec![TemplateComponent::default(); MAX_TEMPLATE_COMPONENTS + 1].into(),
+                ),
                 ..BibliographySpec::default()
             }),
             ..Style::default()

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -49,7 +49,10 @@ pub(crate) use reference::matched_localized_template;
 pub use reference::{
     LocalizedTemplateSpec, ResolvedLocalizedTemplate, TemplatePreset, TemplateReference,
 };
-pub(crate) use resolution::{inherited_variant_context, resolve_style_template_variants};
+pub(crate) use resolution::{
+    inherited_variant_context, resolve_style_template_variants,
+    resolve_style_template_variants_with_overlay,
+};
 
 /// Resolve a style's local template variants in place without inherited
 /// context, materializing every diff variant as a full template.
@@ -646,12 +649,12 @@ impl TemplateComponent {
     }
 }
 
-/// Type-specific template override, either as a complete legacy template or a V3 diff.
+/// Template definition, either as a complete template or an inherited structural diff.
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(untagged)]
 pub enum TemplateVariant {
-    /// Complete replacement template used by Template V1/V2 styles.
+    /// Complete replacement template.
     Full(Vec<TemplateComponent>),
     /// Structural diff applied to a parent template during style resolution.
     Diff(TemplateVariantDiff),
@@ -691,12 +694,13 @@ impl From<Vec<TemplateComponent>> for TemplateVariant {
     }
 }
 
-/// Structural diff that derives a type-specific template from a parent template.
+/// Structural diff that derives a template from an inherited or selected parent.
 #[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct TemplateVariantDiff {
     /// Optional parent type variant selector within the same section.
+    /// Fallback-template diffs reject this field during resolution.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extends: Option<TypeSelector>,
     /// Rendering-only modifications applied in authored order.

--- a/crates/citum-schema-style/src/template/resolution.rs
+++ b/crates/citum-schema-style/src/template/resolution.rs
@@ -11,15 +11,24 @@ use crate::template::{
     Template, TemplateComponent, TemplateComponentSelector, TemplateVariant, TemplateVariantDiff,
     TemplateVariants, TypeSelector,
 };
-use crate::{CitationSpec, ResolutionError, Style};
+use crate::{BibliographySpec, CitationSpec, ResolutionError, Style};
 
 pub(crate) struct StyleVariantContext {
     citation: Option<CitationVariantContext>,
-    bibliography: Option<TemplateVariants>,
+    bibliography: Option<SectionVariantContext>,
+}
+
+#[derive(Clone, Default)]
+struct SectionVariantContext {
+    fallback: Option<Template>,
+    owns_fallback: bool,
+    type_variants: Option<TemplateVariants>,
 }
 
 #[derive(Clone, Default)]
 pub(crate) struct CitationVariantContext {
+    fallback: Option<Template>,
+    owns_fallback: bool,
     type_variants: Option<TemplateVariants>,
     integral: Option<Box<CitationVariantContext>>,
     non_integral: Option<Box<CitationVariantContext>>,
@@ -27,39 +36,102 @@ pub(crate) struct CitationVariantContext {
     ibid: Option<Box<CitationVariantContext>>,
 }
 
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+enum TemplateOverlayState {
+    #[default]
+    Absent,
+    Null,
+    Present,
+}
+
+#[derive(Clone, Default)]
+struct FallbackOverlayContext {
+    template: TemplateOverlayState,
+    template_ref: bool,
+}
+
+#[derive(Clone, Default)]
+struct CitationOverlayContext {
+    fallback: FallbackOverlayContext,
+    integral: Option<Box<CitationOverlayContext>>,
+    non_integral: Option<Box<CitationOverlayContext>>,
+    subsequent: Option<Box<CitationOverlayContext>>,
+    ibid: Option<Box<CitationOverlayContext>>,
+}
+
+#[derive(Clone, Default)]
+struct StyleOverlayContext {
+    citation: Option<CitationOverlayContext>,
+    bibliography: Option<FallbackOverlayContext>,
+}
+
+struct FallbackResolutionContext<'a> {
+    referenced_template: Option<Template>,
+    inherited_fallback: Option<&'a [TemplateComponent]>,
+    inherited_owns_fallback: bool,
+    outer_fallback: Option<&'a [TemplateComponent]>,
+    overlay: Option<&'a FallbackOverlayContext>,
+    location: &'a str,
+}
+
 pub(crate) fn inherited_variant_context(style: &Style) -> Option<StyleVariantContext> {
     let context = StyleVariantContext {
-        citation: style.citation.as_ref().map(citation_variant_context),
+        citation: style
+            .citation
+            .as_ref()
+            .map(|citation| citation_variant_context(citation, None)),
         bibliography: style
             .bibliography
             .as_ref()
-            .and_then(|bib| bib.type_variants.clone()),
+            .map(bibliography_variant_context),
     };
     (context.citation.is_some() || context.bibliography.is_some()).then_some(context)
 }
 
-pub(crate) fn citation_variant_context(spec: &CitationSpec) -> CitationVariantContext {
+fn bibliography_variant_context(spec: &BibliographySpec) -> SectionVariantContext {
+    SectionVariantContext {
+        fallback: spec.resolve_template(),
+        owns_fallback: spec.template.is_some() || spec.template_ref.is_some(),
+        type_variants: spec.type_variants.clone(),
+    }
+}
+
+fn citation_variant_context(
+    spec: &CitationSpec,
+    outer_fallback: Option<&[TemplateComponent]>,
+) -> CitationVariantContext {
+    let own_fallback = spec.resolve_template();
+    let owns_fallback = spec.template.is_some() || spec.template_ref.is_some();
+    let fallback = own_fallback.or_else(|| {
+        if owns_fallback {
+            None
+        } else {
+            outer_fallback.map(<[_]>::to_vec)
+        }
+    });
     CitationVariantContext {
+        fallback: fallback.clone(),
+        owns_fallback,
         type_variants: spec.type_variants.clone(),
         integral: spec
             .integral
             .as_deref()
-            .map(citation_variant_context)
+            .map(|child| citation_variant_context(child, fallback.as_deref()))
             .map(Box::new),
         non_integral: spec
             .non_integral
             .as_deref()
-            .map(citation_variant_context)
+            .map(|child| citation_variant_context(child, fallback.as_deref()))
             .map(Box::new),
         subsequent: spec
             .subsequent
             .as_deref()
-            .map(citation_variant_context)
+            .map(|child| citation_variant_context(child, fallback.as_deref()))
             .map(Box::new),
         ibid: spec
             .ibid
             .as_deref()
-            .map(citation_variant_context)
+            .map(|child| citation_variant_context(child, fallback.as_deref()))
             .map(Box::new),
     }
 }
@@ -68,34 +140,96 @@ pub(crate) fn resolve_style_template_variants(
     style: &mut Style,
     inherited: Option<&StyleVariantContext>,
 ) -> Result<(), ResolutionError> {
+    let overlay = style_overlay_context(style);
+    resolve_style_template_variants_with_context(style, inherited, &overlay)
+}
+
+pub(crate) fn resolve_style_template_variants_with_overlay(
+    style: &mut Style,
+    inherited: Option<&StyleVariantContext>,
+    overlay: &Style,
+) -> Result<(), ResolutionError> {
+    let overlay = style_overlay_context(overlay);
+    resolve_style_template_variants_with_context(style, inherited, &overlay)
+}
+
+fn resolve_style_template_variants_with_context(
+    style: &mut Style,
+    inherited: Option<&StyleVariantContext>,
+    overlay: &StyleOverlayContext,
+) -> Result<(), ResolutionError> {
+    let style_label = style
+        .info
+        .id
+        .as_deref()
+        .or(style.info.title.as_deref())
+        .unwrap_or("<anonymous>")
+        .to_string();
     if let Some(citation) = style.citation.as_mut() {
         resolve_citation_template_variants(
             citation,
             inherited.and_then(|context| context.citation.as_ref()),
+            overlay.citation.as_ref(),
+            &style_label,
             "citation",
             None,
         )?;
     }
     if let Some(bibliography) = style.bibliography.as_mut() {
-        let section_template = bibliography.resolve_template();
+        let inherited_bibliography = inherited.and_then(|context| context.bibliography.as_ref());
+        let referenced_template = bibliography
+            .template_ref
+            .as_ref()
+            .and_then(crate::template::TemplateReference::bibliography_template);
+        let section_template = resolve_fallback_template_variant(
+            &mut bibliography.template,
+            &mut bibliography.template_ref,
+            FallbackResolutionContext {
+                referenced_template,
+                inherited_fallback: inherited_bibliography
+                    .and_then(|context| context.fallback.as_deref()),
+                inherited_owns_fallback: inherited_bibliography
+                    .is_some_and(|context| context.owns_fallback),
+                outer_fallback: None,
+                overlay: overlay.bibliography.as_ref(),
+                location: &format!("{style_label}.bibliography.template"),
+            },
+        )?;
         resolve_template_variant_map(
             bibliography.type_variants.as_mut(),
             section_template.as_deref(),
-            inherited.and_then(|context| context.bibliography.as_ref()),
+            inherited_bibliography.and_then(|context| context.type_variants.as_ref()),
             "bibliography.type-variants",
         )?;
     }
     Ok(())
 }
 
-pub(crate) fn resolve_citation_template_variants(
+fn resolve_citation_template_variants(
     spec: &mut CitationSpec,
     inherited: Option<&CitationVariantContext>,
+    overlay: Option<&CitationOverlayContext>,
+    style_label: &str,
     location: &str,
     fallback_template: Option<&[TemplateComponent]>,
 ) -> Result<(), ResolutionError> {
-    let section_template = spec.resolve_template();
-    let effective_section_template = section_template.as_deref().or(fallback_template);
+    let referenced_template = spec
+        .template_ref
+        .as_ref()
+        .and_then(crate::template::TemplateReference::citation_template);
+    let section_template = resolve_fallback_template_variant(
+        &mut spec.template,
+        &mut spec.template_ref,
+        FallbackResolutionContext {
+            referenced_template,
+            inherited_fallback: inherited.and_then(|context| context.fallback.as_deref()),
+            inherited_owns_fallback: inherited.is_some_and(|context| context.owns_fallback),
+            outer_fallback: fallback_template,
+            overlay: overlay.map(|context| &context.fallback),
+            location: &format!("{style_label}.{location}.template"),
+        },
+    )?;
+    let effective_section_template = section_template.as_deref();
     resolve_template_variant_map(
         spec.type_variants.as_mut(),
         effective_section_template,
@@ -103,38 +237,207 @@ pub(crate) fn resolve_citation_template_variants(
         &format!("{location}.type-variants"),
     )?;
 
-    for (name, child, inherited_child) in [
+    for (name, child, inherited_child, overlay_child) in [
         (
             "integral",
             spec.integral.as_deref_mut(),
             inherited.and_then(|context| context.integral.as_deref()),
+            overlay.and_then(|context| context.integral.as_deref()),
         ),
         (
             "non-integral",
             spec.non_integral.as_deref_mut(),
             inherited.and_then(|context| context.non_integral.as_deref()),
+            overlay.and_then(|context| context.non_integral.as_deref()),
         ),
         (
             "subsequent",
             spec.subsequent.as_deref_mut(),
             inherited.and_then(|context| context.subsequent.as_deref()),
+            overlay.and_then(|context| context.subsequent.as_deref()),
         ),
         (
             "ibid",
             spec.ibid.as_deref_mut(),
             inherited.and_then(|context| context.ibid.as_deref()),
+            overlay.and_then(|context| context.ibid.as_deref()),
         ),
     ] {
         if let Some(child) = child {
             resolve_citation_template_variants(
                 child,
                 inherited_child,
+                overlay_child,
+                style_label,
                 &format!("{location}.{name}"),
                 effective_section_template,
             )?;
         }
     }
     Ok(())
+}
+
+fn resolve_fallback_template_variant(
+    template: &mut Option<TemplateVariant>,
+    template_ref: &mut Option<crate::template::TemplateReference>,
+    context: FallbackResolutionContext<'_>,
+) -> Result<Option<Template>, ResolutionError> {
+    let overlay_state = context
+        .overlay
+        .map_or(TemplateOverlayState::Absent, |overlay| overlay.template);
+    let overlay_template_ref = context.overlay.is_some_and(|overlay| overlay.template_ref);
+
+    if overlay_state == TemplateOverlayState::Null {
+        *template = None;
+        if !overlay_template_ref {
+            *template_ref = None;
+            return Ok(context.outer_fallback.map(<[_]>::to_vec));
+        }
+        return Ok(context.referenced_template);
+    }
+
+    if overlay_state == TemplateOverlayState::Absent && overlay_template_ref {
+        *template = None;
+        return Ok(context.referenced_template);
+    }
+
+    match template {
+        Some(TemplateVariant::Full(template)) => Ok(Some(template.clone())),
+        Some(TemplateVariant::Diff(diff)) => {
+            if overlay_template_ref {
+                return Err(invalid_fallback_diff(
+                    context.location,
+                    "template-ref and a template diff cannot be declared in the same section",
+                ));
+            }
+            if diff.extends.is_some() {
+                return Err(invalid_fallback_diff(
+                    context.location,
+                    "extends is not allowed because a fallback diff has exactly one inherited base",
+                ));
+            }
+
+            let mut resolved = if context.inherited_owns_fallback {
+                context.inherited_fallback.map(<[_]>::to_vec)
+            } else {
+                context
+                    .outer_fallback
+                    .map(<[_]>::to_vec)
+                    .or_else(|| context.inherited_fallback.map(<[_]>::to_vec))
+            }
+            .ok_or_else(|| {
+                invalid_fallback_diff(
+                    context.location,
+                    "no inherited fallback template is available",
+                )
+            })?;
+            apply_template_variant_diff(&mut resolved, diff, context.location)?;
+            *template = Some(TemplateVariant::Full(resolved.clone()));
+            Ok(Some(resolved))
+        }
+        None => Ok(context
+            .referenced_template
+            .or_else(|| context.outer_fallback.map(<[_]>::to_vec))),
+    }
+}
+
+fn invalid_fallback_diff(location: &str, reason: &str) -> ResolutionError {
+    ResolutionError::InvalidFallbackTemplateDiff {
+        location: location.to_string(),
+        reason: reason.to_string(),
+    }
+}
+
+fn style_overlay_context(style: &Style) -> StyleOverlayContext {
+    let raw = style.raw_yaml.as_ref();
+    StyleOverlayContext {
+        citation: style.citation.as_ref().map(|citation| {
+            citation_overlay_context(citation, raw.and_then(|raw| raw_child(raw, "citation")))
+        }),
+        bibliography: style.bibliography.as_ref().map(|bibliography| {
+            fallback_overlay_context(
+                bibliography.template.is_some(),
+                bibliography.template_ref.is_some(),
+                raw.and_then(|raw| raw_child(raw, "bibliography")),
+            )
+        }),
+    }
+}
+
+fn citation_overlay_context(
+    spec: &CitationSpec,
+    raw: Option<&serde_yaml::Value>,
+) -> CitationOverlayContext {
+    CitationOverlayContext {
+        fallback: fallback_overlay_context(
+            spec.template.is_some(),
+            spec.template_ref.is_some(),
+            raw,
+        ),
+        integral: spec
+            .integral
+            .as_deref()
+            .map(|child| {
+                citation_overlay_context(child, raw.and_then(|raw| raw_child(raw, "integral")))
+            })
+            .map(Box::new),
+        non_integral: spec
+            .non_integral
+            .as_deref()
+            .map(|child| {
+                citation_overlay_context(child, raw.and_then(|raw| raw_child(raw, "non-integral")))
+            })
+            .map(Box::new),
+        subsequent: spec
+            .subsequent
+            .as_deref()
+            .map(|child| {
+                citation_overlay_context(child, raw.and_then(|raw| raw_child(raw, "subsequent")))
+            })
+            .map(Box::new),
+        ibid: spec
+            .ibid
+            .as_deref()
+            .map(|child| {
+                citation_overlay_context(child, raw.and_then(|raw| raw_child(raw, "ibid")))
+            })
+            .map(Box::new),
+    }
+}
+
+fn fallback_overlay_context(
+    has_template: bool,
+    has_template_ref: bool,
+    raw: Option<&serde_yaml::Value>,
+) -> FallbackOverlayContext {
+    let Some(mapping) = raw.and_then(serde_yaml::Value::as_mapping) else {
+        return FallbackOverlayContext {
+            template: if has_template {
+                TemplateOverlayState::Present
+            } else {
+                TemplateOverlayState::Absent
+            },
+            template_ref: has_template_ref,
+        };
+    };
+    let template_key = serde_yaml::Value::String("template".to_string());
+    let template_ref_key = serde_yaml::Value::String("template-ref".to_string());
+    FallbackOverlayContext {
+        template: match mapping.get(&template_key) {
+            Some(value) if value.is_null() => TemplateOverlayState::Null,
+            Some(_) => TemplateOverlayState::Present,
+            None => TemplateOverlayState::Absent,
+        },
+        template_ref: mapping
+            .get(&template_ref_key)
+            .is_some_and(|value| !value.is_null()),
+    }
+}
+
+fn raw_child<'a>(value: &'a serde_yaml::Value, key: &str) -> Option<&'a serde_yaml::Value> {
+    value
+        .as_mapping()?
+        .get(serde_yaml::Value::String(key.to_string()))
 }
 
 pub(crate) fn resolve_template_variant_map(

--- a/crates/citum-schema-style/src/tests.rs
+++ b/crates/citum-schema-style/src/tests.rs
@@ -966,16 +966,19 @@ bibliography:
 fn template_v3_nested_citation_diff_can_use_outer_template() {
     let style = Style {
         citation: Some(CitationSpec {
-            template: Some(vec![
-                TemplateComponent::Contributor(template::TemplateContributor {
-                    contributor: template::ContributorRole::Author.into(),
-                    ..Default::default()
-                }),
-                TemplateComponent::Title(template::TemplateTitle {
-                    title: template::TitleType::Primary,
-                    ..Default::default()
-                }),
-            ]),
+            template: Some(
+                vec![
+                    TemplateComponent::Contributor(template::TemplateContributor {
+                        contributor: template::ContributorRole::Author.into(),
+                        ..Default::default()
+                    }),
+                    TemplateComponent::Title(template::TemplateTitle {
+                        title: template::TitleType::Primary,
+                        ..Default::default()
+                    }),
+                ]
+                .into(),
+            ),
             integral: Some(Box::new(CitationSpec {
                 type_variants: Some(indexmap::IndexMap::from([(
                     TypeSelector::Single("personal_communication".to_string()),
@@ -2044,6 +2047,7 @@ fn contributor_list_resource_validation_reports_authored_field_paths() {
             .bibliography
             .as_mut()
             .and_then(|bibliography| bibliography.template.as_mut())
+            .and_then(template::TemplateVariant::as_template_mut)
             .and_then(|template| template.first_mut())
             .expect("test style should contain a bibliography component");
         let template::TemplateComponent::Contributor(contributor) = component else {
@@ -2299,6 +2303,7 @@ bibliography:
         .bibliography
         .as_ref()
         .and_then(|bib| bib.template.as_ref())
+        .and_then(template::TemplateVariant::as_template)
         .expect("bibliography template should be present");
 
     assert_eq!(template.len(), 2);
@@ -2354,6 +2359,7 @@ bibliography:
         .bibliography
         .as_ref()
         .and_then(|bib| bib.template.as_ref())
+        .and_then(template::TemplateVariant::as_template)
         .expect("bibliography template should be present");
 
     // The marker is never a template component, so inheritance can only carry
@@ -2415,6 +2421,7 @@ bibliography:
         .bibliography
         .as_ref()
         .and_then(|bib| bib.template.as_ref())
+        .and_then(template::TemplateVariant::as_template)
         .expect("bibliography template should be present");
 
     assert_eq!(

--- a/crates/citum-schema-style/tests/bdd_inheritance.rs
+++ b/crates/citum-schema-style/tests/bdd_inheritance.rs
@@ -22,9 +22,9 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 //! are resolved deterministically and predictably in `merge_style_overlay`.
 
 use citum_schema_style::{
-    Style, StyleDocumentFormat,
+    ResolutionError, Style, StyleDocumentFormat,
     locale::GeneralTerm,
-    template::{SimpleVariable, TemplateComponent, TypeSelector},
+    template::{DateVariable, SimpleVariable, TemplateComponent, TemplateVariant, TypeSelector},
 };
 use rstest::rstest;
 use std::collections::HashSet;
@@ -375,6 +375,479 @@ fn make_resolver(
         }
     }
     R(base)
+}
+
+#[derive(Clone, Copy, Debug)]
+enum FallbackSurface {
+    Citation,
+    Bibliography,
+}
+
+impl FallbackSurface {
+    fn key(self) -> &'static str {
+        match self {
+            Self::Citation => "citation",
+            Self::Bibliography => "bibliography",
+        }
+    }
+
+    fn template(self, style: &Style) -> Option<&[TemplateComponent]> {
+        match self {
+            Self::Citation => style.citation.as_ref()?.template.as_ref(),
+            Self::Bibliography => style.bibliography.as_ref()?.template.as_ref(),
+        }
+        .and_then(TemplateVariant::as_template)
+    }
+
+    fn resolves_template(self, style: &Style) -> bool {
+        match self {
+            Self::Citation => style
+                .citation
+                .as_ref()
+                .and_then(|spec| spec.resolve_template()),
+            Self::Bibliography => style
+                .bibliography
+                .as_ref()
+                .and_then(|spec| spec.resolve_template()),
+        }
+        .is_some()
+    }
+}
+
+fn fallback_style_yaml(
+    id: &str,
+    extends: Option<&str>,
+    surface: FallbackSurface,
+    body: &str,
+) -> String {
+    let extends = extends.map_or_else(String::new, |parent| format!("extends: {parent}\n"));
+    let body = body
+        .lines()
+        .map(|line| format!("  {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "version: \"0.44.0\"\ninfo: {{ id: {id} }}\n{extends}{}:\n{body}\n",
+        surface.key()
+    )
+}
+
+fn resolve_fallback_overlay(base_yaml: &str, overlay_yaml: &str) -> Result<Style, ResolutionError> {
+    let base = parse_fallback_style(base_yaml);
+    let overlay = parse_fallback_style(overlay_yaml);
+    let mut visited = HashSet::new();
+    overlay.try_into_resolved_recursive_with(Some(&make_resolver(base)), &mut visited)
+}
+
+fn parse_fallback_style(yaml: &str) -> Style {
+    Style::from_yaml_str(yaml).expect("fallback conformance style should parse")
+}
+
+#[rstest]
+#[case::citation(FallbackSurface::Citation)]
+#[case::bibliography(FallbackSurface::Bibliography)]
+fn given_list_fallback_when_parsed_then_it_remains_a_full_template(
+    #[case] surface: FallbackSurface,
+) {
+    let yaml = fallback_style_yaml(
+        "full-template",
+        None,
+        surface,
+        "template:\n  - title: primary\n  - variable: doi",
+    );
+    let style = Style::from_yaml_str(&yaml).expect("legacy list template should parse");
+
+    let variant = match surface {
+        FallbackSurface::Citation => style
+            .citation
+            .as_ref()
+            .and_then(|spec| spec.template.as_ref()),
+        FallbackSurface::Bibliography => style
+            .bibliography
+            .as_ref()
+            .and_then(|spec| spec.template.as_ref()),
+    };
+    assert!(matches!(variant, Some(TemplateVariant::Full(template)) if template.len() == 2));
+}
+
+#[rstest]
+#[case::citation(FallbackSurface::Citation)]
+#[case::bibliography(FallbackSurface::Bibliography)]
+fn given_parent_full_fallback_when_child_removes_component_then_diff_resolves_to_full(
+    #[case] surface: FallbackSurface,
+) {
+    let base = fallback_style_yaml(
+        "base",
+        None,
+        surface,
+        "template:\n  - title: primary\n  - variable: doi",
+    );
+    let overlay = fallback_style_yaml(
+        "overlay",
+        Some("base"),
+        surface,
+        "template:\n  remove:\n    - match: { variable: doi }",
+    );
+    let resolved =
+        resolve_fallback_overlay(&base, &overlay).expect("inherited fallback diff should resolve");
+    let template = surface
+        .template(&resolved)
+        .expect("resolved fallback should be full");
+
+    assert_eq!(template.len(), 1);
+    assert!(matches!(template[0], TemplateComponent::Title(_)));
+}
+
+#[rstest]
+#[case::citation(FallbackSurface::Citation)]
+#[case::bibliography(FallbackSurface::Bibliography)]
+fn given_parent_template_ref_when_child_diffs_fallback_then_reference_is_the_base(
+    #[case] surface: FallbackSurface,
+) {
+    let base = fallback_style_yaml("base", None, surface, "template-ref: chicago-author-date");
+    let overlay = fallback_style_yaml(
+        "overlay",
+        Some("base"),
+        surface,
+        "template:\n  remove:\n    - match: { date: issued }",
+    );
+    let resolved = resolve_fallback_overlay(&base, &overlay)
+        .expect("a parent template reference should provide the diff base");
+    let template = surface
+        .template(&resolved)
+        .expect("resolved fallback should be full");
+
+    assert!(!template.iter().any(
+        |component| matches!(component, TemplateComponent::Date(date) if date.date == DateVariable::Issued)
+    ));
+}
+
+#[rstest]
+#[case::citation(FallbackSurface::Citation)]
+#[case::bibliography(FallbackSurface::Bibliography)]
+fn given_root_fallback_diff_when_resolved_then_missing_base_is_structured_error(
+    #[case] surface: FallbackSurface,
+) {
+    let yaml = fallback_style_yaml(
+        "root-diff",
+        None,
+        surface,
+        "template:\n  remove:\n    - match: { variable: doi }",
+    );
+    let error = Style::from_yaml_str(&yaml)
+        .expect("diff syntax should parse")
+        .try_into_resolved()
+        .expect_err("root diff must not resolve without a base");
+
+    assert!(matches!(
+        error,
+        ResolutionError::InvalidFallbackTemplateDiff { location, reason }
+            if location == format!("root-diff.{}.template", surface.key())
+                && reason == "no inherited fallback template is available"
+    ));
+}
+
+#[rstest]
+#[case::citation(FallbackSurface::Citation)]
+#[case::bibliography(FallbackSurface::Bibliography)]
+fn given_fallback_diff_extends_when_resolved_then_it_is_rejected(#[case] surface: FallbackSurface) {
+    let yaml = fallback_style_yaml(
+        "fallback-extends",
+        None,
+        surface,
+        "template:\n  extends: book\n  remove:\n    - match: { variable: doi }",
+    );
+    let error = Style::from_yaml_str(&yaml)
+        .expect("diff syntax should parse")
+        .try_into_resolved()
+        .expect_err("fallback extends must be rejected");
+
+    assert!(matches!(
+        error,
+        ResolutionError::InvalidFallbackTemplateDiff { reason, .. }
+            if reason.starts_with("extends is not allowed")
+    ));
+}
+
+#[rstest]
+#[case::citation(FallbackSurface::Citation)]
+#[case::bibliography(FallbackSurface::Bibliography)]
+fn given_template_ref_and_diff_in_one_section_when_resolved_then_conflict_is_rejected(
+    #[case] surface: FallbackSurface,
+) {
+    let yaml = fallback_style_yaml(
+        "conflicting-base",
+        None,
+        surface,
+        "template-ref: chicago-author-date\ntemplate:\n  remove:\n    - match: { date: issued }",
+    );
+    let error = Style::from_yaml_str(&yaml)
+        .expect("conflicting fields should parse independently")
+        .try_into_resolved()
+        .expect_err("same-section base selection must be rejected");
+
+    assert!(matches!(
+        error,
+        ResolutionError::InvalidFallbackTemplateDiff { reason, .. }
+            if reason == "template-ref and a template diff cannot be declared in the same section"
+    ));
+}
+
+#[rstest]
+#[case::citation(FallbackSurface::Citation)]
+#[case::bibliography(FallbackSurface::Bibliography)]
+fn given_parent_template_ref_when_child_clears_template_then_fallback_is_absent(
+    #[case] surface: FallbackSurface,
+) {
+    let base = fallback_style_yaml("base", None, surface, "template-ref: chicago-author-date");
+    let overlay = fallback_style_yaml("overlay", Some("base"), surface, "template: ~");
+    let resolved = resolve_fallback_overlay(&base, &overlay)
+        .expect("explicit null should clear an inherited fallback");
+
+    assert!(!surface.resolves_template(&resolved));
+}
+
+#[rstest]
+#[case::citation_missing(
+    FallbackSurface::Citation,
+    "template:\n  - title: primary",
+    "template:\n  remove:\n    - match: { variable: doi }",
+    false
+)]
+#[case::bibliography_missing(
+    FallbackSurface::Bibliography,
+    "template:\n  - title: primary",
+    "template:\n  remove:\n    - match: { variable: doi }",
+    false
+)]
+#[case::citation_ambiguous(
+    FallbackSurface::Citation,
+    "template:\n  - title: primary\n  - title: primary",
+    "template:\n  remove:\n    - match: { title: primary }",
+    true
+)]
+#[case::bibliography_ambiguous(
+    FallbackSurface::Bibliography,
+    "template:\n  - title: primary\n  - title: primary",
+    "template:\n  remove:\n    - match: { title: primary }",
+    true
+)]
+fn given_invalid_fallback_selector_when_resolved_then_existing_selector_error_is_preserved(
+    #[case] surface: FallbackSurface,
+    #[case] base_body: &str,
+    #[case] overlay_body: &str,
+    #[case] ambiguous: bool,
+) {
+    let base = fallback_style_yaml("base", None, surface, base_body);
+    let overlay = fallback_style_yaml("overlay", Some("base"), surface, overlay_body);
+    let error = resolve_fallback_overlay(&base, &overlay)
+        .expect_err("invalid fallback selector must not resolve");
+
+    assert!(
+        matches!(
+            error,
+            ResolutionError::TemplateVariantAmbiguousAnchor { .. }
+        ) == ambiguous
+            && matches!(error, ResolutionError::TemplateVariantAnchorNotFound { .. }) != ambiguous
+    );
+}
+
+#[test]
+fn nested_citation_fallback_diff_uses_the_effective_outer_fallback() {
+    let yaml = r#"
+version: "0.44.0"
+info: { id: nested-fallback }
+citation:
+  template:
+    - title: primary
+    - variable: publisher
+  subsequent:
+    integral:
+      template:
+        remove:
+          - match: { variable: publisher }
+"#;
+    let resolved = Style::from_yaml_str(yaml)
+        .expect("nested fallback diff should parse")
+        .try_into_resolved()
+        .expect("nested fallback diff should use the effective outer fallback");
+    let template = resolved
+        .citation
+        .as_ref()
+        .and_then(|citation| citation.subsequent.as_deref())
+        .and_then(|subsequent| subsequent.integral.as_deref())
+        .and_then(|integral| integral.template.as_ref())
+        .and_then(TemplateVariant::as_template)
+        .expect("nested fallback should resolve to full");
+
+    assert_eq!(template.len(), 1);
+    assert!(matches!(template[0], TemplateComponent::Title(_)));
+}
+
+#[test]
+fn inherited_nested_citation_fallback_diff_uses_the_parent_mode_fallback() {
+    let base = r#"
+version: "0.44.0"
+info: { id: base }
+citation:
+  template:
+    - title: primary
+  subsequent:
+    template:
+      - variable: doi
+      - variable: url
+"#;
+    let overlay = r#"
+version: "0.44.0"
+extends: base
+info: { id: overlay }
+citation:
+  subsequent:
+    template:
+      remove:
+        - match: { variable: url }
+"#;
+    let resolved = resolve_fallback_overlay(base, overlay)
+        .expect("nested diff should use the inherited mode-specific fallback");
+    let template = resolved
+        .citation
+        .as_ref()
+        .and_then(|citation| citation.subsequent.as_deref())
+        .and_then(|subsequent| subsequent.template.as_ref())
+        .and_then(TemplateVariant::as_template)
+        .expect("nested fallback should resolve to full");
+
+    assert_eq!(template.len(), 1);
+    assert!(matches!(
+        template[0],
+        TemplateComponent::Variable(ref variable) if variable.variable == SimpleVariable::Doi
+    ));
+}
+
+#[test]
+fn inherited_nested_citation_diff_does_not_bypass_an_unresolved_template_reference() {
+    let base = r#"
+version: "0.44.0"
+info: { id: base }
+citation:
+  template:
+    - title: primary
+  subsequent:
+    template-ref: https://example.com/citation-template
+"#;
+    let overlay = r#"
+version: "0.44.0"
+extends: base
+info: { id: overlay }
+citation:
+  subsequent:
+    template:
+      remove:
+        - match: { title: primary }
+"#;
+    let error = resolve_fallback_overlay(base, overlay)
+        .expect_err("an unresolved explicit template reference must still own the diff base");
+
+    assert!(matches!(
+        error,
+        ResolutionError::InvalidFallbackTemplateDiff { location, reason }
+            if location == "overlay.citation.subsequent.template"
+                && reason == "no inherited fallback template is available"
+    ));
+}
+
+#[test]
+fn nested_citation_null_clears_own_fallback_and_restores_outer_fallback() {
+    let base = r#"
+version: "0.44.0"
+info: { id: base }
+citation:
+  template:
+    - title: primary
+  subsequent:
+    template:
+      - variable: doi
+"#;
+    let overlay = r#"
+version: "0.44.0"
+extends: base
+info: { id: overlay }
+citation:
+  subsequent:
+    template: ~
+    type-variants:
+      book:
+        add:
+          - after: { title: primary }
+            component: { variable: publisher }
+"#;
+    let resolved = resolve_fallback_overlay(base, overlay)
+        .expect("cleared nested fallback should restore the effective outer fallback");
+    let subsequent = resolved
+        .citation
+        .as_ref()
+        .and_then(|citation| citation.subsequent.as_deref())
+        .expect("subsequent citation should remain");
+
+    assert!(subsequent.template.is_none());
+    let template = subsequent
+        .type_variants
+        .as_ref()
+        .and_then(|variants| variants.get(&TypeSelector::Single("book".to_string())))
+        .and_then(TemplateVariant::as_template)
+        .expect("type diff should resolve against the restored outer fallback");
+    assert_eq!(template.len(), 2);
+    assert!(matches!(template[0], TemplateComponent::Title(_)));
+    assert!(matches!(
+        template[1],
+        TemplateComponent::Variable(ref variable)
+            if variable.variable == SimpleVariable::Publisher
+    ));
+}
+
+#[rstest]
+#[case::citation(FallbackSurface::Citation)]
+#[case::bibliography(FallbackSurface::Bibliography)]
+fn given_fallback_and_type_diffs_when_resolved_then_fallback_resolves_first(
+    #[case] surface: FallbackSurface,
+) {
+    let base = fallback_style_yaml(
+        "base",
+        None,
+        surface,
+        "template:\n  - title: primary\n  - variable: doi",
+    );
+    let overlay = fallback_style_yaml(
+        "overlay",
+        Some("base"),
+        surface,
+        "template:\n  remove:\n    - match: { variable: doi }\ntype-variants:\n  book:\n    add:\n      - after: { title: primary }\n        component: { variable: publisher }",
+    );
+    let resolved = resolve_fallback_overlay(&base, &overlay)
+        .expect("fallback should resolve before its type variant");
+    let variants = match surface {
+        FallbackSurface::Citation => resolved
+            .citation
+            .as_ref()
+            .and_then(|spec| spec.type_variants.as_ref()),
+        FallbackSurface::Bibliography => resolved
+            .bibliography
+            .as_ref()
+            .and_then(|spec| spec.type_variants.as_ref()),
+    }
+    .expect("type variants should remain");
+    let template = variants
+        .get(&TypeSelector::Single("book".to_string()))
+        .and_then(TemplateVariant::as_template)
+        .expect("type diff should resolve to full");
+
+    assert_eq!(template.len(), 2);
+    assert!(matches!(template[0], TemplateComponent::Title(_)));
+    assert!(matches!(
+        template[1],
+        TemplateComponent::Variable(ref variable)
+            if variable.variable == SimpleVariable::Publisher
+    ));
 }
 
 #[test]

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -6325,7 +6325,7 @@
           ]
         },
         "template-ref": {
-          "description": "Reference to an embedded template preset or external template.\n\nIf both `template-ref` and `template` are present, `template` takes precedence.",
+          "description": "Reference to an embedded template preset or external template.\n\nA complete `template` takes precedence. Pairing `template-ref` with a\ntemplate diff in the same section is invalid.",
           "anyOf": [
             {
               "$ref": "#/$defs/TemplateReference"
@@ -6336,14 +6336,15 @@
           ]
         },
         "template": {
-          "description": "Default template when no localized override is selected.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/$defs/TemplateComponent"
-          }
+          "description": "Default template or inherited template diff when no localized override is selected.\nDiffs are materialized as complete templates during style resolution.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemplateVariant"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "locales": {
           "description": "Locale-specific template overrides checked before the default template.",
@@ -6849,62 +6850,11 @@
         }
       ]
     },
-    "LocalizedTemplateSpec": {
-      "description": "Locale-scoped template override with optional fallback behavior.",
-      "type": "object",
-      "properties": {
-        "locale": {
-          "description": "Language tags that should select this template override.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "default": {
-          "description": "Whether this override is the fallback when no locale matches.",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "template": {
-          "description": "Template used when this localized override is selected.",
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/TemplateComponent"
-          }
-        },
-        "type-variants": {
-          "description": "Locale-owned type-specific template replacements.\n\nThese take precedence over the section-level type variants when this locale matches.",
-          "type": [
-            "object",
-            "null"
-          ],
-          "propertyNames": {
-            "type": "string",
-            "pattern": "^\\s*(?:book|manual|report|thesis|webpage|map|post|interview|manuscript|personal-communication|document|chapter|entry|entry-dictionary|entry-encyclopedia|post-weblog|preprint|paper-conference|article-journal|article-magazine|article-newspaper|broadcast|collection|legal-case|statute|treaty|hearing|regulation|brief|classic|patent|dataset|standard|software|motion-picture|article|pamphlet|periodical|graphic|event|song|bill-proceeding|bill-record|default)(?:\\s*,\\s*(?:book|manual|report|thesis|webpage|map|post|interview|manuscript|personal-communication|document|chapter|entry|entry-dictionary|entry-encyclopedia|post-weblog|preprint|paper-conference|article-journal|article-magazine|article-newspaper|broadcast|collection|legal-case|statute|treaty|hearing|regulation|brief|classic|patent|dataset|standard|software|motion-picture|article|pamphlet|periodical|graphic|event|song|bill-proceeding|bill-record|default))*\\s*$"
-          },
-          "additionalProperties": {
-            "type": "array",
-            "items": {
-              "$ref": "#/$defs/TemplateComponent"
-            }
-          }
-        }
-      },
-      "required": [
-        "template"
-      ],
-      "unevaluatedProperties": false
-    },
     "TemplateVariant": {
-      "description": "Type-specific template override, either as a complete legacy template or a V3 diff.",
+      "description": "Template definition, either as a complete template or an inherited structural diff.",
       "anyOf": [
         {
-          "description": "Complete replacement template used by Template V1/V2 styles.",
+          "description": "Complete replacement template.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/TemplateComponent"
@@ -6917,11 +6867,11 @@
       ]
     },
     "TemplateVariantDiff": {
-      "description": "Structural diff that derives a type-specific template from a parent template.",
+      "description": "Structural diff that derives a template from an inherited or selected parent.",
       "type": "object",
       "properties": {
         "extends": {
-          "description": "Optional parent type variant selector within the same section.",
+          "description": "Optional parent type variant selector within the same section.\nFallback-template diffs reject this field during resolution.",
           "anyOf": [
             {
               "$ref": "#/$defs/TypeSelector"
@@ -7212,6 +7162,57 @@
         "component"
       ]
     },
+    "LocalizedTemplateSpec": {
+      "description": "Locale-scoped template override with optional fallback behavior.",
+      "type": "object",
+      "properties": {
+        "locale": {
+          "description": "Language tags that should select this template override.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "default": {
+          "description": "Whether this override is the fallback when no locale matches.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "template": {
+          "description": "Template used when this localized override is selected.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TemplateComponent"
+          }
+        },
+        "type-variants": {
+          "description": "Locale-owned type-specific template replacements.\n\nThese take precedence over the section-level type variants when this locale matches.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "propertyNames": {
+            "type": "string",
+            "pattern": "^\\s*(?:book|manual|report|thesis|webpage|map|post|interview|manuscript|personal-communication|document|chapter|entry|entry-dictionary|entry-encyclopedia|post-weblog|preprint|paper-conference|article-journal|article-magazine|article-newspaper|broadcast|collection|legal-case|statute|treaty|hearing|regulation|brief|classic|patent|dataset|standard|software|motion-picture|article|pamphlet|periodical|graphic|event|song|bill-proceeding|bill-record|default)(?:\\s*,\\s*(?:book|manual|report|thesis|webpage|map|post|interview|manuscript|personal-communication|document|chapter|entry|entry-dictionary|entry-encyclopedia|post-weblog|preprint|paper-conference|article-journal|article-magazine|article-newspaper|broadcast|collection|legal-case|statute|treaty|hearing|regulation|brief|classic|patent|dataset|standard|software|motion-picture|article|pamphlet|periodical|graphic|event|song|bill-proceeding|bill-record|default))*\\s*$"
+          },
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/TemplateComponent"
+            }
+          }
+        }
+      },
+      "required": [
+        "template"
+      ],
+      "unevaluatedProperties": false
+    },
     "CitationCollapse": {
       "description": "Citation collapse behavior for multi-item citations.",
       "oneOf": [
@@ -7374,7 +7375,7 @@
           ]
         },
         "template-ref": {
-          "description": "Reference to an embedded template preset or external template.\n\nIf both `template-ref` and `template` are present, `template` takes precedence.",
+          "description": "Reference to an embedded template preset or external template.\n\nA complete `template` takes precedence. Pairing `template-ref` with a\ntemplate diff in the same section is invalid.",
           "anyOf": [
             {
               "$ref": "#/$defs/TemplateReference"
@@ -7385,14 +7386,15 @@
           ]
         },
         "template": {
-          "description": "Default template for entries when no localized override is selected.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "$ref": "#/$defs/TemplateComponent"
-          }
+          "description": "Default template or inherited template diff when no localized override is selected.\nDiffs are materialized as complete templates during style resolution.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemplateVariant"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "locales": {
           "description": "Locale-specific template overrides checked before the default template.",

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -192,7 +192,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | [`APA_SQI_ALIGNMENT_AND_PRESET_REFACTOR.md`](./APA_SQI_ALIGNMENT_AND_PRESET_REFACTOR.md) — APA SQI alignment and preset-first cleanup | Active | `bibliography.rs`, `citations.rs` |
 | [`CHICAGO_18_COVERAGE.md`](./CHICAGO_18_COVERAGE.md) — Chicago 18th and APA 8th high-fidelity coverage enhancement | Active | `bibliography.rs`, `citations.rs` |
 | [`CHICAGO_VARIANT_AXES.md`](./CHICAGO_VARIANT_AXES.md) — mapping `style-variant-builder`'s template-diff model onto Citum `extends:`/type-variant inheritance | Draft | `crates/citum-schema-style/tests/bdd_inheritance.rs` |
-| [`STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md`](./STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md) — bounded template reuse, inherited fallback diffs, and auditable field coverage | Draft | — |
+| [`STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md`](./STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md) — bounded template reuse, inherited fallback diffs, and auditable field coverage | Active | `crates/citum-schema-style/tests/bdd_inheritance.rs` |
 | [`UNIFIED_SCOPED_OPTIONS.md`](./UNIFIED_SCOPED_OPTIONS.md) — typed scoped options replacing flat author-facing contracts | Active | `crates/citum-schema-style/tests/` |
 | [`PER_DOCUMENT_CONFIG_OVERRIDES.md`](./PER_DOCUMENT_CONFIG_OVERRIDES.md) — eligible options and syntax for per-document configuration overrides | Draft | `bibliography.rs::local_overrides` |
 | [`SCHEMA_SPLIT_AND_CONVERT_NAMESPACE.md`](./SCHEMA_SPLIT_AND_CONVERT_NAMESPACE.md) — crate-level schema split and CLI conversion namespace | Active | `crates/citum-schema/tests/` |

--- a/docs/specs/STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md
+++ b/docs/specs/STYLE_TEMPLATE_EXPRESSIVENESS_AND_PARITY.md
@@ -1,6 +1,6 @@
 # Style Template Expressiveness and Parity Coverage Specification
 
-**Status:** Draft
+**Status:** Active
 **Version:** 1.0
 **Date:** 2026-08-09
 **Supersedes:** (none)
@@ -39,8 +39,7 @@ In scope:
 Out of scope:
 
 - adding a general macro or expression language;
-- implementing the fallback diff or coverage tooling in this documentation
-  change;
+- implementing the coverage tooling tracked by `csl26-02yg` in this change;
 - changing a style, converter, rendering engine, fixture, or workflow control
   surface;
 - committing the pilot packet or individual model review records;
@@ -326,7 +325,7 @@ manifest, trace, join, and parity-ratchet path.
       denominators are defined independently.
 - [x] The pilot findings are separated into facts and inferences without
       adopting the reported totals as a baseline.
-- [ ] `csl26-4xg9` implements fallback diffs and passes citation and
+- [x] `csl26-4xg9` implements fallback diffs and passes citation and
       bibliography conformance tests.
 - [ ] `csl26-02yg` implements the manifest, trace or conformance evidence,
       stable joins, complete output, and byte-regeneration gate.
@@ -335,6 +334,8 @@ manifest, trace, join, and parity-ratchet path.
 
 ## Changelog
 
+- 2026-08-09: Activated the fallback-template diff contract with schema,
+  resolver, and citation/bibliography conformance coverage.
 - 2026-08-09: Initial Draft. Adjudicated the shortened-notes pilot, narrowed
   the fallback design to the existing `template` field, and split coverage
   disposition from comparison eligibility.


### PR DESCRIPTION
## Summary

- widen citation and bibliography fallback templates to `TemplateVariant`
- apply fallback diffs to the inherited effective template before type variants
- preserve sequence YAML, explicit null clears, template presets, and nested-mode inheritance
- reject root diffs without a base, fallback `extends`, and same-section preset-plus-diff ambiguity
- emit structured selector and fallback-resolution diagnostics
- regenerate the style schema and add citation/bibliography conformance coverage

## Review basis

This implements the narrow schema/engine gap identified by the adjudicated Fable review. It does not add a macro or conditional language, adopt the pilot totals as a baseline, or expand the parity-coverage harness. Coverage work remains in `csl26-02yg`.

## Scope

The public Rust fields `CitationSpec.template` and `BibliographySpec.template` now use `Option<TemplateVariant>`. Existing YAML sequence templates continue to deserialize as `TemplateVariant::Full`, and resolved styles never retain a fallback `Diff`.

No Cargo manifests, embedded styles, `styles-legacy` content, harness policy, or coverage packets change in this PR.

## Validation

- `just schema-gen`
- `just pre-commit` — 2,445 tests passed
- manual `jj` commit-message and pre-push hooks — 2,445 tests passed
- `cargo nextest run -p citum-schema-style --test bdd_inheritance` — 42 tests passed
- `cargo nextest run -p citum-schema-style` — 455 tests passed
- `python3 scripts/audit-rust-review-smells.py --changed`
- `git diff --check`

## Risk

This is intentionally marked breaking because Rust struct-literal callers must wrap full templates as `TemplateVariant::Full` (or use `Into`). Authored YAML sequences are backward-compatible. The broad mechanical call-site updates are the direct consequence of that public type change; semantic behavior is concentrated in the schema resolver and its conformance tests.

Stacked on #1155.
