### PR TITLE
fix(report): validate managed renderer binaries

### DIFF
--- a/.beans/archive/csl26-b68i--rebuild-report-core-managed-binaries-before-measur.md
+++ b/.beans/archive/csl26-b68i--rebuild-report-core-managed-binaries-before-measur.md
@@ -1,7 +1,7 @@
 ---
 # csl26-b68i
 title: Rebuild report-core managed binaries before measurement
-status: todo
+status: completed
 type: bug
 priority: high
 tags:
@@ -9,7 +9,13 @@ tags:
     - harness
     - fidelity
 created_at: 2026-08-09T18:48:19Z
-updated_at: 2026-08-09T18:48:19Z
+updated_at: 2026-08-11T18:41:53Z
 ---
 
 The 2026-08-09 shortened-notes audit ran report-core twice at source revision 0b2e44f9 with empty cache directories. The first default-feature run reused target/debug/citum and reported 20/473; after cargo build -q --bin citum and an explicit --citum-bin, the same source and fixtures reported 34/473. Fresh report data caches do not protect against stale managed binaries, and the report cache provenance does not include a binary/source identity. Make the default managed-binary path ask Cargo to validate the binary, include a renderer identity in cache/provenance, and add a regression test. Evidence: docs/architecture/audits/2026-08-09-shortened-notes-coverage/authority-report.json.
+
+
+
+## Summary of Changes
+
+Made every managed report-core binary path run `cargo build -q --bin citum` before measurement while preserving explicit binary overrides. Added regression coverage for an existing default-feature binary. Existing cache keys already include `citumBinHash`, so stale renderer outputs are no longer silently reused after validation.

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -348,28 +348,17 @@ function resolveCitumBinary(explicitPath = null, allFeatures = false, dependenci
     }
   }
 
-  const managedCandidates = [
-    cargoTargetDir ? path.join(cargoTargetDir, 'debug', 'citum') : null,
-    cargoTargetDir ? path.join(cargoTargetDir, 'release', 'citum') : null,
-    path.join(PROJECT_ROOT, 'target', 'debug', 'citum'),
-    path.join(PROJECT_ROOT, 'target', 'release', 'citum'),
-  ].filter(Boolean);
-  if (!allFeatures) {
-    const existing = managedCandidates.find((candidate) => fileExists(candidate));
-    if (existing) return path.resolve(existing);
-  }
-
   const buildArgs = ['build', '-q', '--bin', 'citum'];
   if (allFeatures) {
     buildArgs.push('--all-features');
   }
 
-  // The canonical all-features path must ask Cargo to validate the managed
-  // binary. Merely reusing target/debug/citum can silently measure the wrong
-  // feature set; an up-to-date Cargo build is effectively a no-op. Default
-  // feature callers retain the cheap existing-binary path used by unit tests.
+  // Every managed path must ask Cargo to validate the binary before measuring.
+  // Merely reusing target/debug/citum can silently measure a stale source or
+  // feature set; an up-to-date Cargo build is effectively a no-op.
   runCargo('cargo', buildArgs, {
     cwd: PROJECT_ROOT,
+    env: { ...process.env, ...environment },
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
   });

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -1691,6 +1691,31 @@ test('resolveCitumBinary rebuilds a Cargo-managed binary for the requested featu
   }]);
 });
 
+test('resolveCitumBinary validates an existing managed binary for default features', () => {
+  const targetDir = path.join(os.tmpdir(), 'report-core-default-managed-target');
+  const builtBinary = path.join(targetDir, 'debug', 'citum');
+  const calls = [];
+  let cargoEnvironment;
+
+  const resolved = resolveCitumBinary(null, false, {
+    environment: { CARGO_TARGET_DIR: targetDir },
+    fileExists(candidate) {
+      return candidate === builtBinary;
+    },
+    runCargo(command, args, options) {
+      calls.push({ command, args });
+      cargoEnvironment = options.env;
+    },
+  });
+
+  assert.equal(resolved, builtBinary);
+  assert.deepEqual(calls, [{
+    command: 'cargo',
+    args: ['build', '-q', '--bin', 'citum'],
+  }]);
+  assert.equal(cargoEnvironment.CARGO_TARGET_DIR, targetDir);
+});
+
 test('resolveCitumBinary trusts an explicitly supplied binary without rebuilding', () => {
   const explicitBinary = path.join(os.tmpdir(), 'citum-explicit');
   let cargoCalls = 0;


### PR DESCRIPTION
## Summary

- validate every Cargo-managed `citum` binary before report measurements
- keep explicit `--citum-bin` and `CITUM_BIN` overrides trusted
- add regression coverage for an existing default-feature managed binary
- close `csl26-b68i`

The report cache already fingerprints the resolved renderer binary. This change
ensures the default managed path validates that binary against the current
source and feature set before the fingerprint is used.

## Validation

- `node --test --test-name-pattern='resolveCitumBinary' scripts/report-core.test.js` — 3 passed
- `bash scripts/check-bean-hygiene.sh` — passed
- `git diff --check` — passed

The full report-core test command was attempted but its first-time Cargo build
did not reach the JavaScript assertions after more than 40 minutes, so it was
stopped; the focused resolver suite passed independently.
