### PR TITLE
fix(ci): widen fidelity timeout for cold builds

### DIFF
--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Run corpus-aware script tests
         if: ${{ steps.fidelity-scope.outputs.mode == 'all' }}
-        run: node --test --test-timeout=180000 scripts/oracle.test.js scripts/report-core.test.js scripts/check-core-quality.test.js scripts/oracle-yaml.test.js
+        run: node --test --test-timeout=300000 scripts/oracle.test.js scripts/report-core.test.js scripts/check-core-quality.test.js scripts/oracle-yaml.test.js
 
       - name: Check core fidelity and SQI drift
         run: |


### PR DESCRIPTION
## Summary
- `scripts/report-core.test.js`'s `resolveCitumBinary rebuilds a Cargo-managed binary` test does an actual `cargo build` of the `citum` binary (`typst`, `deno_core`, `wasmi`, `resvg`, `krilla`, `gix`, `ratatui` — a large static dependency tree).
- On a `Cargo.lock` change, a cold build of that binary can exceed the shared `180000`ms per-file `node --test` timeout on standard CI runners, even with `sccache` warm on individual objects — the final link step is single-threaded and CPU-heavy.
- Raise `--test-timeout` from `180000` to `300000` in `fidelity.yml`'s "Run corpus-aware script tests" step.

## Evidence
- Reproduced the exact CI command locally (`node --test --test-timeout=180000 scripts/oracle.test.js scripts/report-core.test.js scripts/check-core-quality.test.js scripts/oracle-yaml.test.js`) — 141/141 pass in ~105s with a warm local build cache.
- On CI, after a `Cargo.lock` bump (`#1164`), the same command hung with zero log output for ~173s before being killed at the 180s ceiling — reproduced 5/5 times, always at the same point.

## Validation
- `node --test --test-timeout=300000 scripts/oracle.test.js scripts/report-core.test.js scripts/check-core-quality.test.js scripts/oracle-yaml.test.js` — passes locally (unaffected by the timeout value in the warm-cache case).
