### PR TITLE
fix(schema): flip T&F CSE title-quote

### DIFF
--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -451,6 +451,58 @@ fn given_elsevier_harvard_shaped_by_category_config_when_type_varies_then_quotin
     assert_eq!(result, expected);
 }
 
+/// Mirrors taylor-and-francis-council-of-science-editors-author-date-core.yaml's
+/// citation-scoped `by-category` config (SUBSTITUTED_VALUE_FORMATTING.md):
+/// `title-quote: by-category` with no `titles:` block at all. Unlike
+/// elsevier-harvard, this style's real `author`/`author-short` macros are
+/// unconditionally plain (bare `<text variable="title" form="short"/>`, no
+/// type branching) -- so the absence of a `titles:` config is the correct,
+/// complete fix, not a coverage gap: no category ever resolves, so nothing
+/// is ever quoted or emphasized, matching the oracle-verified real rule.
+fn cse_style_substitute_title_style() -> Style {
+    Style {
+        info: StyleInfo {
+            title: Some("T&F CSE Substitute Title Quote Test".to_string()),
+            id: Some("cse-substitute-title-quote-test".into()),
+            ..Default::default()
+        },
+        options: Some(Config {
+            substitute: Some(SubstituteConfig::Explicit(Substitute {
+                template: vec![citum_schema::options::SubstituteKey::Title],
+                title_quote: Some(SubstituteTitleQuoteMode::ByCategory),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }),
+        citation: Some(CitationSpec {
+            template: Some(vec![citum_schema::tc_contributor!(Author, Long)].into()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+#[rstest]
+#[case::book(MonographType::Book)]
+#[case::report(MonographType::Report)]
+#[case::post(MonographType::Post)]
+#[case::interview(MonographType::Interview)]
+fn given_cse_shaped_by_category_config_with_no_titles_block_when_type_varies_then_title_always_renders_plain(
+    #[case] kind: MonographType,
+) {
+    let style = cse_style_substitute_title_style();
+    let mut bibliography = indexmap::IndexMap::new();
+    bibliography.insert(
+        "item1".to_string(),
+        make_authorless_monograph("item1", "Title", kind),
+    );
+    let processor = Processor::new(style, bibliography);
+
+    let result = process_citation_ids(&processor, &["item1"]);
+
+    assert_eq!(result, "Title");
+}
+
 fn integral_name_state_overrides_processor_memory() {
     let mut bibliography = indexmap::IndexMap::new();
     bibliography.insert(

--- a/crates/citum-schema-style/embedded/styles/taylor-and-francis-council-of-science-editors-author-date-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/taylor-and-francis-council-of-science-editors-author-date-core.yaml
@@ -47,6 +47,20 @@ options:
   punctuation-in-quote: true
 citation:
   options:
+    # citation-scoped per SUBSTITUTED_VALUE_FORMATTING.md's resolved decision.
+    # Real taylor-and-francis-council-of-science-editors-author-date.csl's
+    # `author`/`author-short` macros both render a substituted title with a
+    # bare `<text variable="title" form="short"/>` -- no font-style or quotes
+    # attribute, no type branching, in either citation or bibliography
+    # context. Unlike apa-7th/elsevier-harvard, there is no italic bucket to
+    # configure: every reference type genuinely renders plain, oracle-verified
+    # (dead-sea-scrolls, plus book/report/article-journal fixtures) -- so no
+    # `titles:` block is needed here. Absent `titles:`, category resolution
+    # returns nothing and the title renders exactly as unset, matching the
+    # real rule; this is the correct, complete config for this style, not an
+    # oversight.
+    substitute:
+      title-quote: by-category
     contributors:
       shorten:
         min: 3

--- a/crates/citum-schema-style/embedded/styles/taylor-and-francis-council-of-science-editors-author-date-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/taylor-and-francis-council-of-science-editors-author-date-core.yaml
@@ -26,8 +26,12 @@ options:
     group:
       template: [author, year]
     disambiguate:
-      names: false
-      add-givenname: false
+      # Migration bug (found while investigating unrelated exactParity
+      # divergences on this style): real CSL sets
+      # disambiguate-add-names="true" disambiguate-add-givenname="true" --
+      # both were wrongly migrated as false.
+      names: true
+      add-givenname: true
       year-suffix: true
   substitute: editor-translator-title-long
   contributors:


### PR DESCRIPTION
## Summary

Stage 2 of `csl26-p7a8`, stacked on `#1191` → `#1189` → `#1188`: the second
embedded-style flip, per the spec's agreed order (fully type-representable
styles first, `apa-7th` last).

- [x] `elsevier-harvard` — `#1189`
- [x] `taylor-and-francis-council-of-science-editors-author-date(-core)` —
      this PR

## Commit 1: the title-quote flip

Unlike `apa-7th`/`elsevier-harvard`, this style has **no italic bucket at
all**. Both `author` and `author-short` in the real
`taylor-and-francis-council-of-science-editors-author-date.csl` render a
substituted title with a bare `<text variable="title" form="short"/>` — no
`font-style`/`quotes` attribute, no type branching, in either citation or
bibliography context. Citum's current always-quote default is wrong for
*every* author-less reference under this style today, independent of this
feature.

Adds citation-scoped `substitute.title-quote: by-category` with
**deliberately no `titles:` block**: since no category ever resolves,
nothing is ever quoted or emphasized — the correct, complete fix here, not
a coverage gap (there's no italic bucket to miss, unlike `elsevier-harvard`).

## Commit 2: a real bug found while checking the numbers

`report-core.js --style
taylor-and-francis-council-of-science-editors-author-date` showed
`exactParity` unchanged (23/67) before/after the title flip — asked whether
that meant other issues were being waved off rather than actually
investigated. They were: the real CSL sets
`disambiguate-add-names="true" disambiguate-add-givenname="true"` on
`<citation>`; the migrated YAML had both `false`. Fixed. `exactParity`:
23/67 → 26/67.

Three divergences remain, characterized but **not** fixed here — they go
well beyond a YAML tweak and are out of this stack's scope:
- **et-al name-list expansion depth** — oracle still shows 3 names before
  "et al." where Citum shows 1, even with `disambiguate.names` enabled.
  Needs engine-side investigation.
- **same-author consecutive-cite collapsing** — the real CSL has no
  `collapse` attribute at all, so citeproc-js keeps same-author multi-item
  citations separate (`"Garcia 2019a; Garcia 2019b"`); Citum joins them
  with a comma. No YAML-level `collapse` config exists in the schema for
  this — looks like an unconditional author-date-mode engine default with
  no override.
- **missing-date fallback** — real CSL's date macro renders nothing when
  `issued` is absent; Citum always injects a "n.d." term.
  `DateConfig.no_date_form` only selects *which* term to show, not whether
  to show one — confirmed there's no schema field to suppress this. Purely
  an engine gap.

These deserve their own investigation/beans rather than blocking or
expanding this stack further.

## Test plan

- [x] Oracle-verified (citeproc-js vs. Citum): `dead-sea-scrolls` plus
      book/report/article-journal fixtures for the title flip
- [x] `node scripts/report-core.js --style
      taylor-and-francis-council-of-science-editors-author-date`:
      compatibility 63/67 unchanged, exactParity 23/67 → 26/67
- [x] New `#[rstest]` coverage in `crates/citum-engine/tests/citations.rs`
      mirroring the title-quote config across book/report/post/interview
- [x] `just pre-commit` (fmt, clippy -D warnings, `cargo nextest run`):
      2549/2549 passing
