### PR TITLE
feat(engine): date substitute implementation

### DIFF
--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -1094,7 +1094,13 @@ impl<'a> Disambiguator<'a> {
         let Some((component, config)) = component_and_config else {
             return String::new();
         };
-        Self::date_component_discriminant(&component, reference, self.locale, config.dates.as_ref())
+        Self::date_component_discriminant(
+            &component,
+            reference,
+            self.locale,
+            config,
+            &reference.ref_type(),
+        )
     }
 
     /// The literal locale message ID the implicit no-date branch in
@@ -1120,9 +1126,12 @@ impl<'a> Disambiguator<'a> {
         component: &citum_schema::template::TemplateDate,
         reference: &Reference,
         locale: &citum_schema::locale::Locale,
-        date_config: Option<&citum_schema::options::dates::DateConfig>,
+        config: &citum_schema::options::Config,
+        ref_type: &str,
     ) -> String {
         use citum_schema::template::{DateVariable, TemplateComponent};
+
+        let date_config = config.dates.as_ref();
 
         if matches!(component.date, DateVariable::Accessed) {
             if crate::values::date::resolve_date_variable(&component.date, reference)
@@ -1143,7 +1152,7 @@ impl<'a> Disambiguator<'a> {
             // this is terminal even when the value fails to format (e.g. a
             // literal date under a numeric `form`, which the renderer also
             // shows as nothing). Reuses the same fallback-candidate helper as
-            // the loop below: its prefix/suffix/wrap contribution is inert
+            // the loop below: its visible rendering configuration is inert
             // here (constant across every reference resolving this same
             // component, so it can never split two references from each
             // other), but `date.note` is per-reference *data*, not
@@ -1163,26 +1172,36 @@ impl<'a> Disambiguator<'a> {
             .unwrap_or_default();
         }
 
-        let Some(fallbacks) = component.fallback.as_ref() else {
+        let source =
+            crate::values::date::effective_date_candidate_source(component, config, ref_type);
+        let Some(fallbacks) = source.template_components() else {
             return if matches!(component.date, DateVariable::Issued) {
-                format!(
-                    "term:{}:{}",
-                    Self::IMPLICIT_NO_DATE_TERM,
-                    crate::values::effective_item_language(reference).unwrap_or_default()
+                crate::values::date::fallback_message_discriminant(
+                    &citum_schema::template::TemplateMessage {
+                        message: Self::IMPLICIT_NO_DATE_TERM.to_string(),
+                        form: Some(citum_schema::locale::TermForm::Short),
+                        ..Default::default()
+                    },
+                    locale,
+                    config,
                 )
+                .unwrap_or_default()
             } else {
                 String::new()
             };
         };
 
-        for candidate in fallbacks {
+        for candidate in fallbacks.iter() {
             match candidate {
                 TemplateComponent::Message(message) => {
-                    return format!(
-                        "term:{}:{}",
-                        message.message,
-                        crate::values::effective_item_language(reference).unwrap_or_default()
-                    );
+                    let Some(discriminant) =
+                        crate::values::date::fallback_message_discriminant(message, locale, config)
+                    else {
+                        // Rendering skips unresolved or suppressed messages and
+                        // continues to the next fallback candidate.
+                        continue;
+                    };
+                    return discriminant;
                 }
                 TemplateComponent::Date(inner) => {
                     let Some(value) =
@@ -2595,11 +2614,19 @@ mod tests {
     #[case::real_issued_value_wins_without_consulting_fallback(
         "2020",
         None,
-        "2020||None|None|None"
+        "2020||None|None|None|None|None|None|None|None"
     )]
     #[case::present_accessed_stops_the_chain_with_no_identity("", Some("2020"), "")]
-    #[case::absent_accessed_falls_through_to_the_no_date_term("", None, "term:term.no-date:")]
-    #[case::empty_string_accessed_is_treated_as_absent("", Some(""), "term:term.no-date:")]
+    #[case::absent_accessed_falls_through_to_the_no_date_term(
+        "",
+        None,
+        "no date|None|None|None|None|None|None|None|None"
+    )]
+    #[case::empty_string_accessed_is_treated_as_absent(
+        "",
+        Some(""),
+        "no date|None|None|None|None|None|None|None|None"
+    )]
     fn given_an_issued_with_accessed_fallback_when_computing_the_collision_discriminant_then_it_matches(
         #[case] issued: &str,
         #[case] accessed: Option<&str>,
@@ -2609,8 +2636,13 @@ mod tests {
         let component = issued_with_accessed_fallback();
 
         let locale = Locale::en_us();
-        let discriminant =
-            Disambiguator::date_component_discriminant(&component, &reference, &locale, None);
+        let discriminant = Disambiguator::date_component_discriminant(
+            &component,
+            &reference,
+            &locale,
+            &Config::default(),
+            &reference.ref_type(),
+        );
 
         assert_eq!(discriminant, expected);
     }
@@ -2618,6 +2650,7 @@ mod tests {
     #[rstest]
     #[case::explicit_message_fallback(Some(vec![TemplateComponent::Message(TemplateMessage {
         message: "term.no-date".to_string(),
+        form: Some(citum_schema::locale::TermForm::Short),
         ..Default::default()
     })]))]
     #[case::implicit_no_fallback_at_all(None)]
@@ -2633,8 +2666,13 @@ mod tests {
         };
 
         let locale = Locale::en_us();
-        let discriminant =
-            Disambiguator::date_component_discriminant(&component, &reference, &locale, None);
+        let discriminant = Disambiguator::date_component_discriminant(
+            &component,
+            &reference,
+            &locale,
+            &Config::default(),
+            &reference.ref_type(),
+        );
 
         // Both the implicit (no `fallback:` at all) and explicit
         // (`fallback: [message: term.no-date]`) paths render the identical
@@ -2642,7 +2680,41 @@ mod tests {
         // identical collision-key discriminant — otherwise a style that
         // mixes the two forms across type-variants would split undated
         // references that render identical text.
-        assert_eq!(discriminant, "term:term.no-date:");
+        assert_eq!(discriminant, "n.d.|None|None|None|None|None|None|None|None");
+    }
+
+    #[test]
+    fn unresolved_message_fallback_continues_to_the_next_candidate() {
+        let reference = make_dated_ref("d2", "Smith", "", None);
+        let component = TemplateDate {
+            date: DateVariable::Issued,
+            form: DateForm::Year,
+            fallback: Some(vec![
+                TemplateComponent::Message(TemplateMessage {
+                    message: "term.does-not-exist".to_string(),
+                    ..TemplateMessage::default()
+                }),
+                TemplateComponent::Message(TemplateMessage {
+                    message: "term.no-date".to_string(),
+                    ..TemplateMessage::default()
+                }),
+            ]),
+            ..TemplateDate::default()
+        };
+
+        let locale = Locale::en_us();
+        let discriminant = Disambiguator::date_component_discriminant(
+            &component,
+            &reference,
+            &locale,
+            &Config::default(),
+            &reference.ref_type(),
+        );
+
+        assert_eq!(
+            discriminant,
+            "no date|None|None|None|None|None|None|None|None"
+        );
     }
 
     #[test]
@@ -2656,8 +2728,13 @@ mod tests {
         };
 
         let locale = Locale::en_us();
-        let discriminant =
-            Disambiguator::date_component_discriminant(&component, &reference, &locale, None);
+        let discriminant = Disambiguator::date_component_discriminant(
+            &component,
+            &reference,
+            &locale,
+            &Config::default(),
+            &reference.ref_type(),
+        );
 
         assert_eq!(discriminant, "");
     }
@@ -2701,11 +2778,11 @@ mod tests {
 
         assert_eq!(
             visible.as_deref(),
-            Some("1947|民国36年|Some(Custom(\"c\"))|None|None")
+            Some("1947|民国36年|None|None|None|None|None|Some(Custom(\"c\"))|None|None")
         );
         assert_eq!(
             suppressed.as_deref(),
-            Some("1947||Some(Custom(\"c\"))|None|None")
+            Some("1947||None|None|None|None|None|Some(Custom(\"c\"))|None|None")
         );
     }
 
@@ -2761,11 +2838,11 @@ mod tests {
             .date_slot_discriminant(&reference);
 
         assert_eq!(
-            bibliography_owned, "1995|source calendar|None|None|None",
+            bibliography_owned, "1995|source calendar|None|None|None|None|None|None|None|None",
             "a bibliography-selected slot must use effective bibliography date options"
         );
         assert_eq!(
-            citation_owned, "1995|source calendar|None|None|None",
+            citation_owned, "1995|source calendar|None|None|None|None|None|None|None|None",
             "the citation fallback slot must use effective citation date options"
         );
     }
@@ -2819,10 +2896,18 @@ mod tests {
         let reference = make_ref_with_copyright("r1", "Smith", copyright);
         let locale = Locale::en_us();
 
-        let discriminant =
-            Disambiguator::date_component_discriminant(&component, &reference, &locale, None);
+        let discriminant = Disambiguator::date_component_discriminant(
+            &component,
+            &reference,
+            &locale,
+            &Config::default(),
+            &reference.ref_type(),
+        );
 
-        assert_eq!(discriminant, "1995||None|None|None");
+        assert_eq!(
+            discriminant,
+            "1995||None|None|None|None|None|None|None|None"
+        );
     }
 
     /// GB/T 7714's real `book,thesis,map` fallback chain: `copyright`
@@ -2891,10 +2976,20 @@ mod tests {
         }));
         let locale = Locale::en_us();
 
-        let copyright_discriminant =
-            Disambiguator::date_component_discriminant(&component, &copyright_ref, &locale, None);
-        let printing_discriminant =
-            Disambiguator::date_component_discriminant(&component, &printing_ref, &locale, None);
+        let copyright_discriminant = Disambiguator::date_component_discriminant(
+            &component,
+            &copyright_ref,
+            &locale,
+            &Config::default(),
+            &copyright_ref.ref_type(),
+        );
+        let printing_discriminant = Disambiguator::date_component_discriminant(
+            &component,
+            &printing_ref,
+            &locale,
+            &Config::default(),
+            &printing_ref.ref_type(),
+        );
 
         assert_ne!(
             copyright_discriminant, printing_discriminant,

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -1038,6 +1038,11 @@ impl Renderer<'_> {
             first_reference_note_number,
         } = request;
         let ref_type = reference.ref_type();
+        let template = crate::values::date::materialize_identity_date_substitute(
+            template,
+            &self.config,
+            &ref_type,
+        );
         let locale = self.locale_for_reference(reference, context);
         let options = RenderOptions {
             config: self.config.clone(),
@@ -1056,7 +1061,7 @@ impl Renderer<'_> {
         // when the template actually renders it.  Suppressing a `disambiguate-only`
         // title without emitting the note number as a replacement identifier would
         // silently reintroduce ambiguity for colliding works.
-        let effective_first_ref_note = if template_uses_first_ref_note_number(template) {
+        let effective_first_ref_note = if template_uses_first_ref_note_number(&template) {
             first_reference_note_number
         } else {
             None
@@ -1071,7 +1076,7 @@ impl Renderer<'_> {
             first_reference_note_number: effective_first_ref_note,
         });
         let mut components =
-            self.render_template_components::<F>(reference, &ref_type, &options, &hint, template);
+            self.render_template_components::<F>(reference, &ref_type, &options, &hint, &template);
 
         self.apply_sentence_initial_context::<F>(&mut components, context, note_start_text_case);
 
@@ -1351,6 +1356,7 @@ impl Renderer<'_> {
             component,
             TemplateComponent::Date(citum_schema::template::TemplateDate {
                 date: citum_schema::template::DateVariable::Issued,
+                fallback: None,
                 ..
             })
         ) || reference.effective_issued_date().is_some()

--- a/crates/citum-engine/src/processor/rendering/tests.rs
+++ b/crates/citum-engine/src/processor/rendering/tests.rs
@@ -1410,3 +1410,262 @@ mod fallback_chain_disamb_suffix {
         );
     }
 }
+
+mod date_substitute_options {
+    use super::*;
+    use citum_schema::options::DateSubstitutePreset;
+    use citum_schema::reference::{
+        Contributor, DateValue, Monograph, MonographType, MultilingualString, StructuredName, Title,
+    };
+
+    fn undated_reference(id: &str, ref_type: &str, accessed_year: Option<i32>) -> Reference {
+        Reference::from(LegacyReference {
+            id: id.to_string(),
+            ref_type: ref_type.to_string(),
+            author: Some(vec![Name::new("Anon", "")]),
+            title: Some(format!("Title {id}")),
+            accessed: accessed_year.map(LegacyDateVariable::year),
+            ..Default::default()
+        })
+    }
+
+    fn issued_with_inline_empty() -> TemplateComponent {
+        TemplateComponent::Date(TemplateDate {
+            date: DateVariable::Issued,
+            form: DateForm::Year,
+            fallback: Some(vec![]),
+            ..Default::default()
+        })
+    }
+
+    fn style_with_policy(
+        preset: Option<DateSubstitutePreset>,
+        template: Vec<TemplateComponent>,
+    ) -> Style {
+        let mut style = bibliography_style_with_template(template);
+        style.options = Some(Config {
+            date_substitute: preset.map(DateSubstitutePreset::config),
+            ..Default::default()
+        });
+        style
+    }
+
+    #[test]
+    fn omitted_policy_preserves_inline_empty_while_standard_is_explicit() {
+        let reference = undated_reference("book", "book", None);
+        let omitted = render_single_bibliography_entry(
+            style_with_policy(None, vec![issued_with_inline_empty()]),
+            reference.clone(),
+        );
+        let standard = render_single_bibliography_entry(
+            style_with_policy(
+                Some(DateSubstitutePreset::Standard),
+                vec![issued_with_inline_empty()],
+            ),
+            reference,
+        );
+
+        assert_eq!(omitted, "");
+        assert_eq!(standard, "n.d.");
+    }
+
+    #[test]
+    fn matched_empty_identity_slot_does_not_replace_later_inline_fallback() {
+        let later_display_date = TemplateComponent::Date(TemplateDate {
+            date: DateVariable::Issued,
+            form: DateForm::Year,
+            fallback: Some(vec![TemplateComponent::Message(TemplateMessage {
+                message: "term.no-date".to_string(),
+                form: Some(citum_schema::locale::TermForm::Short),
+                ..Default::default()
+            })]),
+            suppress_disamb_suffix: Some(true),
+            ..Default::default()
+        });
+        let style = style_with_policy(
+            Some(DateSubstitutePreset::GbT7714_2025AuthorDate),
+            vec![issued_with_inline_empty(), later_display_date],
+        );
+
+        let rendered = render_single_bibliography_entry(
+            style,
+            undated_reference("journal", "article-journal", None),
+        );
+
+        assert_eq!(rendered, "n.d.");
+    }
+
+    #[test]
+    fn accessed_web_candidate_uses_the_authored_bracket_rendering() {
+        let style = style_with_policy(
+            Some(DateSubstitutePreset::GbT7714_2025AuthorDate),
+            vec![issued_with_inline_empty()],
+        );
+
+        let rendered = render_single_bibliography_entry(
+            style,
+            undated_reference("web", "webpage", Some(2020)),
+        );
+
+        assert_eq!(rendered, "[2020]");
+    }
+
+    #[test]
+    fn message_candidate_uses_central_component_rendering() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+date-substitute:
+  default:
+  - message: term.no-date
+    form: short
+    small-caps: true
+    quote: true
+"#,
+        )
+        .expect("date-substitute config should parse");
+        let style = {
+            let mut style = bibliography_style_with_template(vec![issued_with_inline_empty()]);
+            style.options = Some(config);
+            style
+        };
+
+        let rendered =
+            render_single_bibliography_entry(style, undated_reference("book", "book", None));
+
+        assert_eq!(rendered, "“N.D.”");
+    }
+
+    #[test]
+    fn suppressed_candidate_continues_to_the_next_candidate() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+date-substitute:
+  default:
+  - message: term.no-date
+    form: short
+    suppress: true
+  - date: accessed
+    form: year
+"#,
+        )
+        .expect("date-substitute config should parse");
+        let style = {
+            let mut style = bibliography_style_with_template(vec![issued_with_inline_empty()]);
+            style.options = Some(config);
+            style
+        };
+
+        let rendered = render_single_bibliography_entry(
+            style,
+            undated_reference("web", "webpage", Some(2020)),
+        );
+
+        assert_eq!(rendered, "2020");
+    }
+
+    #[test]
+    fn unmatched_selector_preserves_the_inline_candidate_source() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+date-substitute:
+  book: []
+"#,
+        )
+        .expect("selector map should parse");
+        let inline_no_date = TemplateComponent::Date(TemplateDate {
+            date: DateVariable::Issued,
+            form: DateForm::Year,
+            fallback: Some(vec![TemplateComponent::Message(TemplateMessage {
+                message: "term.no-date".to_string(),
+                form: Some(citum_schema::locale::TermForm::Short),
+                ..Default::default()
+            })]),
+            ..Default::default()
+        });
+        let style = {
+            let mut style = bibliography_style_with_template(vec![inline_no_date]);
+            style.options = Some(config);
+            style
+        };
+
+        let rendered =
+            render_single_bibliography_entry(style, undated_reference("report", "report", None));
+
+        assert_eq!(rendered, "n.d.");
+    }
+
+    #[test]
+    fn matched_empty_source_is_shared_with_disambiguation() {
+        let template = vec![
+            TemplateComponent::Contributor(TemplateContributor {
+                contributor: ContributorRole::Author.into(),
+                form: ContributorForm::Long,
+                name_order: Some(NameOrder::FamilyFirst),
+                ..Default::default()
+            }),
+            issued_with_inline_empty(),
+            TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                ..Default::default()
+            }),
+        ];
+        let style = style_with_policy(Some(DateSubstitutePreset::GbT7714_2025AuthorDate), template);
+        let mut bibliography = Bibliography::new();
+        bibliography.insert(
+            "first".to_string(),
+            undated_reference("first", "article-journal", None),
+        );
+        bibliography.insert(
+            "second".to_string(),
+            undated_reference("second", "article-journal", None),
+        );
+
+        let rendered = Processor::new(style, bibliography)
+            .render_bibliography_with_format_standalone::<crate::render::plain::PlainText>();
+
+        assert_eq!(rendered, "Anon. a. Title first\n\nAnon. b. Title second");
+    }
+
+    #[test]
+    fn options_date_candidate_obeys_its_suppress_note_flag() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+dates:
+  note-wrap: parentheses
+date-substitute:
+  default:
+  - date: copyright
+    form: year
+    prefix: c
+    suppress-note: true
+"#,
+        )
+        .expect("date-substitute config should parse");
+        let style = {
+            let mut style = bibliography_style_with_template(vec![issued_with_inline_empty()]);
+            style.options = Some(config);
+            style
+        };
+        let reference = Reference::Monograph(Box::new(Monograph {
+            id: Some("annotated-copyright".into()),
+            r#type: MonographType::Book,
+            title: Some(Title::Single("Annotated copyright".to_string())),
+            author: Some(Contributor::StructuredName(StructuredName {
+                family: MultilingualString::Simple("Anon".to_string()),
+                given: MultilingualString::Simple(String::new()),
+                suffix: None,
+                dropping_particle: None,
+                non_dropping_particle: None,
+            })),
+            copyright: Some(DateValue {
+                value: "1947".to_string(),
+                note: Some("Minguo 36".to_string()),
+            }),
+            ..Default::default()
+        }));
+
+        let rendered = render_single_bibliography_entry(style, reference);
+
+        assert_eq!(rendered, "c1947");
+    }
+}

--- a/crates/citum-engine/src/values/contributor/mod.rs
+++ b/crates/citum-engine/src/values/contributor/mod.rs
@@ -299,20 +299,19 @@ fn resolve_author_fallback<F: crate::render::format::OutputFormat<Output = Strin
     let fallbacks = component.fallback.as_ref()?;
     for fallback in fallbacks {
         if let Some(values) = fallback.values::<F>(reference, hints, options) {
-            let output = crate::values::date::apply_fallback_component_rendering(
-                fmt,
-                &values.value,
-                values.pre_formatted,
-                fallback.rendering(),
-                reference,
-                options,
+            let substituted_key = values.substituted_key.clone();
+            let output = crate::values::date::render_fallback_component(
+                fmt, fallback, values, reference, options,
             );
+            if output.trim().is_empty() {
+                continue;
+            }
             return Some(ProcValues {
                 value: output,
                 prefix: None,
                 suffix: None,
-                url: values.url,
-                substituted_key: values.substituted_key,
+                url: None,
+                substituted_key,
                 pre_formatted: true,
             });
         }

--- a/crates/citum-engine/src/values/date.rs
+++ b/crates/citum-engine/src/values/date.rs
@@ -13,11 +13,13 @@ use crate::values::{ComponentValues, ProcHints, ProcValues, RenderOptions};
 use citum_edtf::{Edtf, Timezone, UnspecifiedYear, Year};
 use citum_schema::locale::{GeneralTerm, SubYearCode, TermForm};
 use citum_schema::options::dates::{DateRangeFormat, TimeFormat};
+use citum_schema::options::{Config, DateSubstituteCandidate};
 use citum_schema::reference::types::RefDate;
 use citum_schema::reference::{ClassExtension, WorkRelation};
 use citum_schema::template::{
     DateForm, DateVariable as TemplateDateVar, Rendering, TemplateComponent, TemplateDate,
 };
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 /// Zero-pad a rendered day when `zero_pad` is set, otherwise render it as-is.
@@ -88,6 +90,118 @@ pub(crate) fn resolve_date_variable(
     }
 }
 
+/// Effective source for the identity date's fallback candidates.
+///
+/// The variants preserve the semantic distinction between omitted options,
+/// an authored policy with no matching selector, and a matched selector whose
+/// candidate list may intentionally be empty.
+pub(crate) enum EffectiveDateCandidateSource<'a> {
+    /// `date-substitute` was omitted; preserve inline or implicit behavior.
+    Inline(Option<&'a [TemplateComponent]>),
+    /// A policy exists but no selector matched; preserve inline or implicit behavior.
+    Unmatched(Option<&'a [TemplateComponent]>),
+    /// A selector matched; its list replaces the inline chain as a whole.
+    Matched(&'a [DateSubstituteCandidate]),
+}
+
+impl<'a> EffectiveDateCandidateSource<'a> {
+    /// Materialize the effective source as ordinary template components.
+    pub(crate) fn template_components(&self) -> Option<Cow<'a, [TemplateComponent]>> {
+        match self {
+            Self::Inline(inline) | Self::Unmatched(inline) => inline.map(Cow::Borrowed),
+            Self::Matched(candidates) => Some(Cow::Owned(
+                candidates
+                    .iter()
+                    .map(DateSubstituteCandidate::to_template_component)
+                    .collect(),
+            )),
+        }
+    }
+}
+
+/// Resolve the effective candidate source for an identity date component.
+pub(crate) fn effective_date_candidate_source<'a>(
+    component: &'a TemplateDate,
+    config: &'a Config,
+    ref_type: &str,
+) -> EffectiveDateCandidateSource<'a> {
+    let inline = component.fallback.as_deref();
+    let Some(policy) = config.date_substitute.as_ref() else {
+        return EffectiveDateCandidateSource::Inline(inline);
+    };
+    policy.candidates_for(ref_type).map_or_else(
+        || EffectiveDateCandidateSource::Unmatched(inline),
+        EffectiveDateCandidateSource::Matched,
+    )
+}
+
+/// Materialize an options-level candidate chain on the first eligible date.
+///
+/// Traversal is recursive and authored-order preserving. Only the first date
+/// whose `suppress-disamb-suffix` is not true is the identity slot; later
+/// dates retain their inline fallbacks.
+pub(crate) fn materialize_identity_date_substitute<'a>(
+    template: &'a [TemplateComponent],
+    config: &Config,
+    ref_type: &str,
+) -> Cow<'a, [TemplateComponent]> {
+    let Some(identity_date) = first_identity_date(template) else {
+        return Cow::Borrowed(template);
+    };
+    let EffectiveDateCandidateSource::Matched(candidates) =
+        effective_date_candidate_source(identity_date, config, ref_type)
+    else {
+        return Cow::Borrowed(template);
+    };
+
+    let mut resolved = template.to_vec();
+    replace_first_identity_date(&mut resolved, candidates);
+    Cow::Owned(resolved)
+}
+
+fn first_identity_date(template: &[TemplateComponent]) -> Option<&TemplateDate> {
+    for component in template {
+        match component {
+            TemplateComponent::Date(date) if date.suppress_disamb_suffix != Some(true) => {
+                return Some(date);
+            }
+            TemplateComponent::Group(group) => {
+                if let Some(date) = first_identity_date(&group.group) {
+                    return Some(date);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn replace_first_identity_date(
+    template: &mut [TemplateComponent],
+    candidates: &[DateSubstituteCandidate],
+) -> bool {
+    for component in template {
+        match component {
+            TemplateComponent::Date(date) if date.suppress_disamb_suffix != Some(true) => {
+                date.fallback = Some(
+                    candidates
+                        .iter()
+                        .map(DateSubstituteCandidate::to_template_component)
+                        .collect(),
+                );
+                return true;
+            }
+            TemplateComponent::Group(group) => {
+                if replace_first_identity_date(&mut group.group, candidates) {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
 /// The same date-text formatting `TemplateDate::values` applies to a
 /// resolved date value — `form`-restricted range/single-date formatting plus
 /// uncertainty/approximation markers — before any year-suffix disambiguation
@@ -108,9 +222,9 @@ pub(crate) fn formatted_date_text(
 
 /// Text uniquely identifying what a date component renders for a specific
 /// reference, for collision-key purposes: the `form`-restricted formatted
-/// value (`formatted_date_text`) plus the candidate's prefix/suffix/wrap
-/// and the resolved value's `note` — the same extra text
-/// `apply_fallback_component_rendering`/`append_note` add to the bare value
+/// value (`formatted_date_text`) plus the candidate's visible rendering
+/// configuration and the resolved value's `note` — the same extra text
+/// `render_fallback_component`/`append_note` add to the bare value
 /// during real rendering. Two candidates whose rendered text differs only in
 /// these respects (e.g. a `c`-prefixed `copyright` year and a
 /// `印刷`-suffixed `printing` year that happen to share the same bare year)
@@ -118,7 +232,7 @@ pub(crate) fn formatted_date_text(
 ///
 /// This does not need to *look like* the rendered text — it only needs the
 /// invariant "same render inputs ⟺ same discriminant" — so it Debug-formats
-/// the affix/wrap config rather than running the full punctuation-
+/// the visible rendering config rather than running the full punctuation-
 /// realization pipeline, which would require threading a complete
 /// `RenderOptions` and `OutputFormat` into `Disambiguator` for no
 /// observable benefit. See csl26-huuz, flagged in PR review.
@@ -138,9 +252,39 @@ pub(crate) fn fallback_candidate_discriminant(
     .filter(|note| !note.is_empty())
     .unwrap_or_default();
     Some(format!(
-        "{formatted}|{note}|{:?}|{:?}|{:?}",
-        rendering.prefix, rendering.suffix, rendering.wrap
+        "{formatted}|{note}|{}",
+        visible_rendering_discriminant(rendering)
     ))
+}
+
+/// Resolve the visible collision-key text for a message fallback candidate.
+pub(crate) fn fallback_message_discriminant(
+    message: &citum_schema::template::TemplateMessage,
+    locale: &citum_schema::locale::Locale,
+    config: &Config,
+) -> Option<String> {
+    if message.rendering.suppress == Some(true) {
+        return None;
+    }
+    let value = crate::values::message::resolve_template_message_value(message, config, locale)?;
+    Some(format!(
+        "{value}|{}",
+        visible_rendering_discriminant(&message.rendering)
+    ))
+}
+
+fn visible_rendering_discriminant(rendering: &Rendering) -> String {
+    format!(
+        "{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}|{:?}",
+        rendering.emph,
+        rendering.quote,
+        rendering.strong,
+        rendering.small_caps,
+        rendering.vertical_align,
+        rendering.prefix,
+        rendering.suffix,
+        rendering.wrap
+    )
 }
 
 fn event_date(reference: &Reference) -> Option<DateValue> {
@@ -1045,89 +1189,41 @@ fn format_single_date(
     }
 }
 
-/// Apply a fallback component's own `wrap`/`prefix`/`suffix` rendering.
+/// Render a resolved fallback component through the central component renderer.
 ///
 /// `component.values()` only resolves the raw fallback string — it does not
 /// go through the generic per-component dispatch that normally applies a
-/// component's own rendering (that happens one layer up, outside the
-/// recursive fallback call). This applies it directly so e.g. `wrap:
-/// brackets` on a fallback `accessed` date isn't silently dropped. Shared by
-/// [`TemplateDate::values`] and `TemplateContributor`'s author-slot
-/// fallback (`crate::values::contributor`) — both fallback shapes need the
-/// identical post-render treatment.
-pub(crate) fn apply_fallback_component_rendering<
-    F: crate::render::format::OutputFormat<Output = String>,
->(
+/// component's rendering. Routing the resolved value back through the central
+/// renderer preserves the ordinary component contract, including suppression,
+/// emphasis, quotes, strong, small caps, vertical alignment, wrapping, and
+/// affixes. Shared by date and terminal contributor fallback chains.
+pub(crate) fn render_fallback_component<F: crate::render::format::OutputFormat<Output = String>>(
     fmt: &F,
-    value: &str,
-    pre_formatted: bool,
-    rendering: &citum_schema::template::Rendering,
+    component: &TemplateComponent,
+    values: ProcValues<String>,
     reference: &Reference,
     options: &RenderOptions<'_>,
 ) -> F::Output {
-    let mut output = if pre_formatted {
-        fmt.join(vec![value.to_string()], "")
-    } else {
-        fmt.text(value)
+    let proc_item = crate::render::ProcTemplateComponent {
+        template_component: component.clone(),
+        template_index: options.current_template_index,
+        value: values.value,
+        prefix: values.prefix,
+        suffix: values.suffix,
+        url: values.url,
+        ref_type: Some(reference.ref_type()),
+        config: Some(options.config.clone()),
+        bibliography_config: options.bibliography_config.clone(),
+        item_language: crate::values::effective_component_language(reference, component),
+        quote_marks: crate::render::format::QuoteMarks::from(options.locale),
+        sentence_initial: false,
+        pre_formatted: values.pre_formatted,
     };
-    if let Some(wrap_config) = rendering.wrap.as_ref() {
-        let (script, realization) = crate::values::punctuation_realization_context(
-            crate::values::effective_item_language(reference).as_deref(),
-            options.config.multilingual.as_ref(),
-            options.locale.punctuation_realization.as_ref(),
-        );
-        output = fmt.wrap_punctuation(
-            &wrap_config.punctuation,
-            output,
-            &crate::render::format::QuoteMarks::default(),
-            script,
-            realization.as_deref(),
-        );
-    }
-    let (script, realization) = crate::values::punctuation_realization_context(
-        crate::values::effective_item_language(reference).as_deref(),
-        options.config.multilingual.as_ref(),
-        options.locale.punctuation_realization.as_ref(),
-    );
-    let prefix = rendering
-        .prefix
-        .as_ref()
-        .map(|punctuation| {
-            crate::render::format::realize_punctuation(
-                punctuation,
-                script,
-                realization.as_deref(),
-                crate::render::format::PunctuationPosition::Prefix,
-            )
-        })
-        .unwrap_or_default();
-    let suffix = rendering
-        .suffix
-        .as_ref()
-        .map(|punctuation| {
-            crate::render::format::realize_punctuation(
-                punctuation,
-                script,
-                realization.as_deref(),
-                crate::render::format::PunctuationPosition::Suffix,
-            )
-        })
-        .unwrap_or_default();
-    if !prefix.is_empty() || !suffix.is_empty() {
-        output = crate::render::format::apply_punctuation_affixes(
-            fmt,
-            rendering
-                .prefix
-                .as_ref()
-                .map(|punctuation| (punctuation, prefix.as_ref())),
-            output,
-            rendering
-                .suffix
-                .as_ref()
-                .map(|punctuation| (punctuation, suffix.as_ref())),
-        );
-    }
-    output
+    crate::render::render_component_with_format_and_renderer::<F>(
+        &proc_item,
+        fmt,
+        options.show_semantics,
+    )
 }
 
 /// Render a date component's fallback chain when its own date variable is
@@ -1146,7 +1242,7 @@ pub(crate) fn apply_fallback_component_rendering<
 ///
 /// For a `date:` candidate, the letter must land inside that candidate's own
 /// wrap (e.g. brackets) — so it is inlined into the raw formatted text
-/// *before* `apply_fallback_component_rendering` applies the wrap, not
+/// *before* `render_fallback_component` applies the wrap, not
 /// appended to the already-wrapped output the way the `message:` case is.
 /// A candidate that is itself `date: issued` cannot reach this function with
 /// a resolvable value: `disamb_eligible` above requires the *outer*
@@ -1175,34 +1271,29 @@ fn render_date_fallback_chain<F: crate::render::format::OutputFormat<Output = St
         && date_component.suppress_disamb_suffix != Some(true);
 
     for component in fallbacks {
-        let Some(values) = component.values::<F>(reference, hints, options) else {
+        let Some(mut values) = component.values::<F>(reference, hints, options) else {
             continue;
         };
+        let substituted_key = values.substituted_key.clone();
         let suffix_label = disamb_eligible
             .then(|| compute_disamb_suffix_label(hints, options, fmt))
             .flatten();
 
-        let (raw_value, inlined) = match (component, suffix_label.as_deref()) {
+        let inlined = match (component, suffix_label.as_deref()) {
             (TemplateComponent::Date(inner), Some(suffix)) => {
                 let year = resolve_date_variable(&inner.date, reference)
                     .map(|d| d.year())
                     .unwrap_or_default();
-                (
-                    inline_disamb_suffix(&values.value, &inner.form, &year, suffix),
-                    true,
-                )
+                values.value = inline_disamb_suffix(&values.value, &inner.form, &year, suffix);
+                true
             }
-            _ => (values.value.clone(), false),
+            _ => false,
         };
 
-        let mut output = apply_fallback_component_rendering(
-            fmt,
-            &raw_value,
-            values.pre_formatted,
-            component.rendering(),
-            reference,
-            options,
-        );
+        let mut output = render_fallback_component(fmt, component, values, reference, options);
+        if output.trim().is_empty() {
+            continue;
+        }
         if !inlined
             && matches!(component, TemplateComponent::Message(_))
             && let Some(suffix) = suffix_label.as_deref()
@@ -1213,8 +1304,8 @@ fn render_date_fallback_chain<F: crate::render::format::OutputFormat<Output = St
             value: output,
             prefix: None,
             suffix: None,
-            url: values.url,
-            substituted_key: values.substituted_key,
+            url: None,
+            substituted_key,
             pre_formatted: true,
         });
     }
@@ -1375,6 +1466,46 @@ pub fn int_to_letter(n: u32) -> Option<String> {
 )]
 mod tests {
     use super::*;
+
+    #[test]
+    fn unmatched_date_substitute_policy_keeps_the_template_borrowed() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+date-substitute:
+  book: []
+"#,
+        )
+        .expect("date-substitute config should parse");
+        let template = vec![TemplateComponent::Date(TemplateDate {
+            date: TemplateDateVar::Issued,
+            form: DateForm::Year,
+            ..TemplateDate::default()
+        })];
+
+        let resolved = materialize_identity_date_substitute(&template, &config, "report");
+
+        assert!(matches!(resolved, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn matched_date_substitute_policy_materializes_an_owned_template() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+date-substitute:
+  book: []
+"#,
+        )
+        .expect("date-substitute config should parse");
+        let template = vec![TemplateComponent::Date(TemplateDate {
+            date: TemplateDateVar::Issued,
+            form: DateForm::Year,
+            ..TemplateDate::default()
+        })];
+
+        let resolved = materialize_identity_date_substitute(&template, &config, "book");
+
+        assert!(matches!(resolved, Cow::Owned(_)));
+    }
 
     #[test]
     fn test_int_to_letter() {

--- a/crates/citum-engine/src/values/message.rs
+++ b/crates/citum-engine/src/values/message.rs
@@ -15,6 +15,48 @@ use citum_schema::locale::{MessageArgs, MessageEvaluator, Mf2MessageEvaluator};
 use citum_schema::template::{MessageArgSource, TemplateMessage};
 use std::collections::HashMap;
 
+/// Resolve a zero-argument template message through the active config and locale.
+///
+/// Shared with date-slot disambiguation so message candidates are skipped when
+/// unresolved and use the same form, strip-periods, and text-case semantics as
+/// rendering.
+pub(crate) fn resolve_template_message_value(
+    component: &TemplateMessage,
+    config: &citum_schema::options::Config,
+    locale: &citum_schema::locale::Locale,
+) -> Option<String> {
+    let args = MessageArgs::default();
+    let mut value = if let Some(pattern) = config.messages.get(&component.message) {
+        Mf2MessageEvaluator.evaluate(pattern, &args)?
+    } else {
+        locale.resolve_template_message(
+            &component.message,
+            &args,
+            component.form.as_ref(),
+            component.gender.clone(),
+        )?
+    };
+
+    if component
+        .rendering
+        .strip_periods
+        .or(config.strip_periods)
+        .unwrap_or(false)
+    {
+        value = crate::values::strip_trailing_periods(&value);
+    }
+
+    if let Some(text_case) = component.rendering.text_case {
+        value = crate::values::text_case::apply_text_case_with_language(
+            &value,
+            text_case,
+            Some(locale.locale.as_str()),
+        );
+    }
+
+    (!value.trim().is_empty()).then_some(value)
+}
+
 impl ComponentValues for TemplateMessage {
     fn values<F: crate::render::format::OutputFormat<Output = String>>(
         &self,
@@ -22,6 +64,17 @@ impl ComponentValues for TemplateMessage {
         hints: &ProcHints,
         options: &RenderOptions<'_>,
     ) -> Option<ProcValues<F::Output>> {
+        if self.args.is_empty() {
+            let value =
+                resolve_template_message_value(self, options.config.as_ref(), options.locale)?;
+            let term_backed = self.message.starts_with("term.");
+            return Some(ProcValues {
+                value,
+                pre_formatted: !term_backed,
+                ..Default::default()
+            });
+        }
+
         let mut named = HashMap::with_capacity(self.args.len());
 
         for (name, source) in &self.args {

--- a/crates/citum-schema-style/src/options/date_substitute.rs
+++ b/crates/citum-schema-style/src/options/date_substitute.rs
@@ -1,0 +1,338 @@
+/*
+SPDX-License-Identifier: MIT OR Apache-2.0
+SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
+*/
+
+//! Options-level fallback policies for the identity date slot.
+
+use crate::locale::TermForm;
+use crate::template::{
+    DateForm, DateVariable, Rendering, TemplateComponent, TemplateDate, TemplateMessage,
+    TypeSelector,
+};
+use indexmap::IndexMap;
+#[cfg(feature = "schema")]
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// An options-level date fallback candidate.
+///
+/// The closed candidate set deliberately permits only dates and locale messages.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(untagged)]
+pub enum DateSubstituteCandidate {
+    /// Render another date variable.
+    Date(DateSubstituteDate),
+    /// Render a locale message, normally `term.no-date`.
+    Message(DateSubstituteMessage),
+}
+
+impl DateSubstituteCandidate {
+    /// Materialize this closed candidate as an ordinary template component.
+    #[must_use]
+    pub fn to_template_component(&self) -> TemplateComponent {
+        match self {
+            Self::Date(candidate) => TemplateComponent::Date(TemplateDate {
+                date: candidate.date.clone(),
+                form: candidate.form.clone(),
+                suppress_note: candidate.suppress_note,
+                rendering: candidate.rendering.clone(),
+                ..TemplateDate::default()
+            }),
+            Self::Message(candidate) => TemplateComponent::Message(TemplateMessage {
+                message: candidate.message.clone(),
+                form: candidate.form.clone(),
+                rendering: candidate.rendering.clone(),
+                ..TemplateMessage::default()
+            }),
+        }
+    }
+}
+
+/// A date candidate in an options-level substitution policy.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct DateSubstituteDate {
+    /// Date variable to try.
+    pub date: DateVariable,
+    /// Rendering form for the candidate date.
+    pub form: DateForm,
+    /// Suppress an opaque calendar annotation for this candidate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suppress_note: Option<bool>,
+    /// Candidate-local rendering configuration.
+    #[serde(flatten, default)]
+    pub rendering: Rendering,
+}
+
+/// A locale-message candidate in an options-level substitution policy.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct DateSubstituteMessage {
+    /// Locale message ID to render.
+    pub message: String,
+    /// Optional term form for a term-backed message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub form: Option<TermForm>,
+    /// Candidate-local rendering configuration.
+    #[serde(flatten, default)]
+    pub rendering: Rendering,
+}
+
+/// A flat, insertion-ordered date-substitution selector map.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DateSubstitute(IndexMap<TypeSelector, Vec<DateSubstituteCandidate>>);
+
+#[cfg(feature = "schema")]
+impl JsonSchema for DateSubstitute {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "DateSubstitute".into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        crate::template::type_keyed_map_schema::<Vec<DateSubstituteCandidate>>(generator)
+    }
+}
+
+impl DateSubstitute {
+    /// Construct a policy from an insertion-ordered selector map.
+    #[must_use]
+    pub fn new(entries: IndexMap<TypeSelector, Vec<DateSubstituteCandidate>>) -> Self {
+        Self(entries)
+    }
+
+    /// Return the policy's insertion-ordered selector map.
+    #[must_use]
+    pub fn entries(&self) -> &IndexMap<TypeSelector, Vec<DateSubstituteCandidate>> {
+        &self.0
+    }
+
+    /// Resolve candidates for a reference type.
+    ///
+    /// The first matching non-default selector wins, followed by the exact
+    /// `default` selector. `None` preserves inline or implicit behavior; an
+    /// empty matched slice intentionally blanks the identity date slot.
+    #[must_use]
+    pub fn candidates_for(&self, ref_type: &str) -> Option<&[DateSubstituteCandidate]> {
+        self.0
+            .iter()
+            .find(|(selector, _)| !selector.is_default() && selector.matches(ref_type))
+            .map(|(_, candidates)| candidates.as_slice())
+            .or_else(|| {
+                self.0
+                    .iter()
+                    .find(|(selector, _)| selector.is_default())
+                    .map(|(_, candidates)| candidates.as_slice())
+            })
+    }
+
+    /// Merge another selector map over this one per key.
+    ///
+    /// Each candidate list replaces as a whole. Replaced keys keep their
+    /// existing insertion position and new keys append.
+    pub fn merge(&mut self, other: &Self) {
+        for (selector, candidates) in &other.0 {
+            self.0.insert(selector.clone(), candidates.clone());
+        }
+    }
+}
+
+/// A named or explicit date-substitution policy.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(untagged)]
+pub enum DateSubstituteEntry {
+    /// A named built-in policy.
+    Preset(DateSubstitutePreset),
+    /// An explicit flat selector map.
+    Explicit(DateSubstitute),
+}
+
+impl DateSubstituteEntry {
+    /// Eagerly expand this entry to its concrete selector map.
+    #[must_use]
+    pub fn resolve(&self) -> DateSubstitute {
+        match self {
+            Self::Preset(preset) => preset.config(),
+            Self::Explicit(config) => config.clone(),
+        }
+    }
+}
+
+/// Built-in identity-date substitution policies.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum DateSubstitutePreset {
+    /// Generic no-date baseline.
+    #[default]
+    Standard,
+    /// Shared numeric and note-base policy for GB/T 7714-2025.
+    #[serde(rename = "gb-t-7714-2025")]
+    GbT7714_2025,
+    /// Author-date policy for GB/T 7714-2025.
+    #[serde(rename = "gb-t-7714-2025-author-date")]
+    GbT7714_2025AuthorDate,
+}
+
+impl DateSubstitutePreset {
+    /// Expand the preset to a concrete insertion-ordered selector map.
+    #[must_use]
+    pub fn config(self) -> DateSubstitute {
+        match self {
+            Self::Standard => standard_config(),
+            Self::GbT7714_2025 => gb_t_config(),
+            Self::GbT7714_2025AuthorDate => gb_t_author_date_config(),
+        }
+    }
+}
+
+fn selector(value: &str) -> TypeSelector {
+    value.parse().unwrap_or_else(|never| match never {})
+}
+
+fn message_no_date() -> DateSubstituteCandidate {
+    DateSubstituteCandidate::Message(DateSubstituteMessage {
+        message: "term.no-date".to_string(),
+        form: Some(TermForm::Short),
+        rendering: Rendering::default(),
+    })
+}
+
+fn date_candidate(
+    date: DateVariable,
+    prefix: Option<&str>,
+    suffix: Option<&str>,
+    brackets: bool,
+) -> DateSubstituteCandidate {
+    DateSubstituteCandidate::Date(DateSubstituteDate {
+        date,
+        form: DateForm::Year,
+        suppress_note: None,
+        rendering: Rendering {
+            prefix: prefix.map(Into::into),
+            suffix: suffix.map(Into::into),
+            wrap: brackets.then_some(crate::template::WrapConfig {
+                punctuation: crate::template::WrapPunctuation::Brackets,
+                inner_prefix: None,
+                inner_suffix: None,
+            }),
+            ..Rendering::default()
+        },
+    })
+}
+
+fn publication_year_candidates(include_no_date: bool) -> Vec<DateSubstituteCandidate> {
+    let mut candidates = vec![
+        date_candidate(DateVariable::Copyright, Some("c"), None, false),
+        date_candidate(DateVariable::Printing, None, Some("印刷"), false),
+        date_candidate(DateVariable::Accessed, None, None, true),
+    ];
+    if include_no_date {
+        candidates.push(message_no_date());
+    }
+    candidates
+}
+
+fn standard_config() -> DateSubstitute {
+    DateSubstitute::new(IndexMap::from([(
+        selector("default"),
+        vec![message_no_date()],
+    )]))
+}
+
+fn gb_t_config() -> DateSubstitute {
+    DateSubstitute::new(IndexMap::from([
+        (selector("default"), vec![]),
+        (
+            selector("chapter,entry-dictionary,entry-encyclopedia"),
+            vec![date_candidate(DateVariable::Accessed, None, None, true)],
+        ),
+        (
+            selector("book,thesis,map"),
+            publication_year_candidates(false),
+        ),
+    ]))
+}
+
+fn gb_t_author_date_config() -> DateSubstitute {
+    DateSubstitute::new(IndexMap::from([
+        (selector("default"), vec![message_no_date()]),
+        (selector("article-journal,article-magazine"), vec![]),
+        (
+            selector("webpage,post,post-weblog"),
+            vec![
+                date_candidate(DateVariable::Accessed, None, None, true),
+                message_no_date(),
+            ],
+        ),
+        (
+            selector("book,thesis,map"),
+            publication_year_candidates(true),
+        ),
+    ]))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, reason = "test assertions")]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("standard", DateSubstitutePreset::Standard)]
+    #[case("gb-t-7714-2025", DateSubstitutePreset::GbT7714_2025)]
+    #[case(
+        "gb-t-7714-2025-author-date",
+        DateSubstitutePreset::GbT7714_2025AuthorDate
+    )]
+    fn all_preset_names_deserialize(#[case] yaml: &str, #[case] expected: DateSubstitutePreset) {
+        let actual: DateSubstitutePreset =
+            serde_yaml::from_str(yaml).expect("preset name should parse");
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn preset_resolves_first_matching_selector_before_default() {
+        let policy = DateSubstitutePreset::GbT7714_2025AuthorDate.config();
+
+        let journal = policy
+            .candidates_for("article-journal")
+            .expect("journal selector should match");
+        let report = policy
+            .candidates_for("report")
+            .expect("default selector should match");
+
+        assert!(journal.is_empty());
+        assert!(matches!(report, [DateSubstituteCandidate::Message(_)]));
+    }
+
+    #[test]
+    fn selector_merge_replaces_lists_without_reordering_keys() {
+        let mut base = DateSubstitute::new(IndexMap::from([
+            (selector("default"), vec![message_no_date()]),
+            (selector("book"), vec![]),
+        ]));
+        let override_policy = DateSubstitute::new(IndexMap::from([
+            (
+                selector("default"),
+                vec![date_candidate(DateVariable::Accessed, None, None, true)],
+            ),
+            (selector("report"), vec![]),
+        ]));
+
+        base.merge(&override_policy);
+
+        let keys: Vec<String> = base.entries().keys().map(ToString::to_string).collect();
+        assert_eq!(keys, ["default", "book", "report"]);
+        assert!(matches!(
+            base.candidates_for("legal-case"),
+            Some([DateSubstituteCandidate::Date(_)])
+        ));
+    }
+}

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -8,6 +8,7 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 pub mod bibliography;
 pub mod cascade;
 pub mod contributors;
+pub mod date_substitute;
 pub mod dates;
 pub mod integral_name_memory;
 pub mod localization;
@@ -31,6 +32,10 @@ pub use contributors::{
     ContributorSuppressionRule, DelimiterPrecedesLast, DemoteNonDroppingParticle, DisplayAsSort,
     NameForm, RoleLabelDefaults, RoleLabelPresentation, RoleLabelPreset, RoleOptions,
     RoleOptionsEntry, RoleRendering, ShortenListOptions,
+};
+pub use date_substitute::{
+    DateSubstitute, DateSubstituteCandidate, DateSubstituteDate, DateSubstituteEntry,
+    DateSubstituteMessage, DateSubstitutePreset,
 };
 pub use dates::{DateConfig, DateConfigEntry, DateRangeFormat, NoDateForm};
 pub use integral_name_memory::{
@@ -85,6 +90,15 @@ pub struct Config {
         default
     )]
     pub substitute: Option<SubstituteConfig>,
+    /// Identity-date substitution policy. Omission preserves inline or
+    /// implicit date fallback behavior; it does not inject `standard`.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_date_substitute",
+        default
+    )]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<DateSubstituteEntry>"))]
+    pub date_substitute: Option<DateSubstitute>,
     /// Processing mode (author-date, numeric, etc.).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub processing: Option<Processing>,
@@ -212,6 +226,14 @@ pub struct CitationOptions {
         default
     )]
     pub substitute: Option<SubstituteConfig>,
+    /// Citation-local identity-date substitution policy.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_date_substitute",
+        default
+    )]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<DateSubstituteEntry>"))]
+    pub date_substitute: Option<DateSubstitute>,
     /// Processing mode (author-date, numeric, etc.).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub processing: Option<Processing>,
@@ -332,6 +354,14 @@ pub struct BibliographyOptions {
         default
     )]
     pub substitute: Option<SubstituteConfig>,
+    /// Bibliography-local identity-date substitution policy.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_date_substitute",
+        default
+    )]
+    #[cfg_attr(feature = "schema", schemars(with = "Option<DateSubstituteEntry>"))]
+    pub date_substitute: Option<DateSubstitute>,
     /// Processing mode (author-date, numeric, etc.).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub processing: Option<Processing>,
@@ -603,6 +633,17 @@ pub use title_class::{
 };
 pub use titles::{TextCase, TitleRendering, TitlesConfig, TitlesConfigEntry};
 
+fn merge_date_substitute(base: &mut Option<DateSubstitute>, overlay: Option<&DateSubstitute>) {
+    let Some(overlay) = overlay else {
+        return;
+    };
+    if let Some(base) = base {
+        base.merge(overlay);
+    } else {
+        *base = Some(overlay.clone());
+    }
+}
+
 /// Structured link options.
 #[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
@@ -736,6 +777,8 @@ impl Config {
             }
         }
 
+        merge_date_substitute(&mut self.date_substitute, other.date_substitute.as_ref());
+
         if let Some(other_contributors) = &other.contributors {
             if let Some(this_contributors) = &mut self.contributors {
                 this_contributors.merge(other_contributors);
@@ -766,6 +809,7 @@ impl CitationOptions {
         Config {
             messages: HashMap::new(),
             substitute: self.substitute.clone(),
+            date_substitute: self.date_substitute.clone(),
             processing: self.processing.clone(),
             locale_override: None,
             localize: self.localize.clone(),
@@ -852,6 +896,8 @@ impl CitationOptions {
             }
         }
 
+        merge_date_substitute(&mut self.date_substitute, other.date_substitute.as_ref());
+
         if let Some(other_contributors) = &other.contributors {
             if let Some(this_contributors) = &mut self.contributors {
                 this_contributors.merge(other_contributors);
@@ -897,6 +943,7 @@ impl BibliographyOptions {
         Config {
             messages: HashMap::new(),
             substitute: self.substitute.clone(),
+            date_substitute: self.date_substitute.clone(),
             processing: self.processing.clone(),
             locale_override: None,
             localize: self.localize.clone(),
@@ -1008,6 +1055,8 @@ impl BibliographyOptions {
             }
         }
 
+        merge_date_substitute(&mut self.date_substitute, other.date_substitute.as_ref());
+
         if let Some(other_contributors) = &other.contributors {
             if let Some(this_contributors) = &mut self.contributors {
                 this_contributors.merge(other_contributors);
@@ -1052,6 +1101,15 @@ where
     D: serde::Deserializer<'de>,
 {
     let value: Option<DateConfigEntry> = Option::deserialize(deserializer)?;
+    Ok(value.map(|entry| entry.resolve()))
+}
+
+/// Deserialize and eagerly expand a named or explicit date-substitution policy.
+fn deserialize_date_substitute<'de, D>(deserializer: D) -> Result<Option<DateSubstitute>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value: Option<DateSubstituteEntry> = Option::deserialize(deserializer)?;
     Ok(value.map(|entry| entry.resolve()))
 }
 
@@ -1129,6 +1187,12 @@ impl<'de> Deserialize<'de> for Config {
                 default
             )]
             substitute: Option<SubstituteConfig>,
+            #[serde(
+                skip_serializing_if = "Option::is_none",
+                deserialize_with = "deserialize_date_substitute",
+                default
+            )]
+            date_substitute: Option<DateSubstitute>,
             #[serde(skip_serializing_if = "Option::is_none")]
             processing: Option<Processing>,
             #[serde(skip_serializing_if = "Option::is_none")]
@@ -1205,6 +1269,7 @@ impl<'de> Deserialize<'de> for Config {
         Ok(Self {
             messages: wire.messages,
             substitute: wire.substitute,
+            date_substitute: wire.date_substitute,
             processing: wire.processing,
             locale_override: wire.locale_override,
             localize: wire.localize,
@@ -1245,6 +1310,59 @@ impl<'de> Deserialize<'de> for Config {
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    #[test]
+    fn date_substitute_omission_is_not_resolved_to_standard() {
+        let config: Config = serde_yaml::from_str("{}").expect("empty config should parse");
+
+        assert!(config.date_substitute.is_none());
+    }
+
+    #[test]
+    fn date_substitute_preset_is_eagerly_expanded() {
+        let config: Config = serde_yaml::from_str("date-substitute: standard")
+            .expect("standard preset should parse");
+        let serialized = serde_yaml::to_value(&config).expect("config should serialize");
+
+        assert!(
+            config
+                .date_substitute
+                .as_ref()
+                .and_then(|policy| policy.candidates_for("report"))
+                .is_some_and(|candidates| matches!(
+                    candidates,
+                    [DateSubstituteCandidate::Message(_)]
+                ))
+        );
+        assert!(serialized["date-substitute"].is_mapping());
+    }
+
+    #[test]
+    fn explicit_date_substitute_map_preserves_authored_selector_order() {
+        let config: Config = serde_yaml::from_str(
+            r#"
+date-substitute:
+  book,thesis,map:
+  - date: copyright
+    form: year
+    prefix: c
+  default:
+  - message: term.no-date
+    form: short
+"#,
+        )
+        .expect("explicit selector map should parse");
+        let policy = config
+            .date_substitute
+            .expect("date substitute should be present");
+
+        let selectors: Vec<String> = policy.entries().keys().map(ToString::to_string).collect();
+        assert_eq!(selectors, ["book,thesis,map", "default"]);
+        assert!(matches!(
+            policy.candidates_for("book"),
+            Some([DateSubstituteCandidate::Date(_)])
+        ));
+    }
 
     #[test]
     fn test_config_default() {

--- a/crates/citum-schema-style/src/style/validation.rs
+++ b/crates/citum-schema-style/src/style/validation.rs
@@ -63,6 +63,13 @@ impl Style {
         {
             validate_substitute_candidates(substitute, "options.substitute")?;
         }
+        if let Some(date_substitute) = self
+            .options
+            .as_ref()
+            .and_then(|options| options.date_substitute.as_ref())
+        {
+            budget.check_date_substitute(date_substitute, "options.date-substitute")?;
+        }
 
         if let Some(templates) = &self.templates {
             for (name, template) in templates {
@@ -107,6 +114,13 @@ impl Style {
                 });
             }
         }
+        if let Some(date_substitute) = self
+            .options
+            .as_ref()
+            .and_then(|options| options.date_substitute.as_ref())
+        {
+            collect_date_substitute_warnings(date_substitute, "options.date-substitute", warnings);
+        }
         if let Some(bib) = &self.bibliography
             && let Some(type_variants) = &bib.type_variants
         {
@@ -121,6 +135,18 @@ impl Style {
         }
         if let Some(cit) = &self.citation {
             collect_citation_spec_warnings(cit, "citation", warnings);
+        }
+        if let Some(bib) = &self.bibliography
+            && let Some(date_substitute) = bib
+                .options
+                .as_ref()
+                .and_then(|options| options.date_substitute.as_ref())
+        {
+            collect_date_substitute_warnings(
+                date_substitute,
+                "bibliography.options.date-substitute",
+                warnings,
+            );
         }
     }
 
@@ -248,6 +274,17 @@ fn collect_citation_spec_warnings(
     location: &str,
     warnings: &mut Vec<SchemaWarning>,
 ) {
+    if let Some(date_substitute) = spec
+        .options
+        .as_ref()
+        .and_then(|options| options.date_substitute.as_ref())
+    {
+        collect_date_substitute_warnings(
+            date_substitute,
+            &format!("{location}.options.date-substitute"),
+            warnings,
+        );
+    }
     if let Some(type_variants) = &spec.type_variants {
         for selector in type_variants.keys() {
             for name in selector.unknown_type_names() {
@@ -272,12 +309,44 @@ fn collect_citation_spec_warnings(
     }
 }
 
+fn collect_date_substitute_warnings(
+    date_substitute: &crate::options::DateSubstitute,
+    location: &str,
+    warnings: &mut Vec<SchemaWarning>,
+) {
+    for selector in date_substitute.entries().keys() {
+        for name in selector.unknown_type_names() {
+            warnings.push(SchemaWarning::UnknownTypeName {
+                name: name.to_string(),
+                location: location.to_string(),
+            });
+        }
+    }
+}
+
 #[derive(Default)]
 struct TemplateResourceBudget {
     component_count: usize,
 }
 
 impl TemplateResourceBudget {
+    fn check_date_substitute(
+        &mut self,
+        date_substitute: &crate::options::DateSubstitute,
+        location: &str,
+    ) -> Result<(), String> {
+        for (selector, candidates) in date_substitute.entries() {
+            for candidate in candidates {
+                self.check_component(
+                    &candidate.to_template_component(),
+                    &format!("{location}.{selector:?}"),
+                    0,
+                )?;
+            }
+        }
+        Ok(())
+    }
+
     fn check_template(
         &mut self,
         template: &[TemplateComponent],
@@ -458,6 +527,16 @@ impl TemplateResourceBudget {
         {
             validate_substitute_candidates(substitute, &format!("{location}.options.substitute"))?;
         }
+        if let Some(date_substitute) = spec
+            .options
+            .as_ref()
+            .and_then(|options| options.date_substitute.as_ref())
+        {
+            self.check_date_substitute(
+                date_substitute,
+                &format!("{location}.options.date-substitute"),
+            )?;
+        }
         if let Some(template) = &spec.template {
             self.check_variant(template, &format!("{location}.template"), depth)?;
         }
@@ -494,6 +573,16 @@ impl TemplateResourceBudget {
         {
             validate_substitute_candidates(substitute, &format!("{location}.options.substitute"))?;
         }
+        if let Some(date_substitute) = spec
+            .options
+            .as_ref()
+            .and_then(|options| options.date_substitute.as_ref())
+        {
+            self.check_date_substitute(
+                date_substitute,
+                &format!("{location}.options.date-substitute"),
+            )?;
+        }
         if let Some(template) = &spec.template {
             self.check_variant(template, &format!("{location}.template"), depth)?;
         }
@@ -521,6 +610,13 @@ impl TemplateResourceBudget {
 )]
 mod security_resource_tests {
     use super::*;
+    use crate::locale::TermForm;
+    use crate::options::{
+        BibliographyOptions, CitationOptions, Config, DateSubstitute, DateSubstituteCandidate,
+        DateSubstituteMessage,
+    };
+    use crate::template::{Rendering, TypeSelector};
+    use indexmap::IndexMap;
 
     fn nested_group(depth: usize) -> TemplateComponent {
         if depth == 0 {
@@ -531,6 +627,18 @@ mod security_resource_tests {
                 ..TemplateGroup::default()
             })
         }
+    }
+
+    fn date_substitute_with_candidates(count: usize) -> DateSubstitute {
+        let candidate = DateSubstituteCandidate::Message(DateSubstituteMessage {
+            message: "term.no-date".to_string(),
+            form: Some(TermForm::Short),
+            rendering: Rendering::default(),
+        });
+        DateSubstitute::new(IndexMap::from([(
+            TypeSelector::Single("default".to_string()),
+            vec![candidate; count],
+        )]))
     }
 
     #[test]
@@ -565,6 +673,40 @@ mod security_resource_tests {
         let err = style
             .validate_resource_limits()
             .expect_err("oversized template must be rejected");
+
+        assert!(err.contains("maximum template component count"));
+    }
+
+    #[test]
+    fn validate_resource_limits_counts_date_substitute_candidates_across_scopes() {
+        let global_count = MAX_TEMPLATE_COMPONENTS / 3;
+        let citation_count = MAX_TEMPLATE_COMPONENTS / 3;
+        let bibliography_count = MAX_TEMPLATE_COMPONENTS - global_count - citation_count + 1;
+        let style = Style {
+            options: Some(Config {
+                date_substitute: Some(date_substitute_with_candidates(global_count)),
+                ..Config::default()
+            }),
+            citation: Some(CitationSpec {
+                options: Some(CitationOptions {
+                    date_substitute: Some(date_substitute_with_candidates(citation_count)),
+                    ..CitationOptions::default()
+                }),
+                ..CitationSpec::default()
+            }),
+            bibliography: Some(BibliographySpec {
+                options: Some(BibliographyOptions {
+                    date_substitute: Some(date_substitute_with_candidates(bibliography_count)),
+                    ..BibliographyOptions::default()
+                }),
+                ..BibliographySpec::default()
+            }),
+            ..Style::default()
+        };
+
+        let err = style
+            .validate_resource_limits()
+            .expect_err("date-substitute candidates must share the template budget");
 
         assert!(err.contains("maximum template component count"));
     }

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -556,6 +556,15 @@ impl std::str::FromStr for TypeSelector {
 }
 
 impl TypeSelector {
+    /// Return whether this is the exact selector-only `default` branch.
+    ///
+    /// `default` is a fallback branch, not a wildcard, and therefore must not
+    /// participate in an ordinary reference-type match.
+    #[must_use]
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Single(value) if value == "default")
+    }
+
     /// Check whether this selector matches a reference type.
     ///
     /// The incoming `ref_type` is normalized from the CSL 1.0 underscore

--- a/crates/citum-schema-style/src/tests.rs
+++ b/crates/citum-schema-style/src/tests.rs
@@ -775,6 +775,46 @@ fn style_validate_emits_warning_for_unknown_type_in_bib_type_variants() {
 }
 
 #[test]
+fn style_validate_emits_warnings_for_unknown_date_substitute_types_at_every_scope() {
+    let style: Style = serde_yaml::from_str(
+        r#"
+info:
+  title: Date substitute selector warnings
+options:
+  date-substitute:
+    global-typo: []
+citation:
+  options:
+    date-substitute:
+      citation-typo: []
+bibliography:
+  options:
+    date-substitute:
+      bibliography-typo: []
+"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        style.validate(),
+        vec![
+            SchemaWarning::UnknownTypeName {
+                name: "global-typo".to_string(),
+                location: "options.date-substitute".to_string(),
+            },
+            SchemaWarning::UnknownTypeName {
+                name: "citation-typo".to_string(),
+                location: "citation.options.date-substitute".to_string(),
+            },
+            SchemaWarning::UnknownTypeName {
+                name: "bibliography-typo".to_string(),
+                location: "bibliography.options.date-substitute".to_string(),
+            },
+        ]
+    );
+}
+
+#[test]
 fn style_validate_emits_warning_for_unknown_title_mapping_type() {
     let style: Style = serde_yaml::from_str(
         r#"

--- a/crates/citum-schema-style/tests/bdd_scope_cascade.rs
+++ b/crates/citum-schema-style/tests/bdd_scope_cascade.rs
@@ -80,6 +80,37 @@ fn citation_scope_config(style: &Style) -> Config {
     citation_options.merged_with_raw(&base, style.scoped_raw_options.citation.as_ref())
 }
 
+#[test]
+fn given_scope_date_substitute_map_when_cascading_then_lists_merge_per_selector() {
+    let style = resolve(
+        Style::from_yaml_str(
+            r#"
+version: "0.44.0"
+info:
+  title: Scoped Date Substitute
+  id: scoped-date-substitute
+options:
+  date-substitute: standard
+bibliography:
+  options:
+    date-substitute:
+      book: []
+"#,
+        )
+        .expect("valid style"),
+        None,
+    );
+
+    let policy = bibliography_scope_config(&style)
+        .date_substitute
+        .expect("merged date-substitute policy");
+
+    assert!(policy.candidates_for("book").is_some_and(<[_]>::is_empty));
+    assert_eq!(policy.candidates_for("report").map(<[_]>::len), Some(1));
+    let selectors: Vec<String> = policy.entries().keys().map(ToString::to_string).collect();
+    assert_eq!(selectors, ["default", "book"]);
+}
+
 const ROOT_STYLE_BIBLIOGRAPHY_SCOPE: &str = r#"
 version: "0.44.0"
 info:

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -3402,6 +3402,17 @@
             }
           ]
         },
+        "date-substitute": {
+          "description": "Identity-date substitution policy. Omission preserves inline or\nimplicit date fallback behavior; it does not inject `standard`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DateSubstituteEntry"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "processing": {
           "description": "Processing mode (author-date, numeric, etc.).",
           "anyOf": [
@@ -3810,6 +3821,349 @@
           "type": "string",
           "const": "by-category"
         }
+      ]
+    },
+    "DateSubstituteEntry": {
+      "description": "A named or explicit date-substitution policy.",
+      "anyOf": [
+        {
+          "description": "A named built-in policy.",
+          "$ref": "#/$defs/DateSubstitutePreset"
+        },
+        {
+          "description": "An explicit flat selector map.",
+          "$ref": "#/$defs/DateSubstitute"
+        }
+      ]
+    },
+    "DateSubstitutePreset": {
+      "description": "Built-in identity-date substitution policies.",
+      "oneOf": [
+        {
+          "description": "Generic no-date baseline.",
+          "type": "string",
+          "const": "standard"
+        },
+        {
+          "description": "Shared numeric and note-base policy for GB/T 7714-2025.",
+          "type": "string",
+          "const": "gb-t-7714-2025"
+        },
+        {
+          "description": "Author-date policy for GB/T 7714-2025.",
+          "type": "string",
+          "const": "gb-t-7714-2025-author-date"
+        }
+      ]
+    },
+    "DateSubstitute": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "propertyNames": {
+        "type": "string",
+        "pattern": "^\\s*(?:book|manual|report|thesis|webpage|map|post|interview|manuscript|personal-communication|document|chapter|entry|entry-dictionary|entry-encyclopedia|post-weblog|preprint|paper-conference|article-journal|article-magazine|article-newspaper|broadcast|collection|legal-case|statute|treaty|hearing|regulation|brief|classic|patent|dataset|standard|software|motion-picture|article|pamphlet|periodical|graphic|event|song|bill-proceeding|bill-record|default)(?:\\s*,\\s*(?:book|manual|report|thesis|webpage|map|post|interview|manuscript|personal-communication|document|chapter|entry|entry-dictionary|entry-encyclopedia|post-weblog|preprint|paper-conference|article-journal|article-magazine|article-newspaper|broadcast|collection|legal-case|statute|treaty|hearing|regulation|brief|classic|patent|dataset|standard|software|motion-picture|article|pamphlet|periodical|graphic|event|song|bill-proceeding|bill-record|default))*\\s*$"
+      },
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/$defs/DateSubstituteCandidate"
+        }
+      }
+    },
+    "DateSubstituteCandidate": {
+      "description": "An options-level date fallback candidate.\n\nThe closed candidate set deliberately permits only dates and locale messages.",
+      "anyOf": [
+        {
+          "description": "Render another date variable.",
+          "$ref": "#/$defs/DateSubstituteDate"
+        },
+        {
+          "description": "Render a locale message, normally `term.no-date`.",
+          "$ref": "#/$defs/DateSubstituteMessage"
+        }
+      ]
+    },
+    "DateSubstituteDate": {
+      "description": "A date candidate in an options-level substitution policy.",
+      "type": "object",
+      "properties": {
+        "date": {
+          "description": "Date variable to try.",
+          "$ref": "#/$defs/DateVariable"
+        },
+        "form": {
+          "description": "Rendering form for the candidate date.",
+          "$ref": "#/$defs/DateForm"
+        },
+        "suppress-note": {
+          "description": "Suppress an opaque calendar annotation for this candidate.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vertical-align": {
+          "description": "Vertical alignment to apply to rendered output.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Text or a semantic punctuation mark to prepend to the rendered value\n(outside any wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suffix": {
+          "description": "Text or a semantic punctuation mark to append to the rendered value\n(outside any wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "wrap": {
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "description": "Override name form (e.g., initials, full, family-only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "date",
+        "form"
+      ]
+    },
+    "DateSubstituteMessage": {
+      "description": "A locale-message candidate in an options-level substitution policy.",
+      "type": "object",
+      "properties": {
+        "message": {
+          "description": "Locale message ID to render.",
+          "type": "string"
+        },
+        "form": {
+          "description": "Optional term form for a term-backed message.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TermForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "text-case": {
+          "description": "Text-case transform to apply to the rendered value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextCase"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "emph": {
+          "description": "Render in italics/emphasis.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "quote": {
+          "description": "Render in quotes.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "strong": {
+          "description": "Render in bold/strong.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "small-caps": {
+          "description": "Render in small caps.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "vertical-align": {
+          "description": "Vertical alignment to apply to rendered output.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VerticalAlign"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "prefix": {
+          "description": "Text or a semantic punctuation mark to prepend to the rendered value\n(outside any wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suffix": {
+          "description": "Text or a semantic punctuation mark to append to the rendered value\n(outside any wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "wrap": {
+          "description": "Wrapping punctuation and optional inner affixes (text inside the wrap).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WrapConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "suppress": {
+          "description": "If true, suppress this component entirely (render as empty string).\nUseful for type-specific overrides like suppressing publisher for journals.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "initialize-with": {
+          "description": "Override name initialization (e.g., \". \" or \"\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name-form": {
+          "description": "Override name form (e.g., initials, full, family-only).",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NameForm"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "strip-periods": {
+          "description": "Strip trailing periods from rendered value.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "message"
       ]
     },
     "Processing": {
@@ -6528,6 +6882,17 @@
             }
           ]
         },
+        "date-substitute": {
+          "description": "Citation-local identity-date substitution policy.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DateSubstituteEntry"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "processing": {
           "description": "Processing mode (author-date, numeric, etc.).",
           "anyOf": [
@@ -7466,6 +7831,17 @@
           "anyOf": [
             {
               "$ref": "#/$defs/SubstituteConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "date-substitute": {
+          "description": "Bibliography-local identity-date substitution policy.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DateSubstituteEntry"
             },
             {
               "type": "null"

--- a/docs/specs/DATE_SUBSTITUTE.md
+++ b/docs/specs/DATE_SUBSTITUTE.md
@@ -1,6 +1,6 @@
 # Date Substitute Specification
 
-**Status:** Draft
+**Status:** Active
 **Version:** 1.0
 **Date:** 2026-08-12
 **Supersedes:** none
@@ -98,6 +98,12 @@ fields:
 
 The closed candidate type supports only these two variants. It does not accept
 arbitrary `TemplateComponent` values.
+
+Candidate rendering fields have the same semantics as on ordinary date and
+message components. Candidate values pass through the central component
+renderer; suppression, emphasis, quotes, strong, small caps, vertical
+alignment, wrapping, affixes, text case, and period stripping must not be
+silently ignored.
 
 `suppress-note` remains available on date candidates. Omitting it preserves
 the normal date-note behavior from the effective `dates.note-wrap` option;
@@ -310,6 +316,9 @@ identity content must not be split by unrendered raw precision.
   first-match rule.
 - Reuse the schema's existing `TypeSelector` parser, validation, and reference
   type normalization.
+- Include candidates from global, citation, and bibliography policies in the
+  shared hard template-component resource budget, and emit the existing
+  `UnknownTypeName` warning for unrecognized selectors at every scope.
 - The config representation can be an untagged enum of preset scalar and
   explicit map. Preset expansion should produce an owned explicit map at the
   cascade boundary.
@@ -330,18 +339,20 @@ identity content must not be split by unrendered raw precision.
 
 ### Layer 3 — Schema and engine implementation
 
-- [ ] The schema accepts the three preset names and flat ordered selector maps,
+- [x] The schema accepts the three preset names and flat ordered selector maps,
       and generated schemas are current.
-- [ ] `Config.date_substitute: None` preserves inline or implicit behavior;
+- [x] `Config.date_substitute: None` preserves inline or implicit behavior;
       no defaulting path injects `standard`.
-- [ ] Presets expand before inheritance and scope cascading; selector maps
+- [x] Presets expand before inheritance and scope cascading; selector maps
       merge per key and replace complete lists.
-- [ ] Tests cover first-match ordering, `default`, unmatched fallback,
+- [x] Tests cover first-match ordering, `default`, unmatched fallback,
       matched-empty blanking, preset expansion, and scope inheritance.
-- [ ] Rendering and disambiguation consume one resolved candidate source and
+- [x] Rendering and disambiguation consume one resolved candidate source and
       effective scope configuration, including `suppress-note` behavior.
-- [ ] Later and `suppress-disamb-suffix: true` dates retain inline fallback.
-- [ ] This spec changes from Draft to Active in the implementation commit.
+- [x] Options-level candidates participate in resource limits and selector
+      validation, and use ordinary component rendering semantics.
+- [x] Later and `suppress-disamb-suffix: true` dates retain inline fallback.
+- [x] This spec changes from Draft to Active in the implementation commit.
 
 ### Layer 4 — GB/T style migration and fidelity
 
@@ -354,4 +365,6 @@ identity content must not be split by unrendered raw precision.
 
 ## Changelog
 
+- 2026-08-12: Clarified candidate rendering, resource-budget, and selector-warning requirements after implementation review.
+- 2026-08-12: Activated with the Layer 3 schema and engine implementation.
 - 2026-08-12: Initial Draft for Layer 2 of the date-substitute stack.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -69,7 +69,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | Spec | Status | Tests |
 |------|--------|-------|
 | [`DISAMBIGUATION.md`](./DISAMBIGUATION.md) — collision-key model, strategy cascade, multilingual/group disambiguation, APA §8.15 reprint keying | Active | `citations.rs::disambiguation` |
-| [`DATE_SUBSTITUTE.md`](./DATE_SUBSTITUTE.md) — preset or type-scoped fallback policy for the identity date slot | Draft | — |
+| [`DATE_SUBSTITUTE.md`](./DATE_SUBSTITUTE.md) — preset or type-scoped fallback policy for the identity date slot | Active | `citum-engine::processor::rendering::tests::date_substitute_options`, `citum-schema-style::bdd_scope_cascade` |
 | [`CITE_SITE_COMPOUND_GROUPING.md`](./CITE_SITE_COMPOUND_GROUPING.md) — cite-site compound grouping and position-aware overrides | Active | `citations.rs::sorting_and_grouping` |
 | [`INTEGRAL_NAME_MEMORY.md`](./INTEGRAL_NAME_MEMORY.md) — durable author-display state across citation clusters | Active | `citations.rs::integral_name_memory` |
 | [`PERSONAL_COMMUNICATION_CITATION.md`](./PERSONAL_COMMUNICATION_CITATION.md) — rendering of personal communications across style families | Active | `citations.rs::contributor_scoping` |

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -2142,7 +2142,14 @@ function countOptionsPresetUses(styleData) {
     styleData?.bibliography?.options,
   ].filter(Boolean);
 
-  const keys = ['processing', 'contributors', 'dates', 'titles', 'substitute'];
+  const keys = [
+    'processing',
+    'contributors',
+    'dates',
+    'titles',
+    'substitute',
+    'date-substitute',
+  ];
   let uses = 0;
   const fields = [];
 

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -493,6 +493,24 @@ test('computePresetUsageScore treats pure root wrappers as strong preset reuse',
   assert.match(score.note, /root extends/);
 });
 
+test('computePresetUsageScore counts date-substitute presets', () => {
+  const score = computePresetUsageScore({
+    options: {
+      processing: 'author-date',
+      substitute: 'standard',
+      'date-substitute': 'gb-t-7714-2025-author-date',
+    },
+  }, 100);
+
+  assert.equal(score.score, 90);
+  assert.equal(score.optionUses, 3);
+  assert.deepEqual(score.optionPresetFields, [
+    'processing',
+    'substitute',
+    'date-substitute',
+  ]);
+});
+
 test('selectQualityAuthorshipData keeps authored Template V3 diff scopes', () => {
   const authored = {
     bibliography: {


### PR DESCRIPTION
## Summary

- add the public `date-substitute` option at global, citation, and bibliography scopes
- eagerly expand `standard`, `gb-t-7714-2025`, and `gb-t-7714-2025-author-date` presets
- merge ordered selector maps per key while replacing candidate lists as a whole
- resolve the identity date's effective candidate source once for rendering and disambiguation
- count `date-substitute` presets in the style quality reporter
- activate [`docs/specs/DATE_SUBSTITUTE.md`](https://github.com/citum/citum-core/blob/codex/date-substitute-implementation/docs/specs/DATE_SUBSTITUTE.md)

## Behavioral contract

- omission preserves inline or implicit behavior; it does not inject `standard`
- the first matching non-default selector wins, followed by `default`
- a matched empty list intentionally blanks the identity date slot
- later dates and dates with `suppress-disamb-suffix: true` retain inline fallback
- date candidates preserve their own form, rendering, and `suppress-note` policy

## Evidence

- `just schema-gen` generated `docs/schemas/style.json` and data-model references; its final Git staging step was performed by `jj`
- `just schema-validate` passed all production styles and locales (one pre-existing documented Chicago schema skip)
- focused date-substitute suite: 15/15 passed
- quality reporter suite: 66/66 passed
- `just pre-commit`: formatting and all-target/all-feature clippy passed; 2,486/2,486 tests passed
- manual jj hook gates passed: commit message, pre-commit hygiene, and pre-push policy/Rust gates
- `git diff --check` passed

## Stack

1. #1171 — candidate-neutral date-slot foundation
2. #1172 — Draft specification
3. this PR — schema and engine implementation; spec becomes Active
4. #1175 — GB/T style migration to the new presets

This PR is intentionally draft and is based on #1172. Merge remains a maintainer action.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
