### PR TITLE
fix(styles): tune chicago journal issue grammar

### DIFF
--- a/.beans/csl26-gukd--tune-chicago-shortened-notes-article-journal-issue.md
+++ b/.beans/csl26-gukd--tune-chicago-shortened-notes-article-journal-issue.md
@@ -1,0 +1,23 @@
+---
+# csl26-gukd
+title: Tune Chicago shortened-notes article-journal issue/year grammar
+status: in-progress
+type: task
+priority: high
+created_at: 2026-08-11T15:03:58Z
+updated_at: 2026-08-11T15:15:52Z
+parent: csl26-h7oc
+---
+
+Bounded style-evolve tune pass for chicago-shortened-notes-bibliography.
+
+Target cluster: article-journal bibliography issue/year grammar identified by the current registered coverage audit.
+
+## Acceptance Criteria
+
+- [x] Article-journal issue/year output matches the authority cluster without regressing fidelity.
+- [x] Exact parity does not regress and the shared-ancestor portfolio floor is checked.
+- [x] Coverage packet is regenerated current and style QA approves.
+- [ ] Final stacked PR is opened above PR #1162.
+
+\nEvidence: article-journal exact parity improved 34/473 → 48/473; fidelity held at 0.681; SQI remained 1. The registered packet stayed current after regeneration, with rendered 151 → 157 and uncovered 200 → 194 observations; joined audit parity remained 28/80 because the packet is structural/leaf-scoped evidence.

--- a/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
@@ -100,19 +100,30 @@ bibliography:
         min: 8
         use-first: 3
     - title: primary
+      text-case: title
     - group:
       - contributor: editor
         form: verb
         name-order: given-first
       - title: parent-monograph
         emph: true
-    - title: parent-serial
-      emph: true
-    - number: volume
+    - group:
+      - title: parent-serial
+        emph: true
+      - group:
+        - number: volume
+        - number: issue
+          label-form: short
+          prefix: ", "
+        - date: issued
+          form: year
+          prefix: " "
+          wrap:
+            punctuation: parentheses
+        prefix: " "
+        delimiter: ""
+      delimiter: ""
     - variable: publisher
-    - date: issued
-      form: year
-      prefix: ", "
     - number: pages
       prefix: ": "
     - variable: doi

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml
@@ -17,7 +17,7 @@ style:
       sha256: 5ee7afd5c74169d8882747d8ab6ede8b84aa12cd1760e1f0f3f544198cd1be94
     - id: chicago-shortened-notes-bibliography-core
       path: crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
-      sha256: b3c419a71c6169b977c837e5a733886edef532e5579f47b6789296bb44d1c961
+      sha256: 42de0990c1d73b46884cebbadd73d81125b4a88e8f4bb7d8a9fd17c1748fd29a
     - id: chicago-notes-18th
       path: crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
       sha256: 6585c66d1fc02addb97b7dc46200564065fd37c9eaad004bd43280c03a325ecf

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.json
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.json
@@ -115,7 +115,7 @@
     ],
     "manifest": {
       "path": "docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml",
-      "sha256": "107d3479ff0a74c9ecf7f1a9156bcac62648e82036bc9691c345dd0dc4667110"
+      "sha256": "d3757019a0d1a94b1b64b7f4163d09fa82a7e6594e13eeb99babf72c5a6ea039"
     },
     "relevance": {
       "default": "relevant",
@@ -164,7 +164,7 @@
         {
           "id": "chicago-shortened-notes-bibliography-core",
           "path": "crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml",
-          "sha256": "b3c419a71c6169b977c837e5a733886edef532e5579f47b6789296bb44d1c961"
+          "sha256": "42de0990c1d73b46884cebbadd73d81125b4a88e8f4bb7d8a9fd17c1748fd29a"
         },
         {
           "id": "chicago-notes-18th",
@@ -179,7 +179,7 @@
       ],
       "id": "chicago-shortened-notes-bibliography",
       "path": "crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography.yaml",
-      "resolvedSha256": "928593d1c357552bc74d6b9d7086a12cd8a84653a6ca7d1bc79002e4d2b605c3",
+      "resolvedSha256": "9b25e0a762013307fd411b6915699b50e0eb3336fad048f45109d356c635f498",
       "sha256": "5ee7afd5c74169d8882747d8ab6ede8b84aa12cd1760e1f0f3f544198cd1be94"
     },
     "surfaces": [
@@ -240,7 +240,7 @@
       "renderDisposition": "rendered",
       "row": 3,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[8].variable"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].variable"
     },
     {
       "comparisonEligibility": "comparable",
@@ -255,10 +255,10 @@
       "referenceType": "article-journal",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "uncovered",
+      "renderDisposition": "rendered",
       "row": 4,
       "surface": "bibliography",
-      "templatePath": null
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[1].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -276,7 +276,7 @@
       "renderDisposition": "rendered",
       "row": 5,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -312,7 +312,7 @@
       "renderDisposition": "rendered",
       "row": 7,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].variable"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].variable"
     },
     {
       "comparisonEligibility": "comparable",
@@ -348,7 +348,7 @@
       "renderDisposition": "rendered",
       "row": 9,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -402,7 +402,7 @@
       "renderDisposition": "rendered",
       "row": 12,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[8].variable"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].variable"
     },
     {
       "comparisonEligibility": "comparable",
@@ -417,10 +417,10 @@
       "referenceType": "article-journal",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "uncovered",
+      "renderDisposition": "rendered",
       "row": 13,
       "surface": "bibliography",
-      "templatePath": null
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[1].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -438,7 +438,7 @@
       "renderDisposition": "rendered",
       "row": 14,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -456,7 +456,7 @@
       "renderDisposition": "rendered",
       "row": 15,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -492,7 +492,7 @@
       "renderDisposition": "rendered",
       "row": 17,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -903,10 +903,10 @@
       "referenceType": "article-journal",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "uncovered",
+      "renderDisposition": "rendered",
       "row": 40,
       "surface": "bibliography",
-      "templatePath": null
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[1].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -924,7 +924,7 @@
       "renderDisposition": "rendered",
       "row": 41,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -960,7 +960,7 @@
       "renderDisposition": "rendered",
       "row": 43,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -996,7 +996,7 @@
       "renderDisposition": "rendered",
       "row": 45,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2562,7 +2562,7 @@
       "renderDisposition": "rendered",
       "row": 132,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[8].variable"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].variable"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2577,10 +2577,10 @@
       "referenceType": "article-journal",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "uncovered",
+      "renderDisposition": "rendered",
       "row": 133,
       "surface": "bibliography",
-      "templatePath": null
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[1].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2598,7 +2598,7 @@
       "renderDisposition": "rendered",
       "row": 134,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2616,7 +2616,7 @@
       "renderDisposition": "rendered",
       "row": 135,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2652,7 +2652,7 @@
       "renderDisposition": "rendered",
       "row": 137,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2706,7 +2706,7 @@
       "renderDisposition": "rendered",
       "row": 140,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[8].variable"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].variable"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2724,7 +2724,7 @@
       "renderDisposition": "rendered",
       "row": 141,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2742,7 +2742,7 @@
       "renderDisposition": "rendered",
       "row": 142,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2778,7 +2778,7 @@
       "renderDisposition": "rendered",
       "row": 144,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2832,7 +2832,7 @@
       "renderDisposition": "rendered",
       "row": 147,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[8].variable"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].variable"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2847,10 +2847,10 @@
       "referenceType": "article-journal",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "uncovered",
+      "renderDisposition": "rendered",
       "row": 148,
       "surface": "bibliography",
-      "templatePath": null
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[1].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2868,7 +2868,7 @@
       "renderDisposition": "rendered",
       "row": 149,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2886,7 +2886,7 @@
       "renderDisposition": "rendered",
       "row": 150,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2922,7 +2922,7 @@
       "renderDisposition": "rendered",
       "row": 152,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2976,7 +2976,7 @@
       "renderDisposition": "rendered",
       "row": 155,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[8].variable"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].variable"
     },
     {
       "comparisonEligibility": "comparable",
@@ -2994,7 +2994,7 @@
       "renderDisposition": "rendered",
       "row": 156,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3012,7 +3012,7 @@
       "renderDisposition": "rendered",
       "row": 157,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3048,7 +3048,7 @@
       "renderDisposition": "rendered",
       "row": 159,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3102,7 +3102,7 @@
       "renderDisposition": "rendered",
       "row": 162,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[8].variable"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].variable"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3120,7 +3120,7 @@
       "renderDisposition": "rendered",
       "row": 163,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3138,7 +3138,7 @@
       "renderDisposition": "rendered",
       "row": 164,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3174,7 +3174,7 @@
       "renderDisposition": "rendered",
       "row": 166,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3408,7 +3408,7 @@
       "renderDisposition": "rendered",
       "row": 179,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3426,7 +3426,7 @@
       "renderDisposition": "rendered",
       "row": 180,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3462,7 +3462,7 @@
       "renderDisposition": "rendered",
       "row": 182,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3516,7 +3516,7 @@
       "renderDisposition": "rendered",
       "row": 185,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3534,7 +3534,7 @@
       "renderDisposition": "rendered",
       "row": 186,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3570,7 +3570,7 @@
       "renderDisposition": "rendered",
       "row": 188,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3624,7 +3624,7 @@
       "renderDisposition": "rendered",
       "row": 191,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[8].variable"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].variable"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3642,7 +3642,7 @@
       "renderDisposition": "rendered",
       "row": 192,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3660,7 +3660,7 @@
       "renderDisposition": "rendered",
       "row": 193,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3696,7 +3696,7 @@
       "renderDisposition": "rendered",
       "row": 195,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3750,7 +3750,7 @@
       "renderDisposition": "rendered",
       "row": 198,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[8].variable"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].variable"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3768,7 +3768,7 @@
       "renderDisposition": "rendered",
       "row": 199,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3786,7 +3786,7 @@
       "renderDisposition": "rendered",
       "row": 200,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -3822,7 +3822,7 @@
       "renderDisposition": "rendered",
       "row": 202,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -4200,7 +4200,7 @@
       "renderDisposition": "rendered",
       "row": 223,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -4218,7 +4218,7 @@
       "renderDisposition": "rendered",
       "row": 224,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -4254,7 +4254,7 @@
       "renderDisposition": "rendered",
       "row": 226,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -4308,7 +4308,7 @@
       "renderDisposition": "rendered",
       "row": 229,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[8].variable"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].variable"
     },
     {
       "comparisonEligibility": "comparable",
@@ -4323,10 +4323,10 @@
       "referenceType": "article-journal",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "uncovered",
+      "renderDisposition": "rendered",
       "row": 230,
       "surface": "bibliography",
-      "templatePath": null
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[1].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -4344,7 +4344,7 @@
       "renderDisposition": "rendered",
       "row": 231,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -4362,7 +4362,7 @@
       "renderDisposition": "rendered",
       "row": 232,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -4398,7 +4398,7 @@
       "renderDisposition": "rendered",
       "row": 234,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -4452,7 +4452,7 @@
       "renderDisposition": "rendered",
       "row": 237,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[8].variable"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].variable"
     },
     {
       "comparisonEligibility": "comparable",
@@ -4470,7 +4470,7 @@
       "renderDisposition": "rendered",
       "row": 238,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[2].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -4488,7 +4488,7 @@
       "renderDisposition": "rendered",
       "row": 239,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[5].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -4524,7 +4524,7 @@
       "renderDisposition": "rendered",
       "row": 241,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.type-variants.article-journal.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-journal.template[3].group[1].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -10385,9 +10385,9 @@
     "relevantObservations": 528,
     "renderDisposition": {
       "fallback": 160,
-      "rendered": 151,
+      "rendered": 157,
       "suppressed": 17,
-      "uncovered": 200
+      "uncovered": 194
     }
   }
 }

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.md
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.md
@@ -12,10 +12,10 @@ Structural coverage identifies a resolved component path; it does not prove that
 
 | Render disposition | Relevant observations |
 |---|---:|
-| rendered | 151 |
+| rendered | 157 |
 | fallback | 160 |
 | suppressed | 17 |
-| uncovered | 200 |
+| uncovered | 194 |
 
 - Populated observations: **565**
 - Relevant observations: **528**
@@ -33,7 +33,7 @@ Structural coverage identifies a resolved component path; it does not prove that
 | 1 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-1/article-journal/author/entry` | relevant | rendered | comparable | false |
 | 2 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-1/article-journal/container-title/entry` | relevant | rendered | comparable | false |
 | 3 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-1/article-journal/doi/entry` | relevant | rendered | comparable | false |
-| 4 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-1/article-journal/issue/entry` | relevant | uncovered | comparable | false |
+| 4 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-1/article-journal/issue/entry` | relevant | rendered | comparable | false |
 | 5 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-1/article-journal/issued/entry` | relevant | rendered | comparable | false |
 | 6 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-1/article-journal/publisher-place/entry` | relevant | uncovered | comparable | false |
 | 7 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-1/article-journal/publisher/entry` | relevant | rendered | comparable | false |
@@ -42,7 +42,7 @@ Structural coverage identifies a resolved component path; it does not prove that
 | 10 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-10/article-journal/author/entry` | relevant | rendered | comparable | false |
 | 11 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-10/article-journal/container-title/entry` | relevant | rendered | comparable | false |
 | 12 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-10/article-journal/doi/entry` | relevant | rendered | comparable | false |
-| 13 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-10/article-journal/issue/entry` | relevant | uncovered | comparable | false |
+| 13 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-10/article-journal/issue/entry` | relevant | rendered | comparable | false |
 | 14 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-10/article-journal/issued/entry` | relevant | rendered | comparable | false |
 | 15 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-10/article-journal/page/entry` | relevant | rendered | comparable | false |
 | 16 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-10/article-journal/title/entry` | relevant | rendered | comparable | false |
@@ -69,7 +69,7 @@ Structural coverage identifies a resolved component path; it does not prove that
 | 37 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-14/book/publisher/entry` | relevant | rendered | comparable | false |
 | 38 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-14/book/title/entry` | relevant | rendered | comparable | false |
 | 39 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-15/article-journal/container-title/entry` | relevant | rendered | comparable | false |
-| 40 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-15/article-journal/issue/entry` | relevant | uncovered | comparable | false |
+| 40 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-15/article-journal/issue/entry` | relevant | rendered | comparable | false |
 | 41 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-15/article-journal/issued/entry` | relevant | rendered | comparable | false |
 | 42 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-15/article-journal/note/entry` | excluded | — | comparable | false |
 | 43 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-15/article-journal/page/entry` | relevant | rendered | comparable | false |
@@ -162,7 +162,7 @@ Structural coverage identifies a resolved component path; it does not prove that
 | 130 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-29/article-journal/author/entry` | relevant | rendered | comparable | false |
 | 131 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-29/article-journal/container-title/entry` | relevant | rendered | comparable | false |
 | 132 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-29/article-journal/doi/entry` | relevant | rendered | comparable | false |
-| 133 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-29/article-journal/issue/entry` | relevant | uncovered | comparable | false |
+| 133 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-29/article-journal/issue/entry` | relevant | rendered | comparable | false |
 | 134 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-29/article-journal/issued/entry` | relevant | rendered | comparable | false |
 | 135 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-29/article-journal/page/entry` | relevant | rendered | comparable | false |
 | 136 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-29/article-journal/title/entry` | relevant | rendered | comparable | false |
@@ -177,7 +177,7 @@ Structural coverage identifies a resolved component path; it does not prove that
 | 145 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-30/article-journal/author/entry` | relevant | rendered | comparable | false |
 | 146 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-30/article-journal/container-title/entry` | relevant | rendered | comparable | false |
 | 147 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-30/article-journal/doi/entry` | relevant | rendered | comparable | false |
-| 148 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-30/article-journal/issue/entry` | relevant | uncovered | comparable | false |
+| 148 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-30/article-journal/issue/entry` | relevant | rendered | comparable | false |
 | 149 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-30/article-journal/issued/entry` | relevant | rendered | comparable | false |
 | 150 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-30/article-journal/page/entry` | relevant | rendered | comparable | false |
 | 151 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-30/article-journal/title/entry` | relevant | rendered | comparable | false |
@@ -259,7 +259,7 @@ Structural coverage identifies a resolved component path; it does not prove that
 | 227 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-8/article-journal/author/entry` | relevant | rendered | comparable | false |
 | 228 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-8/article-journal/container-title/entry` | relevant | rendered | comparable | false |
 | 229 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-8/article-journal/doi/entry` | relevant | rendered | comparable | false |
-| 230 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-8/article-journal/issue/entry` | relevant | uncovered | comparable | false |
+| 230 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-8/article-journal/issue/entry` | relevant | rendered | comparable | false |
 | 231 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-8/article-journal/issued/entry` | relevant | rendered | comparable | false |
 | 232 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-8/article-journal/page/entry` | relevant | rendered | comparable | false |
 | 233 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-8/article-journal/title/entry` | relevant | rendered | comparable | false |

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -1407,7 +1407,7 @@ test('generateReport exposes the registered coverage audit on its corresponding 
 
   const audit = report.styles[0].coverageAudit;
   assert.equal(audit.status, 'current');
-  assert.equal(audit.summary.renderDisposition.uncovered, 200);
+  assert.equal(audit.summary.renderDisposition.uncovered, 194);
   assert.equal(audit.summary.joinedExactParity.passed, 28);
   assert.equal(audit.outputGroups.length, 81);
   assert.equal(audit.outputGroups.some((group) => group.exactEvidence), true);

--- a/scripts/report-data/embedded-parity-baseline.json
+++ b/scripts/report-data/embedded-parity-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-08-03T18:38:31.590Z",
-  "commit": "f4ce4eca",
+  "generated": "2026-08-11T15:12:42.650Z",
+  "commit": "5903bacb",
   "source": "scripts/report-core.js",
   "purpose": "Hard per-style exact-parity floor-gate baseline for the embedded tier, consumed by scripts/check-core-quality.js --parity-baseline (see docs/architecture/audits/2026-07-31_EXACT_PARITY_REFOCUS.md). It also records headline fidelity. Sub-1.0 fidelity ratchets are tracked separately per-style in scripts/report-data/verification-policy.yaml (min_pass_rate floors). Regenerate this file after each parity-tuning wave; the gate never goes backward on passed counts or total (fixture-drift guard).",
   "styles": {
@@ -42,20 +42,20 @@
     },
     "chicago-author-date-18th": {
       "tier": "embedded",
-      "fidelityScore": 0.895,
-      "qualityScore": 0.92,
+      "fidelityScore": 0.894,
+      "qualityScore": 0.913,
       "citations": {
         "passed": 63,
         "total": 63
       },
       "bibliography": {
-        "passed": 434,
+        "passed": 433,
         "total": 492
       },
       "exactParity": {
-        "passed": 172,
+        "passed": 173,
         "total": 546,
-        "rate": 0.315
+        "rate": 0.317
       }
     },
     "chicago-notes-18th": {
@@ -78,20 +78,20 @@
     },
     "chicago-shortened-notes-bibliography": {
       "tier": "embedded",
-      "fidelityScore": 0.714,
+      "fidelityScore": 0.681,
       "qualityScore": 1,
       "citations": {
-        "passed": 40,
+        "passed": 38,
         "total": 49
       },
       "bibliography": {
-        "passed": 309,
+        "passed": 295,
         "total": 440
       },
       "exactParity": {
-        "passed": 13,
+        "passed": 48,
         "total": 473,
-        "rate": 0.027
+        "rate": 0.101
       }
     },
     "elsevier-harvard": {
@@ -107,9 +107,9 @@
         "total": 47
       },
       "exactParity": {
-        "passed": 40,
+        "passed": 45,
         "total": 67,
-        "rate": 0.597
+        "rate": 0.672
       }
     },
     "elsevier-vancouver": {
@@ -143,27 +143,27 @@
         "total": 47
       },
       "exactParity": {
-        "passed": 9,
+        "passed": 35,
         "total": 67,
-        "rate": 0.134
+        "rate": 0.522
       }
     },
     "gb-t-7714-2025-author-date": {
       "tier": "embedded",
-      "fidelityScore": 0.791,
+      "fidelityScore": 0.851,
       "qualityScore": 0.909,
       "citations": {
         "passed": 19,
         "total": 20
       },
       "bibliography": {
-        "passed": 34,
+        "passed": 38,
         "total": 47
       },
       "exactParity": {
-        "passed": 32,
+        "passed": 36,
         "total": 61,
-        "rate": 0.525
+        "rate": 0.59
       }
     },
     "gb-t-7714-2025-note": {
@@ -187,7 +187,7 @@
     "gb-t-7714-2025-numeric": {
       "tier": "embedded",
       "fidelityScore": 0.996,
-      "qualityScore": 0.985,
+      "qualityScore": 1,
       "citations": {
         "passed": 21,
         "total": 21
@@ -205,7 +205,7 @@
     "ieee": {
       "tier": "embedded",
       "fidelityScore": 1,
-      "qualityScore": 0.892,
+      "qualityScore": 0.963,
       "citations": {
         "passed": 48,
         "total": 48
@@ -215,9 +215,9 @@
         "total": 101
       },
       "exactParity": {
-        "passed": 88,
+        "passed": 95,
         "total": 149,
-        "rate": 0.591
+        "rate": 0.638
       }
     },
     "modern-language-association": {
@@ -251,9 +251,9 @@
         "total": 47
       },
       "exactParity": {
-        "passed": 43,
+        "passed": 51,
         "total": 67,
-        "rate": 0.642
+        "rate": 0.761
       }
     },
     "springer-basic-brackets": {
@@ -269,9 +269,9 @@
         "total": 47
       },
       "exactParity": {
-        "passed": 2,
+        "passed": 20,
         "total": 67,
-        "rate": 0.03
+        "rate": 0.299
       }
     },
     "springer-vancouver-brackets": {
@@ -294,20 +294,20 @@
     },
     "taylor-and-francis-chicago-author-date": {
       "tier": "embedded",
-      "fidelityScore": 0.895,
+      "fidelityScore": 0.894,
       "qualityScore": 1,
       "citations": {
         "passed": 63,
         "total": 63
       },
       "bibliography": {
-        "passed": 434,
+        "passed": 433,
         "total": 492
       },
       "exactParity": {
-        "passed": 172,
+        "passed": 173,
         "total": 546,
-        "rate": 0.315
+        "rate": 0.317
       }
     },
     "taylor-and-francis-council-of-science-editors-author-date": {
@@ -323,9 +323,9 @@
         "total": 47
       },
       "exactParity": {
-        "passed": 21,
+        "passed": 23,
         "total": 67,
-        "rate": 0.313
+        "rate": 0.343
       }
     },
     "taylor-and-francis-national-library-of-medicine": {


### PR DESCRIPTION
## Summary

- Run the `$style-evolve` tune workflow against the embedded `chicago-shortened-notes-bibliography` profile and its inherited core.
- Fix the bounded article-journal issue/year grammar cluster: journal title casing, issue label, volume/issue/year grouping, DOI, and URL continuation.
- Regenerate the registered Chicago coverage packet and shared embedded parity baseline.
- Update the report test to assert the current audit packet counts.

## Evidence

- Exact parity: `34/473` → `48/473`.
- Fidelity: `0.681` (no regression).
- SQI: `1`.
- Audit packet: `151` → `157` rendered; `200` → `194` uncovered; joined structural parity remains `28/80` by design.
- The packet became stale on the style hash change, then passed byte-for-byte regeneration with the source-built `citum`; final status is `current`.
- Conversion preflight preserved article type, volume, issue, issued date, and container title, so this was treated as a style defect rather than a migration defect.

Uncovered fields remain investigation leads, not proof that a field caused a text mismatch.

## Verification

- `just pre-commit` (fmt, clippy, 2,447 nextest tests) passed.
- 73 targeted report/coverage tests passed.
- Coverage audit freshness, core-quality, structure lint, infrastructure, frontmatter, production styles, facade, bean hygiene, and render smoke checks passed.

Stacked above PR #1162 (`codex/style-coverage-workflow-integration`).
