### PR TITLE
feat(engine): warn on bare numeric/alphabetic bibliography markers

### DIFF
--- a/.beans/archive/csl26-tw46--warn-when-bibliography-label-mode-has-no-wrapsepar.md
+++ b/.beans/archive/csl26-tw46--warn-when-bibliography-label-mode-has-no-wrapsepar.md
@@ -1,0 +1,27 @@
+---
+# csl26-tw46
+title: Warn when bibliography label-mode has no wrap/separator
+status: completed
+type: task
+priority: normal
+tags:
+    - engine
+    - warnings
+    - fidelity
+created_at: 2026-08-13T11:51:49Z
+updated_at: 2026-08-13T11:51:58Z
+---
+
+Follow-up from csl26-l5oh (springer/T&F-NLM numeric marker fix, PR #1177): nothing warned when a style declared bibliography.options.label-mode with no label-wrap and no label-separator, which is exactly the shape that let three shipped styles silently render markers flush against the entry body. Adds an engine warning scanner.
+
+## Summary of Changes
+
+Added `bibliography_label_missing_separator_warnings` to `crates/citum-engine/src/api/warnings.rs`, following the existing scanner pattern (`scan_bibliography_config_sort_for_citation_number`). Fires when the resolved bibliography config has `label_mode: Numeric | Alphabetic` with both `label_wrap` and `label_separator` absent — `author-date` mode is exempt since it never produces a bibliography marker (`marker.rs`). Advisory only, not an error: the empty default is correct for some shipped styles.
+
+Wired into the two rendering entry points (`document.rs`, `session.rs`) and into `citum check` (`crates/citum-cli/src/commands/check.rs`) so style authors see it pre-flight.
+
+5 unit tests added (bare label-mode triggers; label-wrap alone suppresses; label-separator alone suppresses; author-date mode suppresses; no label-mode at all is silent).
+
+**Corpus validation** (`citum check` against every embedded + exemplar style file on pre-#1177 main): fires on exactly the three previously-broken styles (springer-basic-brackets, springer-vancouver-brackets, taylor-and-francis-national-library-of-medicine) plus one already-documented intentional case (royal-society-of-chemistry, flush second-field-align per its own in-file comment). Zero noise elsewhere across 35 styles. Confirms the warning would have caught the #1177 bug pre-merge.
+
+`cargo nextest run`: 2506/2506 passed. `cargo clippy --all-targets --all-features -- -D warnings`: clean. `just check-core-quality`: gate passed, zero rendering/parity impact (this is a diagnostic-only addition, no render-path changes).

--- a/crates/citum-cli/src/commands/check.rs
+++ b/crates/citum-cli/src/commands/check.rs
@@ -160,6 +160,10 @@ fn check_style_input(style_input: &str, strict: bool) -> CheckItem {
             let enum_warnings = citum_engine::api::unknown_enum_warnings(&processor);
             warnings.extend(enum_warnings.into_iter().map(|w| w.message));
 
+            let label_warnings =
+                citum_engine::api::bibliography_label_missing_separator_warnings(&processor);
+            warnings.extend(label_warnings.into_iter().map(|w| w.message));
+
             // Forward-compat: report captured `unknown_fields` paths. In strict
             // mode every populated path becomes a hard error; otherwise they
             // surface as warnings alongside enum warnings.

--- a/crates/citum-engine/src/api/document.rs
+++ b/crates/citum-engine/src/api/document.rs
@@ -22,8 +22,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use super::warnings::{
-    term_locale_fallback_warnings, unknown_enum_warnings, unknown_reference_class_warnings,
-    unknown_reference_field_warnings,
+    bibliography_label_missing_separator_warnings, term_locale_fallback_warnings,
+    unknown_enum_warnings, unknown_reference_class_warnings, unknown_reference_field_warnings,
 };
 use super::{
     BibliographyEntry, CitationOccurrence, DocumentOptions, EntryMetadata, FormattedBibliography,
@@ -234,6 +234,7 @@ pub fn format_document_with_style(
     warnings.extend(unknown_reference_field_warnings(&processor.bibliography));
     warnings.extend(unknown_enum_warnings(&processor));
     warnings.extend(term_locale_fallback_warnings(&processor));
+    warnings.extend(bibliography_label_missing_separator_warnings(&processor));
 
     if let Some(opts) = &request.document_options {
         // Rebuild the processor with the document-level integral-name override

--- a/crates/citum-engine/src/api/mod.rs
+++ b/crates/citum-engine/src/api/mod.rs
@@ -35,6 +35,6 @@ pub use types::{
     Warning, WarningLevel,
 };
 pub use warnings::{
-    term_locale_fallback_warnings, unknown_enum_warnings, unknown_reference_class_warnings,
-    unknown_reference_field_warnings,
+    bibliography_label_missing_separator_warnings, term_locale_fallback_warnings,
+    unknown_enum_warnings, unknown_reference_class_warnings, unknown_reference_field_warnings,
 };

--- a/crates/citum-engine/src/api/session.rs
+++ b/crates/citum-engine/src/api/session.rs
@@ -20,8 +20,8 @@ use super::document::{format_bibliography, format_by_kind};
 use super::{
     CitationOccurrence, CitationOccurrenceItem, DocumentOptions, FormatDocumentError,
     FormattedBibliography, FormattedCitation, OutputFormatKind, RefsInput, StyleInput, Warning,
-    WarningLevel, term_locale_fallback_warnings, unknown_enum_warnings,
-    unknown_reference_class_warnings, unknown_reference_field_warnings,
+    WarningLevel, bibliography_label_missing_separator_warnings, term_locale_fallback_warnings,
+    unknown_enum_warnings, unknown_reference_class_warnings, unknown_reference_field_warnings,
 };
 use crate::processor::Processor;
 use crate::reference::{Bibliography, Citation};
@@ -368,6 +368,7 @@ impl DocumentSession {
         warnings.extend(self.ref_warnings.iter().cloned());
         warnings.extend(unknown_enum_warnings(&processor));
         warnings.extend(term_locale_fallback_warnings(&processor));
+        warnings.extend(bibliography_label_missing_separator_warnings(&processor));
 
         if let Some(opts) = &self.document_options {
             // Rebuild the processor with the document-level integral-name override

--- a/crates/citum-engine/src/api/warnings.rs
+++ b/crates/citum-engine/src/api/warnings.rs
@@ -70,6 +70,45 @@ pub fn term_locale_fallback_warnings(processor: &Processor) -> Vec<Warning> {
         .collect()
 }
 
+/// Warn when the bibliography config declares a numeric or alphabetic
+/// reference-marker mode with no `label-wrap` and no `label-separator`,
+/// which renders the marker flush against the entry body (`1Smith`, not
+/// `1. Smith` or `[1] Smith`).
+///
+/// `label-separator` defaults to empty by design, and several shipped
+/// styles depend on a genuinely flush marker — `royal-society-of-chemistry`
+/// documents `second-field-align="flush"` from its CSL source, and
+/// `gb-t-7714-2025-base` documents a bracketed-but-flush marker — so this is
+/// advisory, not an error: it surfaces a configuration shape that is easy to
+/// author unintentionally without asserting it is wrong. `author-date` mode
+/// is exempt: it never produces a bibliography marker (see `marker.rs`), so
+/// wrap and separator are inert for it. See `docs/specs/REFERENCE_MARKERS.md`.
+pub fn bibliography_label_missing_separator_warnings(processor: &Processor) -> Vec<Warning> {
+    let config = processor.get_bibliography_options();
+    let produces_marker = matches!(
+        config.label_mode,
+        Some(
+            citum_schema::options::BibliographyLabelMode::Numeric
+                | citum_schema::options::BibliographyLabelMode::Alphabetic
+        )
+    );
+    if !produces_marker || config.label_wrap.is_some() || config.label_separator.is_some() {
+        return Vec::new();
+    }
+
+    vec![Warning {
+        level: WarningLevel::Warning,
+        code: "bibliography_label_no_separator".to_string(),
+        citation_id: None,
+        ref_id: None,
+        message: "Bibliography configuration declares a numeric or alphabetic label-mode with \
+                  no label-wrap and no label-separator; the reference marker will render flush \
+                  against the entry body (e.g. '1Smith' rather than '1. Smith'). If this is \
+                  intentional (flush second-field-align), no action is needed."
+            .to_string(),
+    }]
+}
+
 /// Scan the bibliography for unknown reference classes and return compatibility warnings.
 pub fn unknown_reference_class_warnings(bibliography: &Bibliography) -> Vec<Warning> {
     bibliography
@@ -403,6 +442,80 @@ fn scan_template_for_unknowns(
 #[allow(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bibliography_label_missing_separator_warnings_reports_bare_numeric_label_mode() {
+        let yaml = "info:\n  title: Test\nbibliography:\n  options:\n    label-mode: numeric\n";
+        let style = citum_schema::Style::from_yaml_str(yaml).unwrap();
+        let processor = Processor::new(style, Bibliography::new());
+
+        let warnings = bibliography_label_missing_separator_warnings(&processor);
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.code == "bibliography_label_no_separator"),
+            "expected a warning for label-mode with no wrap and no separator, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn bibliography_label_missing_separator_warnings_silent_with_label_wrap() {
+        let yaml = "info:\n  title: Test\nbibliography:\n  options:\n    label-mode: numeric\n    label-wrap: period\n";
+        let style = citum_schema::Style::from_yaml_str(yaml).unwrap();
+        let processor = Processor::new(style, Bibliography::new());
+
+        let warnings = bibliography_label_missing_separator_warnings(&processor);
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| w.code == "bibliography_label_no_separator"),
+            "did not expect a warning once label-wrap is declared, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn bibliography_label_missing_separator_warnings_silent_with_label_separator() {
+        let yaml = "info:\n  title: Test\nbibliography:\n  options:\n    label-mode: numeric\n    label-separator: ' '\n";
+        let style = citum_schema::Style::from_yaml_str(yaml).unwrap();
+        let processor = Processor::new(style, Bibliography::new());
+
+        let warnings = bibliography_label_missing_separator_warnings(&processor);
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| w.code == "bibliography_label_no_separator"),
+            "did not expect a warning once label-separator is declared, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn bibliography_label_missing_separator_warnings_silent_for_author_date_mode() {
+        let yaml = "info:\n  title: Test\nbibliography:\n  options:\n    label-mode: author-date\n";
+        let style = citum_schema::Style::from_yaml_str(yaml).unwrap();
+        let processor = Processor::new(style, Bibliography::new());
+
+        let warnings = bibliography_label_missing_separator_warnings(&processor);
+        assert!(
+            !warnings
+                .iter()
+                .any(|w| w.code == "bibliography_label_no_separator"),
+            "author-date mode never produces a bibliography marker, so wrap/separator are \
+             inert; did not expect a warning, got: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn bibliography_label_missing_separator_warnings_silent_with_no_label_mode() {
+        let yaml = "info:\n  title: Test\n";
+        let style = citum_schema::Style::from_yaml_str(yaml).unwrap();
+        let processor = Processor::new(style, Bibliography::new());
+
+        let warnings = bibliography_label_missing_separator_warnings(&processor);
+        assert!(
+            warnings.is_empty(),
+            "did not expect a warning with no bibliography options at all, got: {warnings:?}"
+        );
+    }
 
     #[test]
     fn unknown_enum_warnings_reports_unknown_term_in_integral_sub_spec() {


### PR DESCRIPTION
## Summary
Follow-up to #1177. Nothing warned when a style declared `bibliography.options.label-mode` with no `label-wrap` and no `label-separator` — exactly the shape that let three shipped styles silently render markers flush against the entry body (`1Smith` instead of `1. Smith`).

Adds `bibliography_label_missing_separator_warnings` (`crates/citum-engine/src/api/warnings.rs`), wired into both rendering entry points (`document.rs`, `session.rs`) and into `citum check` for pre-flight use. Advisory only — the empty default is correct for some styles (`royal-society-of-chemistry`'s documented flush `second-field-align`), so this flags a configuration shape rather than asserting it's wrong. `author-date` mode is exempt: it never produces a bibliography marker.

**Corpus check** (`citum check` against every embedded + exemplar style on pre-#1177 `main`): fires on exactly the three previously-broken styles plus that one documented exception — zero noise elsewhere across 35 styles. Confirms this would have caught the #1177 bug before it shipped.

## Test plan
- [x] 5 new unit tests (trigger case + 4 suppression cases)
- [x] `cargo nextest run` (2506/2506)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `just check-core-quality` green — diagnostic-only change, zero rendering/parity impact
