### PR TITLE
fix(styles): improve Chicago shortened-notes parity

### DIFF
--- a/.beans/csl26-gukd--tune-chicago-shortened-notes-article-journal-issue.md
+++ b/.beans/csl26-gukd--tune-chicago-shortened-notes-article-journal-issue.md
@@ -5,7 +5,7 @@ status: in-progress
 type: task
 priority: high
 created_at: 2026-08-11T15:03:58Z
-updated_at: 2026-08-11T15:15:52Z
+updated_at: 2026-08-11T17:25:07Z
 parent: csl26-h7oc
 ---
 
@@ -18,6 +18,10 @@ Target cluster: article-journal bibliography issue/year grammar identified by th
 - [x] Article-journal issue/year output matches the authority cluster without regressing fidelity.
 - [x] Exact parity does not regress and the shared-ancestor portfolio floor is checked.
 - [x] Coverage packet is regenerated current and style QA approves.
-- [ ] Final stacked PR is opened above PR #1162.
+- [x] Final stacked PR #1168 is opened above PR #1162.
 
 \nEvidence: article-journal exact parity improved 34/473 → 48/473; fidelity held at 0.681; SQI remained 1. The registered packet stayed current after regeneration, with rendered 151 → 157 and uncovered 200 → 194 observations; joined audit parity remained 28/80 because the packet is structural/leaf-scoped evidence.
+
+
+
+Final pass evidence: explicit Chicago title casing across inherited bibliography variants plus legal-case and article-magazine variants raised exact parity 48/473 → 60/473, fidelity 0.681 → 0.691, bibliography fidelity count 295/440 → 300/440, and SQI remained 1. Full-portfolio report confirmed no sibling embedded-style floor regressions.

--- a/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
@@ -43,7 +43,7 @@ options:
       and-others: et-al
       delimiter-precedes-last: contextual
     demote-non-dropping-particle: display-and-sort
-  titles: humanities
+  titles: chicago
   page-range-format: chicago16
   punctuation-in-quote: true
 citation:
@@ -129,6 +129,27 @@ bibliography:
     - variable: doi
       prefix: https://doi.org/
     - variable: url
+    article-magazine:
+    - contributor: author
+      form: long
+      name-order: family-first-only
+      shorten:
+        min: 8
+        use-first: 3
+    - title: primary
+      text-case: title
+    - title: parent-serial
+      prefix: ", "
+    - number: volume
+      prefix: " "
+    - number: issue
+      label-form: short
+      prefix: ", "
+    - date: issued
+      form: year
+      prefix: ", "
+    - variable: url
+      prefix: ", "
     book:
     - contributor: author
       form: long
@@ -137,6 +158,7 @@ bibliography:
         min: 8
         use-first: 3
     - title: primary
+      text-case: title
     - contributor: translator
       form: verb
       prefix: ". "
@@ -152,6 +174,7 @@ bibliography:
         min: 8
         use-first: 3
     - title: primary
+      text-case: title
       prefix: ". "
       wrap:
         punctuation: quotes
@@ -183,6 +206,7 @@ bibliography:
         min: 8
         use-first: 3
     - title: primary
+      text-case: title
       prefix: ". "
       wrap:
         punctuation: quotes
@@ -199,6 +223,7 @@ bibliography:
     - title: parent-monograph
       text-case: title
     - title: primary
+      text-case: title
       prefix: ". "
       wrap:
         punctuation: quotes
@@ -216,6 +241,29 @@ bibliography:
       prefix: ". "
     - variable: url
       prefix: ". "
+    legal-case:
+    - contributor: author
+      form: long
+      name-order: family-first-only
+      shorten:
+        min: 8
+        use-first: 3
+    - title: primary
+      text-case: title
+    - group:
+      - number: volume
+      - variable: reporter
+      - number: pages
+      delimiter: " "
+      prefix: ", "
+    - group:
+      - variable: authority
+      - date: issued
+        form: year
+      delimiter: " "
+      wrap:
+        punctuation: parentheses
+      prefix: " "
     personal-communication: []
     patent:
     - contributor: author

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml
@@ -17,7 +17,7 @@ style:
       sha256: 5ee7afd5c74169d8882747d8ab6ede8b84aa12cd1760e1f0f3f544198cd1be94
     - id: chicago-shortened-notes-bibliography-core
       path: crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
-      sha256: 42de0990c1d73b46884cebbadd73d81125b4a88e8f4bb7d8a9fd17c1748fd29a
+      sha256: dfc023a5388f31483039ff348b9cf2741110894935ceea4212b3ed04c258dc62
     - id: chicago-notes-18th
       path: crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
       sha256: 6585c66d1fc02addb97b7dc46200564065fd37c9eaad004bd43280c03a325ecf

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.json
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.json
@@ -115,7 +115,7 @@
     ],
     "manifest": {
       "path": "docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml",
-      "sha256": "d3757019a0d1a94b1b64b7f4163d09fa82a7e6594e13eeb99babf72c5a6ea039"
+      "sha256": "9ec32fcad03c8ce9bfe24ffbec2576ea229c9f69d9d01ebba543f7b7f8bbf144"
     },
     "relevance": {
       "default": "relevant",
@@ -164,7 +164,7 @@
         {
           "id": "chicago-shortened-notes-bibliography-core",
           "path": "crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml",
-          "sha256": "42de0990c1d73b46884cebbadd73d81125b4a88e8f4bb7d8a9fd17c1748fd29a"
+          "sha256": "dfc023a5388f31483039ff348b9cf2741110894935ceea4212b3ed04c258dc62"
         },
         {
           "id": "chicago-notes-18th",
@@ -179,7 +179,7 @@
       ],
       "id": "chicago-shortened-notes-bibliography",
       "path": "crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography.yaml",
-      "resolvedSha256": "9b25e0a762013307fd411b6915699b50e0eb3336fad048f45109d356c635f498",
+      "resolvedSha256": "f2c806245bba015d826b344ef1c10a8e6dbf648465d198c66eea6e7580741448",
       "sha256": "5ee7afd5c74169d8882747d8ab6ede8b84aa12cd1760e1f0f3f544198cd1be94"
     },
     "surfaces": [
@@ -1101,10 +1101,10 @@
       "referenceType": "article-magazine",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "fallback",
+      "renderDisposition": "rendered",
       "row": 51,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.template.template[0].contributor"
+      "templatePath": "resolved.bibliography.type-variants.article-magazine.template[0].contributor"
     },
     {
       "comparisonEligibility": "comparable",
@@ -1119,10 +1119,10 @@
       "referenceType": "article-magazine",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "fallback",
+      "renderDisposition": "rendered",
       "row": 52,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.template.template[2].group[1].title"
+      "templatePath": "resolved.bibliography.type-variants.article-magazine.template[2].title"
     },
     {
       "comparisonEligibility": "comparable",
@@ -1137,10 +1137,10 @@
       "referenceType": "article-magazine",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "uncovered",
+      "renderDisposition": "rendered",
       "row": 53,
       "surface": "bibliography",
-      "templatePath": null
+      "templatePath": "resolved.bibliography.type-variants.article-magazine.template[4].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -1155,10 +1155,10 @@
       "referenceType": "article-magazine",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "fallback",
+      "renderDisposition": "rendered",
       "row": 54,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.template.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.article-magazine.template[5].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -1173,10 +1173,10 @@
       "referenceType": "article-magazine",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "fallback",
+      "renderDisposition": "uncovered",
       "row": 55,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.template.template[7].number"
+      "templatePath": null
     },
     {
       "comparisonEligibility": "comparable",
@@ -1191,10 +1191,10 @@
       "referenceType": "article-magazine",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "fallback",
+      "renderDisposition": "rendered",
       "row": 56,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.template.template[1].title"
+      "templatePath": "resolved.bibliography.type-variants.article-magazine.template[1].title"
     },
     {
       "comparisonEligibility": "comparable",
@@ -1209,10 +1209,10 @@
       "referenceType": "article-magazine",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "fallback",
+      "renderDisposition": "rendered",
       "row": 57,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.template.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.article-magazine.template[3].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -1551,10 +1551,10 @@
       "referenceType": "legal-case",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "uncovered",
+      "renderDisposition": "rendered",
       "row": 76,
       "surface": "bibliography",
-      "templatePath": null
+      "templatePath": "resolved.bibliography.type-variants.legal-case.template[3].group[0].variable"
     },
     {
       "comparisonEligibility": "comparable",
@@ -1569,10 +1569,10 @@
       "referenceType": "legal-case",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "fallback",
+      "renderDisposition": "uncovered",
       "row": 77,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.template.template[2].group[1].title"
+      "templatePath": null
     },
     {
       "comparisonEligibility": "comparable",
@@ -1587,10 +1587,10 @@
       "referenceType": "legal-case",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "fallback",
+      "renderDisposition": "rendered",
       "row": 78,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.template.template[6].date"
+      "templatePath": "resolved.bibliography.type-variants.legal-case.template[3].group[1].date"
     },
     {
       "comparisonEligibility": "comparable",
@@ -1605,10 +1605,10 @@
       "referenceType": "legal-case",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "fallback",
+      "renderDisposition": "rendered",
       "row": 79,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.template.template[7].number"
+      "templatePath": "resolved.bibliography.type-variants.legal-case.template[2].group[2].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -1623,10 +1623,10 @@
       "referenceType": "legal-case",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "fallback",
+      "renderDisposition": "rendered",
       "row": 80,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.template.template[1].title"
+      "templatePath": "resolved.bibliography.type-variants.legal-case.template[1].title"
     },
     {
       "comparisonEligibility": "comparable",
@@ -1641,10 +1641,10 @@
       "referenceType": "legal-case",
       "relevance": "relevant",
       "relevanceRationale": null,
-      "renderDisposition": "fallback",
+      "renderDisposition": "rendered",
       "row": 81,
       "surface": "bibliography",
-      "templatePath": "resolved.bibliography.template.template[4].number"
+      "templatePath": "resolved.bibliography.type-variants.legal-case.template[2].group[0].number"
     },
     {
       "comparisonEligibility": "comparable",
@@ -10384,8 +10384,8 @@
     "populatedObservations": 565,
     "relevantObservations": 528,
     "renderDisposition": {
-      "fallback": 160,
-      "rendered": 157,
+      "fallback": 149,
+      "rendered": 168,
       "suppressed": 17,
       "uncovered": 194
     }

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.md
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.md
@@ -12,8 +12,8 @@ Structural coverage identifies a resolved component path; it does not prove that
 
 | Render disposition | Relevant observations |
 |---|---:|
-| rendered | 157 |
-| fallback | 160 |
+| rendered | 168 |
+| fallback | 149 |
 | suppressed | 17 |
 | uncovered | 194 |
 
@@ -80,13 +80,13 @@ Structural coverage identifies a resolved component path; it does not prove that
 | 48 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-16/article-newspaper/issued/entry` | relevant | fallback | comparable | false |
 | 49 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-16/article-newspaper/section/entry` | relevant | uncovered | comparable | false |
 | 50 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-16/article-newspaper/title/entry` | relevant | fallback | comparable | false |
-| 51 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-17/article-magazine/author/entry` | relevant | fallback | comparable | false |
-| 52 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-17/article-magazine/container-title/entry` | relevant | fallback | comparable | false |
-| 53 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-17/article-magazine/issue/entry` | relevant | uncovered | comparable | false |
-| 54 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-17/article-magazine/issued/entry` | relevant | fallback | comparable | false |
-| 55 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-17/article-magazine/page/entry` | relevant | fallback | comparable | false |
-| 56 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-17/article-magazine/title/entry` | relevant | fallback | comparable | false |
-| 57 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-17/article-magazine/volume/entry` | relevant | fallback | comparable | false |
+| 51 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-17/article-magazine/author/entry` | relevant | rendered | comparable | false |
+| 52 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-17/article-magazine/container-title/entry` | relevant | rendered | comparable | false |
+| 53 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-17/article-magazine/issue/entry` | relevant | rendered | comparable | false |
+| 54 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-17/article-magazine/issued/entry` | relevant | rendered | comparable | false |
+| 55 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-17/article-magazine/page/entry` | relevant | uncovered | comparable | false |
+| 56 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-17/article-magazine/title/entry` | relevant | rendered | comparable | false |
+| 57 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-17/article-magazine/volume/entry` | relevant | rendered | comparable | false |
 | 58 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-18/entry-encyclopedia/author/entry` | relevant | fallback | comparable | false |
 | 59 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-18/entry-encyclopedia/container-title/entry` | relevant | fallback | comparable | false |
 | 60 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-18/entry-encyclopedia/issued/entry` | relevant | fallback | comparable | false |
@@ -105,12 +105,12 @@ Structural coverage identifies a resolved component path; it does not prove that
 | 73 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-2/book/publisher-place/entry` | relevant | suppressed | comparable | true |
 | 74 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-2/book/publisher/entry` | relevant | rendered | comparable | true |
 | 75 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-2/book/title/entry` | relevant | rendered | comparable | true |
-| 76 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-20/legal-case/authority/entry` | relevant | uncovered | comparable | false |
-| 77 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-20/legal-case/container-title/entry` | relevant | fallback | comparable | false |
-| 78 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-20/legal-case/issued/entry` | relevant | fallback | comparable | false |
-| 79 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-20/legal-case/page/entry` | relevant | fallback | comparable | false |
-| 80 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-20/legal-case/title/entry` | relevant | fallback | comparable | false |
-| 81 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-20/legal-case/volume/entry` | relevant | fallback | comparable | false |
+| 76 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-20/legal-case/authority/entry` | relevant | rendered | comparable | false |
+| 77 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-20/legal-case/container-title/entry` | relevant | uncovered | comparable | false |
+| 78 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-20/legal-case/issued/entry` | relevant | rendered | comparable | false |
+| 79 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-20/legal-case/page/entry` | relevant | rendered | comparable | false |
+| 80 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-20/legal-case/title/entry` | relevant | rendered | comparable | false |
+| 81 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-20/legal-case/volume/entry` | relevant | rendered | comparable | false |
 | 82 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-21/patent/author/entry` | relevant | rendered | comparable | false |
 | 83 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-21/patent/country/entry` | relevant | uncovered | comparable | false |
 | 84 | `chicago-shortened-notes-bibliography/bibliography/references-expanded/ITEM-21/patent/issued/entry` | relevant | rendered | comparable | false |

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -1427,7 +1427,7 @@ test('generateReport exposes the registered coverage audit on its corresponding 
   assert.equal(audit.outputGroups.some((group) => group.exactEvidence), true);
   assert.equal(audit.postChangeEvidence.status, 'measured');
   assert.equal(audit.postChangeEvidence.beforeExactParity.passed, 34);
-  assert.equal(audit.postChangeEvidence.afterExactParity.passed, 48);
+  assert.equal(audit.postChangeEvidence.afterExactParity.passed, 60);
 });
 
 test('generateReport supports multi-style selected reports', {

--- a/scripts/report-data/embedded-parity-baseline.json
+++ b/scripts/report-data/embedded-parity-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-08-11T15:12:42.650Z",
-  "commit": "5903bacb",
+  "generated": "2026-08-11T17:17:23.482Z",
+  "commit": "a869fd95",
   "source": "scripts/report-core.js",
   "purpose": "Hard per-style exact-parity floor-gate baseline for the embedded tier, consumed by scripts/check-core-quality.js --parity-baseline (see docs/architecture/audits/2026-07-31_EXACT_PARITY_REFOCUS.md). It also records headline fidelity. Sub-1.0 fidelity ratchets are tracked separately per-style in scripts/report-data/verification-policy.yaml (min_pass_rate floors). Regenerate this file after each parity-tuning wave; the gate never goes backward on passed counts or total (fixture-drift guard).",
   "styles": {
@@ -78,20 +78,20 @@
     },
     "chicago-shortened-notes-bibliography": {
       "tier": "embedded",
-      "fidelityScore": 0.681,
+      "fidelityScore": 0.691,
       "qualityScore": 1,
       "citations": {
         "passed": 38,
         "total": 49
       },
       "bibliography": {
-        "passed": 295,
+        "passed": 300,
         "total": 440
       },
       "exactParity": {
-        "passed": 48,
+        "passed": 60,
         "total": 473,
-        "rate": 0.101
+        "rate": 0.127
       }
     },
     "elsevier-harvard": {


### PR DESCRIPTION
## Summary

Tune the embedded Chicago shortened-notes-and-bibliography profile and its inherited core.

The pass adds explicit Chicago title-case handling across inherited bibliography variants and bounded article-magazine and legal-case coverage. It also refreshes the registered coverage packet and full embedded parity floor.

## Evidence

- Exact parity: 48/473 -> 60/473
- Fidelity: 0.681 -> 0.691
- Bibliography compatibility: 295/440 -> 300/440
- SQI: 1.0, unchanged
- Coverage audit: current; 565 observations
- Full portfolio quality gate: passed; no sibling parity-floor regressions
- Bean hygiene: passed

The remaining residuals are primarily processor/type-coverage and broader Chicago family work, not resolved by this bounded style pass.
