### PR TITLE
feat(report): add post-change audit evidence

### DIFF
--- a/.beans/csl26-ddh5--add-post-change-rendering-evidence-to-coverage-aud.md
+++ b/.beans/csl26-ddh5--add-post-change-rendering-evidence-to-coverage-aud.md
@@ -1,0 +1,12 @@
+---
+# csl26-ddh5
+title: Add post-change rendering evidence to coverage audits
+status: in-progress
+type: task
+priority: high
+created_at: 2026-08-11T15:53:26Z
+updated_at: 2026-08-11T15:53:26Z
+parent: csl26-hk3u
+---
+
+Add optional report-time before/after Citum evidence keyed by stable coverage-audit output identities. Preserve packet v1 structural semantics and non-causal wording; test joins, missing outputs, and accessible collapsed report evidence; open one final stacked PR above #1166.

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/README.md
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/README.md
@@ -15,14 +15,19 @@ index; this note distinguishes observed facts from maintainer inference.
   more exact outputs among 393 comparable outputs and 16 not-comparable outputs.
 - The packet contains **565** populated field observations. Thirty-seven are
   excluded fixture metadata (`citation-key`, `license`, `language`, or `note`).
-  The 528 relevant observations partition into 151 rendered, 160 fallback, 17
-  suppressed, and 200 uncovered observations.
+  The 528 relevant observations partition into 157 rendered, 160 fallback, 17
+  suppressed, and 194 uncovered observations after the article-journal grammar
+  experiment.
 - The 17 suppressions are narrow authority-backed publication-place omissions.
   Bibliography `ITEM-1` remains uncovered because citeproc-js renders its
   `publisher-place` as `(Chicago)`.
 - Coverage is inferred from the Citum-resolved style. It does not prove runtime
-  field consumption, and the 200 uncovered observations are an investigation
-  queue rather than 200 confirmed style defects.
+  field consumption, and the 194 uncovered observations are an investigation
+  queue rather than 194 confirmed style defects.
+- The report-time post-change join measures the current source-built Citum
+  output against the authority run: exact parity moved from **34/473** to
+  **48/473**. This is output evidence, not proof that an uncovered field caused
+  any individual text mismatch.
 - A control run at the same source revision and with an empty report cache reused
   a stale managed binary and produced **20/473**. The full report hashes and both
   commands are recorded in `authority-report.json`.

--- a/docs/compat.html
+++ b/docs/compat.html
@@ -152,10 +152,10 @@
                 </div>
             </div>
             <div class="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
-                <div class="text-sm text-slate-500 font-mono">Generated: Sun, 09 Aug 2026 20:58:42 GMT</div>
+                <div class="text-sm text-slate-500 font-mono">Generated: Tue, 11 Aug 2026 15:58:36 GMT</div>
                 <div class="inline-flex items-center gap-2 px-3 py-1 rounded bg-slate-100 text-slate-700 text-xs font-mono border border-slate-200">
                     <span class="material-icons text-sm">code</span>
-                    <span>4d0cf77b</span>
+                    <span>b8124649</span>
                 </div>
             </div>
             <div class="mt-5 flex flex-wrap gap-3 text-sm font-medium">
@@ -194,8 +194,8 @@
                 <!-- Exact Oracle Text Parity -->
                 <div class="bg-[var(--citum-surface)] rounded-xl border border-slate-200 p-6">
                     <div class="text-sm font-medium text-slate-500 mb-2">Oracle Text Parity</div>
-                    <div class="text-3xl font-bold text-slate-900">1424/3249</div>
-                    <div class="text-xs text-slate-400 mt-2">43.8% divergence-adjusted · portfolio figure is directional; per-style floors gate in CI · 34 N/A · 26 registered divergences excluded</div>
+                    <div class="text-3xl font-bold text-slate-900">1438/3249</div>
+                    <div class="text-xs text-slate-400 mt-2">44.3% divergence-adjusted · portfolio figure is directional; per-style floors gate in CI · 34 N/A · 26 registered divergences excluded</div>
                 </div>
 
                 <!-- Quality Overall -->
@@ -15404,9 +15404,9 @@
                     data-csl-reach="-1"
                     data-citation-rate="0.7755102040816326"
                     data-bibliography-rate="0.6704545454545454"
-                    data-component-rate="0.965"
+                    data-component-rate="0.967"
                     data-fidelity="0.681"
-                    data-exact-parity="0.07188160676532769"
+                    data-exact-parity="0.1014799154334038"
                     data-quality="1"
                     data-sqi-tier-rank="4">
                     <td class="px-6 py-4 text-sm font-medium text-slate-900">
@@ -15435,7 +15435,7 @@
                     </td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium badge-partial">
-                            34/473
+                            48/473
                         </span>
                         <div class="mt-1 text-[10px] text-slate-400">16 N/A</div>
                     </td>
@@ -15640,6 +15640,7 @@
                                     </div>
                                     <a class="text-xs font-semibold text-primary hover:underline" href="https://github.com/citum/citum-core/blob/main/docs/architecture/audits/2026-08-09-shortened-notes-coverage/README.md">Read the maintainer adjudication</a>
                                 </div>
+                                <p class="mt-2 text-xs leading-5 text-blue-900">Measured post-change evidence: exact parity 34/473 → 48/473 across 25 changed outputs. This measures output movement; it does not establish field causality.</p>
 
                                 <div class="mt-4 rounded-lg bg-amber-50 px-4 py-3 ring-1 ring-inset ring-amber-200">
                                     <div class="text-sm font-semibold text-amber-950">Investigation leads, not causal proof</div>
@@ -15649,7 +15650,7 @@
                                 <div class="mt-4 grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6">
                                     <div class="min-w-0 rounded-lg bg-[var(--citum-surface)] px-3 py-3 ring-1 ring-inset ring-slate-200">
                                         <div class="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Rendered</div>
-                                        <div class="mt-1 text-xl font-semibold text-slate-900">151</div>
+                                        <div class="mt-1 text-xl font-semibold text-slate-900">157</div>
                                         <div class="mt-1 text-[11px] leading-4 text-slate-500">Resolved type path</div>
                                     </div>
                                     <div class="min-w-0 rounded-lg bg-[var(--citum-surface)] px-3 py-3 ring-1 ring-inset ring-slate-200">
@@ -15664,7 +15665,7 @@
                                     </div>
                                     <div class="min-w-0 rounded-lg bg-[var(--citum-surface)] px-3 py-3 ring-1 ring-inset ring-slate-200">
                                         <div class="text-[11px] font-semibold uppercase tracking-wide text-slate-500">Uncovered</div>
-                                        <div class="mt-1 text-xl font-semibold text-slate-900">200</div>
+                                        <div class="mt-1 text-xl font-semibold text-slate-900">194</div>
                                         <div class="mt-1 text-[11px] leading-4 text-slate-500">No structural path</div>
                                     </div>
                                     <div class="min-w-0 rounded-lg bg-[var(--citum-surface)] px-3 py-3 ring-1 ring-inset ring-slate-200">
@@ -15729,10 +15730,10 @@
                                         </div>
                                         <div class="mt-3 flex flex-wrap gap-2">
                                             <span class="inline-flex items-center rounded px-2 py-1 text-[11px] font-medium bg-emerald-100 text-emerald-800">
-                                                rendered 7
+                                                rendered 8
                                             </span>
                                             <span class="inline-flex items-center rounded px-2 py-1 text-[11px] font-medium bg-amber-100 text-amber-900">
-                                                uncovered 2
+                                                uncovered 1
                                             </span>
                                         </div>
                                         <ul class="mt-3">
@@ -15775,7 +15776,7 @@
                                                     <div class="mt-1 text-[11px] text-slate-500">ITEM-1 · article-journal</div>
                                                 </div>
                                                 <div>
-                                                    <span class="inline-flex rounded px-2 py-1 text-[11px] font-medium bg-amber-100 text-amber-900">uncovered</span>
+                                                    <span class="inline-flex rounded px-2 py-1 text-[11px] font-medium bg-emerald-100 text-emerald-800">rendered</span>
 
                                                 </div>
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-1/article-journal/issue/entry</code>
@@ -15849,10 +15850,17 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">….” International Encyclopedia of Unified Science<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 2. University of Chicago Press, 1962</mark>. https://doi.org/10.1234/exampl…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">….” International Encyclopedia of Unified Science<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> 2, no. 2 (1962). University of Chicago Press</mark>. https://doi.org/10.1234/exampl…</p></div></div>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
-                                        data-audit-dispositions="rendered uncovered"
+                                        data-audit-dispositions="rendered"
                                         data-audit-comparison="mismatch"
                                         data-audit-needs-review="true">
                                         <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -15867,10 +15875,7 @@
                                         </div>
                                         <div class="mt-3 flex flex-wrap gap-2">
                                             <span class="inline-flex items-center rounded px-2 py-1 text-[11px] font-medium bg-emerald-100 text-emerald-800">
-                                                rendered 7
-                                            </span>
-                                            <span class="inline-flex items-center rounded px-2 py-1 text-[11px] font-medium bg-amber-100 text-amber-900">
-                                                uncovered 1
+                                                rendered 8
                                             </span>
                                         </div>
                                         <ul class="mt-3">
@@ -15913,7 +15918,7 @@
                                                     <div class="mt-1 text-[11px] text-slate-500">ITEM-10 · article-journal</div>
                                                 </div>
                                                 <div>
-                                                    <span class="inline-flex rounded px-2 py-1 text-[11px] font-medium bg-amber-100 text-amber-900">uncovered</span>
+                                                    <span class="inline-flex rounded px-2 py-1 text-[11px] font-medium bg-emerald-100 text-emerald-800">rendered</span>
 
                                                 </div>
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-10/article-journal/issue/entry</code>
@@ -15974,6 +15979,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Smith, Jane and Robert Williams. “Machine Learning for Climate Prediction.” Environmental Research Letters. 15, 2020: 114042. https://doi.org/10.1088/1748-9326/abc123.">Smith, Jane<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> and Robert Williams. “Machine Learning for Climate Prediction.” Environ…</mark>: 114042. https://doi.org/10.108…</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…mate Prediction.” Environmental Research Letters<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 15, 2020</mark>: 114042. https://doi.org/10.108…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…mate Prediction.” Environmental Research Letters<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> 15, no. 11 (2020)</mark>: 114042. https://doi.org/10.108…</p></div></div>
                                             </div>
                                         </details>
                                     </article>
@@ -16068,6 +16080,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Chen, Wei. Neural Networks for Natural Language Understanding. Stanford University, 2019.">Chen, Wei. <mark class="rounded bg-amber-200 px-0.5 text-amber-950">Neural Networks for Natural Language Understanding.</mark> Stanford University, 2019.</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
                                             </div>
                                         </details>
                                     </article>
@@ -16175,6 +16194,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -16267,6 +16293,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="State of JS Team. The State of JavaScript 2023, 2023. https://stateofjs.com/2023.">State of JS Team. <mark class="rounded bg-amber-200 px-0.5 text-amber-950">The State of JavaScript 2023,</mark> 2023. https://stateofjs.com/202…</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
                                             </div>
                                         </details>
                                     </article>
@@ -16366,10 +16399,17 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">Reis, Harry T. and Charles M. Judd <mark class="rounded bg-amber-200 px-0.5 text-amber-950">editors</mark>. Handbook of Research Methods i…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">Reis, Harry T. and Charles M. Judd <mark class="rounded bg-amber-200 px-0.5 text-amber-950">(eds.)</mark>. Handbook of Research Methods i…</p></div></div>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
-                                        data-audit-dispositions="rendered uncovered excluded"
+                                        data-audit-dispositions="rendered excluded"
                                         data-audit-comparison="mismatch"
                                         data-audit-needs-review="true">
                                         <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -16384,10 +16424,7 @@
                                         </div>
                                         <div class="mt-3 flex flex-wrap gap-2">
                                             <span class="inline-flex items-center rounded px-2 py-1 text-[11px] font-medium bg-emerald-100 text-emerald-800">
-                                                rendered 5
-                                            </span>
-                                            <span class="inline-flex items-center rounded px-2 py-1 text-[11px] font-medium bg-amber-100 text-amber-900">
-                                                uncovered 1
+                                                rendered 6
                                             </span>
                                             <span class="inline-flex items-center rounded px-2 py-1 text-[11px] font-medium bg-slate-100 text-slate-600">
                                                 excluded 1
@@ -16411,7 +16448,7 @@
                                                     <div class="mt-1 text-[11px] text-slate-500">ITEM-15 · article-journal</div>
                                                 </div>
                                                 <div>
-                                                    <span class="inline-flex rounded px-2 py-1 text-[11px] font-medium bg-amber-100 text-amber-900">uncovered</span>
+                                                    <span class="inline-flex rounded px-2 py-1 text-[11px] font-medium bg-emerald-100 text-emerald-800">rendered</span>
 
                                                 </div>
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-15/article-journal/issue/entry</code>
@@ -16483,6 +16520,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="“The Role of Theory in Research.” Journal of Theoretical Psychology. 28, 2018: 201–15.">… in Research.” Journal of Theoretical Psychology<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 28, 2018</mark>: 201–15.</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">… in Research.” Journal of Theoretical Psychology<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 28, 2018</mark>: 201–15.</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">… in Research.” Journal of Theoretical Psychology<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> 28, no. 3 (2018)</mark>: 201–15.</p></div></div>
                                             </div>
                                         </details>
                                     </article>
@@ -16577,6 +16621,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Rodriguez, Maria. “Major Breakthrough in Quantum Computing Announced.” The New York Times, 2024.">…r Breakthrough in Quantum Computing Announced.” <mark class="rounded bg-amber-200 px-0.5 text-amber-950">The New York Times</mark>, 2024.</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
                                             </div>
                                         </details>
                                     </article>
@@ -16695,6 +16746,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -16808,6 +16866,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -16913,6 +16978,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -16994,6 +17066,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-2/book/title/entry</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -17099,6 +17178,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -17191,6 +17277,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Johnson, David and Sarah Lee. Method for Efficient Data Compression, issued Jul 13, 2021.">Johnson, David<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> and Sarah Lee. Method for Efficient Data Compression</mark>, issued Jul 13, 2021.</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…ethod for Efficient Data Compression, issued Jul<mark class="rounded bg-amber-200 px-0.5 text-amber-950"></mark> 13, 2021.</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…ethod for Efficient Data Compression, issued Jul<mark class="rounded bg-amber-200 px-0.5 text-amber-950">y</mark> 13, 2021.</p></div></div>
                                             </div>
                                         </details>
                                     </article>
@@ -17298,6 +17391,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -17403,6 +17503,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -17506,6 +17613,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Bengio, Yoshua. The Future of Artificial Intelligence, 2023. https://example.com/interview.">Bengio, Yoshua. <mark class="rounded bg-amber-200 px-0.5 text-amber-950">The Future of Artificial Intelligence</mark>, 2023. https://example.com/inte…</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
                                             </div>
                                         </details>
                                     </article>
@@ -17627,6 +17741,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -17722,6 +17843,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-26/book/title/entry</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -17841,6 +17969,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -17922,7 +18057,7 @@
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
-                                        data-audit-dispositions="rendered uncovered"
+                                        data-audit-dispositions="rendered"
                                         data-audit-comparison="mismatch"
                                         data-audit-needs-review="true">
                                         <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -17937,10 +18072,7 @@
                                         </div>
                                         <div class="mt-3 flex flex-wrap gap-2">
                                             <span class="inline-flex items-center rounded px-2 py-1 text-[11px] font-medium bg-emerald-100 text-emerald-800">
-                                                rendered 7
-                                            </span>
-                                            <span class="inline-flex items-center rounded px-2 py-1 text-[11px] font-medium bg-amber-100 text-amber-900">
-                                                uncovered 1
+                                                rendered 8
                                             </span>
                                         </div>
                                         <ul class="mt-3">
@@ -17983,7 +18115,7 @@
                                                     <div class="mt-1 text-[11px] text-slate-500">ITEM-29 · article-journal</div>
                                                 </div>
                                                 <div>
-                                                    <span class="inline-flex rounded px-2 py-1 text-[11px] font-medium bg-amber-100 text-amber-900">uncovered</span>
+                                                    <span class="inline-flex rounded px-2 py-1 text-[11px] font-medium bg-emerald-100 text-emerald-800">rendered</span>
 
                                                 </div>
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-29/article-journal/issue/entry</code>
@@ -18044,6 +18176,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Smith, John, Alice Lee, Priya Kumar, and Ming Zhou. “Adaptive Climate Risk Modeling in Coastal Cities.” Journal of Climate Analytics. 12, 2021: 101–19. https://doi.org/10.5555/jca.2021.12.2.101.">…in Coastal Cities.” Journal of Climate Analytics<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 12, 2021</mark>: 101–19. https://doi.org/10.555…</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…in Coastal Cities.” Journal of Climate Analytics<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 12, 2021</mark>: 101–19. https://doi.org/10.555…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…in Coastal Cities.” Journal of Climate Analytics<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> 12, no. 2 (2021)</mark>: 101–19. https://doi.org/10.555…</p></div></div>
                                             </div>
                                         </details>
                                     </article>
@@ -18159,10 +18298,17 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…io, and Geoffrey Hinton. “Deep Learning.” Nature<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 521, 2015</mark>: 436–44. https://doi.org/10.103…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…io, and Geoffrey Hinton. “Deep Learning.” Nature<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> 521 (2015)</mark>: 436–44. https://doi.org/10.103…</p></div></div>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
-                                        data-audit-dispositions="rendered uncovered"
+                                        data-audit-dispositions="rendered"
                                         data-audit-comparison="mismatch"
                                         data-audit-needs-review="true">
                                         <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -18177,10 +18323,7 @@
                                         </div>
                                         <div class="mt-3 flex flex-wrap gap-2">
                                             <span class="inline-flex items-center rounded px-2 py-1 text-[11px] font-medium bg-emerald-100 text-emerald-800">
-                                                rendered 7
-                                            </span>
-                                            <span class="inline-flex items-center rounded px-2 py-1 text-[11px] font-medium bg-amber-100 text-amber-900">
-                                                uncovered 1
+                                                rendered 8
                                             </span>
                                         </div>
                                         <ul class="mt-3">
@@ -18223,7 +18366,7 @@
                                                     <div class="mt-1 text-[11px] text-slate-500">ITEM-30 · article-journal</div>
                                                 </div>
                                                 <div>
-                                                    <span class="inline-flex rounded px-2 py-1 text-[11px] font-medium bg-amber-100 text-amber-900">uncovered</span>
+                                                    <span class="inline-flex rounded px-2 py-1 text-[11px] font-medium bg-emerald-100 text-emerald-800">rendered</span>
 
                                                 </div>
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-30/article-journal/issue/entry</code>
@@ -18284,6 +18427,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Smith, John, Alice Lee, Bao Nguyen, and Ravi Patel. “Adaptive Climate Risk Modeling for Inland Regions.” Journal of Climate Analytics. 12, 2021: 201–19. https://doi.org/10.5555/jca.2021.12.3.201.">…or Inland Regions.” Journal of Climate Analytics<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 12, 2021</mark>: 201–19. https://doi.org/10.555…</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…or Inland Regions.” Journal of Climate Analytics<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 12, 2021</mark>: 201–19. https://doi.org/10.555…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…or Inland Regions.” Journal of Climate Analytics<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> 12, no. 3 (2021)</mark>: 201–19. https://doi.org/10.555…</p></div></div>
                                             </div>
                                         </details>
                                     </article>
@@ -18399,6 +18549,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…e Attribution.” Annual Review of Climate Science<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 4, 2019</mark>: 55–80. https://doi.org/10.5555…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…e Attribution.” Annual Review of Climate Science<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> 4 (2019)</mark>: 55–80. https://doi.org/10.5555…</p></div></div>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -18512,6 +18669,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…e Attribution.” Annual Review of Climate Science<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 4, 2019</mark>: 81–104. https://doi.org/10.555…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…e Attribution.” Annual Review of Climate Science<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> 4 (2019)</mark>: 81–104. https://doi.org/10.555…</p></div></div>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -18582,6 +18746,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-33/book/title/entry</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -18674,6 +18845,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-34/manuscript/title/entry</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -18776,6 +18954,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…ative Methods in Sociology.” Sociological Review<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 68, 2020</mark>: 23–45.</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…ative Methods in Sociology.” Sociological Review<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> 68 (2020)</mark>: 23–45.</p></div></div>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -18876,6 +19061,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Johnson, Brian. “Qualitative Methods in Sociology.” Sociological Review. 68, 2020: 89–112.">…ative Methods in Sociology.” Sociological Review<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 68, 2020</mark>: 89–112.</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…ative Methods in Sociology.” Sociological Review<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 68, 2020</mark>: 89–112.</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…ative Methods in Sociology.” Sociological Review<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> 68 (2020)</mark>: 89–112.</p></div></div>
                                             </div>
                                         </details>
                                     </article>
@@ -18991,6 +19183,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…eat Island Mitigation Strategies.” Urban Climate<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 15, 2022</mark>: 1–18. https://doi.org/10.5555/…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…eat Island Mitigation Strategies.” Urban Climate<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> 15 (2022)</mark>: 1–18. https://doi.org/10.5555/…</p></div></div>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -19102,6 +19301,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Chen, Wei. “Urban Heat Island Measurement Techniques.” Urban Climate. 18, 2024: 45–62. https://doi.org/10.5555/uc.2024.18.45.">…at Island Measurement Techniques.” Urban Climate<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 18, 2024</mark>: 45–62. https://doi.org/10.5555…</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…at Island Measurement Techniques.” Urban Climate<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 18, 2024</mark>: 45–62. https://doi.org/10.5555…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…at Island Measurement Techniques.” Urban Climate<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> 18 (2024)</mark>: 45–62. https://doi.org/10.5555…</p></div></div>
                                             </div>
                                         </details>
                                     </article>
@@ -19217,6 +19423,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -19298,6 +19511,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-5/report/title/entry</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -19406,6 +19626,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -19508,10 +19735,17 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…aswani, Ashish, Noam Shazeer, Niki Parmar, et al<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> “Attention Is All You Need.” Advances in Neural Information Processing …</mark>: 5998–6008.</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…aswani, Ashish, Noam Shazeer, Niki Parmar, et al<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. “Attention Is All You Need.” Advances in Neural Information Processing…</mark>: 5998–6008.</p></div></div>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
-                                        data-audit-dispositions="rendered uncovered"
+                                        data-audit-dispositions="rendered"
                                         data-audit-comparison="mismatch"
                                         data-audit-needs-review="true">
                                         <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -19526,10 +19760,7 @@
                                         </div>
                                         <div class="mt-3 flex flex-wrap gap-2">
                                             <span class="inline-flex items-center rounded px-2 py-1 text-[11px] font-medium bg-emerald-100 text-emerald-800">
-                                                rendered 7
-                                            </span>
-                                            <span class="inline-flex items-center rounded px-2 py-1 text-[11px] font-medium bg-amber-100 text-amber-900">
-                                                uncovered 1
+                                                rendered 8
                                             </span>
                                         </div>
                                         <ul class="mt-3">
@@ -19572,7 +19803,7 @@
                                                     <div class="mt-1 text-[11px] text-slate-500">ITEM-8 · article-journal</div>
                                                 </div>
                                                 <div>
-                                                    <span class="inline-flex rounded px-2 py-1 text-[11px] font-medium bg-amber-100 text-amber-900">uncovered</span>
+                                                    <span class="inline-flex rounded px-2 py-1 text-[11px] font-medium bg-emerald-100 text-emerald-800">rendered</span>
 
                                                 </div>
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-8/article-journal/issue/entry</code>
@@ -19633,6 +19864,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Kuhn, Thomas S. “Scientific Paradigms and Normal Science.” Philosophy of Science. 37, 1970: 1–13. https://doi.org/10.1086/288273.">…digms and Normal Science.” Philosophy of Science<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 37, 1970</mark>: 1–13. https://doi.org/10.1086/…</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…digms and Normal Science.” Philosophy of Science<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 37, 1970</mark>: 1–13. https://doi.org/10.1086/…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…digms and Normal Science.” Philosophy of Science<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> 37, no. 1 (1970)</mark>: 1–13. https://doi.org/10.1086/…</p></div></div>
                                             </div>
                                         </details>
                                     </article>
@@ -19746,6 +19984,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Smith, John and Mary Anderson. “Climate Change and Extreme Weather Events.” Nature Climate Change. 10, 2020: 850–55. https://doi.org/10.1038/s41558-020-0871-4.">Smith, John<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> and Mary Anderson. “Climate Change and Extreme Weather Events.” Nature …</mark>: 850–55. https://doi.org/10.103…</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…d Extreme Weather Events.” Nature Climate Change<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 10, 2020</mark>: 850–55. https://doi.org/10.103…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…d Extreme Weather Events.” Nature Climate Change<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> 10 (2020)</mark>: 850–55. https://doi.org/10.103…</p></div></div>
                                             </div>
                                         </details>
                                     </article>
@@ -19889,6 +20134,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -20003,6 +20255,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Merriam-Webster.com Dictionary. “Self-report.” Accessed Jul 12, 2019. https://www.merriam-webster.com/dictionary/self-report.">Merriam-Webster.<mark class="rounded bg-amber-200 px-0.5 text-amber-950">c</mark>om Dictionary. “Self-report.” Ac…</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">…ster.com Dictionary. “Self-report.” Accessed Jul<mark class="rounded bg-amber-200 px-0.5 text-amber-950"></mark> 12, 2019. https://www.merriam-w…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">…ster.com Dictionary. “Self-report.” Accessed Jul<mark class="rounded bg-amber-200 px-0.5 text-amber-950">y</mark> 12, 2019. https://www.merriam-w…</p></div></div>
                                             </div>
                                         </details>
                                     </article>
@@ -20133,6 +20392,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Strengthening the federal student loan program for borrowers, 2014. https://www.help.senate.gov/hearings/strengthening-the-federal-student-loan-program-for-borrowers.">…g the federal student loan program for borrowers<mark class="rounded bg-amber-200 px-0.5 text-amber-950">, 2014</mark>. https://www.help.senate.gov/he…</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
                                             </div>
                                         </details>
                                     </article>
@@ -20274,6 +20540,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Every Student Succeeds Act. 20, 2015. https://www.congress.gov/114/plaws/publ95/PLAW-114publ95.pdf.">Every Student Succeeds Act<mark class="rounded bg-amber-200 px-0.5 text-amber-950">. 20, 2015</mark>. https://www.congress.gov/114/p…</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
                                             </div>
                                         </details>
                                     </article>
@@ -20428,6 +20701,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -20580,6 +20860,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -20719,6 +21006,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Tactile Labs. Latero tactile display, 2015. http://tactilelabs.com/products/haptics/latero-tactile-display/.">Tactile Labs. Latero <mark class="rounded bg-amber-200 px-0.5 text-amber-950">tactile display, 2015</mark>. http://tactilelabs.com/product…</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
                                             </div>
                                         </details>
                                     </article>
@@ -20953,6 +21247,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="bibliography"
@@ -21100,6 +21401,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="U.K., U.S., and U.S.S.R. Treaty Banning Nuclear Weapon Tests in the Atmosphere, in Outer Space and Under Water. U.S.T.. 14, 1963: 1313."><mark class="rounded bg-amber-200 px-0.5 text-amber-950">U.K., U.S., and U.S.S.R. Treaty Banning Nuclear Weapon Tests in the Atmo…</mark> 1313.</p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
                                             </div>
                                         </details>
                                     </article>
@@ -21317,6 +21625,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">Smith, Lee, Kumar, et al<mark class="rounded bg-amber-200 px-0.5 text-amber-950">, “Adaptive Climate Risk Modeling in Coastal Cities”; Smith, Lee, Nguyen…</mark>, “Adaptive Climate Risk Modelin…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">Smith, Lee, Kumar, et al<mark class="rounded bg-amber-200 px-0.5 text-amber-950">., “Adaptive Climate Risk Modeling in Coastal Cities”; Smith, Lee, Nguye…</mark>, “Adaptive Climate Risk Modelin…</p></div></div>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -21510,6 +21825,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -21638,6 +21960,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-1/article-journal/volume/single-item-1%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -21752,6 +22081,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-10/article-journal/volume/single-item-10%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -21846,6 +22182,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -21938,6 +22281,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-12/paper-conference/title/single-item-12%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">Mikolov et al<mark class="rounded bg-amber-200 px-0.5 text-amber-950"></mark>, “Distributed Representations o…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">Mikolov et al<mark class="rounded bg-amber-200 px-0.5 text-amber-950">.</mark>, “Distributed Representations o…</p></div></div>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -22032,6 +22382,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -22116,6 +22473,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-14/book/title/single-item-14%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -22222,6 +22586,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-15/article-journal/volume/single-item-15%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -22303,6 +22674,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-16/article-newspaper/title/single-item-16%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -22406,6 +22784,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-17/article-magazine/volume/single-item-17%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -22509,6 +22894,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-18/entry-encyclopedia/volume/single-item-18%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -22614,6 +23006,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -22698,6 +23097,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-2/book/title/single-item-2%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -22803,6 +23209,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -22884,6 +23297,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-21/patent/title/single-item-21%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -22976,6 +23396,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-22/motion-picture/title/single-item-22%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -23081,6 +23508,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -23184,6 +23618,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Bengio, The Future of Artificial Intelligence.">Bengio, <mark class="rounded bg-amber-200 px-0.5 text-amber-950">The Future of Artificial Intelligence.</mark></p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
                                             </div>
                                         </details>
                                     </article>
@@ -23295,6 +23736,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-25/book/translator/single-item-25%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -23393,6 +23841,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-26/book/title/single-item-26%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -23499,6 +23954,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-27/report/title/single-item-27%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -23591,6 +24053,13 @@
                                                     <div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-slate-500">Citum</div>
                                                     <p class="audit-observation-id font-mono text-xs leading-5 text-slate-700" title="Smith., Discussion on Citum Schema Design."><mark class="rounded bg-amber-200 px-0.5 text-amber-950">Smith., Discussion on Citum Schema Design.</mark></p>
                                                 </div>
+                                            </div>
+                                        </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">Smith.<mark class="rounded bg-amber-200 px-0.5 text-amber-950"></mark>, Discussion on Citum Schema Des…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">Smith.<mark class="rounded bg-amber-200 px-0.5 text-amber-950"> </mark>, Discussion on Citum Schema Des…</p></div></div>
                                             </div>
                                         </details>
                                     </article>
@@ -23720,6 +24189,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">Smith, Lee, Kumar, et al<mark class="rounded bg-amber-200 px-0.5 text-amber-950"></mark>, “Adaptive Climate Risk Modelin…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">Smith, Lee, Kumar, et al<mark class="rounded bg-amber-200 px-0.5 text-amber-950">.</mark>, “Adaptive Climate Risk Modelin…</p></div></div>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -23823,6 +24299,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-3/article-journal/volume/single-item-3%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">LeCun et al<mark class="rounded bg-amber-200 px-0.5 text-amber-950"></mark>, “Deep Learning.”</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">LeCun et al<mark class="rounded bg-amber-200 px-0.5 text-amber-950">.</mark>, “Deep Learning.”</p></div></div>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -23950,6 +24433,13 @@
                                                 </div>
                                             </div>
                                         </details>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before mismatch · after mismatch</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">Smith, Lee, Nguyen, et al<mark class="rounded bg-amber-200 px-0.5 text-amber-950"></mark>, “Adaptive Climate Risk Modelin…</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">Smith, Lee, Nguyen, et al<mark class="rounded bg-amber-200 px-0.5 text-amber-950">.</mark>, “Adaptive Climate Risk Modelin…</p></div></div>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -24053,6 +24543,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-31/article-journal/volume/single-item-31%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -24156,6 +24653,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-32/article-journal/volume/single-item-32%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -24259,6 +24763,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-4/chapter/title/single-item-4%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -24343,6 +24854,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-5/report/title/single-item-5%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -24438,6 +24956,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-6/book/title/single-item-6%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -24530,6 +25055,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-7/article-journal/volume/single-item-7%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">Vaswani et al<mark class="rounded bg-amber-200 px-0.5 text-amber-950"></mark>, “Attention Is All You Need.”</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">Vaswani et al<mark class="rounded bg-amber-200 px-0.5 text-amber-950">.</mark>, “Attention Is All You Need.”</p></div></div>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -24644,6 +25176,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-8/article-journal/volume/single-item-8%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
                                         data-audit-surface="citation"
@@ -24747,6 +25286,13 @@
                                                 <code class="audit-observation-id min-w-0 text-[11px] leading-4 text-slate-500" title="Stable observation ID">chicago-shortened-notes-bibliography/citation/citations-note-expanded/ITEM-9/article-journal/volume/single-item-9%3A1</code>
                                             </li>
                                         </ul>
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before exact · after exact</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                <p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>
+                                            </div>
+                                        </details>
                                     </article>
                                 </div>
                             </section>

--- a/scripts/check-style-coverage-audits.test.js
+++ b/scripts/check-style-coverage-audits.test.js
@@ -177,6 +177,23 @@ test('coverage audit view groups fields by stable output identity with collapsed
   assert.equal(view.adjudicationRecord.href.endsWith('.json'), false);
 });
 
+test('coverage audit view measures current before/after output evidence separately from the packet', () => {
+  const { manifest, packet } = baselineFixture();
+  validateCoveragePacket(packet, registration(), manifest);
+  const report = readJson('report.json');
+  const view = buildCoverageAuditView(packet, registration(), report, report);
+  assert.equal(view.postChangeEvidence.status, 'measured');
+  assert.deepEqual(view.postChangeEvidence.beforeExactParity, view.postChangeEvidence.afterExactParity);
+  assert.equal(view.postChangeEvidence.changedOutputs.length, 0);
+  assert.equal(view.outputGroups.every((group) => group.postChangeEvidence), true);
+
+  const changedReport = structuredClone(report);
+  changedReport.styles[0].oracleDetail[0].exactCitum += ' changed';
+  const changedView = buildCoverageAuditView(packet, registration(), report, changedReport);
+  assert.equal(changedView.postChangeEvidence.changedOutputs.length, 1);
+  assert.equal(changedView.postChangeEvidence.changedOutputs[0].surface, 'bibliography');
+});
+
 test('status lookup reports unregistered styles without selecting arbitrary audit directories', () => {
   const provenance = { coverage_audits: [registration()] };
 

--- a/scripts/lib/style-coverage-audits.js
+++ b/scripts/lib/style-coverage-audits.js
@@ -221,13 +221,22 @@ function entryMap(entries, evidenceRunId, surface) {
   return result;
 }
 
-function buildCoverageAuditView(packet, registration, authorityReport) {
+function buildCoverageAuditView(packet, registration, authorityReport, currentReport = null) {
   const styleReport = selectAuthorityStyle(authorityReport, registration.style_id);
+  const currentStyleReport = currentReport
+    ? selectAuthorityStyle(currentReport, registration.style_id)
+    : null;
   const evidenceRunId = packet.auditManifest.authority.evidenceRunId;
   const evidence = {
     citation: entryMap(styleReport.citationEntries, evidenceRunId, 'citation'),
     bibliography: entryMap(styleReport.oracleDetail, evidenceRunId, 'bibliography'),
   };
+  const currentEvidence = currentStyleReport
+    ? {
+      citation: entryMap(currentStyleReport.citationEntries, evidenceRunId, 'citation'),
+      bibliography: entryMap(currentStyleReport.oracleDetail, evidenceRunId, 'bibliography'),
+    }
+    : null;
   const groups = new Map();
 
   for (const observation of packet.observations) {
@@ -260,6 +269,18 @@ function buildCoverageAuditView(packet, registration, authorityReport) {
           }
           : null,
       };
+      const currentEntry = currentEvidence?.[observation.surface].get(outputId) || null;
+      if (currentEntry && authorityEntry) {
+        const beforeText = authorityEntry.exactCitum ?? authorityEntry.citum ?? authorityEntry.actual ?? '';
+        const afterText = currentEntry.exactCitum ?? currentEntry.citum ?? currentEntry.actual ?? '';
+        group.postChangeEvidence = {
+          beforeExact: authorityEntry.exactMatch === true,
+          afterExact: currentEntry.exactMatch === true,
+          changed: beforeText !== afterText,
+          beforeCitum: beforeText,
+          afterCitum: afterText,
+        };
+      }
       groups.set(key, group);
     }
 
@@ -285,6 +306,14 @@ function buildCoverageAuditView(packet, registration, authorityReport) {
   const outputGroups = [...groups.values()].sort((left, right) => (
     left.surface.localeCompare(right.surface) || left.outputId.localeCompare(right.outputId)
   ));
+  const changedOutputs = outputGroups
+    .filter((group) => group.postChangeEvidence?.changed)
+    .map((group) => ({
+      surface: group.surface,
+      outputId: group.outputId,
+      beforeExact: group.postChangeEvidence.beforeExact,
+      afterExact: group.postChangeEvidence.afterExact,
+    }));
   return {
     schema: REPORT_AUDIT_SCHEMA,
     status: 'current',
@@ -297,6 +326,16 @@ function buildCoverageAuditView(packet, registration, authorityReport) {
       href: registration.adjudication_href,
     },
     summary: packet.summary,
+    postChangeEvidence: currentStyleReport
+      ? {
+        schema: 'citum.report-coverage-audit-post-change/v1',
+        status: 'measured',
+        beforeExactParity: styleReport.exactParity,
+        afterExactParity: currentStyleReport.exactParity,
+        changedOutputs,
+        unavailableOutputs: outputGroups.filter((group) => !group.postChangeEvidence).length,
+      }
+      : null,
     filters: {
       surfaces: ['bibliography', 'citation'],
       dispositions: ['rendered', 'fallback', 'suppressed', 'uncovered', 'excluded'],
@@ -306,7 +345,7 @@ function buildCoverageAuditView(packet, registration, authorityReport) {
   };
 }
 
-function loadCoverageAuditViews(provenanceConfig, selectedStyles = null) {
+function loadCoverageAuditViews(provenanceConfig, selectedStyles = null, currentReports = null) {
   const selected = selectedStyles ? new Set(selectedStyles) : null;
   const views = new Map();
   for (const registration of provenanceConfig.coverage_audits || []) {
@@ -316,7 +355,8 @@ function loadCoverageAuditViews(provenanceConfig, selectedStyles = null) {
     const packet = readData(resolveRepoPath(registration.packet));
     validateCoveragePacket(packet, registration, manifest);
     const authorityReport = readData(resolveRepoPath(manifest.authority.report.path));
-    views.set(registration.style_id, buildCoverageAuditView(packet, registration, authorityReport));
+    const currentReport = currentReports?.get(registration.style_id) || null;
+    views.set(registration.style_id, buildCoverageAuditView(packet, registration, authorityReport, currentReport));
   }
   return views;
 }

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -2908,11 +2908,6 @@ async function generateReport(options) {
   const runtime = createReportRuntime(options);
   const preflightIssues = preflightSnapshots(coreStyles, verificationPolicy, stylesDir);
   const noteStyles = buildNoteStyleLookup();
-  const coverageAuditViews = loadCoverageAuditViews(
-    provenanceConfig,
-    coreStyles.map((style) => style.name)
-  );
-
   if (!runtime.allowLiveFallback && preflightIssues.length > 0) {
     for (const issue of preflightIssues) {
       process.stderr.write(`[snapshot ${issue.status}] ${issue.style}: ${issue.message}\n`);
@@ -2933,6 +2928,12 @@ async function generateReport(options) {
     }
     return result;
   });
+
+  const coverageAuditViews = loadCoverageAuditViews(
+    provenanceConfig,
+    coreStyles.map((style) => style.name),
+    new Map(styleJobs.map((job) => [job.styleRecord.name, job.styleRecord]))
+  );
 
   const styles = styleJobs
     .map((job) => {
@@ -4051,6 +4052,22 @@ function renderCoverageAuditExplorer(style) {
                                         </details>`;
       })()
       : '';
+    const postChangeEvidence = group.postChangeEvidence
+      ? (() => {
+        const evidence = group.postChangeEvidence;
+        const diff = evidence.changed
+          ? renderInlineTextDifference(evidence.beforeCitum, evidence.afterCitum)
+          : null;
+        return `
+                                        <details class="mt-3 rounded-lg bg-blue-50/70 ring-1 ring-inset ring-blue-200">
+                                            <summary class="cursor-pointer px-3 py-2 text-xs font-semibold text-blue-950">Measured post-change evidence · before ${evidence.beforeExact ? 'exact' : 'mismatch'} · after ${evidence.afterExact ? 'exact' : 'mismatch'}</summary>
+                                            <div class="px-3 pb-3 pt-1">
+                                                <p class="text-[11px] leading-4 text-blue-900">This is a measured rendering delta, not proof that an uncovered field caused the mismatch.</p>
+                                                ${diff ? `<div class="mt-2 grid min-w-0 gap-3 lg:grid-cols-2"><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">Before</div><p class="font-mono text-xs leading-5 text-blue-950">${diff.benchmark}</p></div><div class="min-w-0"><div class="mb-1 text-[11px] font-semibold uppercase tracking-wide text-blue-800">After</div><p class="font-mono text-xs leading-5 text-blue-950">${diff.citum}</p></div></div>` : '<p class="mt-2 text-xs text-blue-900">The rendered Citum text is unchanged.</p>'}
+                                            </div>
+                                        </details>`;
+      })()
+      : '';
 
     return `
                                     <article class="audit-output rounded-xl bg-[var(--citum-surface)] p-4 ring-1 ring-inset ring-slate-200"
@@ -4071,7 +4088,7 @@ function renderCoverageAuditExplorer(style) {
                                         <div class="mt-3 flex flex-wrap gap-2">${dispositionBadges}
                                         </div>
                                         <ul class="mt-3">${fields}
-                                        </ul>${exactDifference}
+                                        </ul>${exactDifference}${postChangeEvidence}
                                     </article>`;
   }).join('');
 
@@ -4084,6 +4101,7 @@ function renderCoverageAuditExplorer(style) {
                                     </div>
                                     <a class="text-xs font-semibold text-primary hover:underline" href="${escapeHtml(audit.adjudicationRecord.href)}">${escapeHtml(audit.adjudicationRecord.label)}</a>
                                 </div>
+                                ${audit.postChangeEvidence?.status === 'measured' ? `<p class="mt-2 text-xs leading-5 text-blue-900">Measured post-change evidence: exact parity ${audit.postChangeEvidence.beforeExactParity.passed}/${audit.postChangeEvidence.beforeExactParity.total} → ${audit.postChangeEvidence.afterExactParity.passed}/${audit.postChangeEvidence.afterExactParity.total} across ${audit.postChangeEvidence.changedOutputs.length} changed outputs. This measures output movement; it does not establish field causality.</p>` : ''}
 
                                 <div class="mt-4 rounded-lg bg-amber-50 px-4 py-3 ring-1 ring-inset ring-amber-200">
                                     <div class="text-sm font-semibold text-amber-950">Investigation leads, not causal proof</div>

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const yaml = require('js-yaml');
 
 const {
   validateVerificationPolicy,
@@ -1275,9 +1276,20 @@ test('generateHtml groups families and exposes unadjudicated oracle text drift',
 
 test('generateHtml replaces registered diff tables with the accessible audit-first explorer', () => {
   const provenance = loadReportProvenance();
+  const auditManifest = yaml.load(fs.readFileSync(path.join(
+    projectRoot,
+    'docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml'
+  ), 'utf8'));
+  const authorityReport = JSON.parse(fs.readFileSync(path.join(
+    projectRoot,
+    auditManifest.authority.report.path
+  ), 'utf8'));
   const coverageAudit = loadCoverageAuditViews(
     provenance,
-    ['chicago-shortened-notes-bibliography']
+    ['chicago-shortened-notes-bibliography'],
+    new Map([
+      ['chicago-shortened-notes-bibliography', authorityReport],
+    ])
   ).get('chicago-shortened-notes-bibliography');
   const html = generateHtml({
     generated: '2026-08-09T00:00:00.000Z',
@@ -1367,6 +1379,8 @@ test('generateHtml replaces registered diff tables with the accessible audit-fir
   assert.match(html, /text-base sm:text-sm/);
   assert.match(html, /chicago-shortened-notes-bibliography\/bibliography\/references-expanded\/ITEM-1\/article-journal\/issue\/entry/);
   assert.match(html, /<details[^>]*>[\s\S]*Exact Oracle\/Citum difference/);
+  assert.match(html, /Measured post-change evidence/);
+  assert.match(html, /before exact/);
   assert.doesNotMatch(html, /<details[^>]*open/);
   assert.match(html, /Supplemental benchmark remains visible/);
   assert.match(html, /Read the maintainer adjudication/);
@@ -1411,6 +1425,9 @@ test('generateReport exposes the registered coverage audit on its corresponding 
   assert.equal(audit.summary.joinedExactParity.passed, 28);
   assert.equal(audit.outputGroups.length, 81);
   assert.equal(audit.outputGroups.some((group) => group.exactEvidence), true);
+  assert.equal(audit.postChangeEvidence.status, 'measured');
+  assert.equal(audit.postChangeEvidence.beforeExactParity.passed, 34);
+  assert.equal(audit.postChangeEvidence.afterExactParity.passed, 48);
 });
 
 test('generateReport supports multi-style selected reports', {


### PR DESCRIPTION
## Summary

- Add optional report-time post-change rendering evidence to registered coverage audits.
- Join current source-built Citum output to the existing stable `surface/outputId` groups.
- Keep packet schema v1, structural dispositions, freshness checks, and non-causal wording unchanged.
- Regenerate `docs/compat.html` and document the measured Chicago before/after result.

## Evidence model

Registered audit views now expose a separate `postChangeEvidence` section with:

- authority-run exact parity;
- current-run exact parity;
- changed output identities and before/after exact state;
- collapsed per-output Citum text evidence.

This is measured output movement, not proof that an uncovered field caused a mismatch.
Unaudited styles retain the existing report behavior.

## Verification

- 74 targeted report/coverage tests pass, including stable-ID joins, changed-output detection, missing evidence, and accessible collapsed HTML.
- Coverage audit freshness passes byte-for-byte.
- Testing infrastructure, strict frontmatter, bean hygiene, and diff checks pass.
- The Chicago report measures `34/473` → `48/473` exact parity; structural packet counts remain separate (`157` rendered / `194` uncovered).

Stacked directly above PR #1166.
