### PR TITLE
feat(scripts): score citation components too

### DIFF
--- a/.beans/csl26-7z59--no-date-rendering-has-no-suppress-option-unlike-re.md
+++ b/.beans/csl26-7z59--no-date-rendering-has-no-suppress-option-unlike-re.md
@@ -1,0 +1,55 @@
+---
+# csl26-7z59
+title: No-date rendering has no suppress option, unlike real CSL
+status: todo
+type: bug
+priority: normal
+tags:
+    - rendering
+    - dates
+    - engine
+    - citation
+created_at: 2026-08-16T00:16:33Z
+updated_at: 2026-08-16T00:16:33Z
+---
+
+Found while validating csl26-p7a8's title-quote flip for
+taylor-and-francis-council-of-science-editors-author-date via
+report-core.js exactParity comparison against citeproc-js.
+
+Real CSL's year-date macro is a bare
+<date variable="issued"><date-part name="year"/></date> with no
+fallback branch. CSL 1.0 renders nothing when the date variable is
+entirely absent unless the style explicitly authors a fallback (e.g.
+<if variable="issued">...<else><text term="no date"/></else></if>).
+This style doesn't. citeproc-js confirms: an author-less-except-for-a-
+surname-that-happens-to-be-"Forthcoming" reference with no `issued`
+field renders "(Forthcoming)" -- author only, no date placeholder.
+
+Citum always injects a "n.d." (or "no date") term when a date:issued
+template component's date is absent:
+"(Forthcoming n.d.)" instead of "(Forthcoming)".
+
+Confirmed via crates/citum-schema-style/src/options/dates.rs that
+there is no schema field to suppress this -- `DateConfig.no_date_form`
+only selects which term to render (`short` -> "n.d.", `long` -> "no
+date"), not whether to render one. This is a pure engine-level
+default with no per-style override, unlike the disambiguate and
+substitute-title gaps in sibling beans csl26-8nrt/csl26-ecfn.
+
+## Investigation needed
+- [ ] Confirm this is a genuine engine gap (not a schema field I
+      missed) by grepping the full date-rendering path in
+      citum-engine for where the no-date fallback gets applied.
+- [ ] Decide the fix shape: a new DateConfig field (e.g.
+      `no-date-form: none` alongside `short`/`long`), or treat
+      "no fallback" as the new default and require styles to opt
+      IN to a no-date term (matches CSL's actual default -- likely
+      the more correct direction, but is a broader behavior change
+      needing its own before/after report-core.js sweep across the
+      full embedded-style corpus, not just this one style).
+- [ ] Whichever direction: add tests and a DIVERGENCE_REGISTER.md
+      entry documenting the decision.
+- [ ] Re-run report-core.js --style
+      taylor-and-francis-council-of-science-editors-author-date
+      after the fix to confirm impact.

--- a/.beans/csl26-8nrt--disambiguate-add-names-doesnt-expand-et-al-name-li.md
+++ b/.beans/csl26-8nrt--disambiguate-add-names-doesnt-expand-et-al-name-li.md
@@ -1,0 +1,53 @@
+---
+# csl26-8nrt
+title: Disambiguate-add-names doesn't expand et-al name-list depth
+status: todo
+type: bug
+priority: normal
+tags:
+    - rendering
+    - disambiguation
+    - engine
+    - citation
+created_at: 2026-08-16T00:16:01Z
+updated_at: 2026-08-16T00:16:01Z
+---
+
+Found while validating csl26-p7a8's title-quote flip for
+taylor-and-francis-council-of-science-editors-author-date via
+report-core.js exactParity (23/67 -> 26/67 after fixing the
+disambiguate.names/add-givenname migration bug in the same style, see
+bean csl26-p7a8 and PR #1192).
+
+Real CSL: <citation et-al-min="3" et-al-use-first="1"
+disambiguate-add-names="true" .../>. Fixing the migrated
+disambiguate.names: false -> true resolved one et-al-related
+divergence (disambiguate-add-names-et-al) but two remain:
+
+- et-al-single-long-list: oracle "(Smith, Lee, Kumar, et al. 2021)"
+  (3 names before et al.) vs Citum "(Smith et al. 2021)" (1 name).
+- et-al-with-locator: same pattern, "(Smith, Lee, Nguyen, et al.
+  2021, p. 205)" vs "(Smith et al. 2021, p. 205)".
+
+Both fixture items are citations-expanded.json entries under
+taylor-and-francis-council-of-science-editors-author-date. With
+disambiguate.names: true now set, Citum enables name-list expansion
+but doesn't compute the same expansion DEPTH citeproc-js does --
+citeproc-js's disambiguate-add-names widens the visible et-al-use-first
+count until a colliding group is distinguishable (or some other rule
+determines 3 names is needed here); Citum's expansion doesn't appear
+to widen past its own default at all for these cases, or widens by a
+different rule.
+
+## Investigation needed
+- [ ] Confirm whether these two cases involve an actual colliding
+      author-group (another citation in the same test corpus sharing
+      "Smith" as first author) that would explain citeproc-js's
+      3-name expansion, or whether it's unconditional for 3+ authors
+      regardless of collision.
+- [ ] Locate the et-al/disambiguate-add-names expansion-depth logic
+      in citum-engine (likely near the disambiguation module) and
+      compare its widening rule against citeproc-js's.
+- [ ] Fix and add regression tests; re-run report-core.js --style
+      taylor-and-francis-council-of-science-editors-author-date to
+      confirm exactParity improvement.

--- a/.beans/csl26-ecfn--unconditional-same-author-collapse-contradicts-csl.md
+++ b/.beans/csl26-ecfn--unconditional-same-author-collapse-contradicts-csl.md
@@ -1,0 +1,58 @@
+---
+# csl26-ecfn
+title: Unconditional same-author collapse contradicts CSL's opt-in semantics
+status: todo
+type: bug
+priority: normal
+tags:
+    - rendering
+    - disambiguation
+    - citation
+    - divergence
+created_at: 2026-08-16T00:16:16Z
+updated_at: 2026-08-16T00:16:16Z
+---
+
+Found while validating csl26-p7a8's title-quote flip for
+taylor-and-francis-council-of-science-editors-author-date via
+report-core.js exactParity comparison against citeproc-js.
+
+The real CSL (taylor-and-francis-council-of-science-editors-author-date.csl)
+has no `collapse` attribute at all on <citation>. In CSL 1.0, collapse
+is opt-in -- with no attribute, same-author multi-item citations stay
+as separate grouped entries joined by the citation's own delimiter.
+citeproc-js confirms this:
+
+- disambiguate-year-suffix: oracle "(Garcia 2019a; Garcia 2019b)"
+- subsequent-author-consecutive: oracle "(Chen 2022; Chen 2024)"
+
+Citum instead unconditionally collapses same-author consecutive
+cites into a comma-joined year list ("(Garcia 2019a, 2019b)",
+"(Chen 2022, 2024)"), regardless of the style's `collapse` setting.
+
+This is not a bug in the sense of unintended behavior -- it's
+csl26-dpep ("fix(engine): same-author multicite collapse --
+first-class rule for both modes"), a deliberate Citum design
+decision to always collapse same-author multicites. But that
+decision was never recorded in docs/adjudication/DIVERGENCE_REGISTER.md,
+and this T&F CSE oracle comparison is concrete evidence it diverges
+from real citeproc-js output for a style that doesn't request
+collapsing.
+
+## Needs adjudication, not just a fix
+- [ ] Determine whether Citum's always-collapse behavior should
+      become conditional on a style-level setting (mirroring CSL's
+      collapse attribute more faithfully), or whether this stays a
+      deliberate Citum design principle that gets registered as an
+      accepted divergence (matching the pattern of other entries in
+      DIVERGENCE_REGISTER.md, e.g. div-014).
+- [ ] If conditional: design the schema field, default it to
+      preserve csl26-dpep's current behavior for styles that don't
+      set it explicitly (or default to opt-in per real CSL
+      semantics -- this is the actual adjudication question).
+- [ ] Either way, add a DIVERGENCE_REGISTER.md entry.
+- [ ] Re-run report-core.js --style
+      taylor-and-francis-council-of-science-editors-author-date
+      after the decision lands to confirm impact.
+
+Related: csl26-dpep (the engine change establishing this behavior).

--- a/scripts/oracle-fast.js
+++ b/scripts/oracle-fast.js
@@ -30,6 +30,8 @@ const {
   compareText,
   normalizeText,
   parseComponents,
+  compareComponents,
+  compareCitationComponents,
   analyzeOrdering,
   findRefDataForEntry,
 } = require('./oracle-utils');
@@ -284,6 +286,18 @@ function run() {
       caseSensitive: opts.caseSensitive,
     });
     if (match) rawResults.citations.passed++; else rawResults.citations.failed++;
+
+    // Always run real component detection (matching or not) -- citation
+    // text rarely carries more than contributors + year, so a passing-
+    // entry shortcut (as the bibliography path below takes) would badly
+    // overweight it. See oracle.js's citation loop for the same approach.
+    const itemComparison = compareCitationComponents(
+      comparison.expected,
+      comparison.actual,
+      cite.items || [],
+      testItems
+    );
+
     rawResults.citations.entries.push({
       id: cite.id,
       oracle: comparison.expected,
@@ -296,6 +310,10 @@ function run() {
       exactAdjudication: comparison.exactAdjudication,
       match,
       caseMismatch: comparison.caseMismatch,
+      components: itemComparison.segmented
+        ? { matches: itemComparison.matches, differences: itemComparison.differences }
+        : {},
+      componentsSegmented: itemComparison.segmented,
     });
 
     for (const item of cite.items || []) {
@@ -371,23 +389,7 @@ function run() {
         if (refData) {
           const oComp = parseComponents(pair.oracle, refData);
           const cComp = parseComponents(pair.citum, refData);
-          const differences = [];
-          const matches = [];
-          const keys = ['contributors', 'year', 'title', 'containerTitle', 'volume',
-            'issue', 'pages', 'publisher', 'doi', 'edition', 'editors',
-            'translators', 'interviewers', 'recipients'];
-          for (const key of keys) {
-            const ov = oComp[key];
-            const cv = cComp[key];
-            if (!ov.found && !cv.found) continue;
-            if (ov.found && cv.found) {
-              matches.push({ component: key, status: 'match' });
-            } else if (ov.found && !cv.found) {
-              differences.push({ component: key, issue: 'missing', expected: ov.value, detail: 'Missing in Citum output' });
-            } else {
-              differences.push({ component: key, issue: 'extra', found: cv.value, detail: 'Extra in Citum output' });
-            }
-          }
+          const { differences, matches } = compareComponents(oComp, cComp, refData);
           entryResult.components = { differences, matches };
 
           const oOrder = analyzeOrdering(pair.oracle, refData);

--- a/scripts/oracle-utils.js
+++ b/scripts/oracle-utils.js
@@ -439,6 +439,183 @@ function findContributorComponent(normalizedEntry, names, occupiedPositions = []
   return null;
 }
 
+/**
+ * Find a cite item's own primary-name occurrence for segment-anchoring
+ * purposes -- family name only, deliberately not expanded to a nearby
+ * given-name/initial the way `findContributorComponent` does.
+ *
+ * `findContributorComponent`'s given-name expansion scans a 50-character
+ * window around the family name, which is safe within a single
+ * bibliography entry (one person's name, one nearby initial) but not
+ * within a multi-item citation cluster: a short cluster like
+ * "(Smith 2020; Jones 2021)" puts a *different* person's initial ("J")
+ * well within 50 characters of "Smith", so the expansion would sweep
+ * "Jones" into "Smith"'s anchor. Segmentation only needs a stable
+ * boundary, not the full name span, so this intentionally skips that
+ * expansion; `parseComponents`/`compareComponents` still does full
+ * given-name-aware component comparison afterward, once each item's text
+ * has already been sliced down to its own segment.
+ */
+function findFamilyNameAnchor(normalizedEntry, names, occupiedPositions = []) {
+  if (!Array.isArray(names) || names.length === 0) return null;
+
+  const family = names[0].family || names[0].literal || '';
+  if (!family) return null;
+
+  const entryLower = normalizedEntry.toLowerCase();
+  const familyLower = family.toLowerCase();
+  let idx = entryLower.indexOf(familyLower);
+  while (idx !== -1) {
+    const pos = { start: idx, end: idx + family.length };
+    if (!occupiedPositions.some((occupied) => positionsOverlap(occupied, pos))) {
+      return { found: true, value: sliceMatchedValue(normalizedEntry, pos), pos };
+    }
+    idx = entryLower.indexOf(familyLower, idx + 1);
+  }
+  return null;
+}
+
+/**
+ * Find a reference's issued year within a rendered citation, with an
+ * optional trailing single-letter disambiguation suffix (e.g. "2019a").
+ * Used as the fallback anchor for `splitCitationIntoItemSegments` when a
+ * cite item's own author name has already been consumed by an earlier
+ * item in the same cluster (the same-author-collapsed case, e.g. a
+ * rendered "Garcia 2019a, 2019b" where "Garcia" occurs only once).
+ */
+function findYearComponent(normalizedEntry, refData, occupiedPositions = []) {
+  const year = refData?.issued?.['date-parts']?.[0]?.[0];
+  if (year == null) return null;
+
+  const entryLower = normalizedEntry.toLowerCase();
+  const regex = new RegExp(`(?<![0-9])${escapeRegex(String(year))}[a-z]?`, 'gi');
+  let match = regex.exec(entryLower);
+  while (match !== null) {
+    const pos = { start: match.index, end: match.index + match[0].length };
+    if (!occupiedPositions.some((occupied) => positionsOverlap(occupied, pos))) {
+      return { found: true, value: sliceMatchedValue(normalizedEntry, pos), pos };
+    }
+    match = regex.exec(entryLower);
+  }
+  return null;
+}
+
+/**
+ * Locate the boundary of each cited item's own text within a rendered
+ * multi-item citation cluster (e.g. "(Garcia, 2019a; Garcia, 2019b)"),
+ * anchored on each item's own primary-name occurrence, falling back to
+ * its year (with disambiguation suffix) when the name has already been
+ * claimed by an earlier item in the cluster.
+ *
+ * Returns `items.length` segments in cite order, or `null` if any item's
+ * anchor can't be distinctly located, or if the located anchors don't
+ * come out in cite order (a same-author collapse with unpredictable
+ * suffix placement, for example). Callers must treat `null` as "not
+ * segmentable" -- guessing at a boundary risks attributing one item's
+ * rendered text to a different item's reference data, which would
+ * silently corrupt the component comparison rather than just skip it.
+ *
+ * @param {string} citationText - one side's rendered citation cluster (oracle or Citum)
+ * @param {Array<{id: string}>} items - cite.items, in cite order
+ * @param {Object} testItems - id -> reference data lookup
+ * @returns {Array<{start: number, end: number, refData: Object}>|null}
+ */
+function splitCitationIntoItemSegments(citationText, items, testItems) {
+  const normalized = normalizeText(citationText);
+  const anchors = [];
+  const occupiedPositions = [];
+
+  for (const item of items) {
+    const refData = testItems[item.id];
+    if (!refData) return null;
+
+    const names = refData.author && refData.author.length > 0 ? refData.author : refData.editor;
+    const nameAnchor = Array.isArray(names) && names.length > 0
+      ? findFamilyNameAnchor(normalized, names, occupiedPositions)
+      : null;
+
+    // Always also try to claim this item's own year, even when the name is
+    // what determines the segment boundary -- otherwise a later item that
+    // must fall back to year-anchoring (the same-author-collapsed case,
+    // e.g. "Garcia 2019a, 2019b") could mistake an earlier item's own
+    // unclaimed year for its own, since only the name would be occupied.
+    const yearAnchor = findYearComponent(normalized, refData, occupiedPositions);
+
+    const anchor = nameAnchor || yearAnchor;
+    if (!anchor) return null;
+
+    anchors.push(anchor.pos);
+    occupiedPositions.push(anchor.pos);
+    if (yearAnchor && yearAnchor.pos !== anchor.pos) {
+      occupiedPositions.push(yearAnchor.pos);
+    }
+  }
+
+  // Cite order is assumed to match render order -- true for every style
+  // this repo ships (items within a cluster aren't independently
+  // reordered). Verify defensively rather than assume: if the anchors
+  // didn't come out left-to-right in cite order, bail rather than guess.
+  for (let i = 1; i < anchors.length; i++) {
+    if (anchors[i].start < anchors[i - 1].start) return null;
+  }
+
+  return anchors.map((anchor, i) => {
+    const end = i + 1 < anchors.length ? anchors[i + 1].start : normalized.length;
+    return { start: anchor.start, end, refData: testItems[items[i].id] };
+  });
+}
+
+/**
+ * Compare a rendered citation cluster against the oracle, component by
+ * component, per cite item. Single-item clusters compare directly (the
+ * same 1:1 shape as a bibliography entry); multi-item clusters are
+ * segmented first via `splitCitationIntoItemSegments`.
+ *
+ * Returns `{ segmented: false }` -- not zeroed-out matches/differences --
+ * when either side can't be segmented, so callers can exclude these
+ * citations from an aggregate rate instead of miscounting them as
+ * complete mismatches.
+ *
+ * @param {string} oracleText
+ * @param {string} citumText
+ * @param {Array<{id: string}>} items - cite.items, in cite order
+ * @param {Object} testItems - id -> reference data lookup
+ */
+function compareCitationComponents(oracleText, citumText, items, testItems) {
+  if (!Array.isArray(items) || items.length === 0) return { segmented: false };
+
+  if (items.length === 1) {
+    const refData = testItems[items[0].id];
+    if (!refData) return { segmented: false };
+    const oracleComp = parseComponents(oracleText, refData);
+    const citumComp = parseComponents(citumText, refData);
+    const { matches, differences } = compareComponents(oracleComp, citumComp, refData);
+    return { segmented: true, matches, differences };
+  }
+
+  const oracleSegments = splitCitationIntoItemSegments(oracleText, items, testItems);
+  const citumSegments = splitCitationIntoItemSegments(citumText, items, testItems);
+  if (!oracleSegments || !citumSegments) return { segmented: false };
+
+  const normalizedOracle = normalizeText(oracleText);
+  const normalizedCitum = normalizeText(citumText);
+  const allMatches = [];
+  const allDifferences = [];
+
+  for (let i = 0; i < items.length; i++) {
+    const refData = testItems[items[i].id];
+    const oracleSlice = sliceMatchedValue(normalizedOracle, oracleSegments[i]) ?? '';
+    const citumSlice = sliceMatchedValue(normalizedCitum, citumSegments[i]) ?? '';
+    const oracleComp = parseComponents(oracleSlice, refData);
+    const citumComp = parseComponents(citumSlice, refData);
+    const { matches, differences } = compareComponents(oracleComp, citumComp, refData);
+    allMatches.push(...matches);
+    allDifferences.push(...differences);
+  }
+
+  return { segmented: true, matches: allMatches, differences: allDifferences };
+}
+
 // -- Component parsing --
 
 /**
@@ -705,6 +882,9 @@ module.exports = {
   isCaseOnlyMismatch,
   parseComponents,
   compareComponents,
+  findYearComponent,
+  splitCitationIntoItemSegments,
+  compareCitationComponents,
   analyzeOrdering,
   findRefMatchForEntry,
   hasPrimaryNames,

--- a/scripts/oracle.js
+++ b/scripts/oracle.js
@@ -32,6 +32,7 @@ const {
   normalizeText,
   parseComponents,
   compareComponents,
+  compareCitationComponents,
   analyzeOrdering,
   findRefDataForEntry,
   loadLocale,
@@ -911,6 +912,25 @@ function runOracle(cliOptions = parseArgs()) {
       } else {
         rawResults.citations.failed++;
       }
+
+      // Unlike bibliography entries (which always carry ~11 tracked
+      // fields, so a passing entry can shortcut to "11/11 matched"),
+      // citation text rarely carries more than contributors + year --
+      // hardcoding a field count for a passing citation would badly
+      // overweight it relative to what's actually present. Always run
+      // real component detection instead, matching or not; a true match
+      // naturally yields 0 differences without needing a shortcut.
+      const itemComparison = compareCitationComponents(
+        comparison.expected,
+        comparison.actual,
+        cite.items,
+        testItems
+      );
+      const componentsSegmented = itemComparison.segmented;
+      const components = itemComparison.segmented
+        ? { matches: itemComparison.matches, differences: itemComparison.differences }
+        : {};
+
       rawResults.citations.entries.push({
         id,
         oracle: comparison.expected,
@@ -923,6 +943,8 @@ function runOracle(cliOptions = parseArgs()) {
         exactAdjudication: comparison.exactAdjudication,
         match,
         caseMismatch: comparison.caseMismatch,
+        components,
+        componentsSegmented,
       });
 
       const citationTypes = collectCitationTypes(cite, testItems);

--- a/scripts/oracle.test.js
+++ b/scripts/oracle.test.js
@@ -18,7 +18,12 @@ const {
   collapseClusteredCitumCitations,
   resolveAuthoredStylePath,
 } = require('./oracle');
-const { compareText, parseComponents } = require('./oracle-utils');
+const {
+  compareText,
+  parseComponents,
+  splitCitationIntoItemSegments,
+  compareCitationComponents,
+} = require('./oracle-utils');
 const {
   attachRegisteredDivergenceAdjustments,
   canonicalizeAffectedIdsToOracleOrder,
@@ -1507,4 +1512,109 @@ test('compareComponents reports differing component values as mismatches', () =>
     found: 'Beta',
     detail: 'Value differs between oracle and Citum',
   }]);
+});
+
+test('splitCitationIntoItemSegments anchors distinct-author items by name', () => {
+  const testItems = {
+    smith2020: { id: 'smith2020', author: [{ family: 'Smith', given: 'Jane' }], issued: { 'date-parts': [[2020]] } },
+    jones2021: { id: 'jones2021', author: [{ family: 'Jones', given: 'Tom' }], issued: { 'date-parts': [[2021]] } },
+  };
+  const items = [{ id: 'smith2020' }, { id: 'jones2021' }];
+
+  const segments = splitCitationIntoItemSegments('(Smith 2020; Jones 2021)', items, testItems);
+
+  assert.equal(segments.length, 2);
+  assert.equal('(Smith 2020; Jones 2021)'.slice(segments[0].start, segments[0].end), 'Smith 2020; ');
+  assert.equal('(Smith 2020; Jones 2021)'.slice(segments[1].start, segments[1].end), 'Jones 2021)');
+});
+
+test('splitCitationIntoItemSegments falls back to year anchors for a same-author collapsed citation', () => {
+  const testItems = {
+    garcia2019a: { id: 'garcia2019a', author: [{ family: 'Garcia', given: 'Maria' }], issued: { 'date-parts': [[2019]] } },
+    garcia2019b: { id: 'garcia2019b', author: [{ family: 'Garcia', given: 'Maria' }], issued: { 'date-parts': [[2019]] } },
+  };
+  const items = [{ id: 'garcia2019a' }, { id: 'garcia2019b' }];
+
+  // Citum collapses same-author consecutive cites (csl26-dpep); the real
+  // author name appears only once, so item 2 has no distinct name
+  // occurrence and must anchor on its own year+suffix instead.
+  const segments = splitCitationIntoItemSegments('(Garcia 2019a, 2019b)', items, testItems);
+
+  assert.equal(segments.length, 2);
+  assert.equal('(Garcia 2019a, 2019b)'.slice(segments[0].start, segments[0].end), 'Garcia 2019a, ');
+  assert.equal('(Garcia 2019a, 2019b)'.slice(segments[1].start, segments[1].end), '2019b)');
+});
+
+test('splitCitationIntoItemSegments returns null when an item has no locatable anchor', () => {
+  const testItems = {
+    smith2020: { id: 'smith2020', author: [{ family: 'Smith', given: 'Jane' }], issued: { 'date-parts': [[2020]] } },
+    jones2021: { id: 'jones2021', author: [{ family: 'Jones', given: 'Tom' }], issued: { 'date-parts': [[2021]] } },
+  };
+  const items = [{ id: 'smith2020' }, { id: 'jones2021' }];
+
+  // Neither author nor either year appears anywhere in this text.
+  const segments = splitCitationIntoItemSegments('(n.d.)', items, testItems);
+
+  assert.equal(segments, null);
+});
+
+test('compareCitationComponents isolates the collapsed item\'s missing author instead of failing the whole citation', () => {
+  const testItems = {
+    garcia2019a: {
+      id: 'garcia2019a',
+      author: [{ family: 'Garcia', given: 'Maria' }],
+      issued: { 'date-parts': [[2019]] },
+    },
+    garcia2019b: {
+      id: 'garcia2019b',
+      author: [{ family: 'Garcia', given: 'Maria' }],
+      issued: { 'date-parts': [[2019]] },
+    },
+  };
+  const items = [{ id: 'garcia2019a' }, { id: 'garcia2019b' }];
+
+  const result = compareCitationComponents(
+    '(Garcia 2019a; Garcia 2019b)',
+    '(Garcia 2019a, 2019b)',
+    items,
+    testItems
+  );
+
+  assert.equal(result.segmented, true);
+  // Both years and item 1's contributor match; only item 2's elided
+  // "Garcia" registers as a real, isolated difference -- not a total
+  // mismatch for the whole citation.
+  assert.equal(result.matches.length, 3);
+  assert.deepEqual(result.differences, [{
+    component: 'contributors',
+    issue: 'missing',
+    expected: 'Garcia',
+    detail: 'Missing in Citum output',
+  }]);
+});
+
+test('compareCitationComponents reports segmented:false when neither side has a locatable anchor', () => {
+  const testItems = {
+    smith2020: { id: 'smith2020', author: [{ family: 'Smith', given: 'Jane' }], issued: { 'date-parts': [[2020]] } },
+    jones2021: { id: 'jones2021', author: [{ family: 'Jones', given: 'Tom' }], issued: { 'date-parts': [[2021]] } },
+  };
+  const items = [{ id: 'smith2020' }, { id: 'jones2021' }];
+
+  const result = compareCitationComponents('(n.d.)', '(n.d.)', items, testItems);
+
+  assert.deepEqual(result, { segmented: false });
+});
+
+test('compareCitationComponents compares single-item citations directly, matching bibliography\'s 1:1 shape', () => {
+  const testItems = {
+    smith2020: { id: 'smith2020', author: [{ family: 'Smith', given: 'Jane' }], issued: { 'date-parts': [[2020]] } },
+  };
+  const items = [{ id: 'smith2020' }];
+
+  const result = compareCitationComponents('(Smith 2020)', '(Smith, 2020)', items, testItems);
+
+  assert.equal(result.segmented, true);
+  assert.equal(result.differences.length, 0);
+  assert.ok(result.matches.some((m) => m.component === 'contributors'));
+  assert.ok(result.matches.some((m) => m.component === 'year'));
 });

--- a/scripts/report-core.js
+++ b/scripts/report-core.js
@@ -1884,6 +1884,47 @@ function computeComponentMatchRate(oracleResult) {
   return totalComponents > 0 ? parseFloat((totalMatches / totalComponents).toFixed(3)) : null;
 }
 
+/**
+ * Compute citation-side component match rate from oracle result.
+ *
+ * Unlike `computeComponentMatchRate` (bibliography), there is no "passing
+ * entry = 11/11" shortcut here: `oracle.js` always runs real component
+ * detection for citations (matching text or not), so `totalMatches`/
+ * `totalComponents` already reflect exactly what's present. Citations
+ * whose text couldn't be segmented into per-item spans
+ * (`componentsSegmented === false` -- typically a same-author-collapsed
+ * multi-item citation where neither side's rendering carries enough of a
+ * distinguishing anchor per item) are excluded from the rate entirely
+ * rather than counted as complete mismatches; `unresolvedSegmentation`
+ * reports how many were excluded so a low rate isn't silently inflated by
+ * coverage gaps in the segmenter itself.
+ */
+function computeCitationComponentMatchRate(oracleResult) {
+  if (oracleResult.error || !oracleResult.citations) return { rate: null, unresolvedSegmentation: 0 };
+
+  let totalMatches = 0;
+  let totalComponents = 0;
+  let unresolvedSegmentation = 0;
+
+  for (const entry of oracleResult.citations.entries || []) {
+    if (entry.componentsSegmented === false) {
+      unresolvedSegmentation++;
+      continue;
+    }
+    if (entry.components) {
+      const matches = (entry.components.matches || []).length;
+      const diffs = (entry.components.differences || []).length;
+      totalMatches += matches;
+      totalComponents += matches + diffs;
+    }
+  }
+
+  return {
+    rate: totalComponents > 0 ? parseFloat((totalMatches / totalComponents).toFixed(3)) : null,
+    unresolvedSegmentation,
+  };
+}
+
 function clamp(min, max, value) {
   return Math.max(min, Math.min(max, value));
 }
@@ -2744,6 +2785,8 @@ async function processStyleReport(runtime, styleSpec, context) {
         citationsByType: oracleResult.citationsByType || {},
         error: oracleResult.error || null,
         componentMatchRate: null,
+        citationComponentMatchRate: null,
+        citationComponentUnresolvedSegmentation: 0,
         statusTier,
         componentSummary: {},
         citationEntries: null,
@@ -2863,6 +2906,7 @@ async function processStyleReport(runtime, styleSpec, context) {
   const rawCitations = oracleResult.citations || { passed: 0, total: 0 };
   const rawBibliography = oracleResult.bibliography || { passed: 0, total: 0 };
   const componentMatchRate = computeComponentMatchRate(oracleResult);
+  const citationComponentMatchRate = computeCitationComponentMatchRate(oracleResult);
   const qualityMetrics = computeQualityMetrics(styleSpec, oracleResult, styleYamlPath);
   const qualityScore = qualityMetrics.score / 100;
 
@@ -2902,6 +2946,8 @@ async function processStyleReport(runtime, styleSpec, context) {
     citationsByType: oracleResult.citationsByType || {},
     error: combinedStyleError,
     componentMatchRate,
+    citationComponentMatchRate: citationComponentMatchRate.rate,
+    citationComponentUnresolvedSegmentation: citationComponentMatchRate.unresolvedSegmentation,
     statusTier,
     componentSummary: oracleResult.componentSummary || {},
     citationEntries: oracleResult.citations ? oracleResult.citations.entries : null,
@@ -3569,6 +3615,22 @@ function generateHtmlTable(report) {
       componentRateHtml = `<span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium ${componentBadgeClass}">${pct}%</span>`;
     }
 
+    let citationComponentRateHtml = '';
+    if (style.citationComponentMatchRate !== null && style.citationComponentMatchRate !== undefined) {
+      const citationRate2 = style.citationComponentMatchRate;
+      const citationPct = (citationRate2 * 100).toFixed(0);
+      let citationComponentBadgeClass = 'bg-red-100 text-red-700';
+      if (citationRate2 >= 0.9) {
+        citationComponentBadgeClass = 'bg-emerald-100 text-emerald-700';
+      } else if (citationRate2 >= 0.7) {
+        citationComponentBadgeClass = 'bg-amber-100 text-amber-700';
+      }
+      const unresolvedNote = style.citationComponentUnresolvedSegmentation > 0
+        ? ` <span class="text-slate-400">(${style.citationComponentUnresolvedSegmentation} unsegmented)</span>`
+        : '';
+      citationComponentRateHtml = `<div class="mt-1 text-[10px]"><span class="inline-flex items-center px-2 py-0.5 rounded font-medium ${citationComponentBadgeClass}">cite ${citationPct}%</span>${unresolvedNote}</div>`;
+    }
+
     const toggleId = `toggle-${style.name}`;
     const contentId = `content-${style.name}`;
     tableRows += `
@@ -3611,6 +3673,7 @@ function generateHtmlTable(report) {
                     </td>
                     <td class="hidden md:table-cell px-6 py-4">
                         ${componentRateHtml}
+                        ${citationComponentRateHtml}
                     </td>
                     <td class="px-6 py-4">
                         <span class="inline-flex items-center px-3 py-1 rounded text-xs font-medium ${exactParityBadge}">


### PR DESCRIPTION
## Summary

Extends `report-core.js`'s component-level scoring to citations, not just
bibliography.

`exactParity` is binary per-entry (byte-exact string match) with no partial
credit — a citation off by one character and a citation that's completely
wrong both just count as "failed". `componentMatchRate` is the graduated
alternative already in this codebase, but `computeComponentMatchRate` only
ever iterated `oracleResult.bibliography.entries` — citation entries got a
hardcoded empty `components: {}` in both `oracle.js` and its snapshot-based
sibling `oracle-fast.js` (report-core's actual comparator for `--style`
runs), so a citation-side graduated metric didn't exist at all.

## What's added

- `splitCitationIntoItemSegments` (`oracle-utils.js`): locates each cite
  item's own text span within a multi-item citation cluster, anchoring on
  the item's primary-author family name, falling back to its issued year
  (with disambiguation suffix) when the name has already been claimed by
  an earlier item — the same-author-collapsed case, e.g. a rendered
  "Garcia 2019a, 2019b" where "Garcia" appears only once. Segmentation runs
  independently per side (oracle text and Citum text each get their own
  anchors), so it degrades gracefully instead of guessing: if either side's
  items can't be distinctly located, the whole citation is excluded from
  the rate (`componentsSegmented: false`) and counted separately via
  `citationComponentUnresolvedSegmentation`, not silently miscounted as a
  total mismatch. Single-item citations skip segmentation and compare
  directly, matching bibliography's existing 1:1 shape.
- `citationComponentMatchRate` (`report-core.js`), reported alongside the
  existing `componentMatchRate`, plus a small addition to the compat
  dashboard HTML showing both.

## Two real bugs found and fixed while building this

1. **`findContributorComponent`'s given-name expansion is unsafe across
   multiple people.** Its 50-character window (designed to find a given
   name/initial near a family name *within one bibliography entry*) is
   wide enough to sweep a *different* person's initial into the wrong
   anchor in a short citation cluster — `"(Smith 2020; Jones 2021)"` put
   "Jones"'s "J" well within 50 characters of "Smith", corrupting the
   segment boundary. Didn't touch the existing function (used correctly
   elsewhere); added `findFamilyNameAnchor`, a narrower family-name-only
   anchor used only for segment-boundary-finding. Full given-name-aware
   comparison still happens via the existing `parseComponents`/
   `compareComponents` once each item's text is already sliced down.
2. **`oracle-fast.js`'s bibliography component comparison was a
   hand-duplicated reimplementation of `compareComponents`**, missing the
   `value_mismatch` case entirely — a field present on both sides with
   *different* values silently counted as a match. Replaced with a call to
   the real, shared function.

## Test plan

- [x] New unit tests in `oracle.test.js` for `splitCitationIntoItemSegments`
      / `compareCitationComponents`: distinct-author segmentation,
      same-author-collapsed fallback, unsegmentable graceful failure,
      single-item direct comparison
- [x] `node --test scripts/*.test.js scripts/lib/*.test.js`: 306/306 passing
- [x] Before/after full-corpus `report-core.js` run (35 embedded styles):
      citations/bibliography/exactParity/quality totals byte-identical —
      the new work is additive. `componentMatchRate` dropped slightly for
      16 styles that were hitting the `value_mismatch` bug — the fix
      working as intended, not a regression.
- [x] Validated end-to-end against
      `taylor-and-francis-council-of-science-editors-author-date`'s real
      divergences (csl26-8nrt, csl26-ecfn, csl26-7z59): the collapse
      divergence isolates to "one missing name mention" (3/4 components
      matched) instead of a flat fail; et-al-depth and no-date
      divergences correctly show 0 differences (genuinely outside the
      tracked 14-field component set — not a false pass).
      `citationComponentMatchRate` populates for 21/35 styles; the
      remaining unresolved-segmentation cases cluster almost entirely in
      numeric-citation styles (`[1]`, no name/year to anchor on),
      correctly reported as unsegmentable rather than guessed.
- Scripts-only change; no `.rs`/`Cargo.*` touched
