### PR TITLE
refactor(styles): use date substitute presets

### DIFF
--- a/.beans/archive/csl26-qbmd--add-a-date-substitute-options-mechanism-mirroring.md
+++ b/.beans/archive/csl26-qbmd--add-a-date-substitute-options-mechanism-mirroring.md
@@ -1,7 +1,7 @@
 ---
 # csl26-qbmd
 title: Add a date-substitute options mechanism mirroring author-substitute
-status: in-progress
+status: completed
 type: feature
 priority: normal
 tags:
@@ -9,7 +9,7 @@ tags:
     - fidelity
     - gb-t-7714
 created_at: 2026-08-12T13:59:09Z
-updated_at: 2026-08-12T15:53:10Z
+updated_at: 2026-08-12T18:28:05Z
 parent: csl26-ccdt
 ---
 
@@ -32,7 +32,14 @@ Four-layer stacked PR:
 
 1. PR #1171 — candidate-neutral date-slot foundation.
 2. `docs/specs/DATE_SUBSTITUTE.md` — Draft specification.
-3. Schema and engine implementation; spec becomes Active.
-4. GB/T style migration to the two GB/T presets with fidelity validation.
+3. PR #1174 — schema, engine, generated schema, Active spec, and quality
+   reporter support for the preset.
+4. PR #1175 — GB/T migration to the two named presets with fidelity
+   validation.
 
 Related: `docs/specs/DISAMBIGUATION.md`, csl26-sea6.
+
+Validation: `just pre-commit` (2486/2486), schema validation, three targeted
+GB/T reports, the full 19-style embedded parity-floor sweep, and the core
+quality gate. Numeric and note metrics are unchanged; author-date exact parity
+rises from 36/61 to 37/62 and SQI rises from 91.1 to 92.3.

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-author-date.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-author-date.yaml
@@ -20,6 +20,7 @@ info:
     - href: https://std.samr.gov.cn/gb/search/gbDetailed?id=4507EFE13D37CB6AE06397BE0A0A601F
       rel: documentation
 options:
+  date-substitute: gb-t-7714-2025-author-date
   # GB/T 7714's anonymous-author placeholder (`佚名`/`Anon`), used by
   # `contributor: author`'s `fallback:` on every bibliography type-variant
   # below, is sourced from each locale file's `messages.term.anonymous`
@@ -343,9 +344,6 @@ bibliography:
       form: year
       suppress-note: true
       suffix: '. '
-      fallback:
-      - message: term.no-date
-        form: short
     - title: primary
     - message: gb-t-7714-type-code
       args:
@@ -387,10 +385,9 @@ bibliography:
     - date: issued
       form: year
       suffix: '. '
-      # An undated article-journal/article-magazine renders no date text at
-      # all here — not 无日期/n.d. like every other type-variant — and if
-      # disambiguation still requires a letter, it renders standalone, alone
-      # in the date position. This matches the shipped upstream CSL: its
+      # The author-date preset intentionally renders no date text for an
+      # undated article-journal/article-magazine — not 无日期/n.d. like most
+      # other type-variants. This matches the shipped upstream CSL: its
       # `date-intext` macro's `type="article-journal article-magazine"`
       # branch is fully self-contained — none of its three inner sub-cases
       # (volume/issue present, available-date present, plain else) ever
@@ -401,10 +398,7 @@ bibliography:
       # from the macro alone — open question, see csl26-9qat. This is a
       # style-data decision pinned to the current oracle, revisitable
       # without any engine change if that bean's standard-derived gold
-      # strings later disagree. See csl26-huuz. `fallback: []` (rather than
-      # a dedicated flag) is provisional pending a `date-substitute`
-      # options-level mechanism — see the follow-up bean tracking that.
-      fallback: []
+      # strings later disagree. See csl26-huuz.
     - title: primary
     - message: gb-t-7714-type-code
       args:
@@ -457,9 +451,6 @@ bibliography:
       form: year
       suppress-note: true
       suffix: '. '
-      fallback:
-      - message: term.no-date
-        form: short
     - title: primary
     - message: gb-t-7714-type-code
       args:
@@ -507,9 +498,6 @@ bibliography:
     - date: issued
       form: year
       suffix: '. '
-      fallback:
-      - message: term.no-date
-        form: short
     - group:
       - group:
         - title: primary
@@ -575,9 +563,6 @@ bibliography:
     - date: issued
       form: year
       suffix: '. '
-      fallback:
-      - message: term.no-date
-        form: short
     - title: primary
     - message: gb-t-7714-type-code
       args:
@@ -612,9 +597,6 @@ bibliography:
       form: year
       suppress-note: true
       suffix: '. '
-      fallback:
-      - message: term.no-date
-        form: short
     - group:
       - title: primary
       - variable: archive-location
@@ -659,19 +641,6 @@ bibliography:
     - date: issued
       form: year
       suffix: '. '
-      fallback:
-      - date: copyright
-        form: year
-        prefix: c
-      - date: printing
-        form: year
-        suffix: 印刷
-      - date: accessed
-        form: year
-        wrap:
-          punctuation: brackets
-      - message: term.no-date
-        form: short
     - group:
       - title: primary
       - group:
@@ -733,9 +702,6 @@ bibliography:
       form: year
       suppress-note: true
       suffix: '. '
-      fallback:
-      - message: term.no-date
-        form: short
     - title: primary
     - message: gb-t-7714-type-code
       args:
@@ -772,9 +738,6 @@ bibliography:
     - date: issued
       form: year
       suffix: '. '
-      fallback:
-      - message: term.no-date
-        form: short
     - title: primary
     - message: gb-t-7714-type-code
       args:
@@ -821,9 +784,6 @@ bibliography:
       form: year
       suppress-note: true
       suffix: '. '
-      fallback:
-      - message: term.no-date
-        form: short
     - title: primary
     - number: patent-number
       prefix: { mark: colon }
@@ -860,9 +820,6 @@ bibliography:
       form: year
       suppress-note: true
       suffix: '. '
-      fallback:
-      - message: term.no-date
-        form: short
     - title: primary
     - message: gb-t-7714-type-code
       args:
@@ -900,17 +857,10 @@ bibliography:
       form: year
       suppress-note: true
       suffix: '. '
-      # Upstream's `date-intext` macro checks `accessed` before falling to
-      # the "no date" term (`<else-if variable="accessed">`), rendering the
-      # bracketed access year in the author-date position — distinct from
-      # the full access date the unconditional `date: accessed` component
-      # below always renders when present. See csl26-huuz.
-      fallback:
-      - date: accessed
-        form: year
-        wrap: { punctuation: brackets }
-      - message: term.no-date
-        form: short
+      # The author-date preset mirrors upstream's `date-intext` macro by
+      # checking `accessed` before the no-date term and rendering a bracketed
+      # access year in this identity position. The later unconditional
+      # `date: accessed` still renders the full access date. See csl26-huuz.
     - title: primary
     - message: gb-t-7714-type-code
       args:
@@ -948,9 +898,6 @@ bibliography:
       form: year
       suppress-note: true
       suffix: '. '
-      fallback:
-      - message: term.no-date
-        form: short
     - title: primary
     - number: report-number
       prefix: { mark: colon }
@@ -992,9 +939,6 @@ bibliography:
     - date: issued
       form: year
       suffix: '. '
-      fallback:
-      - message: term.no-date
-        form: short
     - number: standard-number
       suffix: ' '
     - title: primary

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-base.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-base.yaml
@@ -10,6 +10,7 @@ info:
   default-locale: zh-CN
 options:
   processing: numeric
+  date-substitute: gb-t-7714-2025
   multilingual:
     punctuation-width: mixed
   messages:
@@ -157,7 +158,6 @@ bibliography:
       punctuation: brackets
   - date: issued
     form: year
-    fallback: []
   - number: pages
   - variable: publisher
   - variable: publisher-place
@@ -226,7 +226,6 @@ bibliography:
       suppress: false
     - date: issued
       form: year
-      fallback: []
       suppress: false
     - date: accessed
       form: year
@@ -320,11 +319,6 @@ bibliography:
               delimiter: { mark: colon }
             - date: issued
               form: year
-              fallback:
-              - date: accessed
-                form: year
-                wrap:
-                  punctuation: brackets
             delimiter: { mark: comma }
           - number: pages
           delimiter: { mark: colon }
@@ -382,11 +376,6 @@ bibliography:
               delimiter: { mark: colon }
             - date: issued
               form: year
-              fallback:
-              - date: accessed
-                form: year
-                wrap:
-                  punctuation: brackets
             delimiter: { mark: comma }
           - number: pages
           delimiter: { mark: colon }
@@ -448,7 +437,6 @@ bibliography:
       suppress: false
     - date: issued
       form: year
-      fallback: []
       suppress: false
     - date: accessed
       form: year
@@ -509,7 +497,6 @@ bibliography:
     - variable: publisher
     - date: issued
       form: year-month-day
-      fallback: []
       wrap: parentheses
     - date: accessed
       form: year-month-day
@@ -555,7 +542,6 @@ bibliography:
           - group:
             - date: issued
               form: year
-              fallback: []
             render-when:
               field-present: volume-or-issue
           - group:
@@ -612,7 +598,6 @@ bibliography:
       suffix: { mark: comma }
     - date: issued
       form: year-month-day
-      fallback: []
     - number: pages
       wrap: parentheses
     - variable: url
@@ -674,11 +659,6 @@ bibliography:
             delimiter: { mark: colon }
           - date: issued
             form: year
-            fallback:
-            - date: accessed
-              form: year
-              wrap:
-                punctuation: brackets
           delimiter: { mark: comma }
         - number: pages
         delimiter: { mark: colon }
@@ -713,7 +693,6 @@ bibliography:
         delimiter: { mark: colon }
       - date: issued
         form: year
-        fallback: []
       delimiter: { mark: comma }
     - variable: url
       prefix: '. '
@@ -746,11 +725,6 @@ bibliography:
         delimiter: { mark: colon }
       - date: issued
         form: year-month-day
-        fallback:
-        - date: accessed
-          form: year-month-day
-          wrap:
-            punctuation: brackets
       delimiter: { mark: comma }
     - variable: url
       prefix: '. '
@@ -805,11 +779,11 @@ bibliography:
           # `book`/`thesis`/`map` route through this imprint position even
           # without a publisher (unlike `software`, which has no matching
           # branch at all and falls to the generic online-resource shape
-          # below instead) — an absent issued date falls back through GB/T
-          # 7714 §7.5.4.3's publication-year substitutes (copyright, then
-          # printing year), and finally to the ACCESSED YEAR ONLY (not a
+          # below instead) — the options-level GB/T date-substitute preset
+          # supplies §7.5.4.3's publication-year substitutes (copyright,
+          # then printing year), and finally the ACCESSED YEAR ONLY (not a
           # full date), matching the pinned CSL-M source's shared `date`
-          # macro, not `creation-accessed-date`.
+          # macro rather than `creation-accessed-date`.
           #
           # KNOWN DIVERGENCE (pending reviewer sign-off, PR discussion): the
           # printing-year suffix here and the estimated-year bracket wrap
@@ -822,17 +796,6 @@ bibliography:
           # pinned source is expected either way.
           - date: issued
             form: year
-            fallback:
-            - date: copyright
-              form: year
-              prefix: c
-            - date: printing
-              form: year
-              suffix: 印刷
-            - date: accessed
-              form: year
-              wrap:
-                punctuation: brackets
           delimiter: { mark: comma }
         - number: pages
         delimiter: { mark: colon }
@@ -862,7 +825,6 @@ bibliography:
       suffix: '. '
     - date: issued
       form: year-month-day
-      fallback: []
       wrap: parentheses
     - date: accessed
       form: year-month-day
@@ -908,7 +870,6 @@ bibliography:
           delimiter: ''
         - date: issued
           form: year
-          fallback: []
         delimiter: { mark: comma }
       - number: pages
       delimiter: { mark: colon }
@@ -937,7 +898,6 @@ bibliography:
       suffix: '. '
     - date: issued
       form: year-month-day
-      fallback: []
     - number: pages
       prefix: { mark: colon }
     - variable: url
@@ -963,7 +923,6 @@ bibliography:
       suffix: '. '
     - date: issued
       form: year-month-day
-      fallback: []
       wrap: parentheses
     - date: accessed
       form: year-month-day
@@ -992,7 +951,6 @@ bibliography:
       suffix: '. '
     - date: issued
       form: year-month-day
-      fallback: []
       wrap: parentheses
     - date: accessed
       form: year-month-day
@@ -1029,7 +987,6 @@ bibliography:
           delimiter: { mark: colon }
         - date: issued
           form: year-month-day
-          fallback: []
         delimiter: { mark: comma }
       - number: pages
       delimiter: { mark: colon }
@@ -1081,7 +1038,6 @@ bibliography:
     - group:
       - date: issued
         form: year
-        fallback: []
       - number: pages
       delimiter: { mark: colon }
     treaty:
@@ -1110,7 +1066,6 @@ bibliography:
     - group:
       - date: issued
         form: year
-        fallback: []
       - number: pages
       delimiter: { mark: colon }
     regulation,statute:
@@ -1150,7 +1105,6 @@ bibliography:
       suffix: '. '
     - date: issued
       form: year
-      fallback: []
       wrap: parentheses
       suffix: '. '
     - variable: url
@@ -1175,7 +1129,6 @@ bibliography:
       suffix: '. '
     - date: issued
       form: year
-      fallback: []
     - variable: url
       prefix: '. '
     - identifier: cstr
@@ -1206,7 +1159,6 @@ bibliography:
       suffix: '. '
     - date: issued
       form: year
-      fallback: []
     - variable: url
       prefix: '. '
     - identifier: cstr
@@ -1230,7 +1182,6 @@ bibliography:
       suffix: '. '
     - date: issued
       form: year-month-day
-      fallback: []
       wrap: parentheses
       suffix: '. '
     - variable: url

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-note.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-note.yaml
@@ -54,7 +54,6 @@ citation:
     strip-periods: true
   - date: issued
     form: year
-    fallback: []
   - date: accessed
     form: year
     wrap:
@@ -111,7 +110,6 @@ citation:
       strip-periods: true
     - date: issued
       form: year
-      fallback: []
       suppress: false
     - date: accessed
       form: year
@@ -176,7 +174,6 @@ citation:
       strip-periods: true
     - date: issued
       form: year
-      fallback: []
       suppress: false
     - date: accessed
       form: year

--- a/docs/specs/DATE_SUBSTITUTE.md
+++ b/docs/specs/DATE_SUBSTITUTE.md
@@ -14,16 +14,17 @@ reference's identity date is missing. The policy removes repeated inline
 and guarantees that rendering and disambiguation resolve the same candidate
 source under the same effective citation or bibliography configuration.
 
-A survey of the 32 embedded style YAML files found 64 `fallback:` keys, all in
-three GB/T files. Fifty are date fallbacks: 25 in
+A pre-migration survey of the 32 embedded style YAML files found 64
+`fallback:` keys, all in three GB/T files. Fifty were date fallbacks: 25 in
 `gb-t-7714-2025-base.yaml`, 22 in `gb-t-7714-2025-author-date.yaml`, and 3 in
 `gb-t-7714-2025-note.yaml`. The other 14 are terminal author fallbacks in the
 author-date style: after its options-level author-substitute chain is
 exhausted, each `contributor: author` component renders `term.anonymous`.
 Those author fallbacks belong to the existing author-substitute contract, not
-this date-substitute contract. Among the date fallbacks, not all belong to the
-identity date slot, but their concentration still shows that the repeated
-behavior is a style-family policy rather than a generic template default.
+this date-substitute contract. Layer 4 moved the identity-date policy into the
+two GB/T presets; the author-date style retains eight inline fallbacks only on
+later display dates. The concentration showed that the repeated behavior was
+a style-family policy rather than a generic template default.
 
 ## Scope
 
@@ -356,15 +357,16 @@ identity content must not be split by unrendered raw precision.
 
 ### Layer 4 — GB/T style migration and fidelity
 
-- [ ] GB/T numeric and note-base styles use `gb-t-7714-2025`.
-- [ ] GB/T author-date uses `gb-t-7714-2025-author-date`.
-- [ ] Migrated identity slots remove redundant inline fallback while
+- [x] GB/T numeric and note-base styles use `gb-t-7714-2025`.
+- [x] GB/T author-date uses `gb-t-7714-2025-author-date`.
+- [x] Migrated identity slots remove redundant inline fallback while
       display-only date fallbacks remain inline.
-- [ ] GB/T oracle results meet or exceed the pre-migration baseline, and the
+- [x] GB/T oracle results meet or exceed the pre-migration baseline, and the
       exemplar/core-quality sweep reports no unrelated regression.
 
 ## Changelog
 
+- 2026-08-12: Migrated the GB/T family to the named presets in Layer 4.
 - 2026-08-12: Clarified candidate rendering, resource-budget, and selector-warning requirements after implementation review.
 - 2026-08-12: Activated with the Layer 3 schema and engine implementation.
 - 2026-08-12: Initial Draft for Layer 2 of the date-substitute stack.

--- a/scripts/report-data/embedded-parity-baseline.json
+++ b/scripts/report-data/embedded-parity-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-08-11T17:17:23.482Z",
-  "commit": "a869fd95",
+  "generated": "2026-08-12T19:33:57.951Z",
+  "commit": "b7ca0a0b",
   "source": "scripts/report-core.js",
   "purpose": "Hard per-style exact-parity floor-gate baseline for the embedded tier, consumed by scripts/check-core-quality.js --parity-baseline (see docs/architecture/audits/2026-07-31_EXACT_PARITY_REFOCUS.md). It also records headline fidelity. Sub-1.0 fidelity ratchets are tracked separately per-style in scripts/report-data/verification-policy.yaml (min_pass_rate floors). Regenerate this file after each parity-tuning wave; the gate never goes backward on passed counts or total (fixture-drift guard).",
   "styles": {
@@ -151,7 +151,7 @@
     "gb-t-7714-2025-author-date": {
       "tier": "embedded",
       "fidelityScore": 0.851,
-      "qualityScore": 0.909,
+      "qualityScore": 0.923,
       "citations": {
         "passed": 19,
         "total": 20
@@ -161,9 +161,9 @@
         "total": 47
       },
       "exactParity": {
-        "passed": 36,
-        "total": 61,
-        "rate": 0.59
+        "passed": 37,
+        "total": 62,
+        "rate": 0.597
       }
     },
     "gb-t-7714-2025-note": {


### PR DESCRIPTION
## Summary

- select `gb-t-7714-2025` in the shared numeric/note base and `gb-t-7714-2025-author-date` in the author-date style
- remove 41 repeated identity-date fallback lists from the GB/T family
- retain the nine later/display-date fallbacks whose behavior remains component-local
- update the Active specification's migration record, embedded parity baseline, and completed tracking bean

## Comparison baseline

All `was` and `unchanged` deltas below compare this layer with its immediate
parent, PR #1174 at `707dc000`. The absolute fidelity, exact-parity, and SQI
values are the normal style-report results for each snapshot. The full
embedded-core sweep was compared with #1174's checked-in parity floor before
the Layer 4 baseline was regenerated.

## Style QA

| Style | Fidelity | Citation | Bibliography | Exact parity | SQI |
| --- | ---: | ---: | ---: | ---: | ---: |
| GB/T author-date | 85.1% (unchanged) | 19/20 | 38/47 | 37/62 (was 36/61) | 92.3 (was 91.1) |
| GB/T numeric | 99.6% (unchanged) | 21/21 | 249/250 | 257/262 (unchanged) | 100 (unchanged) |
| GB/T note | 98.2% (unchanged) | 31/35 | 249/250 | 240/276 (unchanged) | 94.1 (unchanged) |

Verdict: approve. Fidelity is unchanged, exact parity does not regress, author-date exact parity and SQI improve, and the full embedded-core sweep found no changes outside the intended author-date record.

## Evidence

- coverage preflight: all three GB/T leaf styles are not registered in a coverage audit
- targeted before/after reports passed for author-date, numeric, and note
- full 19-style embedded parity-floor sweep changed only the intended author-date record
- core quality gate passed all 35 styles; one unrelated pre-existing IEEE preset-usage warning remains
- `just schema-validate` passed all production styles and locales (one pre-existing documented Chicago schema skip)
- all three GB/T styles rendered successfully against `references-expanded.json`
- quality reporter suite: 66/66 passed
- `just pre-commit`: formatting and all-target/all-feature clippy passed; 2,486/2,486 tests passed
- manual jj hook gates passed: commit messages, pre-commit hygiene, and pre-push policy/Rust gates
- `git diff --check` passed

## Stack

1. #1171 — candidate-neutral date-slot foundation
2. #1172 — Draft specification
3. #1174 — schema and engine implementation; spec becomes Active
4. this PR — GB/T style migration to the new presets

This PR is intentionally draft and is based on #1174. Merge remains a maintainer action.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
