### PR TITLE
fix(schema): flip elsevier-harvard title-quote

### DIFF
--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -35,9 +35,9 @@ use citum_schema::{
         AndOptions, CitationLabelMode, Config, ContributorConfig, DateConfig,
         DelimiterPrecedesLast, DisplayAsSort, GivennameRule, IntegralNameContexts,
         IntegralNameMemoryConfig, IntegralNameScope, MultilingualConfig, MultilingualMode,
-        NameForm, Processing, ProcessingCustom, ShortenListOptions, SubsequentNameForm, Substitute,
-        SubstituteConfig, SubstituteTitleQuoteMode, TitleRendering, TitlesConfig,
-        TwoNameDelimiterPolicy,
+        NameForm, Processing, ProcessingCustom, ReferenceTypeName, ShortenListOptions,
+        SubsequentNameForm, Substitute, SubstituteConfig, SubstituteTitleQuoteMode, TitleCategory,
+        TitleRendering, TitlesConfig, TwoNameDelimiterPolicy,
     },
     reference::{DateValue, InputReference, Monograph, MonographType, Title},
 };
@@ -351,6 +351,104 @@ fn authorless_book_cited_by_title_in_citation_defaults_to_unconditional_quoting(
     let result = process_citation_ids(&processor, &["item1"]);
 
     assert_eq!(result, "\u{201c}Title\u{201d}");
+}
+
+fn make_authorless_monograph(id: &str, title: &str, kind: MonographType) -> InputReference {
+    InputReference::Monograph(Box::new(Monograph {
+        id: Some(id.into()),
+        r#type: kind,
+        title: Some(Title::Single(title.to_string())),
+        ..Default::default()
+    }))
+}
+
+/// Mirrors elsevier-harvard-core.yaml's citation-scoped `by-category` config
+/// (SUBSTITUTED_VALUE_FORMATTING.md): book/report/graphic/motion-picture/song/
+/// statute map to `monograph` (emph); `thesis` is explicitly overridden away
+/// from the engine's hardcoded book/thesis/report default so it stays
+/// quoted, matching elsevier-harvard.csl's real `author-short` rule; the
+/// `component` and `default` categories both declare `quote: true` so no
+/// reachable type silently falls through to plain text.
+fn elsevier_harvard_style_substitute_title_style() -> Style {
+    let mut type_mapping = std::collections::HashMap::new();
+    type_mapping.insert(ReferenceTypeName::new("book"), TitleCategory::Monograph);
+    type_mapping.insert(ReferenceTypeName::new("report"), TitleCategory::Monograph);
+    type_mapping.insert(ReferenceTypeName::new("thesis"), TitleCategory::Default);
+
+    Style {
+        info: StyleInfo {
+            title: Some("Elsevier Harvard Substitute Title Quote Test".to_string()),
+            id: Some("elsevier-harvard-substitute-title-quote-test".into()),
+            ..Default::default()
+        },
+        options: Some(Config {
+            substitute: Some(SubstituteConfig::Explicit(Substitute {
+                template: vec![citum_schema::options::SubstituteKey::Title],
+                title_quote: Some(SubstituteTitleQuoteMode::ByCategory),
+                ..Default::default()
+            })),
+            titles: Some(TitlesConfig {
+                type_mapping: Some(type_mapping),
+                monograph: Some(TitleRendering {
+                    emph: Some(true),
+                    ..Default::default()
+                }),
+                component: Some(TitleRendering {
+                    quote: Some(true),
+                    ..Default::default()
+                }),
+                default: Some(TitleRendering {
+                    quote: Some(true),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        citation: Some(CitationSpec {
+            template: Some(vec![citum_schema::tc_contributor!(Author, Long)].into()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+#[rstest]
+#[case::book_maps_to_monograph_and_italicizes(MonographType::Book, "_Title_")]
+#[case::report_maps_to_monograph_and_italicizes(MonographType::Report, "_Title_")]
+#[case::thesis_overridden_away_from_monograph_stays_quoted(
+    MonographType::Thesis,
+    "\u{201c}Title\u{201d}"
+)]
+#[case::post_falls_to_component_bucket_and_quotes(MonographType::Post, "\u{201c}Title\u{201d}")]
+#[case::interview_falls_to_default_bucket_and_quotes(
+    MonographType::Interview,
+    "\u{201c}Title\u{201d}"
+)]
+fn given_elsevier_harvard_shaped_by_category_config_when_type_varies_then_quoting_matches_the_type_mapping(
+    #[case] kind: MonographType,
+    #[case] expected: &str,
+) {
+    // Regression coverage for the elsevier-harvard flip in
+    // SUBSTITUTED_VALUE_FORMATTING.md stage 2: `book`/`report` (explicit
+    // `type-mapping` to `monograph`) italicize; `thesis` (explicitly
+    // overridden to `default`, since the engine's hardcoded type-class
+    // table would otherwise route it to `monograph` too) and `post` (the
+    // engine's hardcoded `component` bucket) and `interview` (falls to
+    // `default`, in neither hardcoded bucket) all stay quoted -- matching
+    // real elsevier-harvard.csl's `author-short` macro, oracle-verified
+    // against citeproc-js in the spec.
+    let style = elsevier_harvard_style_substitute_title_style();
+    let mut bibliography = indexmap::IndexMap::new();
+    bibliography.insert(
+        "item1".to_string(),
+        make_authorless_monograph("item1", "Title", kind),
+    );
+    let processor = Processor::new(style, bibliography);
+
+    let result = process_citation_ids(&processor, &["item1"]);
+
+    assert_eq!(result, expected);
 }
 
 fn integral_name_state_overrides_processor_memory() {

--- a/crates/citum-schema-style/embedded/styles/elsevier-harvard-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/elsevier-harvard-core.yaml
@@ -56,6 +56,45 @@ citation:
       - editor
       - translator
       - title
+      title-quote: by-category
+    # citation-scoped per SUBSTITUTED_VALUE_FORMATTING.md's resolved decision
+    # (supporting title config for a by-category substitute flip is
+    # citation-scoped by default). Real elsevier-harvard.csl's citation-context
+    # substitute macro (author-short) is type-conditional, not the unconditional
+    # italic an earlier spec draft wrongly assumed: bill/book/graphic/legal_case/
+    # legislation/motion_picture/report/song italicize, everything else quotes.
+    # legal-case is excluded here -- it never reaches this substitute tier under
+    # this style; its citation.type-variants.legal-case entry above already
+    # handles it via a dedicated title-first template. bill is CSL-polymorphic
+    # (converts to document/hearing/bill-proceeding/bill-record depending on
+    # data shape -- see CSL_TYPE_CONVERSION_CONTRACT.md) and is deliberately not
+    # mapped here; it falls through to the quoted default below, a documented
+    # divergence from citeproc-js rather than a silent gap.
+    titles:
+      type-mapping:
+        book: monograph
+        report: monograph
+        graphic: monograph
+        motion-picture: monograph
+        song: monograph
+        statute: monograph
+        # thesis defaults to monograph under the engine's hardcoded type-class
+        # table, but elsevier-harvard.csl quotes it (not in the italic list) --
+        # override explicitly so it doesn't silently inherit an italic it
+        # shouldn't have.
+        thesis: default
+      monograph:
+        emph: true
+      # component covers article-journal/chapter/entry/entry-dictionary/
+      # entry-encyclopedia/paper-conference/post/post-weblog under the engine's
+      # hardcoded type-class table; default covers everything else
+      # (manuscript, interview, webpage, document, hearing, ...). Both need an
+      # explicit quote so those types don't silently render plain under
+      # by-category -- see the titles.default coverage gap in the spec.
+      component:
+        quote: true
+      default:
+        quote: true
     contributors:
       shorten:
         min: 3


### PR DESCRIPTION
## Summary

Stage 2 of `csl26-p7a8`, stacked on `#1188`: the first embedded-style
`title-quote: by-category` flip, per the spec's agreed order (fully
type-representable styles first, `apa-7th` last, pending the `quote-when`
engine capability).

- [x] `elsevier-harvard` — this PR

## Correction found while implementing

`elsevier-harvard`'s citation-context substitute rule was recorded in the
spec as unconditional italic — wrong. It's actually type-conditional
(`author-short`: `bill`/`book`/`graphic`/`legal_case`/`legislation`/
`motion_picture`/`report`/`song` italicize, everything else quotes), the same
short-vs-long macro contamination the spec already documents for
`apa.csl`/`chicago-author-date.csl`. Caught before implementing, not after —
`#1188` has been corrected (v1.3) to match.

## What changed

`citation.options.substitute.title-quote: by-category` plus a
`titles.type-mapping` covering the oracle-verified italic-bucket types
(`book`/`report`/`graphic`/`motion-picture`/`song`/`statute` → `monograph`,
`emph: true`), an explicit `thesis` → `default` override (the engine's
hardcoded type-class table would otherwise route `thesis` to `monograph`
too), and `titles.component`/`titles.default` both `quote: true` so no
reachable type silently falls through to plain text.

`legal-case` is untouched — it never reaches this substitute tier under this
style; it's already handled by its own `citation.type-variants.legal-case`
template. `bill` is CSL-polymorphic (converts to `document`/`hearing`/
`bill-proceeding`/`bill-record` depending on data shape) and is deliberately
left unmapped, falling through to the quoted default — a documented
divergence from citeproc-js, not a silent gap.

## Test plan

- [x] Oracle-verified (citeproc-js vs. Citum): `dead-sea-scrolls` plus three
      synthetic fixtures covering both branches (book/report → italic,
      article-journal → quote)
- [x] `node scripts/report-core.js --style elsevier-harvard`: zero
      regression (compatibility 67/67, exactParity 45/67, unchanged
      before/after — the affected types aren't in that fixture's
      author-less pairing, so the fix is real but not exercised by the
      tracked metric)
- [x] New `#[rstest]` coverage in `crates/citum-engine/tests/citations.rs`
      mirroring the real config: book/report → italicize, thesis/post/
      interview → stay quoted (covers the monograph, component, and
      default buckets)
- [x] `just pre-commit` (fmt, clippy -D warnings, `cargo nextest run`):
      2545/2545 passing
