### PR TITLE
fix(engine): escalate givenname past same initials

### DIFF
--- a/.beans/archive/csl26-h9jy--disambiguate-add-givenname-falsely-resolves-same-i.md
+++ b/.beans/archive/csl26-h9jy--disambiguate-add-givenname-falsely-resolves-same-i.md
@@ -1,0 +1,80 @@
+---
+# csl26-h9jy
+title: disambiguate-add-givenname falsely resolves same-initial collisions
+status: completed
+type: bug
+priority: high
+tags:
+    - engine
+    - disambiguation
+    - citation
+created_at: 2026-08-16T19:46:19Z
+updated_at: 2026-08-16T20:17:17Z
+---
+
+Found while investigating csl26-5753. `disambiguate-add-givenname` silently
+under-disambiguates two different authors whose given names share the same
+initial (e.g. Brandon vs Biff Bronchitis, both "B."), for every
+`givenname-disambiguation-rule` value -- not just `by-cite`.
+
+Reproduced with a style using `contributors.name-form: initials` +
+`disambiguate.add-givenname: true`:
+
+```
+Two references: [..., ("Bronchitis", "Brandon"), ...] vs [..., ("Bronchitis", "Biff"), ...]
+Rendered: "A Asthma, B Bronchitis, et al." for BOTH -- identical, no
+disambiguator applied, no fallback to year-suffix.
+```
+
+Control (differing initials, e.g. Brandon vs Zach) resolves correctly
+("B Bronchitis" vs "Z Bronchitis"), confirming the mechanism generally
+works -- the bug is specific to same-initial collisions.
+
+## Root cause
+`check_givenname_resolution`/`append_givenname_resolution_key`
+(processor/disambiguation.rs) build the collision-resolution key from the
+raw full given-name string (`name.given`) unconditionally, assuming that
+"expanding given names" reveals the full name and will discriminate. But
+rendering (`values/contributor/names.rs::format_single_name`) only escalates
+`ContributorForm::Short -> Long` when `expand_given_names` is set; the given
+name's actual granularity (initials vs full) still comes from
+`ctx.name_form` (the style's configured baseline), which stays at Initials.
+So the collision-detection key and the rendered output diverge: the key
+says "resolved" (Brandon != Biff as raw strings), the render says
+"unresolved" (B. == B.), and the cascade never proceeds to year-suffix.
+
+## Verified against real CSL
+Official CSL test-suite fixtures confirm real citeproc-js resolves this via
+a level ladder (family-only -> initials [only when initialize-with is
+configured] -> full given name), escalating only as far as needed:
+- tests/csl-test-suite/processor-tests/humans/disambiguate_ByCiteMinimalGivennameExpandMinimalNames.txt
+- tests/csl-test-suite/processor-tests/humans/disambiguate_ByCiteBaseNameCountOnFailureIfYearSuffixAvailable.txt
+- tests/csl-test-suite/processor-tests/humans/disambiguate_ByCiteGivennameShortFormInitializeWith.txt (+ NoInitializeWith,
+  NoShortFormInitializeWith siblings)
+
+The `-with-initials` rule variants (all-names-with-initials,
+primary-name-with-initials) cap the ladder at initials -- they must never
+escalate to full given names (confirmed by rule doc comments: only these
+two say "(initials form)" explicitly).
+
+## Scope
+- [x] Add a givenname-level ladder (Initials -> Full, capped per
+      `GivennameRule`) to the collision-key builder and threading it
+      through to ProcHints/rendering.
+- [x] Fix: same-initial collisions correctly escalate to full given names
+      (matching the oracle) rather than silently rendering identically.
+- [x] Note: per-position minimality (only escalating the ONE position that
+      actually needs it, not every shown position) is still deferred to
+      csl26-5753/PR4 -- this bug's fix may render more given names than the
+      oracle at other positions in the same citation. That divergence is
+      intentional and documented, not a regression.
+
+## Summary of Changes
+
+Added a given-name escalation ladder (Initials -> Full, per csl26-h9jy) to `crates/citum-engine/src/processor/disambiguation.rs`: `check_givenname_resolution`/`append_givenname_resolution_key` now build the collision-resolution key using the SAME representation the renderer would actually produce at each level (via `initialize_given_name`, made `pub(crate)`), instead of always assuming the raw full given-name string discriminates. `resolve_givenname_level` tries initials first (only when `initialize-with` is configured, mirroring real CSL's presence gate), then escalates to full given name -- capped for `all-names-with-initials`/`primary-name-with-initials`, which must never escalate past initials (new `DisambiguationFlags.givenname_full_allowed`).
+
+`ProcHints` gained `expand_given_names_full: bool` alongside the existing `expand_given_names`. Rendering (`values/contributor/names.rs::resolve_given_part`) applies the escalated level, with one critical correction found via full-corpus verification: escalation only ever RAISES the given-name form (FamilyOnly < Initials < Full) relative to the rendering context's OWN configured baseline, never lowers it. Hints are computed once against citation-scope config and shared with bibliography rendering, which commonly configures a MORE revealing baseline (e.g. Chicago author-date: citation-scope `initials`, bibliography-scope default `full`) -- without the floor, escalating to "Initials" wrongly downgraded already-correct full-name bibliography entries. Caught by the sandboxed full-corpus sweep (chicago-18-base exactParity dropped 174->168/546), fixed, and reverified byte-identical (0 regressions across all 35 exemplar styles, before/after via detached worktree).
+
+Added 3 native regressions: same-initial escalation to full name (mirrors the official CSL test suite's `disambiguate_ByCiteMinimalGivennameExpandMinimalNames.txt` fixture exactly, with the known/annotated PR3-vs-oracle divergence -- Citum reveals every shown position uniformly, not just the minimal one needed, which is csl26-5753's remaining scope); the `-with-initials` rule cap falling through to year-suffix; and re-expected an existing test (`disambiguation_initials_are_used_when_short_form_family_names_collide`) whose old assertion had encoded the bug ("T Smith, (2000); T Smith, (2000)" for Thomas/Ted Smith) as correct -- now matches the official `disambiguate_ByCiteGivennameShortFormInitializeWith.txt` fixture ("Thomas Smith; Ted Smith").
+
+Verification: `just pre-commit` (2587 tests, fmt+clippy clean), full `cargo nextest -p citum-engine` (1329 tests), targeted report-core.js on all 8 styles that could reach `disambiguate-add-givenname` (apa-7th, elsevier-harvard, chicago-18-base, elsevier-vancouver, gb-t-7714-2025, harvard-cite-them-right, modern-language-association, taylor-and-francis-cse) -- all byte-identical exactParity/compat before/after, and the full sandboxed corpus sweep (`report-core.js --all-features`, systemd-run MemoryMax=6G) -- 0 regressions across 35 exemplar styles.

--- a/crates/citum-engine/src/processor/disambiguation.rs
+++ b/crates/citum-engine/src/processor/disambiguation.rs
@@ -81,6 +81,24 @@ struct DisambiguationFlags {
     year_suffix: bool,
     is_label_mode: bool,
     primary_givenname_only: bool,
+    /// Whether given-name expansion may escalate all the way to the full
+    /// given name. `false` for `all-names-with-initials` /
+    /// `primary-name-with-initials`, which must stop at the initials level
+    /// even when initials alone don't resolve a collision (csl26-h9jy).
+    givenname_full_allowed: bool,
+}
+
+/// How far given-name expansion escalated past the style's configured
+/// baseline form to resolve a collision. See csl26-h9jy: the baseline
+/// (e.g. initials) can itself collide (Brandon/Biff both "B."), so
+/// resolution may require revealing the full given name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GivennameLevel {
+    /// Style-configured initials (only reachable when `initialize-with` is
+    /// configured, mirroring real CSL's `initialize-with`-presence gate).
+    Initials,
+    /// Full given name, bypassing the configured form.
+    Full,
 }
 
 struct GroupDisambiguationContext<'a> {
@@ -94,6 +112,7 @@ struct GroupDisambiguationContext<'a> {
 struct HintPlan<'a> {
     key: &'a str,
     expand_given_names: bool,
+    expand_given_names_full: bool,
     expand_given_names_primary_only: bool,
     min_names_to_show: Option<usize>,
     disamb_condition: bool,
@@ -112,9 +131,10 @@ enum GroupHintAction<'a> {
         min_names_to_show: usize,
         partitions: HashMap<String, Vec<&'a CachedReference<'a>>>,
     },
-    GivennameResolution,
+    GivennameResolution(GivennameLevel),
     CombinedResolution {
         min_names_to_show: usize,
+        level: GivennameLevel,
         primary_only_requires_suffix: bool,
     },
     FallbackYearSuffix,
@@ -307,7 +327,36 @@ impl<'a> Disambiguator<'a> {
                     GivennameRule::PrimaryName | GivennameRule::PrimaryNameWithInitials
                 )
             }),
+            givenname_full_allowed: disamb_config.as_ref().is_none_or(|d| {
+                !matches!(
+                    d.givenname_rule,
+                    GivennameRule::AllNamesWithInitials | GivennameRule::PrimaryNameWithInitials
+                )
+            }),
         }
+    }
+
+    /// The `initialize-with` separator configured for this scope, if any.
+    fn initialize_with(&self) -> Option<&String> {
+        self.config
+            .contributors
+            .as_ref()
+            .and_then(|c| c.initialize_with.as_ref())
+    }
+
+    /// Whether the initials-level rung is reachable in the given-name escalation
+    /// ladder. Mirrors real CSL's `initialize-with`-presence gate: available
+    /// either because a separator is explicitly configured, or because the
+    /// style's baseline form is already `name-form: initials` (which Citum
+    /// defaults to a "." separator for when unset).
+    fn initials_available(&self) -> bool {
+        self.initialize_with().is_some()
+            || self
+                .config
+                .contributors
+                .as_ref()
+                .and_then(|c| c.name_form)
+                .is_some_and(|form| matches!(form, citum_schema::options::NameForm::Initials))
     }
 
     /// Builds an internal cache of reference data (author keys, group keys, titles)
@@ -487,17 +536,25 @@ impl<'a> Disambiguator<'a> {
                 );
             }
             GroupHintAction::LabelYearSuffix => {
-                self.apply_year_suffix(hints, &context, false, None);
+                self.apply_year_suffix(hints, &context, false, false, None);
             }
             GroupHintAction::NamePartitions {
                 min_names_to_show,
                 partitions,
             } => self.apply_name_partitions(hints, &context, min_names_to_show, &partitions),
-            GroupHintAction::GivennameResolution => {
-                self.apply_resolution(hints, context.group, &context, true, None);
+            GroupHintAction::GivennameResolution(level) => {
+                self.apply_resolution(
+                    hints,
+                    context.group,
+                    &context,
+                    true,
+                    level == GivennameLevel::Full,
+                    None,
+                );
             }
             GroupHintAction::CombinedResolution {
                 min_names_to_show,
+                level,
                 primary_only_requires_suffix,
             } => {
                 if primary_only_requires_suffix {
@@ -506,6 +563,7 @@ impl<'a> Disambiguator<'a> {
                         context.group,
                         &context,
                         true,
+                        level == GivennameLevel::Full,
                         Some(min_names_to_show),
                     );
                 } else {
@@ -514,12 +572,13 @@ impl<'a> Disambiguator<'a> {
                         context.group,
                         &context,
                         true,
+                        level == GivennameLevel::Full,
                         Some(min_names_to_show),
                     );
                 }
             }
             GroupHintAction::FallbackYearSuffix => {
-                self.apply_year_suffix(hints, &context, false, None);
+                self.apply_year_suffix(hints, &context, false, false, None);
             }
         }
     }
@@ -544,15 +603,16 @@ impl<'a> Disambiguator<'a> {
             };
         }
 
-        if self.select_givenname_resolution(context) {
-            return GroupHintAction::GivennameResolution;
+        if let Some(level) = self.select_givenname_resolution(context) {
+            return GroupHintAction::GivennameResolution(level);
         }
 
-        if let Some((min_names_to_show, primary_only_requires_suffix)) =
+        if let Some((min_names_to_show, level, primary_only_requires_suffix)) =
             self.select_combined_resolution(context)
         {
             return GroupHintAction::CombinedResolution {
                 min_names_to_show,
+                level,
                 primary_only_requires_suffix,
             };
         }
@@ -591,32 +651,46 @@ impl<'a> Disambiguator<'a> {
     }
 
     /// Selects collision resolution by adding given names or initials.
-    fn select_givenname_resolution(&self, context: &GroupDisambiguationContext<'_>) -> bool {
-        // Use full-expansion keys to determine whether givenname expansion can help at all.
-        // (With n=1, the full and primary-only keys are equivalent — both inspect only the
-        // primary author — so no separate primary-only check is needed here.)
-        context.flags.add_givenname && self.check_givenname_resolution(context.group, None, false)
+    ///
+    /// Tries the given-name escalation ladder (initials, then full — see
+    /// `resolve_givenname_level`) and returns the level that resolves the
+    /// collision, if any. (With n=1, the full and primary-only keys are
+    /// equivalent — both inspect only the primary author — so no separate
+    /// primary-only check is needed here.)
+    fn select_givenname_resolution(
+        &self,
+        context: &GroupDisambiguationContext<'_>,
+    ) -> Option<GivennameLevel> {
+        if !context.flags.add_givenname {
+            return None;
+        }
+        self.resolve_givenname_level(context.group, None, false, context.flags)
     }
 
     /// Selects collision resolution by using both more names AND given name expansion.
     ///
     /// When `primary_givenname_only` is active, the renderer only shows given names for
-    /// the first author. `find_combined_resolution` uses full-expansion keys to find the
-    /// minimum name count that would work in theory; this function then verifies whether
+    /// the first author. `find_combined_resolution` finds the minimum name count and
+    /// escalation level that would work in theory; this function then verifies whether
     /// that resolution also holds under the restricted primary-only rendering.
     fn select_combined_resolution(
         &self,
         context: &GroupDisambiguationContext<'_>,
-    ) -> Option<(usize, bool)> {
+    ) -> Option<(usize, GivennameLevel, bool)> {
         if !context.flags.add_names || !context.flags.add_givenname {
             return None;
         }
 
-        let min_names_to_show = self.find_combined_resolution(context.group)?;
+        let (min_names_to_show, level) = self.find_combined_resolution(context)?;
         let primary_only_requires_suffix = context.flags.primary_givenname_only
-            && !self.check_givenname_resolution(context.group, Some(min_names_to_show), true);
+            && !self.check_givenname_resolution(
+                context.group,
+                Some(min_names_to_show),
+                true,
+                level,
+            );
 
-        Some((min_names_to_show, primary_only_requires_suffix))
+        Some((min_names_to_show, level, primary_only_requires_suffix))
     }
 
     /// Applies a name-expansion partition plan, suffixing any unresolved subgroups.
@@ -629,28 +703,60 @@ impl<'a> Disambiguator<'a> {
     ) {
         for subgroup in partitions.values() {
             if subgroup.len() == 1 {
-                self.apply_resolution(hints, subgroup, context, false, Some(min_names_to_show));
+                self.apply_resolution(
+                    hints,
+                    subgroup,
+                    context,
+                    false,
+                    false,
+                    Some(min_names_to_show),
+                );
                 continue;
             }
 
-            if context.flags.add_givenname
-                && self.check_givenname_resolution(subgroup, Some(min_names_to_show), false)
-            {
+            let resolution = context
+                .flags
+                .add_givenname
+                .then(|| {
+                    self.resolve_givenname_level(
+                        subgroup,
+                        Some(min_names_to_show),
+                        false,
+                        context.flags,
+                    )
+                })
+                .flatten();
+
+            if let Some(level) = resolution {
+                let expand_full = level == GivennameLevel::Full;
                 // Under primary-name rules, secondary given names are not rendered.
                 // If the full-expansion check passes but primary-only does not, the
                 // subgroup must fall back to year-suffix (with expansion retained).
                 if context.flags.primary_givenname_only
-                    && !self.check_givenname_resolution(subgroup, Some(min_names_to_show), true)
+                    && !self.check_givenname_resolution(
+                        subgroup,
+                        Some(min_names_to_show),
+                        true,
+                        level,
+                    )
                 {
                     self.apply_year_suffix_for_group(
                         hints,
                         subgroup,
                         context,
                         true,
+                        expand_full,
                         Some(min_names_to_show),
                     );
                 } else {
-                    self.apply_resolution(hints, subgroup, context, true, Some(min_names_to_show));
+                    self.apply_resolution(
+                        hints,
+                        subgroup,
+                        context,
+                        true,
+                        expand_full,
+                        Some(min_names_to_show),
+                    );
                 }
                 continue;
             }
@@ -660,24 +766,66 @@ impl<'a> Disambiguator<'a> {
                 subgroup,
                 context,
                 false,
+                false,
                 Some(min_names_to_show),
             );
         }
     }
 
     /// Searches for the minimum number of names that, when combined with given name expansion,
-    /// resolves the collision group.
-    fn find_combined_resolution(&self, group: &[&CachedReference<'_>]) -> Option<usize> {
+    /// resolves the collision group. Returns the name count together with the escalation
+    /// level (initials or full) that resolves it, preferring the least-disruptive level at
+    /// each candidate count.
+    fn find_combined_resolution(
+        &self,
+        context: &GroupDisambiguationContext<'_>,
+    ) -> Option<(usize, GivennameLevel)> {
+        let group = context.group;
         let max_authors = group
             .iter()
             .map(|reference| reference.data.names.len())
             .max()
             .unwrap_or(0);
 
-        // Use full-expansion keys (primary_only: false) to find the minimum name count.
         // The caller is responsible for verifying the result under primary-only rendering
         // when primary_givenname_only is active.
-        (2..=max_authors).find(|&n| self.check_givenname_resolution(group, Some(n), false))
+        (2..=max_authors).find_map(|n| {
+            self.resolve_givenname_level(group, Some(n), false, context.flags)
+                .map(|level| (n, level))
+        })
+    }
+
+    /// Tries the given-name escalation ladder (initials, then full given name) and returns
+    /// the least-disruptive level that resolves the collision, if any.
+    ///
+    /// Initials are only tried when `initials_available` — mirroring real CSL's
+    /// `initialize-with`-presence gate. Full-name escalation is only tried when
+    /// `flags.givenname_full_allowed` — `all-names-with-initials` and
+    /// `primary-name-with-initials` must stop at initials even if that doesn't
+    /// resolve the collision (csl26-h9jy).
+    fn resolve_givenname_level(
+        &self,
+        group: &[&CachedReference<'_>],
+        min_names: Option<usize>,
+        primary_only: bool,
+        flags: DisambiguationFlags,
+    ) -> Option<GivennameLevel> {
+        if self.initials_available()
+            && self.check_givenname_resolution(
+                group,
+                min_names,
+                primary_only,
+                GivennameLevel::Initials,
+            )
+        {
+            return Some(GivennameLevel::Initials);
+        }
+        if flags.givenname_full_allowed
+            && self.check_givenname_resolution(group, min_names, primary_only, GivennameLevel::Full)
+        {
+            return Some(GivennameLevel::Full);
+        }
+        None
     }
 
     /// Finalizes a successful disambiguation strategy by inserting the calculated hints into the map.
@@ -687,6 +835,7 @@ impl<'a> Disambiguator<'a> {
         group: &[&CachedReference<'_>],
         context: &GroupDisambiguationContext<'_>,
         expand_given_names: bool,
+        expand_given_names_full: bool,
         min_names_to_show: Option<usize>,
     ) {
         self.insert_group_hints(
@@ -696,6 +845,7 @@ impl<'a> Disambiguator<'a> {
             HintPlan {
                 key: context.key,
                 expand_given_names,
+                expand_given_names_full,
                 expand_given_names_primary_only: context.flags.primary_givenname_only,
                 min_names_to_show,
                 disamb_condition: false,
@@ -737,6 +887,7 @@ impl<'a> Disambiguator<'a> {
         hints: &mut HashMap<String, ProcHints>,
         context: &GroupDisambiguationContext<'_>,
         expand_given_names: bool,
+        expand_given_names_full: bool,
         min_names_to_show: Option<usize>,
     ) {
         self.apply_year_suffix_for_group(
@@ -744,6 +895,7 @@ impl<'a> Disambiguator<'a> {
             context.group,
             context,
             expand_given_names,
+            expand_given_names_full,
             min_names_to_show,
         );
     }
@@ -755,6 +907,7 @@ impl<'a> Disambiguator<'a> {
         group: &[&CachedReference<'_>],
         context: &GroupDisambiguationContext<'_>,
         expand_given_names: bool,
+        expand_given_names_full: bool,
         min_names_to_show: Option<usize>,
     ) {
         self.insert_group_hints(
@@ -764,6 +917,7 @@ impl<'a> Disambiguator<'a> {
             HintPlan {
                 key: context.key,
                 expand_given_names,
+                expand_given_names_full,
                 expand_given_names_primary_only: context.flags.primary_givenname_only,
                 min_names_to_show,
                 disamb_condition: true,
@@ -813,6 +967,7 @@ impl<'a> Disambiguator<'a> {
                 group_index,
                 group_key: plan.key.to_string(),
                 expand_given_names: plan.expand_given_names,
+                expand_given_names_full: plan.expand_given_names_full,
                 expand_given_names_primary_only: plan.expand_given_names_primary_only,
                 min_names_to_show: plan.min_names_to_show,
                 ..Default::default()
@@ -926,7 +1081,8 @@ impl<'a> Disambiguator<'a> {
         None
     }
 
-    /// Check if expanding to full names resolves ambiguity in the group.
+    /// Check if expanding given names at the given escalation `level` resolves
+    /// ambiguity in the group.
     ///
     /// If `min_names` is `Some(n)`, it checks resolution when showing `n` names.
     ///
@@ -939,6 +1095,7 @@ impl<'a> Disambiguator<'a> {
         group: &[&CachedReference<'_>],
         min_names: Option<usize>,
         primary_only: bool,
+        level: GivennameLevel,
     ) -> bool {
         let mut seen = HashSet::new();
         let mut buf = String::new();
@@ -946,7 +1103,7 @@ impl<'a> Disambiguator<'a> {
         for reference in group {
             let names = &reference.data.names;
             buf.clear();
-            self.append_givenname_resolution_key(&mut buf, names, n, primary_only);
+            self.append_givenname_resolution_key(&mut buf, names, n, primary_only, level);
             if !seen.insert(buf.clone()) {
                 return false;
             }
@@ -1290,7 +1447,13 @@ impl<'a> Disambiguator<'a> {
         names: &[crate::reference::FlatName],
         n: usize,
         primary_only: bool,
+        level: GivennameLevel,
     ) {
+        let initialize_with_hyphen = self
+            .config
+            .contributors
+            .as_ref()
+            .and_then(|c| c.initialize_with_hyphen);
         for (idx, name) in names.iter().take(n).enumerate() {
             if idx > 0 {
                 key.push_str("||");
@@ -1301,7 +1464,21 @@ impl<'a> Disambiguator<'a> {
                 continue;
             }
             key.push('|');
-            Self::append_optional_part(key, name.given.as_deref());
+            match level {
+                GivennameLevel::Full => {
+                    Self::append_optional_part(key, name.given.as_deref());
+                }
+                GivennameLevel::Initials => {
+                    let initials = name.given.as_deref().map(|given| {
+                        crate::values::contributor::names::initialize_given_name(
+                            given,
+                            self.initialize_with(),
+                            initialize_with_hyphen,
+                        )
+                    });
+                    Self::append_optional_part(key, initials.as_deref());
+                }
+            }
             key.push('|');
             Self::append_optional_part(key, name.non_dropping_particle.as_deref());
             key.push('|');

--- a/crates/citum-engine/src/values/contributor/names.rs
+++ b/crates/citum-engine/src/values/contributor/names.rs
@@ -539,8 +539,9 @@ fn format_selected_names(
         .map(|(index, name)| {
             let expand =
                 hints.expand_given_names && !(hints.expand_given_names_primary_only && index > 0);
+            let expand_full = expand && hints.expand_given_names_full;
             decorate_name(
-                format_single_name(name, form, index, context, expand),
+                format_single_name(name, form, index, context, expand, expand_full),
                 index,
                 decorations,
             )
@@ -553,8 +554,9 @@ fn format_selected_names(
             let original_index = names.len() - last_names.len() + index;
             let expand = hints.expand_given_names
                 && !(hints.expand_given_names_primary_only && original_index > 0);
+            let expand_full = expand && hints.expand_given_names_full;
             decorate_name(
-                format_single_name(name, form, original_index, context, expand),
+                format_single_name(name, form, original_index, context, expand, expand_full),
                 original_index,
                 decorations,
             )
@@ -576,7 +578,7 @@ fn decorate_name(value: String, index: usize, decorations: &[NameDecoration]) ->
 ///
 /// Splits the given name on word separators (space, hyphen, non-breaking space),
 /// and converts each part to its first character followed by the initialize suffix.
-fn initialize_given_name(
+pub(crate) fn initialize_given_name(
     given: &str,
     initialize_with: Option<&String>,
     initialize_with_hyphen: Option<bool>,
@@ -944,6 +946,52 @@ fn effective_suffix(raw_suffix: &str, strip_periods: bool) -> String {
     }
 }
 
+/// Determine how to render the given name based on `NameForm` and any
+/// disambiguation escalation.
+///
+/// `initialize-with` only controls the separator between initials, not
+/// whether to use initials at all; `name-form` controls the form.
+///
+/// Given-name disambiguation escalation (`expand_given_names`) bypasses the
+/// style's configured form entirely (including `FamilyOnly`) once it
+/// applies: the configured form is what already collided, so this position
+/// must show at least the escalated level to carry disambiguating weight.
+/// Mirrors the same ladder `append_givenname_resolution_key` uses to decide
+/// resolution, so key and render agree (csl26-h9jy). Not escalated at all
+/// (`expand_given_names: false`) renders exactly as before that fix.
+fn resolve_given_part(
+    given: &str,
+    ctx: &NameFormatContext,
+    expand_given_names: bool,
+    expand_given_names_full: bool,
+) -> String {
+    let baseline_name_form = ctx.name_form.unwrap_or(NameForm::Full);
+
+    // Escalation only ever raises the form (FamilyOnly < Initials < Full),
+    // never lowers it. Disambiguation hints are computed once against the
+    // citation-scope contributor config and shared with bibliography
+    // rendering (which commonly configures a different, often *more*
+    // revealing, baseline — e.g. Chicago's citation-scope `initials` vs its
+    // bibliography-scope default `full`). Without this floor, escalating to
+    // "Initials" here would wrongly downgrade a bibliography entry that was
+    // already rendering the full given name (csl26-h9jy).
+    let effective_name_form = if !expand_given_names {
+        baseline_name_form
+    } else if expand_given_names_full || baseline_name_form == NameForm::Full {
+        NameForm::Full
+    } else {
+        NameForm::Initials
+    };
+
+    match effective_name_form {
+        NameForm::FamilyOnly => String::new(),
+        NameForm::Initials => {
+            initialize_given_name(given, ctx.initialize_with, ctx.initialize_with_hyphen)
+        }
+        NameForm::Full => given.to_string(),
+    }
+}
+
 /// Format a single name.
 pub(crate) fn format_single_name(
     name: &crate::reference::FlatName,
@@ -951,6 +999,7 @@ pub(crate) fn format_single_name(
     index: usize,
     ctx: &NameFormatContext,
     expand_given_names: bool,
+    expand_given_names_full: bool,
 ) -> String {
     fn join_particle_family(particle: &str, family: &str) -> String {
         if particle.ends_with('-') {
@@ -1036,21 +1085,8 @@ pub(crate) fn format_single_name(
                 family.to_string()
             };
 
-            // Determine how to render the given name based on NameForm.
-            // initialize-with only controls the separator between initials, not whether
-            // to use initials at all. name-form controls the form.
-            let effective_name_form = match ctx.name_form {
-                Some(f) => f,
-                None => NameForm::Full,
-            };
-
-            let given_part = match effective_name_form {
-                NameForm::FamilyOnly => String::new(),
-                NameForm::Initials => {
-                    initialize_given_name(given, ctx.initialize_with, ctx.initialize_with_hyphen)
-                }
-                NameForm::Full => given.to_string(),
-            };
+            let given_part =
+                resolve_given_part(given, ctx, expand_given_names, expand_given_names_full);
 
             // Construct particle part (dropping + demoted non-dropping)
             let mut particle_part = String::new();

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -865,6 +865,12 @@ pub struct ProcHints {
     pub expand_given_names: bool,
     /// Whether to expand given names for primary author only.
     pub expand_given_names_primary_only: bool,
+    /// When `expand_given_names` is set, whether the expansion must escalate
+    /// past the style's configured given-name form (e.g. initials) to the
+    /// full given name to actually resolve the collision. Set when the
+    /// initials-level representation still collides (e.g. "Brandon" and
+    /// "Biff" both reduce to "B."). See csl26-h9jy.
+    pub expand_given_names_full: bool,
     /// Minimum number of names to show to resolve ambiguity (overrides et-al-use-first).
     pub min_names_to_show: Option<usize>,
     /// Citation number for numeric citation styles (1-based).

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -372,6 +372,7 @@ fn given_literal_short_name_when_first_integral_mention_then_parenthetical_form_
         0,
         &ctx,
         false,
+        false,
     );
 
     assert_eq!(result, "World Health Organization (WHO)");
@@ -388,6 +389,7 @@ fn given_literal_short_name_when_subsequent_integral_mention_then_short_form_ren
         &ContributorForm::Long,
         0,
         &ctx,
+        false,
         false,
     );
 
@@ -406,6 +408,7 @@ fn given_short_then_bracketed_option_when_first_integral_mention_then_bracketed_
         0,
         &ctx,
         false,
+        false,
     );
 
     assert_eq!(result, "WHO [World Health Organization]");
@@ -423,6 +426,7 @@ fn given_non_integral_context_when_integral_name_state_is_set_then_literal_short
         &ContributorForm::Long,
         0,
         &ctx,
+        false,
         false,
     );
 
@@ -1953,7 +1957,8 @@ fn test_demote_non_dropping_particle() {
         Some(&DemoteNonDroppingParticle::Never),
         None,
     );
-    let res_never = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let res_never =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(res_never, "van Beethoven, Ludwig");
 
     // Case 2: Display-and-sort (demote)
@@ -1967,7 +1972,8 @@ fn test_demote_non_dropping_particle() {
         Some(&DemoteNonDroppingParticle::DisplayAndSort),
         None,
     );
-    let res_demote = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let res_demote =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(res_demote, "Beethoven, Ludwig van");
 
     // Case 3: Sort-only (same as Never for display)
@@ -1982,7 +1988,7 @@ fn test_demote_non_dropping_particle() {
         None,
     );
     let res_sort_only =
-        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(res_sort_only, "van Beethoven, Ludwig");
 
     // Case 4: Not inverted (should be same for all)
@@ -1997,7 +2003,7 @@ fn test_demote_non_dropping_particle() {
         None,
     );
     let res_straight =
-        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(res_straight, "Ludwig van Beethoven");
 }
 
@@ -2020,7 +2026,8 @@ fn test_initialize_with_variants_for_multi_part_given_names() {
         None,
         None,
     );
-    let compact = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let compact =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(compact, "Kuhn, TS");
 
     let init_space = " ".to_string();
@@ -2033,7 +2040,8 @@ fn test_initialize_with_variants_for_multi_part_given_names() {
         None,
         None,
     );
-    let space = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let space =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(space, "Kuhn, T S");
 
     let init_dot = ".".to_string();
@@ -2046,7 +2054,7 @@ fn test_initialize_with_variants_for_multi_part_given_names() {
         None,
         None,
     );
-    let dot = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let dot = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(dot, "Kuhn, T.S.");
 
     let init_dot_space = ". ".to_string();
@@ -2059,7 +2067,8 @@ fn test_initialize_with_variants_for_multi_part_given_names() {
         None,
         None,
     );
-    let dot_space = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let dot_space =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(dot_space, "Kuhn, T. S.");
 }
 
@@ -2083,7 +2092,7 @@ fn test_initialize_with_hyphen_guard() {
         None,
     );
     let hyphen_default =
-        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(hyphen_default, "Kuhn, J.-P.");
 
     let ctx = make_name_format_context(
@@ -2096,7 +2105,7 @@ fn test_initialize_with_hyphen_guard() {
         None,
     );
     let hyphen_disabled =
-        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(hyphen_disabled, "Kuhn, J.");
 }
 
@@ -2113,7 +2122,8 @@ fn test_name_form_variants() {
 
     // Full: render complete given names
     let ctx = make_name_format_context(None, None, None, None, Some(NameForm::Full), None, None);
-    let full = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let full =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(full, "John David Smith");
 
     // FamilyOnly: suppress given names entirely
@@ -2127,7 +2137,7 @@ fn test_name_form_variants() {
         None,
     );
     let family_only =
-        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(family_only, "Smith");
 
     // Initials with explicit initialize_with
@@ -2141,14 +2151,15 @@ fn test_name_form_variants() {
         None,
         None,
     );
-    let initials = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let initials =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(initials, "J. D. Smith");
 
     // Initials with defaulted initialize_with (None → ". ")
     let ctx =
         make_name_format_context(None, None, None, None, Some(NameForm::Initials), None, None);
     let initials_default =
-        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(initials_default, "J. D. Smith");
 
     // Semantic split: name_form=None + initialize_with=Some → Full (not Initials).
@@ -2156,7 +2167,7 @@ fn test_name_form_variants() {
     // The migrator is responsible for co-emitting name_form: Initials with initialize_with.
     let ctx = make_name_format_context(None, None, Some(&init_str), None, None, None, None);
     let semantic_split =
-        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(semantic_split, "John David Smith");
 }
 
@@ -2174,7 +2185,8 @@ fn test_name_form_initials_hyphen_default_separator() {
     // Default separator ". " should produce "J.-P." not "J. -P."
     let ctx =
         make_name_format_context(None, None, None, None, Some(NameForm::Initials), None, None);
-    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let result =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(result, "J.-P. Sartre");
 }
 
@@ -4358,7 +4370,7 @@ fn test_sort_separator_space() {
         Some(&sep_space),
     );
     let result_space =
-        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(result_space, "Smith J");
 
     // Test with default (no sort_separator set): should produce "Smith, J" (with comma)
@@ -4372,7 +4384,7 @@ fn test_sort_separator_space() {
         None,
     );
     let result_default =
-        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(result_default, "Smith, J");
 }
 
@@ -4391,7 +4403,8 @@ fn test_suffix_uses_sort_separator_not_space() {
 
     let ctx =
         make_name_format_context(Some(DisplayAsSort::All), None, None, None, None, None, None);
-    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let result =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
     assert_eq!(result, "Smith, J., Jr.");
 }
 
@@ -4413,7 +4426,8 @@ fn katakana_names_use_script_delimiter_in_original_order() {
         make_name_format_context(None, None, None, None, Some(NameForm::Full), None, None);
     ctx.script_configs = Some(&scripts);
 
-    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let result =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
 
     assert_eq!(result, "マイケル・ジャクソン");
 }
@@ -4444,7 +4458,8 @@ fn katakana_names_use_script_sort_separator_when_inverted() {
     );
     ctx.script_configs = Some(&scripts);
 
-    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let result =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
 
     assert_eq!(result, "ジャクソン、マイケル");
 }
@@ -4472,8 +4487,14 @@ fn katakana_name_renders_correctly_in_both_orders() {
     let mut ctx_original =
         make_name_format_context(None, None, None, None, Some(NameForm::Full), None, None);
     ctx_original.script_configs = Some(&scripts);
-    let original =
-        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx_original, false);
+    let original = contributor::format_single_name(
+        &name,
+        &ContributorForm::Long,
+        0,
+        &ctx_original,
+        false,
+        false,
+    );
 
     let mut ctx_inverted = make_name_format_context(
         Some(DisplayAsSort::All),
@@ -4485,8 +4506,14 @@ fn katakana_name_renders_correctly_in_both_orders() {
         None,
     );
     ctx_inverted.script_configs = Some(&scripts);
-    let inverted =
-        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx_inverted, false);
+    let inverted = contributor::format_single_name(
+        &name,
+        &ContributorForm::Long,
+        0,
+        &ctx_inverted,
+        false,
+        false,
+    );
 
     assert_eq!(original, "マイケル・ジャクソン");
     assert_eq!(inverted, "ジャクソン、マイケル");
@@ -4511,7 +4538,8 @@ fn native_cjk_names_use_native_ordering_without_space() {
         make_name_format_context(None, None, None, None, Some(NameForm::Full), None, None);
     ctx.script_configs = Some(&scripts);
 
-    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let result =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
 
     assert_eq!(result, "北川善太郎");
 }
@@ -4535,7 +4563,8 @@ fn latin_names_ignore_unmatched_script_separators() {
         make_name_format_context(None, None, None, None, Some(NameForm::Full), None, None);
     ctx.script_configs = Some(&scripts);
 
-    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let result =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
 
     assert_eq!(result, "Michael Jackson");
 }
@@ -4567,7 +4596,8 @@ fn component_sort_separator_overrides_script_sort_separator() {
     ctx.script_configs = Some(&scripts);
     ctx.component_sort_separator = Some(&component_separator);
 
-    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let result =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
 
     assert_eq!(result, "ジャクソン / マイケル");
 }
@@ -4591,7 +4621,8 @@ fn mixed_kana_names_match_kana_config() {
         make_name_format_context(None, None, None, None, Some(NameForm::Full), None, None);
     ctx.script_configs = Some(&scripts);
 
-    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let result =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
 
     assert_eq!(result, "タロウ・やまだ");
 }
@@ -4623,7 +4654,8 @@ fn explicit_name_order_overrides_use_native_ordering() {
     );
     ctx.script_configs = Some(&scripts);
 
-    let result = contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false);
+    let result =
+        contributor::format_single_name(&name, &ContributorForm::Long, 0, &ctx, false, false);
 
     // Explicit given-first order wins over script use-native-ordering.
     assert_eq!(result, "善太郎北川");
@@ -4659,7 +4691,8 @@ fn native_ordering_applies_when_display_as_sort_is_set() {
     ctx.script_configs = Some(&scripts);
 
     // Index 1 — not inverted by display-as-sort:first; native ordering must apply.
-    let result = contributor::format_single_name(&name, &ContributorForm::Long, 1, &ctx, false);
+    let result =
+        contributor::format_single_name(&name, &ContributorForm::Long, 1, &ctx, false, false);
 
     assert_eq!(result, "北川善太郎");
 }

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -1194,6 +1194,95 @@ fn given_a_by_cite_style_with_an_et_al_collision_when_a_colliding_reference_is_c
     });
 }
 
+/// Regression for csl26-h9jy, mirroring the official CSL test suite's
+/// `disambiguate_ByCiteMinimalGivennameExpandMinimalNames.txt` fixture
+/// exactly (same names, same style shape: et-al-min 3, et-al-use-first 1,
+/// by-cite, initials baseline). Two references share their first and third
+/// authors verbatim (Albert Asthma; Charles/Curtis Cold differs only at
+/// position 3, never shown); only the second author (Brandon vs Biff
+/// Bronchitis) differs at a shown position, and both reduce to the same
+/// initial ("B."), so initials alone don't resolve it — full-name escalation
+/// is required.
+///
+/// **Known, intentional divergence from the oracle:** citeproc-js escalates
+/// only the one position that needs it —
+/// `"A. Asthma, Brandon Bronchitis, et al."` — because it tracks expansion
+/// per name position. Citum's `ProcHints.expand_given_names_full` is a
+/// per-reference flag, so it escalates every shown position uniformly,
+/// including position 1 (which gains nothing from it — both entries share
+/// the same person there). The citations still correctly differ overall,
+/// so this is verbose relative to the oracle, not a misdisambiguation.
+/// Per-position minimality is tracked separately as csl26-5753.
+fn disambiguation_givenname_escalation_reveals_every_shown_position_not_just_the_minimal_one() {
+    let input = vec![
+        make_book_multi_author(
+            "ambigs-16",
+            vec![
+                ("Asthma", "Albert"),
+                ("Bronchitis", "Brandon"),
+                ("Cold", "Charles"),
+            ],
+            1990,
+            "Book M",
+        ),
+        make_book_multi_author(
+            "ambigs-17",
+            vec![
+                ("Asthma", "Albert"),
+                ("Bronchitis", "Biff"),
+                ("Cold", "Curtis"),
+            ],
+            1990,
+            "Book M",
+        ),
+    ];
+    let citation_items = vec![vec!["ambigs-16", "ambigs-17"]];
+    let expected = "Albert Asthma, Biff Bronchitis, et al., (1990); Albert Asthma, Brandon Bronchitis, et al., (1990)";
+
+    run_test_case_native_with_options(common::TestCaseOptions {
+        input: &input,
+        citation_items: &citation_items,
+        expected,
+        mode: "citation",
+        disambiguate_year_suffix: false,
+        disambiguate_names: true,
+        disambiguate_givenname: true,
+        et_al_min: Some(3),
+        et_al_use_first: Some(1),
+    });
+}
+
+/// Regression for csl26-h9jy: `all-names-with-initials` and
+/// `primary-name-with-initials` must cap given-name escalation at initials —
+/// unlike the default `by-cite`/`all-names`/`primary-name` rules, they may
+/// never escalate to the full given name to resolve a same-initial collision
+/// (only these two `GivennameRule` variants say "(initials form)" in their
+/// doc comments). A same-initial collision under the cap must fall through
+/// to year-suffix instead.
+fn disambiguation_with_initials_rule_caps_escalation_at_initials() {
+    let input = vec![
+        make_book("smith-thomas", "Smith", "Thomas", 2000, "Book A"),
+        make_book("smith-ted", "Smith", "Ted", 2000, "Book B"),
+    ];
+    let mut bibliography = indexmap::IndexMap::new();
+    for reference in input {
+        let id = reference.id().expect("fixture id").to_string();
+        bibliography.insert(id, reference);
+    }
+    let processor = Processor::new(
+        build_author_date_style_with_givenname_rule(GivennameRule::AllNamesWithInitials),
+        bibliography,
+    );
+
+    let result = process_citation_ids(&processor, &["smith-thomas", "smith-ted"]);
+
+    // Suffix order follows the resolved bibliography sort (§3 of
+    // DISAMBIGUATION.md), not citation order — not this test's concern; the
+    // behavior under test is that no given name (not even an initial) is
+    // retained once the collision falls through to year-suffix.
+    assert_eq!(result, "Smith, (2000b); Smith, (2000a)");
+}
+
 /// Test given name expansion with initial form (`initialize_with`).
 fn disambiguation_initials_are_used_when_short_form_family_names_collide() {
     let input = vec![
@@ -1211,9 +1300,15 @@ fn disambiguation_initials_are_used_when_short_form_family_names_collide() {
     // Within the Doe collision group, output order follows the author sort
     // key (family, then given), not citation-item registration order: with
     // the family name tied, "Aloysius" sorts before "John".
+    //
+    // Thomas/Ted Smith share an initial ("T."), so initials alone don't
+    // resolve the collision — the escalation ladder continues to the full
+    // given name (csl26-h9jy), matching the official CSL test suite's
+    // disambiguate_ByCiteGivennameShortFormInitializeWith fixture exactly
+    // ("Thomas Smith; Ted Smith").
     let expected = "Roe, (2000)
 A Doe, (2000); J Doe, (2000)
-T Smith, (2000); T Smith, (2000)";
+Ted Smith, (2000); Thomas Smith, (2000)";
 
     run_test_case_native_with_options(common::TestCaseOptions {
         input: &input,
@@ -2660,9 +2755,25 @@ mod disambiguation {
     }
 
     #[test]
+    fn givenname_escalation_reveals_every_shown_position_not_just_the_minimal_one() {
+        announce_behavior(
+            "A same-initial collision escalates to the full given name at every shown position, not just the one position that needs it — verbose relative to citeproc-js's per-position minimality (csl26-5753), but not a misdisambiguation.",
+        );
+        super::disambiguation_givenname_escalation_reveals_every_shown_position_not_just_the_minimal_one();
+    }
+
+    #[test]
+    fn with_initials_rule_caps_escalation_at_initials() {
+        announce_behavior(
+            "all-names-with-initials and primary-name-with-initials must never escalate a same-initial collision to the full given name — they fall back to year-suffix instead.",
+        );
+        super::disambiguation_with_initials_rule_caps_escalation_at_initials();
+    }
+
+    #[test]
     fn initials_are_used_when_short_form_family_names_collide() {
         announce_behavior(
-            "Short-form family-name collisions should expand to initials when that is the configured fallback.",
+            "Short-form family-name collisions should expand to initials when that is the configured fallback, escalating to the full given name when initials alone still collide.",
         );
         super::disambiguation_initials_are_used_when_short_form_family_names_collide();
     }


### PR DESCRIPTION
**Fixes csl26-h9jy: `disambiguate-add-givenname` silently rendered two different authors identically whenever their given names shared an initial.**

## Summary

Found while investigating csl26-5753 (by-cite per-position minimality). Reproduced with a style using `contributors.name-form: initials` + `disambiguate.add-givenname: true` — an ordinary, common combination, nothing by-cite-specific:

```
Two authors: Brandon Bronchitis vs Biff Bronchitis (both reduce to "B.")
Rendered: "A Asthma, B Bronchitis, et al." for BOTH — identical, no
disambiguator, no fallback to year-suffix.
```

`check_givenname_resolution`/`append_givenname_resolution_key`
(`processor/disambiguation.rs`) built the collision-resolution key from the
raw full given-name string, assuming "expanding given names" reveals the
full name and will discriminate. But rendering only ever showed whatever
form the style configured (often initials) — the key said "resolved," the
render said "still identical," and the cascade never reached year-suffix.
Confirmed against the official CSL test suite's
`disambiguate_ByCiteMinimalGivennameExpandMinimalNames.txt` and sibling
fixtures: real CSL resolves this via an escalation ladder (family-only →
initials → full given name), stopping at the first level that splits the
group.

## Scope

- `crates/citum-engine/src/processor/disambiguation.rs` — added the
  escalation ladder (`GivennameLevel`, `resolve_givenname_level`); the
  collision key now uses the same representation the renderer would
  actually produce at each level.
- `crates/citum-engine/src/values/contributor/names.rs` — rendering applies
  the escalated level. **Capped for `all-names-with-initials` /
  `primary-name-with-initials`**, which must never escalate past initials
  (only these two `GivennameRule` doc comments say "(initials form)").
  Escalation only ever *raises* the rendering context's own configured form,
  never lowers it — hints are shared between citation and bibliography
  rendering, which commonly configure different baselines (e.g. Chicago
  author-date: citation-scope `initials`, bibliography-scope `full`); this
  was caught by the full-corpus sweep and fixed before landing.
- `crates/citum-engine/src/values/mod.rs` — `ProcHints` gained
  `expand_given_names_full: bool` alongside the existing
  `expand_given_names`.
- Tests: 3 new native regressions (same-initial escalation mirroring the
  official fixture exactly, the `-with-initials` cap falling to year-suffix,
  and a differing-initials control proving no over-escalation) plus one
  existing test whose old assertion had encoded the bug as correct — now
  matches `disambiguate_ByCiteGivennameShortFormInitializeWith.txt` exactly.

## Validation

- `just pre-commit` clean: fmt, clippy `-D warnings`, `cargo nextest run`
  (2587 tests, full workspace).
- Targeted `report-core.js` on all 8 embedded/community styles that could
  reach `disambiguate-add-givenname` (apa-7th, elsevier-harvard,
  chicago-author-date-18th, elsevier-vancouver-author-date,
  gb-t-7714-2025-author-date, harvard-cite-them-right,
  modern-language-association, taylor-and-francis-cse) — exactParity/compat
  byte-identical before/after.
- Full sandboxed corpus sweep (`report-core.js --all-features`) — 0
  regressions across all 35 exemplar styles (before/after via detached
  worktree).
- Ad hoc (not committed as a fixture — see below): added a temporary
  same-initial pair (Marcus/Miriam Whitfield, same year) to
  `references-expanded.json`/`citations-expanded.json` and ran
  `report-core.js` per-style. Post-fix, `chicago-author-date-18th` and
  `apa-7th` matched the citeproc-js oracle byte-for-byte
  (`Marcus Whitfield 2022; Miriam Whitfield 2022`); pre-fix (this branch's
  parent, `codex/csl26-8nrt-disambiguation-engine-scope`), both collapsed
  to `M. Whitfield 2022; M. Whitfield 2022`. `harvard-cite-them-right`,
  `elsevier-harvard`, `modern-language-association` also escalated
  correctly but didn't byte-match, due to pre-existing unrelated
  divergences (name-order, MLA's disambiguate-only short-title strategy).
  Reverted before committing: `references-expanded.json` is the default
  fixture for nearly the entire corpus, so a 2-entry addition regenerated
  ~2,845 citeproc-js oracle snapshots (~186k lines) for one already-covered
  bug. The native regression tests above are the permanent guard; this was
  one-time confirmation the fix behaves correctly against real embedded
  styles, not a fixture worth carrying forward at that cost.

## Known, intentional divergence from the oracle

Real CSL escalates only the *one* name position that needs it (per-position
minimality). Citum's `expand_given_names_full` is a per-reference flag, so
it escalates every shown position uniformly — verbose relative to the
oracle in some cases, but never a misdisambiguation (citations still
correctly differ overall). Per-position minimality remains **csl26-5753**'s
scope, the reason this investigation started.

## Follow-ups

- `csl26-5753` — real by-cite position-minimal expansion (unblocked by this
  fix; building it on the pre-fix collision-key logic would have inherited
  this same bug).

