### PR TITLE
fix(release): initialize audit submodules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
+          submodules: recursive
           token: ${{ secrets.RELEASE_TOKEN }}
           # persist-credentials: true (default) — needed for git push to release/next
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,7 @@ jobs:
           cargo release --workspace --no-publish --no-push $TAG_FLAG --no-confirm --execute \
             "${{ steps.resolve.outputs.level }}"
 
-          npm ci --prefix scripts
+          npm install --prefix scripts
           cargo build --quiet --bin citum
           node scripts/refresh-style-coverage-audits.js \
             --citum-bin target/debug/citum


### PR DESCRIPTION
## Summary

The release workflow now checks out repository submodules before regenerating registered coverage audit packets.

The release packet manifest references `styles-legacy/chicago-shortened-notes-bibliography.csl`; without submodule initialization, release PR creation fails before pushing `release/next`.

## Validation

- `actionlint .github/workflows/release.yml .github/workflows/ci.yml`
- Repository pre-push checks passed.
- The fix is limited to `submodules: recursive` on the release checkout.
