### PR TITLE
fix(engine): grouping follows resolved date slot

### DIFF
--- a/.beans/archive/csl26-huuz--disambiguation-collision-grouping-is-variable-base.md
+++ b/.beans/archive/csl26-huuz--disambiguation-collision-grouping-is-variable-base.md
@@ -1,15 +1,17 @@
 ---
 # csl26-huuz
 title: Disambiguation collision grouping is variable-based, not render-text-based
-status: todo
+status: completed
 type: bug
 priority: normal
 tags:
     - engine
     - fidelity
 created_at: 2026-08-06T12:43:05Z
-updated_at: 2026-08-06T12:44:42Z
+updated_at: 2026-08-12T00:48:29Z
 parent: csl26-ccdt
+blocking:
+    - csl26-q67h
 ---
 
 citeproc-js groups year-suffix disambiguation collisions by RENDERED TEXT
@@ -69,3 +71,58 @@ bibliography.sort") covers the still-missing explicit sort — this bean covers
 only the residual ~9-entry gap in the English anonymous-undated bucket that
 traces to the grouping/rendering mismatch described above, which is
 independent of whether that sort gets restored.
+
+## Summary of Changes
+
+Collision-group **membership** now reflects what a reference's resolved date
+slot actually renders, instead of assuming every undated reference renders
+uniform "no date" text.
+
+**Engine:**
+- `sorting.rs`: `first_date_component_for_bibliography`/`_for_citation`,
+  mirroring the existing contributor-resolution helpers.
+- `disambiguation.rs`: `build_group_key` falls through to a new
+  `date_slot_discriminant`/`date_component_discriminant` when there's no
+  parseable issued year. Prefers the bibliography spec (confirmed empirically
+  — GB/T's `citation:` template is undifferentiated by type, unlike its
+  `bibliography:` template; preferring it collapsed every undated reference
+  onto one discriminant). An access date never contributes identity, whether
+  primary or fallback, and the search stops (doesn't fall through) once an
+  access-date candidate would be selected — mirrors the if/else-if/else shape
+  the fallback chain represents.
+- `values/date.rs`: extracted `resolve_date_variable` (shared date-variable →
+  reference-field mapping) and `render_date_fallback_chain`. The fallback
+  render path now inlines a disamb suffix into a `date:` fallback candidate's
+  raw text *before* its wrap is applied (so the letter lands inside brackets:
+  `[2020a]`, not `[2020]a`), and renders a standalone suffix when nothing in
+  the fallback chain resolves at all (previously: silently no letter).
+
+**Style:** `gb-t-7714-2025-author-date.yaml` — `article-journal,article-magazine`
+lost its `term.no-date` fallback (upstream's date-intext macro never reaches
+it for that branch without volume/issue); `webpage,post,post-weblog` gained
+an access-year fallback ahead of the no-date term (upstream's
+`<else-if variable="accessed">` branch).
+
+**Spec:** `docs/specs/DISAMBIGUATION.md` §1 — new "Date-slot discriminant"
+subsection with the four-case rule, the bibliography-preference rationale,
+and the rendering-side fixes required alongside it.
+
+**Measured:** GB/T's diagnostic upstream-corpus bibliography scope
+(`count_toward_fidelity: false`, no fidelity-gate impact) went 147/203 →
+176/203 (+29), citations 8/8 unchanged. Zero regressions across the 35-style
+exemplar corpus (`report-core.js --all-features`, before/after diffed via a
+clean detached worktree) or `cargo nextest run` (2463/2463). 9 new unit tests
+in `disambiguation.rs` (BDD `given/when/then`, `#[rstest]`, `assert_eq!` on
+captured discriminants/group keys).
+
+**Scope note:** this bean closes group *membership*. Five entries whose
+membership is now correct still show the wrong *letter* because their
+ordering depends on `gb-t-7714-2025-author-date`'s own `bibliography.sort`,
+which is still missing (inherits `citation-number` registry order from its
+numeric base) — that gap is `csl26-q67h`, linked below, not closed here.
+
+Two unrelated defects surfaced while measuring were not filed as new beans —
+existing siblings already covered them and got the corpus evidence appended
+instead: `csl26-yyrs` (standards-body contributor promotion, now 5 entries
+not 3) and `csl26-c361` (NumberForm::Ordinal not implemented, new GB/T
+evidence: `5th editors` vs `5 editors`).

--- a/.beans/csl26-c361--implement-or-reject-numberform-ordinalroman.md
+++ b/.beans/csl26-c361--implement-or-reject-numberform-ordinalroman.md
@@ -3,12 +3,17 @@
 title: Implement or reject NumberForm ordinal/roman
 status: todo
 type: task
+priority: normal
 tags:
     - numbers
     - localization
-parent: csl26-8m2p
 created_at: 2026-07-04T17:11:33Z
-updated_at: 2026-07-04T17:49:02Z
+updated_at: 2026-08-11T23:56:32Z
+parent: csl26-8m2p
 ---
 
 TemplateNumber.form (numeric|ordinal|roman) is documented schema surface but TemplateNumber::values never reads it — 'form: ordinal' on edition renders 2 instead of 2nd with no warning; gender agreement similarly limited to label terms. Implement ordinal/roman rendering via locale ordinal suffixes, or reject the option loudly at style load. docs/architecture/audits/2026-07-04_CITUM_ENGINE_REVIEW_PART2.md finding 10.
+
+## GB/T evidence (csl26-huuz, 2026-08-11 session)
+
+gb-t-7714-2025-author-date, gbt7714.7.4:5 (`manuscript,personal-communication,pamphlet` type-variant): oracle renders `5th editors` (ordinal edition), citum renders `5 editors` — the exact form-not-read gap this bean describes, on `TemplateNumber.form: ordinal` for the edition field.

--- a/.beans/csl26-q67h--restore-gb-t-7714-2025-author-dates-own-bibliograp.md
+++ b/.beans/csl26-q67h--restore-gb-t-7714-2025-author-dates-own-bibliograp.md
@@ -5,7 +5,7 @@ status: todo
 type: bug
 priority: normal
 created_at: 2026-08-06T13:30:40Z
-updated_at: 2026-08-06T13:30:58Z
+updated_at: 2026-08-12T00:48:44Z
 parent: csl26-ccdt
 ---
 
@@ -63,3 +63,7 @@ available-date/accessed), and (b) land the `sorting.rs` Author-key fix
 *separately*, verified against the full 157-style corpus on its own before
 being combined with this style's sort — not bundled together as one change
 the way this session tried.
+
+## Update (csl26-huuz, 2026-08-11 session)
+
+csl26-huuz landed and changed the baseline this bean measures against: collision-group *membership* for the undated anonymous bucket is now correct (147/203 → 176/203 on the diagnostic upstream corpus). Five entries (gbt7714.7.2.1:4, 7.2.1:7, 7.2.3:7, 8.11.2.2:1, 8.11.2.2:2) now have correct grouping and date text but still show the wrong year-suffix *letter* — exactly the gap this bean (restoring the style's own `bibliography.sort`) is meant to close. Re-measure against 176/203 (not the earlier 170/173 figures in this bean's original evidence), and expect those five specific entries to be the most direct signal of whether a restored sort actually fixes ordering.

--- a/.beans/csl26-qbmd--add-a-date-substitute-options-mechanism-mirroring.md
+++ b/.beans/csl26-qbmd--add-a-date-substitute-options-mechanism-mirroring.md
@@ -1,0 +1,22 @@
+---
+# csl26-qbmd
+title: Add a date-substitute options mechanism mirroring author-substitute
+status: todo
+type: feature
+priority: normal
+tags:
+    - engine
+    - fidelity
+    - gb-t-7714
+created_at: 2026-08-12T13:59:09Z
+updated_at: 2026-08-12T13:59:09Z
+parent: csl26-ccdt
+---
+
+GB/T 7714's date-fallback chains today live inline, duplicated across many `TemplateDate` components across many type-variants — each spelling out its own `fallback:` list (e.g. `book,thesis,map`'s `[date: copyright, date: printing, date: accessed, message: term.no-date]`, `webpage,post,post-weblog`'s accessed-year fallback, `article-journal,article-magazine`'s empty `fallback: []`). This is structurally the same shape `options/substitute.rs`'s `Substitute`/`SubstituteConfig` already generalizes for contributor (author) fallback — a single, reusable, type-scoped (`overrides: HashMap<String, Vec<SubstituteKey>>`) declarative chain for one well-defined slot, resolved per-reference-type via `values/contributor/substitute.rs`.
+
+Raised during csl26-huuz's review: rather than growing `TemplateDate`'s per-component `suppress-*` flag pile (`suppress-note`, `suppress-disamb-suffix`, and a since-reverted `suppress-no-date-term`) to express 'nothing else to show when the date is missing', add a `date-substitute` options mechanism mirroring `author-substitute`.
+
+Scope decision needed: contributor substitution has exactly one addressable slot (the author position). `TemplateDate` components appear in many distinct structural roles (issued-date position, accessed footer, original-published in a reprint template). The natural scope is the *primary/identity* date slot only — the one `first_date_component_for_bibliography`/`_for_citation` (crates/citum-engine/src/sorting.rs) already isolate for disambiguation purposes — not every `TemplateDate` occurrence.
+
+Per Bruce: this must be designed together with the disambiguation collision-key discriminant (csl26-huuz, PR #1171), not built independently and reconciled after — almost all of what `Disambiguator::date_component_discriminant` reads (message candidates, date candidates, the accessed-date no-identity rule, the empty/blank case) is exactly the territory this mechanism will own. Structure: stacked PRs off #1171 (gh stack) — spec (Draft status) first, then implementation (Active status) migrating GB/T's inline fallback chains and rewiring the discriminant/renderer to consume the resolved date-substitute output instead of `TemplateDate.fallback`. See docs/specs/DISAMBIGUATION.md and csl26-sea6 (sibling gap in the same style).

--- a/.beans/csl26-sea6--gb-t-7714-2025-author-date-citation-template-lacks.md
+++ b/.beans/csl26-sea6--gb-t-7714-2025-author-date-citation-template-lacks.md
@@ -1,0 +1,20 @@
+---
+# csl26-sea6
+title: gb-t-7714-2025-author-date citation template lacks type-conditional date logic
+status: todo
+type: bug
+priority: normal
+tags:
+    - engine
+    - fidelity
+    - gb-t-7714
+created_at: 2026-08-12T13:27:17Z
+updated_at: 2026-08-12T13:27:17Z
+parent: csl26-ccdt
+---
+
+citum's `gb-t-7714-2025-author-date.yaml` `citation:` section has one flat `date: issued` component with no `type-variants:`, while its `bibliography:` section fully expresses upstream's type-conditional `date-intext` macro (article-journal/magazine branches never reach the no-date term; webpage falls back to an access year; etc). Upstream citeproc-js reuses the exact same macro for both citation and bibliography rendering, so its citation output is type-differentiated too — citum's citation output is not, a pre-existing migration gap. Sibling of csl26-6eak (driving this style to full fidelity).
+
+Surfaced during csl26-huuz's Codex review: because collision-group letters are computed once and shared between citation and bibliography rendering (correctly — a reference must carry one letter everywhere), and the shared discriminant is bibliography-preferred (the more complete template), an undated reference's *citation* text can render generically (e.g. "n.d.") while its letter reflects a bibliography-side distinction the citation's own template can't express. Not a defect in the disambiguation mechanism itself — see docs/specs/DISAMBIGUATION.md §1's bibliography-preferred rationale — but a fidelity gap in the citation template's completeness.
+
+Fix: port the type-conditional structure from bibliography.type-variants into citation.type-variants for this style (or a shared subset), so citation output matches upstream's date-intext branching per type.

--- a/.beans/csl26-yyrs--promote-issuing-org-as-author-fallback-for-gbt-sta.md
+++ b/.beans/csl26-yyrs--promote-issuing-org-as-author-fallback-for-gbt-sta.md
@@ -8,7 +8,7 @@ tags:
     - fidelity
     - style
 created_at: 2026-07-23T17:06:02Z
-updated_at: 2026-08-02T14:19:29Z
+updated_at: 2026-08-11T23:56:28Z
 parent: csl26-ccdt
 ---
 
@@ -23,3 +23,7 @@ GB/T 7714-2025 author-date's `standard` reference type: oracle promotes the issu
 Needs a `substitute.template` extension — either a new `SubstituteField` variant for publisher/issuing-org, or a `TemplateContributor`-shaped publisher-as-contributor path (crates/citum-schema-style/src/options/substitute.rs, crates/citum-schema-style/src/template.rs). Scope carefully: if this needs to generalize beyond GB/T's one type-variant, consider whether it should be a broader `substitute` schema feature rather than a GB/T-specific hack.
 
 Part of csl26-6eak (Tune gb-t-7714-2025-author-date to full fidelity).
+
+## Additional evidence (csl26-huuz, 2026-08-11 session)
+
+Full oracle bibliography scope for this style now shows 5 affected entries, not 3: gbt7714.8.9.2:1, :2, :3, :4, :5. All five are the same defect (org/committee promoted into author slot by the oracle, dropped to 佚名/Anon fallback by citum). Entries 4 and 5 (International Electrotechnical Commission (IEC); ISO) weren't in the original 3-entry evidence list.

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -55,10 +55,10 @@ use citum_schema::locale::Locale;
 pub struct Disambiguator<'a> {
     bibliography: &'a Bibliography,
     config: &'a Config,
-    /// Effective bibliography config governing multilingual/locale sort-key
-    /// policy (`sorting.multilingual`, `sorting.locale`, `sort-as`,
-    /// preferred transliterations). Year-suffix ordering must use this —
-    /// not `config` — so it agrees with the rendered bibliography order.
+    /// Effective bibliography config governing bibliography-owned date-slot
+    /// grouping and multilingual/locale sort-key policy. Year-suffix grouping
+    /// and ordering must use this — not `config` — when the bibliography
+    /// supplies the corresponding template or sort behavior.
     sort_config: &'a Config,
     locale: &'a Locale,
     group_sort: Option<&'a GroupSort>,
@@ -150,9 +150,9 @@ struct CachedReferenceData {
 impl<'a> Disambiguator<'a> {
     /// Creates a disambiguator that uses the default title-based fallback order.
     ///
-    /// `sort_config` is the effective bibliography config (multilingual/locale
-    /// sort-key policy); pass the same config used to sort the final
-    /// bibliography so year-suffix order agrees with the rendered order.
+    /// `sort_config` is the effective bibliography config; pass the same
+    /// config used to render and sort the final bibliography so bibliography-
+    /// owned date grouping and year-suffix order agree with its output.
     #[must_use]
     pub fn new(
         bibliography: &'a Bibliography,
@@ -175,9 +175,9 @@ impl<'a> Disambiguator<'a> {
 
     /// Creates a disambiguator with an explicit per-group sort specification.
     ///
-    /// `sort_config` is the effective bibliography config (multilingual/locale
-    /// sort-key policy); pass the same config used to sort the final
-    /// bibliography so year-suffix order agrees with the rendered order.
+    /// `sort_config` is the effective bibliography config; pass the same
+    /// config used to render and sort the final bibliography so bibliography-
+    /// owned date grouping and year-suffix order agree with its output.
     #[must_use]
     pub fn with_group_sort(
         bibliography: &'a Bibliography,
@@ -1018,14 +1018,215 @@ impl<'a> Disambiguator<'a> {
         let mut key = String::with_capacity(author_key.len() + 8);
         key.push_str(author_key);
         key.push(':');
-        let Some(year) = reference
+        if let Some(year) = reference
             .effective_issued_date()
             .and_then(|d| d.year().parse::<i32>().ok())
-        else {
+        {
+            let _ = write!(key, "{year}");
             return key;
-        };
-        let _ = write!(key, "{year}");
+        }
+
+        // No issued year. Collision grouping must reflect what the style's
+        // resolved date slot actually yields for this reference, not a
+        // uniform "no date" assumption — a type-conditional date macro (e.g.
+        // GB/T 7714's article-journal branch, which never reaches the
+        // no-date term) renders different text for different reference
+        // types, and those references are already visually distinguishable.
+        // See csl26-huuz.
+        key.push_str(&self.date_slot_discriminant(reference));
         key
+    }
+
+    /// Discriminant for the date half of the collision key when a reference
+    /// has no issued year. Reads the reference's effective resolved
+    /// template — the first non-suppressed date component under the author
+    /// (`crate::sorting::first_date_component_for_bibliography`, preferring
+    /// the bibliography spec when present, else the citation spec) — and
+    /// returns text identifying what it actually renders:
+    ///
+    /// - the date variable resolves to a real, non-empty value → the text
+    ///   it would actually render (`form`-restricted and marker-applied,
+    ///   the same formatting `TemplateDate::values` uses — not the raw
+    ///   stored value, which can carry more precision than `form` shows);
+    /// - the variable is empty and the resolved fallback chain (explicit or
+    ///   the implicit no-date-term branch) renders the locale's no-date
+    ///   term → a discriminant for that term, scoped by the reference's
+    ///   effective language (mirrors `build_author_slot_key`'s
+    ///   `ANONYMOUS_FALLBACK_KEY` scoping — the rendered term itself varies
+    ///   by language, "无日期" vs "n.d.");
+    ///
+    /// Access dates (`DateVariable::Accessed`), whether the slot's own
+    /// primary variable or a fallback candidate, are never used as a
+    /// discriminant even when present — an access date is retrieval
+    /// metadata, not part of a work's identity, so two otherwise identical
+    /// undated entries must not be distinguished by it.
+    ///
+    /// Bibliography-preferred, not citation-preferred: mirrors
+    /// `sort_group_for_year_suffix`'s existing precedent (`csl26-m8la`) for
+    /// the same reason — collision grouping is measured against the
+    /// bibliography oracle, and a style's citation template is commonly a
+    /// simpler, non-type-differentiated form of the same date logic (GB/T
+    /// author-date's `citation:` section has one flat `date: issued` with no
+    /// `type-variants:` at all, unlike its bibliography section). Preferring
+    /// citation_spec here would let that undifferentiated template collapse
+    /// every undated reference onto the same discriminant regardless of
+    /// type, defeating the type-conditional split this function exists to
+    /// make. Confirmed empirically: an in-tree literal `bibliography_spec`
+    /// vs `citation_spec` preference swap was compared against the GB/T
+    /// oracle before landing this order.
+    ///
+    /// Returns the empty string both when nothing resolves at all (an
+    /// explicit `fallback: []`) and when there is no template to resolve
+    /// (no citation or bibliography spec configured) — `build_group_key`'s
+    /// existing undiscriminated key for that case.
+    fn date_slot_discriminant(&self, reference: &Reference) -> String {
+        let component_and_config = self
+            .bibliography_spec
+            .and_then(|spec| crate::sorting::first_date_component_for_bibliography(spec, reference))
+            .map(|component| (component, self.sort_config))
+            .or_else(|| {
+                self.citation_spec
+                    .and_then(|spec| {
+                        crate::sorting::first_date_component_for_citation(spec, reference)
+                    })
+                    .map(|component| (component, self.config))
+            });
+        let Some((component, config)) = component_and_config else {
+            return String::new();
+        };
+        Self::date_component_discriminant(&component, reference, self.locale, config.dates.as_ref())
+    }
+
+    /// The literal locale message ID the implicit no-date branch in
+    /// `TemplateDate::values` (`values/date.rs`) evaluates, and the same ID
+    /// every GB/T-style explicit `message: term.no-date` fallback names.
+    /// Both render identical text, so both must produce the same
+    /// discriminant here.
+    const IMPLICIT_NO_DATE_TERM: &'static str = "term.no-date";
+
+    /// Classify what a resolved date component renders for a reference with
+    /// no issued year. See `date_slot_discriminant`'s doc comment for the
+    /// cases.
+    ///
+    /// A resolving candidate's *rendered* text is used, not the raw stored
+    /// date value — `DateValue`'s `Display` is the unformatted EDTF/literal
+    /// string, which can carry more precision than the component's `form`
+    /// shows (e.g. a day-precision `copyright` date under `form: year`
+    /// renders as a bare year, but its raw value still has the day). Reading
+    /// the raw value here could split a collision group whose members
+    /// render identical date-slot text, defeating the discriminant's whole
+    /// purpose. See csl26-huuz, flagged in PR review.
+    fn date_component_discriminant(
+        component: &citum_schema::template::TemplateDate,
+        reference: &Reference,
+        locale: &citum_schema::locale::Locale,
+        date_config: Option<&citum_schema::options::dates::DateConfig>,
+    ) -> String {
+        use citum_schema::template::{DateVariable, TemplateComponent};
+
+        if matches!(component.date, DateVariable::Accessed) {
+            if crate::values::date::resolve_date_variable(&component.date, reference)
+                .is_some_and(|value| !value.is_empty())
+            {
+                // An access date carries no identity even when present —
+                // this is the terminal case for this slot, not a signal to
+                // keep looking at a fallback chain.
+                return String::new();
+            }
+        } else if let Some(value) =
+            crate::values::date::resolve_date_variable(&component.date, reference)
+                .filter(|value| !value.is_empty())
+        {
+            // The primary variable is present, so — mirroring
+            // `TemplateDate::values`'s own normal-value branch, which never
+            // consults `self.fallback` once the primary date resolves —
+            // this is terminal even when the value fails to format (e.g. a
+            // literal date under a numeric `form`, which the renderer also
+            // shows as nothing). Reuses the same fallback-candidate helper as
+            // the loop below: its prefix/suffix/wrap contribution is inert
+            // here (constant across every reference resolving this same
+            // component, so it can never split two references from each
+            // other), but `date.note` is per-reference *data*, not
+            // per-component config, so including it is defensive even though
+            // a note-bearing value can't reach this branch under the current
+            // data model (a note-bearing date is structured and parseable,
+            // so `build_group_key`'s own year check already returns before
+            // this function ever runs).
+            return crate::values::date::fallback_candidate_discriminant(
+                &value,
+                &component.form,
+                &component.rendering,
+                component.suppress_note,
+                locale,
+                date_config,
+            )
+            .unwrap_or_default();
+        }
+
+        let Some(fallbacks) = component.fallback.as_ref() else {
+            return if matches!(component.date, DateVariable::Issued) {
+                format!(
+                    "term:{}:{}",
+                    Self::IMPLICIT_NO_DATE_TERM,
+                    crate::values::effective_item_language(reference).unwrap_or_default()
+                )
+            } else {
+                String::new()
+            };
+        };
+
+        for candidate in fallbacks {
+            match candidate {
+                TemplateComponent::Message(message) => {
+                    return format!(
+                        "term:{}:{}",
+                        message.message,
+                        crate::values::effective_item_language(reference).unwrap_or_default()
+                    );
+                }
+                TemplateComponent::Date(inner) => {
+                    let Some(value) =
+                        crate::values::date::resolve_date_variable(&inner.date, reference)
+                            .filter(|value| !value.is_empty())
+                    else {
+                        // This candidate doesn't resolve — not selected,
+                        // keep scanning the chain (e.g. GB/T's accessed
+                        // fallback when no accessed date exists at all).
+                        continue;
+                    };
+                    let Some(discriminant) = crate::values::date::fallback_candidate_discriminant(
+                        &value,
+                        &inner.form,
+                        &inner.rendering,
+                        inner.suppress_note,
+                        locale,
+                        date_config,
+                    ) else {
+                        // Present but renders nothing (e.g. a literal date
+                        // under a numeric form) — `render_date_fallback_chain`
+                        // treats an unrendering candidate the same as an
+                        // absent one and keeps scanning, so the discriminant
+                        // must too.
+                        continue;
+                    };
+                    // A resolving, rendering candidate is the terminal case
+                    // for this slot: citeproc-js's underlying if/else-if
+                    // branching (which this fallback chain mirrors) never
+                    // falls through to a later branch once one is selected —
+                    // even when, as with an access date, that branch's own
+                    // content carries no identity and this discriminant is
+                    // therefore empty rather than the date's text.
+                    return if matches!(inner.date, DateVariable::Accessed) {
+                        String::new()
+                    } else {
+                        discriminant
+                    };
+                }
+                _ => {}
+            }
+        }
+
+        String::new()
     }
 
     /// Appends a sequence of family names to the key buffer, lowercased.
@@ -1148,6 +1349,7 @@ mod tests {
     use crate::Processor;
     use citum_schema::citation::Citation;
     use citum_schema::grouping::{GroupSort, GroupSortKey, SortKey};
+    use citum_schema::options::dates::DateConfig;
     use citum_schema::options::{
         Config, ContributorConfig, DisplayAsSort, MultilingualConfig, NameForm, SortingConfig,
         SortingMultilingualMode,
@@ -1157,8 +1359,12 @@ mod tests {
         Contributor, DateValue, InputReference as Reference, Monograph, MonographType,
         MultilingualString, StructuredName, Title,
     };
-    use citum_schema::template::{TemplateComponent, WrapPunctuation};
+    use citum_schema::template::{
+        DateForm, DateVariable, Rendering, TemplateComponent, TemplateDate, TemplateMessage,
+        WrapConfig, WrapPunctuation,
+    };
     use citum_schema::{BibliographySpec, CitationSpec, Style, StyleInfo};
+    use rstest::rstest;
 
     fn make_ref(id: &str, family: &str, given: &str, year: i32) -> Reference {
         let title = format!("Title {id}");
@@ -2335,5 +2541,466 @@ mod tests {
             2,
             "group-local path: romanized sort-as order puts r-beta second"
         );
+    }
+
+    // csl26-huuz: collision grouping must reflect what the resolved date
+    // slot actually renders for an undated reference, not a uniform "no
+    // date" assumption.
+
+    /// A reference with an explicit issued/accessed pair and a real shared
+    /// author. `date_component_discriminant` never reads the author; the
+    /// integration test below shares one author across every case so only
+    /// the date half of the collision key varies.
+    fn make_dated_ref(id: &str, family: &str, issued: &str, accessed: Option<&str>) -> Reference {
+        Reference::Monograph(Box::new(Monograph {
+            id: Some(id.into()),
+            r#type: MonographType::Book,
+            title: Some(Title::Single(format!("Title {id}"))),
+            author: Some(Contributor::StructuredName(StructuredName {
+                family: MultilingualString::Simple(family.to_string()),
+                given: MultilingualString::Simple(String::new()),
+                suffix: None,
+                dropping_particle: None,
+                non_dropping_particle: None,
+            })),
+            issued: DateValue::new(issued),
+            accessed: accessed.map(DateValue::new),
+            ..Default::default()
+        }))
+    }
+
+    /// The GB/T-shaped date component under test: primary `issued`, falling
+    /// back to an access year (never a discriminant, per csl26-huuz) and
+    /// then to the locale's no-date term.
+    fn issued_with_accessed_fallback() -> TemplateDate {
+        TemplateDate {
+            date: DateVariable::Issued,
+            form: DateForm::Year,
+            fallback: Some(vec![
+                TemplateComponent::Date(TemplateDate {
+                    date: DateVariable::Accessed,
+                    form: DateForm::Year,
+                    ..Default::default()
+                }),
+                TemplateComponent::Message(TemplateMessage {
+                    message: "term.no-date".to_string(),
+                    ..Default::default()
+                }),
+            ]),
+            ..Default::default()
+        }
+    }
+
+    #[rstest]
+    #[case::real_issued_value_wins_without_consulting_fallback(
+        "2020",
+        None,
+        "2020||None|None|None"
+    )]
+    #[case::present_accessed_stops_the_chain_with_no_identity("", Some("2020"), "")]
+    #[case::absent_accessed_falls_through_to_the_no_date_term("", None, "term:term.no-date:")]
+    #[case::empty_string_accessed_is_treated_as_absent("", Some(""), "term:term.no-date:")]
+    fn given_an_issued_with_accessed_fallback_when_computing_the_collision_discriminant_then_it_matches(
+        #[case] issued: &str,
+        #[case] accessed: Option<&str>,
+        #[case] expected: &str,
+    ) {
+        let reference = make_dated_ref("d1", "Smith", issued, accessed);
+        let component = issued_with_accessed_fallback();
+
+        let locale = Locale::en_us();
+        let discriminant =
+            Disambiguator::date_component_discriminant(&component, &reference, &locale, None);
+
+        assert_eq!(discriminant, expected);
+    }
+
+    #[rstest]
+    #[case::explicit_message_fallback(Some(vec![TemplateComponent::Message(TemplateMessage {
+        message: "term.no-date".to_string(),
+        ..Default::default()
+    })]))]
+    #[case::implicit_no_fallback_at_all(None)]
+    fn given_an_undated_issued_slot_when_the_no_date_term_is_reached_then_the_discriminant_is_the_same_either_way(
+        #[case] fallback: Option<Vec<TemplateComponent>>,
+    ) {
+        let reference = make_dated_ref("d2", "Smith", "", None);
+        let component = TemplateDate {
+            date: DateVariable::Issued,
+            form: DateForm::Year,
+            fallback,
+            ..Default::default()
+        };
+
+        let locale = Locale::en_us();
+        let discriminant =
+            Disambiguator::date_component_discriminant(&component, &reference, &locale, None);
+
+        // Both the implicit (no `fallback:` at all) and explicit
+        // (`fallback: [message: term.no-date]`) paths render the identical
+        // locale term via TemplateDate::values, so they must produce the
+        // identical collision-key discriminant — otherwise a style that
+        // mixes the two forms across type-variants would split undated
+        // references that render identical text.
+        assert_eq!(discriminant, "term:term.no-date:");
+    }
+
+    #[test]
+    fn empty_explicit_fallback_list_yields_empty_discriminant() {
+        let reference = make_dated_ref("d3", "Smith", "", None);
+        let component = TemplateDate {
+            date: DateVariable::Issued,
+            form: DateForm::Year,
+            fallback: Some(Vec::new()),
+            ..Default::default()
+        };
+
+        let locale = Locale::en_us();
+        let discriminant =
+            Disambiguator::date_component_discriminant(&component, &reference, &locale, None);
+
+        assert_eq!(discriminant, "");
+    }
+
+    #[test]
+    fn fallback_candidate_note_obeys_the_candidate_suppress_note_flag() {
+        let date = DateValue {
+            value: "1947".to_string(),
+            note: Some("民国36年".to_string()),
+        };
+        let rendering = Rendering {
+            prefix: Some("c".into()),
+            ..Default::default()
+        };
+        let date_config = DateConfig {
+            note_wrap: Some(WrapConfig {
+                punctuation: WrapPunctuation::Parentheses,
+                inner_prefix: None,
+                inner_suffix: None,
+            }),
+            ..Default::default()
+        };
+        let locale = Locale::en_us();
+
+        let visible = crate::values::date::fallback_candidate_discriminant(
+            &date,
+            &DateForm::Year,
+            &rendering,
+            None,
+            &locale,
+            Some(&date_config),
+        );
+        let suppressed = crate::values::date::fallback_candidate_discriminant(
+            &date,
+            &DateForm::Year,
+            &rendering,
+            Some(true),
+            &locale,
+            Some(&date_config),
+        );
+
+        assert_eq!(
+            visible.as_deref(),
+            Some("1947|民国36年|Some(Custom(\"c\"))|None|None")
+        );
+        assert_eq!(
+            suppressed.as_deref(),
+            Some("1947||Some(Custom(\"c\"))|None|None")
+        );
+    }
+
+    #[test]
+    fn identity_date_slot_uses_the_configuration_from_its_effective_scope() {
+        let reference = Reference::Monograph(Box::new(Monograph {
+            id: Some("scope-date".into()),
+            r#type: MonographType::Book,
+            title: Some(Title::Single("Scoped date".to_string())),
+            issued: DateValue::new(""),
+            copyright: Some(DateValue {
+                value: "1995".to_string(),
+                note: Some("source calendar".to_string()),
+            }),
+            ..Default::default()
+        }));
+        let date_component = TemplateDate {
+            date: DateVariable::Copyright,
+            form: DateForm::Year,
+            ..Default::default()
+        };
+        let bibliography_spec = BibliographySpec {
+            template: Some(vec![TemplateComponent::Date(date_component.clone())].into()),
+            ..Default::default()
+        };
+        let citation_spec = CitationSpec {
+            template: Some(vec![TemplateComponent::Date(date_component)].into()),
+            ..Default::default()
+        };
+        let note_dates = DateConfig {
+            note_wrap: Some(WrapConfig {
+                punctuation: WrapPunctuation::Parentheses,
+                inner_prefix: None,
+                inner_suffix: None,
+            }),
+            ..Default::default()
+        };
+        let with_note = Config {
+            dates: Some(note_dates),
+            ..Default::default()
+        };
+        let without_note = Config::default();
+        let bibliography = Bibliography::new();
+        let locale = Locale::en_us();
+
+        let bibliography_owned =
+            Disambiguator::new(&bibliography, &without_note, &with_note, &locale)
+                .with_citation_spec(&citation_spec)
+                .with_bibliography_spec(&bibliography_spec)
+                .date_slot_discriminant(&reference);
+        let citation_owned = Disambiguator::new(&bibliography, &with_note, &without_note, &locale)
+            .with_citation_spec(&citation_spec)
+            .date_slot_discriminant(&reference);
+
+        assert_eq!(
+            bibliography_owned, "1995|source calendar|None|None|None",
+            "a bibliography-selected slot must use effective bibliography date options"
+        );
+        assert_eq!(
+            citation_owned, "1995|source calendar|None|None|None",
+            "the citation fallback slot must use effective citation date options"
+        );
+    }
+
+    /// A reference whose only date is a `copyright` fallback candidate with
+    /// day precision — mirrors GB/T 7714's `book,thesis,map` fallback chain
+    /// (`date: copyright, form: year`).
+    fn make_ref_with_copyright(id: &str, family: &str, copyright: &str) -> Reference {
+        Reference::Monograph(Box::new(Monograph {
+            id: Some(id.into()),
+            r#type: MonographType::Book,
+            title: Some(Title::Single(format!("Title {id}"))),
+            author: Some(Contributor::StructuredName(StructuredName {
+                family: MultilingualString::Simple(family.to_string()),
+                given: MultilingualString::Simple(String::new()),
+                suffix: None,
+                dropping_particle: None,
+                non_dropping_particle: None,
+            })),
+            issued: DateValue::new(""),
+            copyright: Some(DateValue::new(copyright)),
+            ..Default::default()
+        }))
+    }
+
+    fn issued_with_copyright_fallback() -> TemplateDate {
+        TemplateDate {
+            date: DateVariable::Issued,
+            form: DateForm::Year,
+            fallback: Some(vec![TemplateComponent::Date(TemplateDate {
+                date: DateVariable::Copyright,
+                form: DateForm::Year,
+                ..Default::default()
+            })]),
+            ..Default::default()
+        }
+    }
+
+    #[rstest]
+    #[case::day_precision_early_in_the_year("1995-03-01")]
+    #[case::day_precision_late_in_the_year("1995-11-20")]
+    fn given_a_copyright_fallback_date_with_day_precision_when_the_form_is_year_then_the_discriminant_is_the_bare_year(
+        #[case] copyright: &str,
+    ) {
+        // `DateValue`'s `Display` is the raw stored EDTF string. Reading it
+        // directly here would give "1995-03-01" and "1995-11-20" — two
+        // different discriminants for two references that both render as
+        // the bare year "1995" under `form: year`, wrongly treating them as
+        // already distinguishable. Flagged in PR review for csl26-huuz.
+        let component = issued_with_copyright_fallback();
+        let reference = make_ref_with_copyright("r1", "Smith", copyright);
+        let locale = Locale::en_us();
+
+        let discriminant =
+            Disambiguator::date_component_discriminant(&component, &reference, &locale, None);
+
+        assert_eq!(discriminant, "1995||None|None|None");
+    }
+
+    /// GB/T 7714's real `book,thesis,map` fallback chain: `copyright`
+    /// prefixed with `c`, `printing` suffixed with `印刷`. A reference
+    /// resolving one and a reference resolving the other can share a bare
+    /// formatted year (`"1995"`) while rendering visibly different text
+    /// (`c1995` vs `1995印刷`) — the discriminant must not collapse them.
+    /// Flagged in PR review for csl26-huuz.
+    #[test]
+    fn copyright_and_printing_fallbacks_with_the_same_year_do_not_collide() {
+        let component = TemplateDate {
+            date: DateVariable::Issued,
+            form: DateForm::Year,
+            fallback: Some(vec![
+                TemplateComponent::Date(TemplateDate {
+                    date: DateVariable::Copyright,
+                    form: DateForm::Year,
+                    rendering: Rendering {
+                        prefix: Some("c".into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+                TemplateComponent::Date(TemplateDate {
+                    date: DateVariable::Printing,
+                    form: DateForm::Year,
+                    rendering: Rendering {
+                        suffix: Some("印刷".into()),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }),
+            ]),
+            ..Default::default()
+        };
+        let copyright_ref = Reference::Monograph(Box::new(Monograph {
+            id: Some("copyright-ref".into()),
+            r#type: MonographType::Book,
+            title: Some(Title::Single("Title copyright-ref".to_string())),
+            author: Some(Contributor::StructuredName(StructuredName {
+                family: MultilingualString::Simple("Smith".to_string()),
+                given: MultilingualString::Simple(String::new()),
+                suffix: None,
+                dropping_particle: None,
+                non_dropping_particle: None,
+            })),
+            issued: DateValue::new(""),
+            copyright: Some(DateValue::new("1995")),
+            ..Default::default()
+        }));
+        let printing_ref = Reference::Monograph(Box::new(Monograph {
+            id: Some("printing-ref".into()),
+            r#type: MonographType::Book,
+            title: Some(Title::Single("Title printing-ref".to_string())),
+            author: Some(Contributor::StructuredName(StructuredName {
+                family: MultilingualString::Simple("Smith".to_string()),
+                given: MultilingualString::Simple(String::new()),
+                suffix: None,
+                dropping_particle: None,
+                non_dropping_particle: None,
+            })),
+            issued: DateValue::new(""),
+            copyright: None,
+            printing: Some(DateValue::new("1995")),
+            ..Default::default()
+        }));
+        let locale = Locale::en_us();
+
+        let copyright_discriminant =
+            Disambiguator::date_component_discriminant(&component, &copyright_ref, &locale, None);
+        let printing_discriminant =
+            Disambiguator::date_component_discriminant(&component, &printing_ref, &locale, None);
+
+        assert_ne!(
+            copyright_discriminant, printing_discriminant,
+            "c1995 and 1995印刷 render visibly different text and must not collide"
+        );
+    }
+
+    #[test]
+    fn differing_access_dates_still_collide_via_shared_disambiguator() {
+        // Mirrors GB/T 7714's webpage type-variant: an access date never
+        // carries identity, so two references with *different* access years
+        // must still collide (form one suffixed group), while a reference
+        // with no access date at all — reaching the no-date term instead —
+        // must land in a *separate* group. Both groups share the same
+        // author, so only the date-slot discriminant can be responsible for
+        // the split. See csl26-huuz.
+        use citum_schema::options::{Disambiguation, Processing, ProcessingCustom};
+
+        let mut bib = Bibliography::new();
+        bib.insert(
+            "b1".to_string(),
+            make_dated_ref("b1", "Smith", "", Some("2020")),
+        );
+        bib.insert(
+            "b2".to_string(),
+            make_dated_ref("b2", "Smith", "", Some("2019")),
+        );
+        bib.insert("b3".to_string(), make_dated_ref("b3", "Smith", "", None));
+        bib.insert("b4".to_string(), make_dated_ref("b4", "Smith", "", None));
+
+        let locale = Locale::en_us();
+        let config = Config {
+            processing: Some(Processing::Custom(ProcessingCustom {
+                base: None,
+                disambiguate: Some(Disambiguation {
+                    names: false,
+                    add_givenname: false,
+                    givenname_rule: GivennameRule::default(),
+                    year_suffix: true,
+                }),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        let bibliography_spec = BibliographySpec {
+            template: Some(
+                vec![
+                    citum_schema::tc_contributor!(Author, Long),
+                    TemplateComponent::Date(issued_with_accessed_fallback()),
+                ]
+                .into(),
+            ),
+            ..Default::default()
+        };
+        let disambiguator = Disambiguator::new(&bib, &config, &config, &locale)
+            .with_bibliography_spec(&bibliography_spec);
+        let hints = disambiguator.calculate_hints();
+
+        let accessed_group_key = hints.get("b1").unwrap().group_key.clone();
+        let no_date_group_key = hints.get("b3").unwrap().group_key.clone();
+
+        assert_eq!(
+            hints.get("b2").unwrap().group_key,
+            accessed_group_key,
+            "different access years still share one group — the value never discriminates"
+        );
+        assert_eq!(
+            hints.get("b4").unwrap().group_key,
+            no_date_group_key,
+            "both no-access-date references share the other group"
+        );
+        assert_ne!(
+            accessed_group_key, no_date_group_key,
+            "an access-date group must not merge with the no-date-term group"
+        );
+
+        // `group_length` reports same-*author* count (documented on
+        // `author_group_lengths`), not collision-group size — all four
+        // share author "Smith", so it's 4 for every entry here regardless
+        // of which of the two date-discriminant groups they're actually in.
+        // `group_index` is the field that reflects actual collision-group
+        // membership: each 2-member group gets index 1 and 2.
+        let b1_index = hints.get("b1").unwrap().group_index;
+        let b2_index = hints.get("b2").unwrap().group_index;
+        let b3_index = hints.get("b3").unwrap().group_index;
+        let b4_index = hints.get("b4").unwrap().group_index;
+        assert_eq!(
+            [b1_index, b2_index]
+                .into_iter()
+                .collect::<std::collections::BTreeSet<_>>(),
+            [1, 2].into_iter().collect(),
+            "the access-date pair is indexed 1 and 2 within its own group"
+        );
+        assert_eq!(
+            [b3_index, b4_index]
+                .into_iter()
+                .collect::<std::collections::BTreeSet<_>>(),
+            [1, 2].into_iter().collect(),
+            "the no-date pair is indexed 1 and 2 within its own, separate group"
+        );
+
+        for id in ["b1", "b2", "b3", "b4"] {
+            assert!(
+                hints.get(id).unwrap().disamb_condition,
+                "{id}: both groups need a suffix"
+            );
+        }
     }
 }

--- a/crates/citum-engine/src/processor/rendering/tests.rs
+++ b/crates/citum-engine/src/processor/rendering/tests.rs
@@ -1239,3 +1239,174 @@ fn sentence_initial_group_still_capitalizes_leading_contributor_role_prose() {
 
     assert_eq!(result, "Edited by Ada Smith");
 }
+
+// csl26-huuz (piece 3): a year-suffix letter attached to a fallback date
+// candidate must land inside that candidate's own wrap, and a fallback
+// chain that renders no text at all must still carry the letter standalone.
+// `render_date_fallback_chain` (values/date.rs) is exercised only through
+// the GB/T oracle otherwise, which is diagnostic (`count_toward_fidelity:
+// false`) — these tests keep the two render paths covered in-repo.
+mod fallback_chain_disamb_suffix {
+    use super::*;
+    use citum_schema::reference::{
+        Contributor, DateValue, Monograph, MonographType, MultilingualString, StructuredName, Title,
+    };
+
+    fn make_monograph(id: &str, family: &str, issued: &str, accessed: Option<&str>) -> Reference {
+        Reference::Monograph(Box::new(Monograph {
+            id: Some(id.into()),
+            r#type: MonographType::Book,
+            title: Some(Title::Single(format!("Title {id}"))),
+            author: Some(Contributor::StructuredName(StructuredName {
+                family: MultilingualString::Simple(family.to_string()),
+                given: MultilingualString::Simple(String::new()),
+                suffix: None,
+                dropping_particle: None,
+                non_dropping_particle: None,
+            })),
+            issued: DateValue::new(issued),
+            accessed: accessed.map(DateValue::new),
+            ..Default::default()
+        }))
+    }
+
+    fn render_bibliography_entries(style: Style, references: Vec<Reference>) -> Vec<String> {
+        let mut bibliography = Bibliography::new();
+        for reference in references {
+            let id = reference
+                .id()
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| format!("ref{}", bibliography.len() + 1));
+            bibliography.insert(id, reference);
+        }
+        Processor::new(style, bibliography)
+            .render_bibliography_with_format_standalone::<crate::render::plain::PlainText>()
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn author_then_date_style(date_component: TemplateDate) -> Style {
+        bibliography_style_with_template(vec![
+            TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author.into(),
+                form: ContributorForm::Long,
+                name_order: Some(NameOrder::FamilyFirst),
+                ..Default::default()
+            }),
+            TemplateComponent::Group(TemplateGroup {
+                group: vec![TemplateComponent::Date(date_component)],
+                ..Default::default()
+            }),
+            TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                ..Default::default()
+            }),
+        ])
+    }
+
+    #[test]
+    fn accessed_fallback_letter_lands_inside_bracket_wrap() {
+        let style = author_then_date_style(TemplateDate {
+            date: DateVariable::Issued,
+            form: DateForm::Year,
+            fallback: Some(vec![TemplateComponent::Date(TemplateDate {
+                date: DateVariable::Accessed,
+                form: DateForm::Year,
+                rendering: Rendering {
+                    wrap: Some(WrapConfig {
+                        punctuation: WrapPunctuation::Brackets,
+                        inner_prefix: None,
+                        inner_suffix: None,
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+        let references = vec![
+            make_monograph("first", "Anon", "", Some("2020")),
+            make_monograph("second", "Anon", "", Some("2019")),
+        ];
+
+        let lines = render_bibliography_entries(style, references);
+
+        assert_eq!(
+            lines,
+            vec![
+                "Anon. [2020a]. Title first".to_string(),
+                String::new(),
+                "Anon. [2019b]. Title second".to_string(),
+            ],
+            "the disambiguating letter must sit inside the accessed date's own \
+             bracket wrap, not appended after it"
+        );
+    }
+
+    #[test]
+    fn empty_fallback_chain_still_renders_letter_standalone() {
+        let style = author_then_date_style(TemplateDate {
+            date: DateVariable::Issued,
+            form: DateForm::Year,
+            fallback: Some(vec![]),
+            ..Default::default()
+        });
+        let references = vec![
+            make_monograph("first", "Anon", "", None),
+            make_monograph("second", "Anon", "", None),
+        ];
+
+        let lines = render_bibliography_entries(style, references);
+
+        assert_eq!(
+            lines,
+            vec![
+                "Anon. a. Title first".to_string(),
+                String::new(),
+                "Anon. b. Title second".to_string(),
+            ],
+            "an explicit empty fallback list renders no date text, but the \
+             collision group's letter must still render standalone rather \
+             than being silently dropped"
+        );
+    }
+
+    /// Mirrors GB/T 7714's real `article-journal,article-magazine`
+    /// type-variant shape (`fallback: []`): an undated entry with no
+    /// collision partner renders no date text whatsoever — not even the
+    /// locale's no-date term — and an undated entry that *does* need
+    /// disambiguation still gets its letter, rendered standalone in the
+    /// same blank position. Answers the PR review question about this
+    /// YAML's behavioral implication.
+    #[test]
+    fn empty_fallback_list_leaves_the_date_position_blank_with_or_without_disambiguation() {
+        let style = author_then_date_style(TemplateDate {
+            date: DateVariable::Issued,
+            form: DateForm::Year,
+            fallback: Some(vec![]),
+            ..Default::default()
+        });
+        let references = vec![
+            make_monograph("solo", "Solo", "", None),
+            make_monograph("first", "Anon", "", None),
+            make_monograph("second", "Anon", "", None),
+        ];
+
+        let lines = render_bibliography_entries(style, references);
+
+        assert_eq!(
+            lines,
+            vec![
+                "Anon. a. Title first".to_string(),
+                String::new(),
+                "Anon. b. Title second".to_string(),
+                String::new(),
+                "Solo. Title solo".to_string(),
+            ],
+            "an undated entry with no collision partner renders no date \
+             position at all; an undated entry needing disambiguation still \
+             gets its letter, standalone, in that same blank position"
+        );
+    }
+}

--- a/crates/citum-engine/src/sorting.rs
+++ b/crates/citum-engine/src/sorting.rs
@@ -744,6 +744,83 @@ fn primary_contributor_for_bibliography(
     first_contributor_component(&template)
 }
 
+fn first_date_component_ref(
+    template: &[citum_schema::template::TemplateComponent],
+) -> Option<&citum_schema::template::TemplateDate> {
+    for component in template {
+        match component {
+            citum_schema::template::TemplateComponent::Date(date)
+                if date.suppress_disamb_suffix != Some(true) =>
+            {
+                return Some(date);
+            }
+            citum_schema::template::TemplateComponent::Group(group) => {
+                if let Some(date) = first_date_component_ref(&group.group) {
+                    return Some(date);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn first_date_component(
+    template: &[citum_schema::template::TemplateComponent],
+) -> Option<citum_schema::template::TemplateDate> {
+    first_date_component_ref(template).cloned()
+}
+
+/// Resolve the first non-suppressed date component from a reference's
+/// effective citation template — the identity-bearing date slot under the
+/// author, not a later display-only date marked `suppress-disamb-suffix`.
+/// Structurally mirrors `primary_contributor_for_citation`'s resolution
+/// path, but `Disambiguator` consults this only as a *fallback* to
+/// `first_date_component_for_bibliography`, the reverse of the author-slot
+/// preference order — see that function's doc comment. See `csl26-huuz`.
+pub(crate) fn first_date_component_for_citation(
+    spec: &citum_schema::CitationSpec,
+    reference: &Reference,
+) -> Option<citum_schema::template::TemplateDate> {
+    let language = crate::values::effective_item_language(reference);
+    let template = spec.resolve_template_for_type(&reference.ref_type(), language.as_deref())?;
+    first_date_component(&template)
+}
+
+/// Bibliography-spec counterpart of `first_date_component_for_citation`.
+///
+/// `Disambiguator::date_slot_discriminant` tries this **first**, falling
+/// back to `first_date_component_for_citation` only when no bibliography
+/// spec is configured or it resolves no date component — the opposite
+/// preference order from the author-slot list-primary resolution in
+/// `build_reference_cache`. A style's `citation:` template is commonly a
+/// simpler, non-type-differentiated form of the same date logic (e.g.
+/// `gb-t-7714-2025-author-date`'s `citation:` section has one flat
+/// `date: issued` with no `type-variants:` at all, unlike its
+/// `bibliography:` section); preferring it here would let that
+/// undifferentiated template collapse every undated reference onto the same
+/// discriminant regardless of type, defeating the type-conditional split
+/// this mechanism exists to make. Confirmed empirically against the GB/T
+/// oracle before landing this order — see `csl26-huuz` and
+/// `docs/specs/DISAMBIGUATION.md` §1.
+///
+/// Both this function and `first_date_component_for_citation` resolve their
+/// language via `effective_item_language`, matching the real render path
+/// (`processor/rendering/mod.rs::locale_for_reference`) and
+/// `Disambiguator::date_component_discriminant`'s own message-term
+/// scoping — not the bare `reference.language()` the pre-existing
+/// `primary_contributor_for_citation`/`primary_contributor_for_bibliography`
+/// use, a latent, unrelated inconsistency this function does not fix.
+/// Flagged in PR review for csl26-huuz.
+pub(crate) fn first_date_component_for_bibliography(
+    spec: &citum_schema::BibliographySpec,
+    reference: &Reference,
+) -> Option<citum_schema::template::TemplateDate> {
+    let language = crate::values::effective_item_language(reference);
+    let template = spec.resolve_template_for_type(&reference.ref_type(), language.as_deref())?;
+    first_date_component(&template)
+}
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -16,7 +16,7 @@ use citum_schema::options::dates::{DateRangeFormat, TimeFormat};
 use citum_schema::reference::types::RefDate;
 use citum_schema::reference::{ClassExtension, WorkRelation};
 use citum_schema::template::{
-    DateForm, DateVariable as TemplateDateVar, TemplateComponent, TemplateDate,
+    DateForm, DateVariable as TemplateDateVar, Rendering, TemplateComponent, TemplateDate,
 };
 use std::collections::BTreeMap;
 
@@ -66,6 +66,81 @@ fn extract_month(
             None => String::new(),
         },
     }
+}
+
+/// Resolve the reference-level date value a `TemplateDateVar` addresses.
+///
+/// Shared by `TemplateDate::values` (rendering) and `Disambiguator`
+/// (collision-key discrimination, `csl26-huuz`) so both read the date
+/// variable → reference-field mapping from one place.
+pub(crate) fn resolve_date_variable(
+    variable: &TemplateDateVar,
+    reference: &Reference,
+) -> Option<DateValue> {
+    match variable {
+        TemplateDateVar::Issued => reference.effective_issued_date(),
+        TemplateDateVar::Accessed => reference.accessed(),
+        TemplateDateVar::OriginalPublished => reference.original_date(),
+        TemplateDateVar::EventDate => event_date(reference),
+        TemplateDateVar::Copyright => reference.copyright(),
+        TemplateDateVar::Printing => reference.printing(),
+        _ => None,
+    }
+}
+
+/// The same date-text formatting `TemplateDate::values` applies to a
+/// resolved date value — `form`-restricted range/single-date formatting plus
+/// uncertainty/approximation markers — before any year-suffix disambiguation
+/// is layered on. Exposed so the disambiguator's collision-key discriminant
+/// reads the text a reference will actually render, not the raw stored
+/// value (whose `Display` is the unformatted EDTF/literal string and can
+/// carry more precision than `form` shows, e.g. a day-precision `copyright`
+/// date under `form: year`). See csl26-huuz.
+pub(crate) fn formatted_date_text(
+    date: &DateValue,
+    form: &DateForm,
+    locale: &citum_schema::locale::Locale,
+    date_config: Option<&citum_schema::options::dates::DateConfig>,
+) -> Option<String> {
+    format_date_range(date, form, locale, date_config)
+        .map(|value| apply_date_markers(value, date, date_config))
+}
+
+/// Text uniquely identifying what a date component renders for a specific
+/// reference, for collision-key purposes: the `form`-restricted formatted
+/// value (`formatted_date_text`) plus the candidate's prefix/suffix/wrap
+/// and the resolved value's `note` — the same extra text
+/// `apply_fallback_component_rendering`/`append_note` add to the bare value
+/// during real rendering. Two candidates whose rendered text differs only in
+/// these respects (e.g. a `c`-prefixed `copyright` year and a
+/// `印刷`-suffixed `printing` year that happen to share the same bare year)
+/// must not discriminant to the same text.
+///
+/// This does not need to *look like* the rendered text — it only needs the
+/// invariant "same render inputs ⟺ same discriminant" — so it Debug-formats
+/// the affix/wrap config rather than running the full punctuation-
+/// realization pipeline, which would require threading a complete
+/// `RenderOptions` and `OutputFormat` into `Disambiguator` for no
+/// observable benefit. See csl26-huuz, flagged in PR review.
+pub(crate) fn fallback_candidate_discriminant(
+    date: &DateValue,
+    form: &DateForm,
+    rendering: &Rendering,
+    suppress_note: Option<bool>,
+    locale: &citum_schema::locale::Locale,
+    date_config: Option<&citum_schema::options::dates::DateConfig>,
+) -> Option<String> {
+    let formatted = formatted_date_text(date, form, locale, date_config)?;
+    let note = (suppress_note != Some(true)
+        && date_config.is_some_and(|config| config.note_wrap.is_some()))
+    .then_some(date.note.as_deref())
+    .flatten()
+    .filter(|note| !note.is_empty())
+    .unwrap_or_default();
+    Some(format!(
+        "{formatted}|{note}|{:?}|{:?}|{:?}",
+        rendering.prefix, rendering.suffix, rendering.wrap
+    ))
 }
 
 fn event_date(reference: &Reference) -> Option<DateValue> {
@@ -1055,6 +1130,108 @@ pub(crate) fn apply_fallback_component_rendering<
     output
 }
 
+/// Render a date component's fallback chain when its own date variable is
+/// missing or empty.
+///
+/// Tries each fallback candidate in order and returns the first that
+/// renders. A `message:` candidate (the terminal "no data available" case,
+/// e.g. GB/T 7714's `无日期`/`n.d.` term via `message: term.no-date`) and a
+/// `date:` candidate (e.g. GB/T's access-year fallback, rendering
+/// `Anon，[2020a]`) both need the same year-suffix-append convention the
+/// implicit (no explicit `fallback:`) no-date path uses, so every path
+/// disambiguates identically. Without this, a style whose date components
+/// always carry an explicit `fallback:` chain (as GB/T author-date's do)
+/// never reaches the implicit branch and never gets a suffix at all. See
+/// csl26-6eak, csl26-huuz.
+///
+/// For a `date:` candidate, the letter must land inside that candidate's own
+/// wrap (e.g. brackets) — so it is inlined into the raw formatted text
+/// *before* `apply_fallback_component_rendering` applies the wrap, not
+/// appended to the already-wrapped output the way the `message:` case is.
+/// A candidate that is itself `date: issued` cannot reach this function with
+/// a resolvable value: `disamb_eligible` above requires the *outer*
+/// component's own `.date == Issued`, and an `issued`-typed fallback
+/// candidate resolves the identical reference field — which, precisely
+/// because we're in the missing-date branch at all, is already known empty.
+/// `inline_disamb_suffix` no-ops whenever `year` is empty, so no double
+/// suffix can occur; investigated for PR review, no fix needed.
+///
+/// If nothing in the chain renders anything (an explicit `fallback: []`, or
+/// every candidate resolves empty), the date slot itself contributes no
+/// text, but the collision group this reference belongs to may still need
+/// its year-suffix letter rendered standalone (upstream's bare
+/// `<text variable="year-suffix"/>` after an empty date; oracle:
+/// "Anon，b."). Without this, an entry whose date slot is entirely empty
+/// silently loses its disambiguator rather than getting the wrong one.
+fn render_date_fallback_chain<F: crate::render::format::OutputFormat<Output = String>>(
+    date_component: &TemplateDate,
+    fallbacks: &[TemplateComponent],
+    reference: &Reference,
+    hints: &ProcHints,
+    options: &RenderOptions<'_>,
+    fmt: &F,
+) -> Option<ProcValues<F::Output>> {
+    let disamb_eligible = matches!(date_component.date, TemplateDateVar::Issued)
+        && date_component.suppress_disamb_suffix != Some(true);
+
+    for component in fallbacks {
+        let Some(values) = component.values::<F>(reference, hints, options) else {
+            continue;
+        };
+        let suffix_label = disamb_eligible
+            .then(|| compute_disamb_suffix_label(hints, options, fmt))
+            .flatten();
+
+        let (raw_value, inlined) = match (component, suffix_label.as_deref()) {
+            (TemplateComponent::Date(inner), Some(suffix)) => {
+                let year = resolve_date_variable(&inner.date, reference)
+                    .map(|d| d.year())
+                    .unwrap_or_default();
+                (
+                    inline_disamb_suffix(&values.value, &inner.form, &year, suffix),
+                    true,
+                )
+            }
+            _ => (values.value.clone(), false),
+        };
+
+        let mut output = apply_fallback_component_rendering(
+            fmt,
+            &raw_value,
+            values.pre_formatted,
+            component.rendering(),
+            reference,
+            options,
+        );
+        if !inlined
+            && matches!(component, TemplateComponent::Message(_))
+            && let Some(suffix) = suffix_label.as_deref()
+        {
+            append_no_date_disamb_suffix(&mut output, suffix, options);
+        }
+        return Some(ProcValues {
+            value: output,
+            prefix: None,
+            suffix: None,
+            url: values.url,
+            substituted_key: values.substituted_key,
+            pre_formatted: true,
+        });
+    }
+
+    disamb_eligible
+        .then(|| compute_disamb_suffix_label(hints, options, fmt))
+        .flatten()
+        .map(|suffix| ProcValues {
+            value: suffix,
+            prefix: None,
+            suffix: None,
+            url: None,
+            substituted_key: None,
+            pre_formatted: true,
+        })
+}
+
 impl ComponentValues for TemplateDate {
     fn values<F: crate::render::format::OutputFormat<Output = String>>(
         &self,
@@ -1063,59 +1240,14 @@ impl ComponentValues for TemplateDate {
         options: &RenderOptions<'_>,
     ) -> Option<ProcValues<F::Output>> {
         let fmt = F::default();
-        let date_opt: Option<DateValue> = match self.date {
-            TemplateDateVar::Issued => reference.effective_issued_date(),
-            TemplateDateVar::Accessed => reference.accessed(),
-            TemplateDateVar::OriginalPublished => reference.original_date(),
-            TemplateDateVar::EventDate => event_date(reference),
-            TemplateDateVar::Copyright => reference.copyright(),
-            TemplateDateVar::Printing => reference.printing(),
-            _ => None,
-        };
+        let date_opt: Option<DateValue> = resolve_date_variable(&self.date, reference);
 
         let Some(date) = date_opt.filter(|d| !d.is_empty()) else {
             // Handle fallback if date is missing
             if let Some(fallbacks) = &self.fallback {
-                for component in fallbacks {
-                    if let Some(values) = component.values::<F>(reference, hints, options) {
-                        let mut output = apply_fallback_component_rendering(
-                            &fmt,
-                            &values.value,
-                            values.pre_formatted,
-                            component.rendering(),
-                            reference,
-                            options,
-                        );
-                        // A `message:` fallback candidate is, by construction,
-                        // the terminal "no data available" case in a date's
-                        // fallback chain (e.g. GB/T 7714's `无日期`/`n.d.`
-                        // term via `message: term.no-date`) — apply the same
-                        // year-suffix-append convention the implicit (no
-                        // explicit `fallback:`) no-date path below already
-                        // uses, so explicit and implicit no-date fallbacks
-                        // disambiguate identically. Without this, a style
-                        // whose date components always carry an explicit
-                        // `fallback:` chain (as GB/T author-date's do) never
-                        // reaches the implicit branch and never gets a
-                        // suffix at all. See csl26-6eak.
-                        if matches!(self.date, TemplateDateVar::Issued)
-                            && self.suppress_disamb_suffix != Some(true)
-                            && matches!(component, TemplateComponent::Message(_))
-                            && let Some(suffix) = compute_disamb_suffix_label(hints, options, &fmt)
-                        {
-                            append_no_date_disamb_suffix(&mut output, &suffix, options);
-                        }
-                        return Some(ProcValues {
-                            value: output,
-                            prefix: None,
-                            suffix: None,
-                            url: values.url,
-                            substituted_key: values.substituted_key,
-                            pre_formatted: true,
-                        });
-                    }
-                }
-                return None;
+                return render_date_fallback_chain::<F>(
+                    self, fallbacks, reference, hints, options, &fmt,
+                );
             }
             // For issued dates, substitute the locale's "no-date" term (e.g. "n.d.")
             if matches!(self.date, TemplateDateVar::Issued)
@@ -1137,7 +1269,24 @@ impl ComponentValues for TemplateDate {
                     pre_formatted: false,
                 });
             }
-            return None;
+            // No fallback and no term to substitute (e.g. the locale defines
+            // no "no date" term at all) — the date position renders nothing,
+            // but this reference's collision group may still need its
+            // year-suffix letter rendered standalone rather than silently
+            // dropped.
+            let disamb_eligible = matches!(self.date, TemplateDateVar::Issued)
+                && self.suppress_disamb_suffix != Some(true);
+            return disamb_eligible
+                .then(|| compute_disamb_suffix_label(hints, options, &fmt))
+                .flatten()
+                .map(|suffix| ProcValues {
+                    value: suffix,
+                    prefix: None,
+                    suffix: None,
+                    url: None,
+                    substituted_key: None,
+                    pre_formatted: true,
+                });
         };
 
         let locale = options.locale;

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-author-date.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-author-date.yaml
@@ -387,9 +387,24 @@ bibliography:
     - date: issued
       form: year
       suffix: '. '
-      fallback:
-      - message: term.no-date
-        form: short
+      # An undated article-journal/article-magazine renders no date text at
+      # all here — not 无日期/n.d. like every other type-variant — and if
+      # disambiguation still requires a letter, it renders standalone, alone
+      # in the date position. This matches the shipped upstream CSL: its
+      # `date-intext` macro's `type="article-journal article-magazine"`
+      # branch is fully self-contained — none of its three inner sub-cases
+      # (volume/issue present, available-date present, plain else) ever
+      # falls through to the outer no-date-term branch, because CSL/CSL-M
+      # `<choose>` selects one top-level branch and never continues past it.
+      # Whether GB/T the *standard* (not just this one implementation)
+      # actually intends blank-vs-n.d. for undated articles isn't derivable
+      # from the macro alone — open question, see csl26-9qat. This is a
+      # style-data decision pinned to the current oracle, revisitable
+      # without any engine change if that bean's standard-derived gold
+      # strings later disagree. See csl26-huuz. `fallback: []` (rather than
+      # a dedicated flag) is provisional pending a `date-substitute`
+      # options-level mechanism — see the follow-up bean tracking that.
+      fallback: []
     - title: primary
     - message: gb-t-7714-type-code
       args:
@@ -885,7 +900,15 @@ bibliography:
       form: year
       suppress-note: true
       suffix: '. '
+      # Upstream's `date-intext` macro checks `accessed` before falling to
+      # the "no date" term (`<else-if variable="accessed">`), rendering the
+      # bracketed access year in the author-date position — distinct from
+      # the full access date the unconditional `date: accessed` component
+      # below always renders when present. See csl26-huuz.
       fallback:
+      - date: accessed
+        form: year
+        wrap: { punctuation: brackets }
       - message: term.no-date
         form: short
     - title: primary

--- a/docs/specs/DISAMBIGUATION.md
+++ b/docs/specs/DISAMBIGUATION.md
@@ -44,7 +44,159 @@ abbreviated by the style's `shorten` config. This matches what the style will
 visually show, so disambiguation keys track rendered output without re-rendering.
 
 **Year key** (`build_group_key`): the `issued` year (`effective_issued_date()`),
-appended to the author key. **No other date field participates in the key.**
+appended to the author key, when that year is present and parses cleanly.
+When it is not — no `issued` value at all, or one that doesn't reduce to a
+clean numeric year (e.g. a literal like `"c1988"`) — the key falls through to
+the **date-slot discriminant** described below (`csl26-huuz`). No other date
+field ever substitutes for a *present* issued year in the key.
+
+#### Date-slot discriminant when the issued year is absent (csl26-huuz)
+
+Grouping by abstract variable equality alone is wrong once a style's date
+slot is type-conditional: two undated references can render *different* text
+for their date position (one style's `article-journal` branch renders
+nothing at all where every other type renders the locale's "no date" term,
+GB/T 7714 §7714.7.2), and two references *are* already visually
+distinguishable whenever their date slots render differently — grouping them
+for year-suffix purposes would be wrong on Citum's own terms, independent of
+what citeproc-js does. Conversely, references whose date slots render
+*identical* text must still collide, or the group won't get the shared
+suffix sequence a reader would expect.
+
+The fix keeps `build_group_key`'s existing shape (author key + a date
+discriminant) but computes the discriminant from the reference's **resolved
+template** — the first date component under the author not marked
+`suppress-disamb-suffix` — instead of assuming a uniform outcome:
+
+1. **The date variable resolves to a real, non-empty value** → the text it
+   would actually *render* is the discriminant: `form`-restricted formatting
+   plus uncertainty/approximation markers, the same pipeline
+   `TemplateDate::values` applies — not the raw stored value, whose `Display`
+   can carry more precision than `form` shows (a day-precision `copyright`
+   date under `form: year` renders as a bare year but its raw value still has
+   the day; reading the raw value could split a group whose members render
+   identically, flagged in PR review). For a fallback candidate specifically,
+   this also includes the candidate's own prefix/suffix/wrap and the
+   resolved value's `note` — the same extra text
+   `apply_fallback_component_rendering`/`append_note` add to the bare value
+   during real rendering (GB/T's `book,thesis,map` chain prefixes
+   `copyright` with `c` and suffixes `printing` with `印刷`; two references
+   resolving each can share a bare year while rendering visibly different
+   text, and must not collide).
+2. **The variable is empty, and the resolved fallback chain (explicit
+   `fallback:`, or the implicit no-`fallback:` branch) renders the locale's
+   no-date term** → a discriminant for that term, scoped by the reference's
+   effective language (mirrors the anonymous-fallback author key below — the
+   term itself varies by language, `无日期` vs `n.d.`). The implicit and an
+   explicit `fallback: [message: term.no-date]` render identical text, so
+   both compute the identical discriminant.
+3. **An access date (`DateVariable::Accessed`) is the only thing that would
+   resolve** — whether it's the slot's own primary variable or a fallback
+   candidate — **the discriminant is empty**, matching case 4, never the
+   access date's value. An access date is retrieval metadata, not part of a
+   work's identity; two references differing only in *when* they were
+   accessed must not be treated as distinguishable. This mirrors, but is not
+   derived from, citeproc-js's `just_looking`-time suppression of accessed
+   dates during its own ambiguity computation — the two independently land
+   on the same rule because it's the correct rule, not because one copies
+   the other.
+4. **Nothing resolves at all** (an explicit `fallback: []`, or no template
+   configured) → empty discriminant, the same value case 3 produces.
+   Expressing "this reference type's date logic has nothing else to show for
+   a missing date" as an empty `fallback:` list overloads an empty
+   collection as a semantic signal — flagged as a design concern, not fixed
+   here. A `date-substitute` options-level mechanism (mirroring
+   `author-substitute`/`Substitute` in `options/substitute.rs`) is planned as
+   a stacked follow-up that would express this declaratively instead —
+   `csl26-qbmd`, designed together with this discriminant rather than as an
+   independent fix, since it will own most of what this function reads.
+
+Case 3's "stop, don't fall through" behavior matters: once a candidate in the
+fallback chain *would* be selected (its underlying variable has a value,
+even if that value contributes no discriminant), the search stops there — it
+does not continue scanning for a later candidate. This mirrors the
+if/else-if/else shape the fallback chain represents: a present access date
+selects that branch, whose content is then suppressed for grouping purposes;
+it does not make the chain fall through to the no-date term as if the access
+branch had never matched.
+
+**Spec resolution order is bibliography-preferred, not citation-preferred**
+(`Disambiguator::date_slot_discriminant`, `first_date_component_for_bibliography`
+before `first_date_component_for_citation`, `sorting.rs`) — the opposite
+order from the author-key list-primary resolution in `build_reference_cache`.
+This was confirmed empirically, not assumed: a style's `citation:` template
+is commonly a simpler, non-type-differentiated form of the same date logic
+(`gb-t-7714-2025-author-date`'s `citation:` section has one flat
+`date: issued` component with no `type-variants:` at all, unlike its
+`bibliography:` section). Preferring `citation_spec` first — the initial
+design — let that undifferentiated template collapse every undated reference
+onto one discriminant regardless of type, silently defeating the
+type-conditional split this mechanism exists to make; verified against the
+GB/T oracle before landing the bibliography-first order.
+
+The selected slot carries its effective scope configuration with it:
+bibliography slots use the effective bibliography options, while the citation
+fallback slot uses the effective citation options. This keeps date markers and
+candidate-note behavior aligned with the scope whose template supplied the
+identity slot.
+
+**Why not compute citation and bibliography membership separately** (raised
+in PR review): a reference's year-suffix letter must be identical everywhere
+it's cited — a citation showing "2020a" and the bibliography showing "2020b"
+for the same reference is a worse, more visible defect than the asymmetry a
+per-scope split would fix. It's also not what the oracle does: this
+mechanism's design evidence was citeproc-js's own `registry.ambigcites` for
+this exact style, captured once for the whole style (无日期×23, n.d.×10,
+empty×3, empty×2) — one set of groups, used for both citation and
+bibliography rendering, because upstream's `date-intext` macro is literally
+the same macro referenced from both the `<citation>` and `<bibliography>`
+layouts in the CSL source. Bibliography-preferred is correct precisely
+*because* citum's bibliography template is the more complete mirror of that
+shared macro. The citation template's own lack of type-conditional structure
+is a separate, pre-existing migration gap, not something this mechanism can
+or should absorb by fragmenting the letter itself; tracked as a follow-up
+under `csl26-6eak`.
+
+Both `first_date_component_for_citation` and
+`first_date_component_for_bibliography` resolve their language via
+`crate::values::effective_item_language`, matching the real render path
+(`processor/rendering/mod.rs::locale_for_reference`) and this mechanism's
+own no-date-term discriminant scoping — not the bare `reference.language()`
+the pre-existing `primary_contributor_for_citation`/
+`primary_contributor_for_bibliography` use (a latent, unrelated
+inconsistency, out of scope here; flagged in PR review).
+
+No new schema surface: `TemplateDate.fallback: Option<Vec<TemplateComponent>>`
+already existed and the renderer already walked it in order
+(`values/date.rs`); the discriminant reads data styles already carry.
+
+**Risk containment:** when the issued year is present and parses, the key is
+byte-identical to before this change. The discriminant path only ever
+*splits* a group whose members' date slots resolve differently — it never
+merges references that previously formed separate groups.
+
+**Rendering fix required alongside grouping.** `values/date.rs`'s fallback
+render path previously only inlined a year-suffix letter for a `message:`
+fallback candidate (`csl26-6eak`), appending it *after* that candidate's own
+wrap/affixes were applied. Two more cases needed the same treatment once
+grouping could split on them:
+- A `date:` fallback candidate (e.g. an access-year fallback rendering
+  `Anon，[2020a]`) needs the letter inlined into the raw formatted text
+  *before* the candidate's own wrap is applied, so it lands inside the
+  brackets rather than after them.
+- An empty resolution (nothing in the fallback chain renders anything) still
+  needs the group's disamb suffix rendered standalone — upstream's bare
+  `<text variable="year-suffix"/>` after an empty date, oracle: `Anon，b.` —
+  otherwise an entry whose date slot is entirely empty silently loses its
+  disambiguator rather than getting the wrong one.
+
+**Scope: membership, not order.** This mechanism fixes collision-group
+*membership*. Within-group *letter order* still rides on §3's resolved-sort
+machinery (`csl26-m8la`) — a style with no real `bibliography.sort` of its
+own (like `gb-t-7714-2025-author-date`, which inherits `citation-number`
+registry order from its numeric base) will still assign letters in registry
+order, which can disagree with the oracle's actual bibliography-sort order
+for groups this mechanism newly separates out. That gap is `csl26-q67h`.
 
 #### Year-suffix when the original-publication date differs
 
@@ -363,6 +515,20 @@ added to the citation context.
   same-surname authors get initials, not a spurious year suffix (csl26-2zy6, row 114)
 - [x] MLA disables `year_suffix` and disambiguates same-author works via the
   `disambiguate-only` short title (csl26-2zy6, row 173)
+- [x] When the issued year is absent, collision-group membership follows a
+  date-slot discriminant computed from the resolved template rather than a
+  uniform "no date" assumption (csl26-huuz)
+- [x] An access date never contributes to the discriminant, whether primary
+  or fallback, present or absent (csl26-huuz)
+- [x] The implicit no-`fallback:` no-date-term path and an explicit
+  `fallback: [message: term.no-date]` compute the identical discriminant
+  (csl26-huuz)
+- [x] A resolving candidate's discriminant reflects `form`-restricted
+  rendered text, prefix/suffix/wrap, and `note` — not the raw stored date
+  value's precision (csl26-huuz)
+- [ ] A declarative, type-scoped mechanism (not an empty `fallback:` list)
+  expresses "nothing else to show for a missing date" (`csl26-qbmd`,
+  stacked follow-up)
 
 ## Related specs
 
@@ -374,6 +540,48 @@ added to the citation context.
 
 ## Changelog
 
+- 2026-08-12: Review follow-up on the date-slot discriminant (csl26-huuz).
+  A resolving candidate's discriminant now reflects `form`-restricted
+  rendered text plus prefix/suffix/wrap/`note` (`values/date.rs` gained
+  `fallback_candidate_discriminant`) instead of the raw stored date value,
+  which could over-collapse two candidates that render visibly different
+  text (a `c`-prefixed `copyright` year and a `印刷`-suffixed `printing`
+  year sharing a bare year, or a day-precision date under `form: year`).
+  `first_date_component_for_citation`/`_for_bibliography` now resolve
+  language via `effective_item_language`, matching the real render path,
+  instead of bare `reference.language()`. Investigated and declined a
+  fourth review finding (splitting citation and bibliography disambiguation
+  membership into separate hints) — see the bibliography-preferred
+  rationale above; a reference's letter must stay identical across both
+  scopes. A `TemplateDate.suppress-no-date-term` flag was tried and reverted
+  before landing — the empty-`fallback:`-list-as-signal concern it answered
+  is real, but a per-component flag would just be one more thing for a
+  planned `date-substitute` options mechanism (`csl26-qbmd`, mirroring
+  `author-substitute`) to deprecate; `gb-t-7714-2025-author-date.yaml`'s
+  `article-journal,article-magazine` stays on `fallback: []` until that
+  mechanism lands, designed together with this discriminant rather than
+  built independently.
+- 2026-08-11: Added the date-slot discriminant (csl26-huuz), closing the gap
+  §1's changelog entry below flagged as unfixed. `build_group_key`'s
+  no-issued-year fallthrough now reads the reference's resolved date
+  component instead of collapsing every undated reference onto one key.
+  Engine: `sorting.rs` gained `first_date_component_for_bibliography`/
+  `_for_citation` (mirroring the existing contributor-resolution helpers);
+  `disambiguation.rs` gained `date_slot_discriminant`/
+  `date_component_discriminant`; `values/date.rs`'s fallback render path
+  (`render_date_fallback_chain`) gained in-wrap suffix inlining for a
+  `date:` fallback candidate and a standalone-suffix case for an empty
+  resolution. Style: `gb-t-7714-2025-author-date.yaml`'s
+  `article-journal,article-magazine` type-variant lost its `term.no-date`
+  fallback (upstream's date-intext macro never reaches it for that branch);
+  its `webpage,post,post-weblog` type-variant gained an access-year fallback
+  ahead of the no-date term. `gb-t-7714-2025-author-date`'s diagnostic
+  upstream-corpus bibliography scope (`count_toward_fidelity: false`, so no
+  fidelity-gate impact) went 147/203 → 176/203; zero regressions across the
+  35-style exemplar corpus (`report-core.js --all-features`) or
+  `cargo nextest run`. The five entries whose date-slot grouping is now
+  correct but whose letters still depend on registry order remain tracked
+  in `csl26-q67h`, not closed here.
 - 2026-08-06: Fixed §3's resolved-`group_sort` case (csl26-m8la).
   `Disambiguator::sort_group_for_year_suffix` pre-sorted every collision group
   title-alphabetically before applying the resolved sort, regardless of whether


### PR DESCRIPTION
**Fixes csl26-huuz** — year-suffix collision grouping now follows what a
reference's resolved date slot actually renders, instead of assuming every
undated reference renders the same "no date" text. This is Layer 1 of the
date-substitute stack: the candidate-neutral engine foundation on which the
Draft spec and implementation layers build.

- `disambiguation.rs`: the date-slot discriminant reads the resolved template
  when no issued year is parseable. The selected identity slot is paired with
  its effective scope configuration: bibliography options for a bibliography
  slot, citation options for the citation fallback slot.
- `values/date.rs`: fallback discrimination accepts date form, rendering, and
  `suppress-note` independently, so the implementation layer can supply either
  inline or options-level candidates without duplicating the algorithm.
- Fallback year-suffix letters land inside candidate wrapping (`[2020a]`, not
  `[2020]a`), while an empty fallback chain still renders the letter standalone.
- `gb-t-7714-2025-author-date.yaml`: two type variants' date fallbacks match
  the upstream CSL-M macro.
- `docs/specs/DISAMBIGUATION.md`: documents identity-slot resolution and the
  effective-scope configuration rule.

**Measured:** GB/T's diagnostic corpus (not fidelity-gated) moved 147/203 to
176/203. The full repository gate passes: formatting, clippy, and 2,471 tests.
The two new stack-alignment regressions cover scoped date configuration and
candidate-note suppression; the PR now carries 15 new tests in total.

**Stack:**

1. #1171 — candidate-neutral date-slot foundation (this PR)
2. Draft `DATE_SUBSTITUTE.md` specification
3. schema and engine implementation; spec becomes Active
4. GB/T style migration to named presets

Closes csl26-huuz. The broader mechanism is tracked by csl26-qbmd.
