### PR TITLE
docs(spec): by-cite disambiguates document-wide

### DIFF
--- a/.beans/csl26-5753--implement-true-by-cite-per-position-given-name-exp.md
+++ b/.beans/csl26-5753--implement-true-by-cite-per-position-given-name-exp.md
@@ -1,0 +1,54 @@
+---
+# csl26-5753
+title: Implement true by-cite per-position given-name expansion ceiling
+status: todo
+type: feature
+priority: normal
+tags:
+    - engine
+    - disambiguation
+    - citation
+created_at: 2026-08-16T18:30:22Z
+updated_at: 2026-08-16T18:30:26Z
+---
+
+Follow-up from csl26-8nrt. docs/specs/DISAMBIGUATION.md §2.1.1 was corrected
+2026-08-16: name disambiguation always compares against every reference in the
+document, for all givenname-disambiguation-rule values, including by-cite. The
+by-cite implementation that violated this (csl26-lvib, 2026-06-02) has been
+removed. As a result, by-cite and all-names are now behaviorally identical in
+Citum -- neither implements the escalation-cap semantics real by-cite has in
+citeproc-js.
+
+citeproc-js's actual by-cite behavior (scripts/node_modules/citeproc/citeproc_commonjs.js):
+- Ambiguity detection is always registry-wide (CSL.Registry.ambigcites),
+  regardless of givenname-disambiguation-rule.
+- by-cite is rewritten to all-names for *position selection* purposes
+  (`if (gdropt === "by-cite") { gdropt = "all-names"; }`).
+- What actually varies is an escalation *ceiling*: `this.givensMax = 2` when
+  by-cite + disambiguate-add-givenname are both active, plus a `request_base`
+  floor check. This caps how far a single rendered cite is forced to expand --
+  e.g. a cite showing two visible authors isn't forced to add given names for
+  a third author hidden behind et-al in that same cite -- without narrowing
+  which references are compared to detect the collision in the first place.
+
+Citum's ProcHints model expresses given-name expansion as an all-or-nothing
+flag (expand_given_names) plus a primary-only restriction
+(expand_given_names_primary_only). There is no way to express "expand given
+names for these specific rendered positions in this specific cite, capped at
+N, per citeproc-js's request_base/givensMax logic" -- implementing true
+by-cite requires that finer-grained model.
+
+## Scope
+- [ ] Design the per-position/per-cite expansion representation (likely an
+      addition to ProcHints or a citation-render-time computation, not a
+      citation-scoped rewrite of the global hint map -- that was the mistake
+      csl26-8nrt corrected).
+- [ ] Port citeproc-js's givensMax/request_base escalation-cap logic
+      (CSL.Disambiguation.prototype.run and configModes, citeproc_commonjs.js
+      ~L24415-24470 and ~L23640-23700).
+- [ ] Add native fixtures that distinguish by-cite from all-names once the
+      distinction is real again (the existing by_cite_scope_fixture tests were
+      rewritten under csl26-8nrt to expect all-names-equivalent output; they
+      will need re-splitting once this lands).
+- [ ] Update docs/specs/DISAMBIGUATION.md §2.1.1 acceptance criteria.

--- a/.beans/csl26-8nrt--disambiguate-add-names-doesnt-expand-et-al-name-li.md
+++ b/.beans/csl26-8nrt--disambiguate-add-names-doesnt-expand-et-al-name-li.md
@@ -1,7 +1,7 @@
 ---
 # csl26-8nrt
 title: Disambiguate-add-names doesn't expand et-al name-list depth
-status: todo
+status: in-progress
 type: bug
 priority: normal
 tags:
@@ -10,7 +10,7 @@ tags:
     - engine
     - citation
 created_at: 2026-08-16T00:16:01Z
-updated_at: 2026-08-16T00:16:01Z
+updated_at: 2026-08-16T18:26:40Z
 ---
 
 Found while validating csl26-p7a8's title-quote flip for

--- a/.beans/csl26-jdp6--disambiguate-givenname-renders-wrong-name-orderpun.md
+++ b/.beans/csl26-jdp6--disambiguate-givenname-renders-wrong-name-orderpun.md
@@ -1,0 +1,45 @@
+---
+# csl26-jdp6
+title: disambiguate-givenname renders wrong name order/punctuation vs oracle
+status: todo
+type: bug
+priority: normal
+tags:
+    - rendering
+    - disambiguation
+    - engine
+    - citation
+created_at: 2026-08-16T18:26:30Z
+updated_at: 2026-08-16T18:26:37Z
+---
+
+Found while investigating csl26-8nrt (by-cite disambiguation scope) via
+taylor-and-francis-council-of-science-editors-author-date's citations-expanded.json
+fixture. For citation id `disambiguate-givenname`:
+
+- Oracle (citeproc-js): (A. Johnson 2020; B. Johnson 2020)
+- Citum:                (Johnson A 2020; Johnson B 2020)
+
+Two divergences bundled together:
+1. Name order — oracle puts the given-name initial before the family name;
+   Citum puts family first. Style sets `display-as-sort: all` (sort order for
+   all contributor positions, not just first).
+2. Initial punctuation — oracle's initial has a trailing period ("A."); Citum's
+   does not ("A").
+
+## Investigation needed
+- [ ] Confirm whether `display-as-sort: all` should force name-order to
+      family-first in citation context per CSL semantics, or whether Citum is
+      wrongly applying it to a position/form where citeproc-js does not.
+- [ ] Check initialize-with punctuation handling for the disambiguation-driven
+      given-name expansion path specifically (contributors.initialize-with is
+      empty string in this style's core options, but citeproc-js still
+      appends "." — check whether initial-formatting is being bypassed for
+      hint-driven expansion).
+- [ ] Locate the render path for given-name expansion in citum-engine
+      (crates/citum-engine/src/values/contributor/names.rs and related name
+      formatting) and compare against real CSL name-part rendering rules for
+      form=short/initials.
+- [ ] Fix and add regression tests; re-run report-core.js --style
+      taylor-and-francis-council-of-science-editors-author-date to confirm
+      exactParity improvement.

--- a/docs/reference/DISAMBIGUATION.md
+++ b/docs/reference/DISAMBIGUATION.md
@@ -25,8 +25,9 @@ not applied. The normative cascade and per-guide application live in the
 > **Same surname ≠ year suffix.** Different authors who share a surname (e.g.
 > "A. Johnson" vs "B. Johnson") are disambiguated by *given names/initials*, never
 > by a year suffix — year suffixes apply only to the *same author, same year*. APA
-> needs a **global** given-name rule (`primary-name-with-initials`) for this, since
-> the `by-cite` default only compares authors cited together.
+> needs `primary-name-with-initials` for this — not because `by-cite` compares fewer
+> references (it doesn't; see below), but because APA §8.20 shows initials on the
+> *first* author only, which `primary-name` restricts to.
 >
 > **MLA disambiguates by short title, not suffix.** MLA is author-*page*: it sets
 > `year-suffix: false` and resolves same-author works with a `disambiguate-only`
@@ -110,30 +111,33 @@ citation:
 
 ### Rules
 
-- **by-cite**: Apply given names only within each citation
-- **all-names**: Apply to all uses of the name (ensures consistency
+All rules detect collisions the same way: against every reference in the document,
+never a subset. What differs is *which name positions* are eligible to expand:
+
+- **by-cite**: currently identical to `all-names` in Citum (see note below) —
+  in real CSL it additionally caps how far one cite is forced to escalate, so a
+  cite already showing enough names to disambiguate doesn't gratuitously add
+  given names for a name hidden behind `et al.`
+- **all-names**: apply to all uses of the name (ensures consistency
   across document)
-- **primary-name**: Apply given names only to the first author position
+- **primary-name**: apply given names only to the first author position
 
 ### Example
 
-Multiple "Smith, J." authors:
+Multiple "Smith, J." authors, disambiguated document-wide:
 
 ```
-By-cite:
-Smith, J. (1980)
-Smith, J. (1985)
-
-All-names (after disambiguation):
 Smith, John (1980)
 Smith, Jane (1985)
-Smith, Jane (1985)
 ```
 
-In Citum, `by-cite` is implemented as a citation-local hint overlay. A reference
-that belongs to a global collision group can render unexpanded when it appears in
-a citation that does not need given-name expansion. `all-names` keeps global
-expansion for every affected reference.
+**Current limitation:** Citum's hint model does not yet support a per-cite
+escalation cap, so `by-cite` and `all-names` produce identical output — both
+expand every colliding reference's name(s) document-wide. See
+[the spec](../specs/DISAMBIGUATION.md), §2.1.1, for the citeproc-js behavior a
+future `by-cite` implementation should match, and `csl26-5753` for the tracked
+gap. A reference is never left unexpanded merely because it was cited alone —
+that was a defect (csl26-8nrt), not `by-cite` semantics.
 
 ## Group-Aware Disambiguation
 
@@ -171,10 +175,11 @@ them in order, stopping at the first successful disambiguation.
 
 ### Example: APA 7th Edition
 
-APA uses all three strategies with a **global** given-name rule (`primary-name`) so
-same-surname authors get first-author initials in every in-text citation (APA §8.20)
-— `by-cite` would only compare authors cited together. This is the major author-date
-guide profile, bundled by the **`author-date-full` preset** (names + add-givenname +
+APA uses all three strategies with the `primary-name` given-name rule so
+same-surname authors get initials on the *first* author only in every in-text
+citation (APA §8.20) — `by-cite` would expand every colliding position instead
+of just the first. This is the major author-date guide profile, bundled by the
+**`author-date-full` preset** (names + add-givenname +
 `primary-name` + year-suffix), which APA and Chicago AD share
 (see [`apa-7th.yaml`](../../crates/citum-schema-style/embedded/styles/apa-7th.yaml)):
 

--- a/docs/specs/DISAMBIGUATION.md
+++ b/docs/specs/DISAMBIGUATION.md
@@ -293,7 +293,7 @@ sub-groups that are still ambiguous, given-name expansion and/or year suffix are
 applied to those sub-groups independently.
 
 Implemented in `apply_group_hints` →
-`try_apply_name_partitions` / `try_apply_givenname_resolution` /
+`apply_name_partitions` / `select_givenname_resolution` /
 `apply_year_suffix`.
 
 ### 2.1 `givenname-disambiguation-rule`
@@ -302,9 +302,21 @@ Specifies which author positions receive given-name expansion. The field lives o
 `Disambiguation` in `citum-schema-style/src/options/processing.rs` as
 `givenname_rule: GivennameRule`. Default: `by-cite`.
 
+**Invariant, all rules:** the ambiguity universe is always every reference in the
+document, never a subset. A collision group is computed once, globally, in
+`Processor::calculate_hints` (`processor/setup.rs`), and that is the only
+computation that runs — no rule recomputes or narrows it. This mirrors
+citeproc-js, whose ambiguity pool (`CSL.Registry.prototype.ambigcites`) is a
+property of the registry, populated over every registered item, with no
+per-cite scoping at any point in `getAmbiguousCite`. Two different authors
+named "Smith" cannot be told apart by looking at one citation in isolation —
+telling them apart requires comparing every "Smith" in the bibliography, which
+is what "disambiguation" means. See §2.1.1 for what actually varies between
+rules.
+
 | CSL value | Engine scope | Notes |
 |---|---|---|
-| `by-cite` *(default)* | citation-local expansion overlay | see §2.1.1 |
+| `by-cite` *(default)* | global collision detection, per-cite expansion ceiling | see §2.1.1 |
 | `all-names` | global expansion | all affected citations use the expanded form consistently |
 | `all-names-with-initials` | expand all positions | initials vs full controlled by contributor config `initialize-with` |
 | `primary-name` | expand **first author only** | required by Chicago author-date |
@@ -314,26 +326,60 @@ Specifies which author positions receive given-name expansion. The field lives o
 config's `initialize-with` / `name-form` settings, not by this rule. The rule
 controls only *which positions* are eligible for expansion.
 
-#### 2.1.1 `by-cite` citation-local expansion (csl26-lvib)
+#### 2.1.1 `by-cite` (csl26-lvib, corrected 2026-08-16)
 
-`by-cite` is applied at citation render time, not by mutating the processor's
-global disambiguation hints. The renderer clones the global hint map for the
-current citation, clears global given-name expansion for the references in that
-citation, then overlays the name-expansion fields computed from only the current
-citation's references. Year suffixes, group order, citation numbers, note
-position, and bibliography rendering continue to use the global hints.
+`by-cite` is a **given-name** rule (cascade strategy 2, §2). It has no authority
+over strategy 1 (et-al expansion via `disambiguate-add-names`) or strategy 3
+(year suffix); both remain global under every `givenname_rule` value, including
+`by-cite`.
 
-`all-names` and `all-names-with-initials` deliberately keep the global hint map:
-if a name is expanded for disambiguation anywhere in the document, all rendered
-uses of that affected reference receive the expanded form. This makes `by-cite`
-and `all-names` observably different on fixtures where a reference belongs to a
-global collision group but appears alone, or outside the citation that needs
-expansion.
+citeproc-js is explicit that `by-cite` does not change *which references are
+compared*: internal to `CSL.Disambiguation`, a `by-cite` rule is rewritten to
+`all-names` for the purpose of selecting eligible positions
+(`if (gdropt === "by-cite") { gdropt = "all-names"; }`), and the ambiguity pool
+those positions are checked against is the same registry-wide pool every other
+rule uses. What `by-cite` actually changes is narrower: it caps how far a
+*given* rendered cite is allowed to escalate (`givensMax`), so a cite showing
+two authors is not forced to add given names for a third author hidden behind
+`et al.` in that same cite. It does not, and cannot, shrink the set of
+references consulted to decide *whether* a collision exists — doing so would
+make disambiguation depend on which references happen to be cited together,
+which defeats disambiguation's purpose (§2.1's invariant above).
 
-The current hint model still expresses given-name expansion as all eligible
-rendered positions or primary-name-only; it does not store an arbitrary mask of
-individual name positions. The `by-cite` implementation therefore scopes the
-decision to the current citation and preserves the existing position model.
+**2026-06-02–2026-08-16 implementation (csl26-lvib) was wrong.** It approximated
+`by-cite`'s per-cite escalation cap by *narrowing the comparison set* instead:
+`citation_scoped_by_cite_hints` cleared the global hints for every reference in
+a citation and recomputed them from a bibliography containing only that
+citation's items, short-circuiting to "no collision" for any citation naming
+fewer than two references. This silently under-disambiguated any reference
+cited alone that belonged to a global collision group — including via strategy
+1 (et-al depth), which `by-cite` has no claim on at all — and made `by-cite`
+observably *narrower* than `all-names` rather than narrower-in-a-different-axis,
+inverting the relationship citeproc-js implements. Found via csl26-8nrt: a
+`disambiguate-add-names` collision (two Smith/Lee/2021 papers diverging at the
+third author) rendered the correct three-name expansion only when both
+colliding references were cited together, and silently collapsed to one name
+whenever either was cited alone.
+
+**Current state:** the citation-scoped overlay has been removed. `by-cite`
+behaves identically to `all-names` — both use the single global hint
+computation, and neither implements a real per-position given-name mask.
+Distinguishing them (a true `givensMax`-style escalation cap, so a solo cite
+does not gratuitously add given names beyond what its own visible names need)
+requires storing an explicit per-position expansion mask in `ProcHints`, which
+the current hint model does not have. That is real, tracked, un-implemented
+scope — not a design decision — filed as `csl26-5753`.
+
+**Rejected alternative:** keep the citation-scoped overlay but carve out
+`min_names_to_show` from the clear whenever the global hint's
+`expand_given_names` is `false` (i.e. the collision was resolved by pure
+et-al expansion, strategy 1, with no given-name involvement). This is a
+minimal, test-preserving patch — every existing `by-cite` test keeps its
+current expected output — but it was rejected: it only patches the strategy-1
+leak this bean found, leaves the deeper error (comparing against a
+citation-scoped subset at all) in place for strategy 2, and requires
+inventing an unwritten rule ("et-al depth is global only when given names
+weren't also involved") with no counterpart in citeproc-js to justify it.
 
 ### 3. Year-suffix assignment ordering
 
@@ -419,12 +465,14 @@ same year*. Mapping to engine flags:
 | MLA 9 | true | true | `by-cite` | **false** | custom block (author-*page*: no suffix; falls through to the `disambiguate-only` short title, §6) |
 | IEEE / AMA | — | — | — | — | numeric; no author-date disambiguation |
 
-**`by-cite` is citation-local in Citum** (§2.1.1): it compares only references that
-appear together in one citation. Same-surname authors usually appear in *separate*
-citations, so a guide that wants initials in every cite (APA §8.20) needs **global**
-detection — the `primary-name` rule, not `by-cite`. Initials vs. full given name is
-then driven by each style's contributor config (`initialize-with` / `name-form`), per
-the §2.1 invariant — so one rule serves APA (initials) and Chicago (full given name).
+APA still needs `primary-name` rather than `by-cite`, but for the reason §2.1's table
+actually gives: `primary-name` restricts expansion to the **first author only** — the
+correct rendering under APA §8.20, which shows initials on the first author of each
+colliding surname, not on every author. `by-cite` carries no such restriction and, per
+§2.1.1, is document-wide like every other rule; it would expand every colliding
+position rather than only the first. Initials vs. full given name is then driven by
+each style's contributor config (`initialize-with` / `name-form`), per the §2.1
+invariant — so one rule serves APA (initials) and Chicago (full given name).
 
 The **`author-date-full` preset** encodes exactly this guide profile —
 names + add-givenname + **`primary-name`** + year-suffix — and APA and Chicago use it
@@ -520,10 +568,15 @@ added to the citation context.
   `primary-name-with-initials` restrict expansion to the first author only (csl26-4ada)
 - [x] `primary-name` falls back to year-suffix when primary-author expansion cannot resolve
   the collision (identical primary authors); et-al expansion retained alongside suffix (csl26-wu1l)
-- [x] `by-cite` given-name expansion is citation-local and distinguishable from
-  `all-names` global expansion (csl26-lvib)
+- [x] Name disambiguation (et-al expansion and given-name expansion alike) always
+  compares against every reference in the document; no `givenname-disambiguation-rule`
+  value narrows the comparison set (§2.1.1, csl26-8nrt — corrects the 2026-06-02
+  citation-scoped `by-cite` implementation)
+- [ ] `by-cite` implements a true per-position given-name expansion ceiling
+  (distinguishable from `all-names`); tracked as `csl26-5753`, §2.1.1
 - [x] Upstream CSL disambiguation fixtures that distinguish `by-cite` and
-  `all-names` are tracked in the disambiguation fixture generator
+  `all-names` are tracked in the disambiguation fixture generator (fixtures now
+  exercise the document-wide behavior both rules share pending the follow-up above)
 - [x] Year-suffix order follows the article-stripped/locale-collated bibliography
   sort, not a raw lowercased title (csl26-2zy6, audit row 138)
 - [x] APA-7th carries `add-givenname` + `primary-name-with-initials` (global) so
@@ -555,6 +608,26 @@ added to the citation context.
 
 ## Changelog
 
+- 2026-08-16: Corrected §2.1.1: `by-cite` is document-wide, not citation-local
+  (csl26-8nrt). The 2026-06-02 `by-cite` implementation (csl26-lvib) approximated
+  a per-cite given-name expansion ceiling by narrowing the comparison set to the
+  current citation's references instead — this cleared `min_names_to_show` for
+  every citation-scoped hint, silently discarding et-al-expansion results
+  (strategy 1) that `by-cite`, a given-name rule (strategy 2), has no authority
+  over. Found via a `disambiguate-add-names` collision (two same-year references
+  diverging only at the third author) that expanded correctly only when both
+  colliding references were cited together, collapsing to one name whenever
+  either was cited alone. citeproc-js confirms the correction: its ambiguity
+  pool (`CSL.Registry.ambigcites`) is populated over the whole registry with no
+  per-cite scoping, and `by-cite` is internally rewritten to `all-names` for
+  position selection — the rule only caps escalation depth, never the
+  comparison set. Engine: removed `citation_scoped_by_cite_hints` and
+  `uses_by_cite_givenname` from `processor/citation.rs`; citations render
+  directly from the global hint map like every other rule. `by-cite` and
+  `all-names` are now behaviorally identical pending a real per-position
+  expansion mask (tracked as `csl26-5753`). Rejected a narrower patch that
+  would have carved out `min_names_to_show` from the clear without removing the
+  citation-scoped comparison itself — see §2.1.1 for why.
 - 2026-08-16: Centralized author and issued-date fallback policy in options.
   Anonymous messages and first-issued date resolution now share the exact
   rendering policy; template fallback chains no longer exist.


### PR DESCRIPTION
**Corrects a design claim in the disambiguation spec: `by-cite` was never citation-local — that was a defect, not intended CSL semantics.**

## Summary

`DISAMBIGUATION.md` §2.1.1 said `by-cite` compares only the references cited
together in one citation. Checked against the vendored citeproc-js source:
the ambiguity pool (`CSL.Registry.ambigcites`) is registry-wide for every
`givenname-disambiguation-rule` value, and `by-cite` is internally rewritten
to `all-names` for position selection — it only caps how far one cite
escalates, never which references are compared. The 2026-06-02 `by-cite`
implementation (csl26-lvib) got this backwards, which is what produces
csl26-8nrt's under-disambiguation bug (fixed in the stacked engine PR
targeting this branch).

## Scope

- `docs/specs/DISAMBIGUATION.md` — rewrites §2.1/§2.1.1/§3.1, records the
  rejected narrower-patch alternative, fixes stale function names in §2,
  adds a changelog entry.
- `docs/reference/DISAMBIGUATION.md` — the style-author-facing how-to doc
  repeated the same wrong claim (and steered APA-style authors toward
  `primary-name` for the wrong reason); corrected in three places.
- Files two follow-up beans found during the investigation:
  - `csl26-5753` — real by-cite position-minimal expansion is not yet
    implemented; `by-cite` and `all-names` are behaviorally identical
    pending it.
  - `csl26-jdp6` — unrelated given-name order/punctuation divergence
    noticed in the same T&F CSE fixture.

## Validation

Docs-only, no build checks required. `./scripts/validate-frontmatter.sh
--copilot-strict` clean (one unrelated pre-existing issue outside this
repo's tracked files).

## Risk

None — no code changes in this PR.

## Follow-ups

- `csl26-5753` tracks implementing a real per-position given-name expansion
  ceiling for `by-cite`, so it's distinguishable from `all-names` again.
