### PR TITLE
fix(styles): chicago author-date given-name disambiguation

### DIFF
--- a/.beans/archive/csl26-tc4x--fix-chicago-author-date-given-name-disambiguation.md
+++ b/.beans/archive/csl26-tc4x--fix-chicago-author-date-given-name-disambiguation.md
@@ -1,0 +1,72 @@
+---
+# csl26-tc4x
+title: Fix Chicago author-date given-name disambiguation + bibliography given-name sort
+status: completed
+type: bug
+priority: high
+tags:
+    - chicago
+    - disambiguation
+    - contributors
+    - sorting
+    - fixtures
+created_at: 2026-08-14T13:51:29Z
+updated_at: 2026-08-14T14:18:28Z
+parent: csl26-40n4
+---
+
+citation.options.contributors: name-form: initials was missing alongside initialize-with, so
+disambiguation's given-name expansion never activated initials (Short->Long flip reads
+ctx.name_form, which defaulted to Full). Also found and fixing: bibliography sort's
+structured_name_sort_text ignores given names entirely (both NameSortOrder arms identical),
+causing family-name ties to fall through to title order instead of given-name order.
+
+## Todo
+- [x] Fix chicago-author-date-18th.yaml: name-form: initials + initialize-with: '. ' in citation.options.contributors
+- [x] Add name-form: full override to personal-communication type-variant (regression guard)
+- [x] Fix misleading ContributorConfig::initialize_with doc comment
+- [x] just schema-gen (doc comment change affects generated schema)
+- [x] Fix structured_name_sort_text/structured_name_sort_as_text given-name blindness in sort_support.rs
+- [x] Add rstest coverage for sort key fix
+- [x] Add pairs-with field to coverage-manifest.json citations entries
+- [x] Enforce pairs-with in check-testing-infra.js + update its test
+- [x] Add fixture-pairing section to RENDERING_WORKFLOW.md
+- [x] Verify: render refs command from user, oracle exact-parity, report-core, check-oracle-regression, pre-commit gate
+
+## Summary of Changes
+
+Root cause: `initialize-with` only sets the initials separator string; `name-form: initials`
+is what activates the initials form. The style's citation-scope contributors config was
+missing `name-form: initials`, so the given-name-expansion disambiguation pass flipped
+Short->Long form but rendered full names anyway.
+
+- `chicago-author-date-18th.yaml`: added `name-form: initials` alongside `initialize-with: '. '`
+  in `citation.options.contributors`; added `name-form: full` override on the
+  `personal-communication` type-variant's long-form author node to guard against a regression
+  there (CMOS 18 14.111 first-mention case).
+- Fixed the misleading `ContributorConfig::initialize_with` doc comment that described CSL
+  semantics ("if None, full names used") rather than Citum's actual split; regenerated schemas.
+- Found and fixed a second, related bug while verifying: `sort_support::structured_name_sort_text`
+  / `structured_name_original_text` ignored given names entirely (both `NameSortOrder` arms
+  identical), so bibliography ties on family name fell through to title order instead of given
+  name. Fixed via a shared `compose_family_given_key` helper (careful to preserve empty-key
+  fallback behavior for anonymous/no-author entries). Updated 3 existing test expectations that
+  encoded the old (wrong) tiebreak order; added dedicated rstest + integration coverage.
+- Added a `pairs-with` field to every `citations`-kind entry in `coverage-manifest.json`,
+  pointing at the references fixture it must render against — verified empirically via
+  citation-id/reference-id overlap for all 10 citations fixtures (uncovered that
+  `citations-compound-numeric.json` actually pairs with `references-compound-numeric-family.json`,
+  not the more obviously-named `compound-numeric-refs.json`). Enforced in
+  `check-testing-infra.js` + tests. Added a "Picking a Fixture Pair" section to
+  RENDERING_WORKFLOW.md leading with `--show-keys`.
+
+Verification: oracle exact citation parity 16/20 -> 17/20 with `disambiguate-givenname` now
+`exactMatch: true`; bibliography byte-identical except the two Johnson entries reordering
+correctly (also fixes a previously-undetected `Smith, Jane`/`Smith, John` mis-ordering); full
+corpus `report-core.js --all-features` + `check-core-quality.js` gate passed (one pre-existing,
+unrelated `ieee` preset-usage warning); `check-oracle-regression.js` clean; full workspace
+`cargo nextest run` 2526/2526 passed; `cargo fmt --check` + `clippy -D warnings` clean.
+
+Deferred as separate beans: `GivennameRule`'s `*WithInitials` variants carry an inert form hint
+(scope/form conflation) — needs a spec PR per schema-change policy. Oracle's `orderingIssues`
+check pairs bibliography entries by id, not position, so it missed the sort bug above.

--- a/.beans/csl26-7u16--oraclejs-orderingissues-check-is-blind-to-position.md
+++ b/.beans/csl26-7u16--oraclejs-orderingissues-check-is-blind-to-position.md
@@ -1,0 +1,32 @@
+---
+# csl26-7u16
+title: oracle.js orderingIssues check is blind to positional bibliography divergence
+status: todo
+type: bug
+priority: normal
+tags:
+    - oracle
+    - sorting
+    - bibliography
+    - testing
+created_at: 2026-08-14T14:17:53Z
+updated_at: 2026-08-14T14:18:17Z
+---
+
+scripts/oracle.js's orderingIssues check pairs bibliography entries by id, not by position, so
+it cannot detect that Citum renders two entries in a different order than citeproc even when
+every individual entry's rendered text matches exactly (component-level and even exact-string
+match per entry). This let a real bug through undetected: chicago-author-date-18th's
+bibliography sort ordered "Johnson, Brian" before "Johnson, Alice" (citeproc: Alice first) and
+"Smith, John" before "Smith, Jane" (citeproc: Jane first) — orderingIssues reported 0 in both
+the buggy and fixed state.
+
+Root cause of the underlying bug (fixed in csl26-tc4x): sort_support::structured_name_sort_text
+ignored given names when building the bibliography author sort key, so family-name ties fell
+through to title order instead of breaking on given name.
+
+## Todo
+- [ ] Change orderingIssues (or add a new check) to compare oracle vs citum bibliography
+      entry order positionally, not just per-id text match
+- [ ] Re-run the full corpus with the new check to see how many other styles have undetected
+      ordering divergence

--- a/.beans/csl26-ymm8--spec-givennamerule-scopeform-conflation-cleanup.md
+++ b/.beans/csl26-ymm8--spec-givennamerule-scopeform-conflation-cleanup.md
@@ -1,0 +1,37 @@
+---
+# csl26-ymm8
+title: 'Spec: GivennameRule scope/form conflation cleanup'
+status: todo
+type: task
+priority: normal
+tags:
+    - schema
+    - chicago
+    - disambiguation
+    - contributors
+created_at: 2026-08-14T14:17:43Z
+updated_at: 2026-08-14T14:18:10Z
+parent: csl26-40n4
+---
+
+GivennameRule has 5 variants (ByCite, AllNames, AllNamesWithInitials, PrimaryName,
+PrimaryNameWithInitials) but the engine collapses them to 2 effective scopes (primary-only vs
+all-names) — the *WithInitials suffixes are inert. Form (full vs initials) is always driven by
+contributors.name-form, independent of GivennameRule. Confirmed by reading
+crates/citum-engine/src/processor/disambiguation.rs (primary_givenname_only is computed by
+matching GivennameRule::PrimaryName | PrimaryNameWithInitials as one arm — the initials
+distinction is never read) and crates/citum-schema-style/src/options/contributors.rs (NameForm
+enum + name_form field, doc comment already says "Initialization formatting details ...
+are separate fields").
+
+This is a schema change to citum-schema-style (removing or repurposing enum variants), so per
+project policy it needs a docs/spec PR reviewed and merged before implementation. Surfaced
+while fixing csl26-tc4x (Chicago author-date given-name disambiguation).
+
+## Todo
+- [ ] Write spec in docs/specs/ proposing either: (a) drop the two *WithInitials variants
+      (breaking, needs migration path for any style using them), or (b) keep them but make
+      the engine actually honor the form hint instead of always deferring to name-form
+- [ ] Survey embedded styles for any current use of GivennameRule::*WithInitials to gauge
+      blast radius
+- [ ] Get spec reviewed/merged (status Draft -> Active) before any implementation PR

--- a/crates/citum-engine/src/sort_support.rs
+++ b/crates/citum-engine/src/sort_support.rs
@@ -274,16 +274,30 @@ fn structured_name_sort_text(
     name_order: NameSortOrder,
     options: &SortKeyOptions,
 ) -> String {
-    match name_order {
-        NameSortOrder::FamilyGiven | NameSortOrder::GivenFamily => {
-            multilingual_string_sort_text(&name.family, options)
-        }
-    }
+    let family = multilingual_string_sort_text(&name.family, options);
+    let given = multilingual_string_sort_text(&name.given, options);
+    compose_family_given_key(&family, &given, name_order)
 }
 
 fn structured_name_original_text(name: &StructuredName, name_order: NameSortOrder) -> String {
+    let family = name.family.to_string();
+    let given = name.given.to_string();
+    compose_family_given_key(&family, &given, name_order)
+}
+
+/// Combine a family and given name into a single composite sort key so a tie
+/// on one part is broken by the other, matching [`flat_names_sort_key`].
+///
+/// An empty result (both parts blank) is preserved as an empty string rather
+/// than a bare separator — callers rely on emptiness to fall back to another
+/// sort key (e.g. title) for anonymous entries.
+fn compose_family_given_key(family: &str, given: &str, name_order: NameSortOrder) -> String {
+    if family.trim().is_empty() && given.trim().is_empty() {
+        return String::new();
+    }
     match name_order {
-        NameSortOrder::FamilyGiven | NameSortOrder::GivenFamily => name.family.to_string(),
+        NameSortOrder::FamilyGiven => format!("{family}\u{0}{given}"),
+        NameSortOrder::GivenFamily => format!("{given}\u{0}{family}"),
     }
 }
 
@@ -485,5 +499,55 @@ mod tests {
         // at primary/secondary levels, so names with and without apostrophes/hyphens compare equal.
         assert_eq!(collator.compare("O'Brien", "Obrien"), Ordering::Equal);
         assert_eq!(collator.compare("al-Rashid", "alRashid"), Ordering::Equal);
+    }
+
+    /// `compose_family_given_key` must break family-name ties with the given
+    /// name (in the order `NameSortOrder` requests), and must not fabricate
+    /// a non-empty key from a bare separator when both parts are blank —
+    /// callers depend on emptiness to fall back to another sort key.
+    #[rstest::rstest]
+    #[case::family_given_order("Johnson", "Alice", NameSortOrder::FamilyGiven, "Johnson\u{0}Alice")]
+    #[case::given_family_order("Johnson", "Alice", NameSortOrder::GivenFamily, "Alice\u{0}Johnson")]
+    #[case::blank_given_still_keys_on_family(
+        "Johnson",
+        "",
+        NameSortOrder::FamilyGiven,
+        "Johnson\u{0}"
+    )]
+    fn given_family_and_given_names_when_composing_sort_key_then_order_matches_name_order(
+        #[case] family: &str,
+        #[case] given: &str,
+        #[case] name_order: NameSortOrder,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(
+            compose_family_given_key(family, given, name_order),
+            expected
+        );
+    }
+
+    #[test]
+    fn given_no_family_or_given_name_when_composing_sort_key_then_result_is_empty() {
+        // then: an empty result (not a bare "\0" separator) so callers can
+        // fall back to another sort key (e.g. title) for anonymous entries.
+        assert_eq!(
+            compose_family_given_key("", "", NameSortOrder::FamilyGiven),
+            ""
+        );
+        assert_eq!(
+            compose_family_given_key("  ", "\t", NameSortOrder::FamilyGiven),
+            ""
+        );
+    }
+
+    /// Same family name, different given names: the composite key must order
+    /// the pair by given name so a same-surname collision (e.g. two Johnson
+    /// works) breaks the tie by given name rather than falling through to an
+    /// unrelated key like title.
+    #[test]
+    fn given_two_names_sharing_a_family_when_composing_sort_keys_then_given_name_breaks_the_tie() {
+        let alice = compose_family_given_key("Johnson", "Alice", NameSortOrder::FamilyGiven);
+        let brian = compose_family_given_key("Johnson", "Brian", NameSortOrder::FamilyGiven);
+        assert!(alice < brian, "expected {alice:?} < {brian:?}");
     }
 }

--- a/crates/citum-engine/src/sorting.rs
+++ b/crates/citum-engine/src/sorting.rs
@@ -1392,9 +1392,12 @@ mod tests {
             Title::Single("War and Peace".to_string()),
         );
 
+        // Family + given (the original, un-transliterated given name "Лев") —
+        // the uniform path ignores `sort_as`/transliterations but still needs
+        // the given name to break family-name ties.
         assert_eq!(
             sorter.extract_author_sort_key(&reference, NameSortOrder::FamilyGiven),
-            "Толстой"
+            "Толстой\u{0}Лев"
         );
     }
 
@@ -1411,9 +1414,12 @@ mod tests {
             Title::Single("War and Peace".to_string()),
         );
 
+        // Family + given (matching the transliteration's own given name "Lev"),
+        // not family alone — the sort key must break given-name ties the same
+        // way the non-romanized path does.
         assert_eq!(
             sorter.extract_author_sort_key(&reference, NameSortOrder::FamilyGiven),
-            "Tolstoĭ"
+            "Tolstoĭ\u{0}Lev"
         );
     }
 

--- a/crates/citum-engine/tests/bibliography.rs
+++ b/crates/citum-engine/tests/bibliography.rs
@@ -2137,6 +2137,48 @@ fn sorting_by_author_orders_entries_alphabetically() {
     assert!(result.find("Adam").unwrap() < result.find("Zoe").unwrap());
 }
 
+/// Regression for the given-name-blind author sort key: two references
+/// sharing the same family name must break the tie by given name, not fall
+/// through to an unrelated key like title.
+fn sorting_by_author_breaks_family_name_ties_with_given_name() {
+    let style = build_sorted_style(vec![SortSpec {
+        key: SortKey::Author,
+        ascending: true,
+    }]);
+
+    let mut bib = indexmap::IndexMap::new();
+    // Registered and titled so that a family-only sort key would (wrongly)
+    // place Brian first via the title fallback ("Qualitative" < "Quantitative").
+    bib.insert(
+        "brian".to_string(),
+        make_book(
+            "brian",
+            "Johnson",
+            "Brian",
+            2020,
+            "Qualitative Methods in Sociology",
+        ),
+    );
+    bib.insert(
+        "alice".to_string(),
+        make_book(
+            "alice",
+            "Johnson",
+            "Alice",
+            2020,
+            "Quantitative Methods in Sociology",
+        ),
+    );
+
+    let processor = Processor::new(style, bib);
+    let result = processor.render_bibliography();
+
+    assert!(
+        result.find("Johnson, Alice").unwrap() < result.find("Johnson, Brian").unwrap(),
+        "expected Alice before Brian on given-name tiebreak: {result}"
+    );
+}
+
 fn sorting_by_year_places_earlier_years_first() {
     let style = build_sorted_style(vec![SortSpec {
         key: SortKey::Year,
@@ -3928,6 +3970,14 @@ mod sorting {
             "A bibliography sorted by author should place entries in alphabetical family-name order.",
         );
         super::sorting_by_author_orders_entries_alphabetically();
+    }
+
+    #[test]
+    fn author_sorting_breaks_family_name_ties_with_given_name() {
+        announce_behavior(
+            "When two entries share a family name, author sorting should break the tie by given name rather than falling through to title order.",
+        );
+        super::sorting_by_author_breaks_family_name_ties_with_given_name();
     }
 
     #[test]

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -970,8 +970,11 @@ fn disambiguation_initials_are_used_when_short_form_family_names_collide() {
         vec!["ITEM-2", "ITEM-3"],
         vec!["ITEM-4", "ITEM-5"],
     ];
+    // Within the Doe collision group, output order follows the author sort
+    // key (family, then given), not citation-item registration order: with
+    // the family name tied, "Aloysius" sorts before "John".
     let expected = "Roe, (2000)
-J Doe, (2000); A Doe, (2000)
+A Doe, (2000); J Doe, (2000)
 T Smith, (2000); T Smith, (2000)";
 
     run_test_case_native_with_options(common::TestCaseOptions {
@@ -1485,11 +1488,14 @@ fn disambiguation_multilingual_contributors_collide_on_original_family_name() {
     let citation_items = vec![vec!["ml-a", "ml-b"]];
 
     // The collision key uses the original Korean family name "김"; both entries
-    // form one group and receive year suffixes.
+    // form one group and receive year suffixes. Suffix assignment follows the
+    // bibliography sort order of the group (family, then given): "영희"
+    // (ml-b) sorts before "철수" (ml-a), so ml-b receives "a" and ml-a
+    // receives "b" even though ml-a is cited first.
     run_test_case_native(
         &input,
         &citation_items,
-        "김, (2020a); 김, (2020b)",
+        "김, (2020b); 김, (2020a)",
         "citation",
     );
 }

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -89,6 +89,9 @@ citation:
       - parent-serial
       - title
     contributors:
+      # when given names are expanded in citations, they are initialized
+      initialize-with: '. '
+      name-form: initials
       shorten:
         min: 3
         use-first: 1
@@ -126,9 +129,15 @@ citation:
         field-absent: title
       delimiter: ''
     - group:
+      # CMOS 18 14.111: an inaccessible personal communication has no
+      # bibliography entry, so the first in-text mention gives the full
+      # given name rather than the initials the citation-scope disambiguation
+      # config would otherwise apply (matches CSL's bare `<name and="text"/>`
+      # at `position="first"`, chicago-author-date.csl author-inline-and-recipient).
       - contributor: author
         form: long
         name-order: given-first
+        name-form: full
         shorten:
           min: 3
           use-first: 1

--- a/crates/citum-schema-style/src/options/contributors.rs
+++ b/crates/citum-schema-style/src/options/contributors.rs
@@ -46,8 +46,15 @@ pub struct ContributorConfig {
     /// When to display a contributor's name in sort order.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub display_as_sort: Option<DisplayAsSort>,
-    /// String to append after initialized given names (e.g., ". " for "J. Smith").
-    /// If None, full given names are used (e.g., "John Smith").
+    /// Separator appended between initials when given names are initialized
+    /// (e.g., ". " for "J. Smith").
+    ///
+    /// This only controls the separator string — it does **not** activate
+    /// initials on its own. Set [`Self::name_form`] to
+    /// [`NameForm::Initials`] to actually render initials; otherwise this
+    /// field is inert and full given names are rendered regardless of its
+    /// value. Defaults to ". " when `name_form: initials` is active and this
+    /// is unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub initialize_with: Option<String>,
     /// Whether to include a hyphen when initializing names (e.g., "J.-P. Sartre").

--- a/docs/guides/RENDERING_WORKFLOW.md
+++ b/docs/guides/RENDERING_WORKFLOW.md
@@ -48,6 +48,42 @@ node ../scripts/check-testing-infra.js
 RIS continuation lines are appended to the previous field value, and CSL `issued` conversion preserves
 non-year values via `literal` when a four-digit year is not parseable.
 
+## Picking a Fixture Pair
+
+`tests/fixtures/` holds many `references-*.json` and `citations-*.json` files, and a citations
+fixture only renders correctly against the specific references fixture it was written for — the
+IDs in a `citations-*.json` file must exist in its paired `references-*.json`. File-name
+similarity is not reliable: `citations-compound-numeric.json` pairs with
+`references-compound-numeric-family.json`, not `compound-numeric-refs.json`, and
+`citations-note-expanded.json` pairs with `references-expanded.json`, not `references-heldout.json`.
+
+Two tools remove the guesswork:
+
+1. **Find the right pair.** `tests/fixtures/coverage-manifest.json` records a `pairs-with` field
+   on every `kind: "citations"` entry, naming the references fixture it must be run against.
+   `scripts/check-testing-infra.js` enforces that every citations entry has one and that it
+   points at a real `kind: "references"` entry, so the manifest can't drift out of sync with the
+   files on disk.
+
+   ```bash
+   # Which references fixture does citations-expanded.json pair with?
+   node -e "
+     const m = require('./tests/fixtures/coverage-manifest.json');
+     const e = m.fixtures.find(f => f.fixture === 'tests/fixtures/citations-expanded.json');
+     console.log(e['pairs-with']);
+   "
+   ```
+
+2. **Find which scenario a rendered line came from.** `citum render refs --show-keys` labels
+   every citation with its scenario id (e.g. `[disambiguate-givenname]`) and every bibliography
+   entry with its reference id, so you don't have to count lines:
+
+   ```bash
+   citum render refs -s styles/embedded/chicago-author-date-18th.yaml \
+     -b tests/fixtures/references-expanded.json \
+     -c tests/fixtures/citations-expanded.json --show-keys
+   ```
+
 ## Style Catalog Scope
 
 Use production styles from `styles/*.yaml` for routine validation and

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -5145,7 +5145,7 @@
           ]
         },
         "initialize-with": {
-          "description": "String to append after initialized given names (e.g., \". \" for \"J. Smith\").\nIf None, full given names are used (e.g., \"John Smith\").",
+          "description": "Separator appended between initials when given names are initialized\n(e.g., \". \" for \"J. Smith\").\n\nThis only controls the separator string — it does **not** activate\ninitials on its own. Set [`Self::name_form`] to\n[`NameForm::Initials`] to actually render initials; otherwise this\nfield is inert and full given names are rendered regardless of its\nvalue. Defaults to \". \" when `name_form: initials` is active and this\nis unset.",
           "type": [
             "string",
             "null"

--- a/scripts/check-testing-infra.js
+++ b/scripts/check-testing-infra.js
@@ -66,6 +66,33 @@ function validateManifestEntry(entry, seenFixtures, seenDomains, projectRoot) {
     const resolved = path.resolve(projectRoot, scriptPath);
     assert(fs.existsSync(resolved), `Referenced owner path does not exist for ${entry.fixture}: ${scriptPath}`);
   }
+
+  // Every citations fixture must record which references fixture it renders
+  // against, so contributors can navigate the fixture directory without
+  // reverse-engineering the pairing from scripts. See
+  // docs/guides/RENDERING_WORKFLOW.md.
+  if (entry.kind === 'citations') {
+    assert(isNonEmptyString(entry['pairs-with']), `Fixture ${entry.fixture} is a citations fixture and must set pairs-with`);
+    const pairedPath = path.resolve(projectRoot, entry['pairs-with']);
+    assert(fs.existsSync(pairedPath), `pairs-with target does not exist for ${entry.fixture}: ${entry['pairs-with']}`);
+  }
+}
+
+// Cross-check `pairs-with` targets once every entry is known: the target
+// must itself be a manifest entry of kind `references`. Run as a second
+// pass over the full fixture list so pairing order in the manifest doesn't
+// matter.
+function validatePairsWithTargets(fixtures) {
+  const byPath = new Map(fixtures.map((entry) => [entry.fixture, entry]));
+  for (const entry of fixtures) {
+    if (entry.kind !== 'citations') continue;
+    const target = byPath.get(entry['pairs-with']);
+    assert(target, `pairs-with target for ${entry.fixture} is not a manifest entry: ${entry['pairs-with']}`);
+    assert(
+      target.kind === 'references',
+      `pairs-with target for ${entry.fixture} must be a references fixture, got kind=${target.kind}: ${entry['pairs-with']}`,
+    );
+  }
 }
 
 function validateCoverageManifest(projectRoot = PROJECT_ROOT) {
@@ -83,6 +110,8 @@ function validateCoverageManifest(projectRoot = PROJECT_ROOT) {
   for (const entry of manifest.fixtures) {
     validateManifestEntry(entry, seenFixtures, seenDomains, projectRoot);
   }
+
+  validatePairsWithTargets(manifest.fixtures);
 
   for (const domain of REQUIRED_DOMAINS) {
     assert(seenDomains.has(domain), `coverage-manifest.json is missing required domain: ${domain}`);

--- a/scripts/check-testing-infra.test.js
+++ b/scripts/check-testing-infra.test.js
@@ -48,6 +48,7 @@ function baseManifest() {
         fixture: 'tests/fixtures/citations-note-expanded.json',
         domain: 'note',
         kind: 'citations',
+        'pairs-with': 'tests/fixtures/references-expanded.json',
         reference_types: ['book'],
         citation_scenarios: ['single item'],
         rendering_risks: ['note rendering'],
@@ -70,6 +71,7 @@ function baseManifest() {
         fixture: 'tests/fixtures/citations-note-positions.json',
         domain: 'note',
         kind: 'citations',
+        'pairs-with': 'tests/fixtures/references-note-positions.json',
         reference_types: ['article-journal'],
         citation_scenarios: ['first', 'ibid', 'subsequent'],
         rendering_risks: ['repeated-note rendering'],
@@ -228,6 +230,46 @@ test('coverage manifest fails when a used_by path is missing', () => {
   writeJson(manifestPath, manifest);
 
   assert.throws(() => validateCoverageManifest(root), /Referenced owner path does not exist/);
+});
+
+test('coverage manifest fails when a citations fixture is missing pairs-with', () => {
+  const root = makeTempProject();
+  seedProject(root);
+  const manifestPath = path.join(root, 'tests/fixtures/coverage-manifest.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const citationsEntry = manifest.fixtures.find((entry) => entry.kind === 'citations');
+  delete citationsEntry['pairs-with'];
+  writeJson(manifestPath, manifest);
+
+  assert.throws(() => validateCoverageManifest(root), /must set pairs-with/);
+});
+
+test('coverage manifest fails when pairs-with points at a non-references fixture', () => {
+  const root = makeTempProject();
+  seedProject(root);
+  const manifestPath = path.join(root, 'tests/fixtures/coverage-manifest.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const citationsEntry = manifest.fixtures.find(
+    (entry) => entry.fixture === 'tests/fixtures/citations-note-expanded.json',
+  );
+  citationsEntry['pairs-with'] = 'tests/fixtures/citations-note-positions.json';
+  writeJson(manifestPath, manifest);
+
+  assert.throws(() => validateCoverageManifest(root), /must be a references fixture/);
+});
+
+test('coverage manifest fails when pairs-with targets an unknown fixture', () => {
+  const root = makeTempProject();
+  seedProject(root);
+  const manifestPath = path.join(root, 'tests/fixtures/coverage-manifest.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const citationsEntry = manifest.fixtures.find(
+    (entry) => entry.fixture === 'tests/fixtures/citations-note-expanded.json',
+  );
+  citationsEntry['pairs-with'] = 'tests/fixtures/references-unknown.json';
+  writeJson(manifestPath, manifest);
+
+  assert.throws(() => validateCoverageManifest(root), /pairs-with target does not exist/);
 });
 
 test('baseline validation fails when metadata fields are missing', () => {

--- a/tests/fixtures/coverage-manifest.json
+++ b/tests/fixtures/coverage-manifest.json
@@ -110,6 +110,7 @@
       "fixture": "tests/fixtures/citations-expanded.json",
       "domain": "core",
       "kind": "citations",
+      "pairs-with": "tests/fixtures/references-expanded.json",
       "reference_types": [
         "article-journal",
         "book",
@@ -152,6 +153,7 @@
       "fixture": "tests/fixtures/citations-note-expanded.json",
       "domain": "note",
       "kind": "citations",
+      "pairs-with": "tests/fixtures/references-expanded.json",
       "reference_types": [
         "all core references paired with note citation scenarios"
       ],
@@ -196,6 +198,7 @@
       "fixture": "tests/fixtures/citations-note-positions.json",
       "domain": "note",
       "kind": "citations",
+      "pairs-with": "tests/fixtures/references-note-positions.json",
       "reference_types": [
         "article-journal"
       ],
@@ -295,6 +298,7 @@
       "fixture": "tests/fixtures/citations-compound-numeric.json",
       "domain": "core",
       "kind": "citations",
+      "pairs-with": "tests/fixtures/references-compound-numeric-family.json",
       "reference_types": [
         "article-journal",
         "book",
@@ -352,6 +356,7 @@
       "fixture": "tests/fixtures/citations-secondary-roles.json",
       "domain": "core",
       "kind": "citations",
+      "pairs-with": "tests/fixtures/references-secondary-roles.json",
       "reference_types": [
         "book",
         "chapter",
@@ -408,6 +413,7 @@
       "fixture": "tests/fixtures/citations-author-date.json",
       "domain": "core",
       "kind": "citations",
+      "pairs-with": "tests/fixtures/references-author-date.json",
       "reference_types": [
         "article-journal",
         "book",
@@ -551,6 +557,7 @@
       "fixture": "tests/fixtures/citations-physics-numeric.json",
       "domain": "core",
       "kind": "citations",
+      "pairs-with": "tests/fixtures/references-physics-numeric.json",
       "reference_types": [
         "article-journal",
         "book",
@@ -608,6 +615,7 @@
       "fixture": "tests/fixtures/citations-humanities-note.json",
       "domain": "note",
       "kind": "citations",
+      "pairs-with": "tests/fixtures/references-humanities-note.json",
       "reference_types": [
         "article-journal",
         "book",
@@ -660,6 +668,7 @@
       "fixture": "tests/fixtures/citations-legal.json",
       "domain": "legal",
       "kind": "citations",
+      "pairs-with": "tests/fixtures/references-legal.json",
       "reference_types": [
         "bill",
         "hearing",
@@ -711,6 +720,7 @@
       "fixture": "tests/fixtures/citations-csl-m-adapted.json",
       "domain": "legal",
       "kind": "citations",
+      "pairs-with": "tests/fixtures/references-csl-m-adapted.json",
       "reference_types": [
         "legal_case",
         "legislation",


### PR DESCRIPTION
## Summary

- **Chicago author-date disambiguation bug**: `initialize-with` only sets the initials separator; `name-form: initials` is what activates the form. Citation-scope config had the former but not the latter, so given-name disambiguation expanded to full names instead of initials. Fixed, with a `name-form: full` guard on the `personal-communication` variant to prevent a regression there.
- **Doc comment fix**: `ContributorConfig::initialize_with` described CSL semantics, not Citum's split — this misled the original one-line fix. Corrected, schemas regenerated.
- **Bibliography sort bug found while verifying**: the author sort key ignored given names, so family-name ties (two "Johnson" entries) fell through to title order. Fixed, with test coverage.
- **Fixture navigation**: added a `pairs-with` field linking each `citations-*.json` fixture to its `references-*.json` (verified by ID overlap, not filename similarity), enforced by `check-testing-infra.js`, documented in `RENDERING_WORKFLOW.md`.

**Follow-ups filed, not fixed here**: `csl26-ymm8` (`GivennameRule`'s `*WithInitials` variants are inert — needs a spec PR), `csl26-7u16` (oracle's `orderingIssues` check pairs by id and missed the sort bug above).

## Test plan

- [x] `cargo nextest run` (2526/2526 passed)
- [x] `cargo fmt --check` / `cargo clippy -D warnings`
- [x] Oracle exact citation parity for `chicago-author-date`: 16/20 → 17/20
- [x] `check-oracle-regression.js`, `report-core.js --all-features`, `check-core-quality.js`, `check-testing-infra.js`
