### PR TITLE
fix(ci): run required checks on stacked-PR bases

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -5,8 +5,7 @@ permissions: {}
 on:
   push:
     branches: ["main"]
-  pull_request:
-    branches: ["main"]
+  pull_request: {}
 
 jobs:
   actionlint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
     paths-ignore:
       - '.beans.yml'
       - '.release-plz.toml'

--- a/.github/workflows/commit-policy.yml
+++ b/.github/workflows/commit-policy.yml
@@ -6,8 +6,7 @@ permissions:
 on:
   push:
     branches: ["main"]
-  pull_request:
-    branches: ["main"]
+  pull_request: {}
 
 jobs:
   commit-policy:

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
     paths:
       - "crates/citum-engine/**"
       - "crates/citum-migrate/**"


### PR DESCRIPTION
## Summary
- `pull_request` triggers on `ci.yml`, `fidelity.yml`, `commit-policy.yml`, and `actions-security.yml` were scoped to `branches: ["main"]`.
- Stacked PRs (base = another PR's branch, e.g. via `gh stack`) never matched that filter, so they got none of these checks — including `zizmor`/`actionlint`, the two contexts `main protect` actually requires to merge. They sat at `mergeable_state: blocked` indefinitely instead of resolving, and their real code changes went unverified by Rust CI/Fidelity until the commit reached `main`.
- Drop the `branches` restriction on `pull_request` (push triggers are untouched, still `main`-only), so every PR gets these checks regardless of base branch.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` on all 4 edited files — parses cleanly.
- [ ] CI green on this PR (bottom of stack, base `main`, so it exercises the same trigger path as before).
- [ ] After merge, verify a stacked PR (base != `main`) now runs the full check set instead of just `check-pr`.
