### PR TITLE
docs+scripts: fixture-change fan-out audit and tooling

### DIFF
--- a/.beans/archive/csl26-nrks--fixture-cache-invalidation-is-whole-file-not-per-e.md
+++ b/.beans/archive/csl26-nrks--fixture-cache-invalidation-is-whole-file-not-per-e.md
@@ -1,0 +1,123 @@
+---
+# csl26-nrks
+title: Fixture-cache invalidation is whole-file, not per-entry
+status: completed
+type: task
+priority: normal
+tags:
+    - test-infrastructure
+    - scripts
+    - architecture
+created_at: 2026-08-16T23:42:13Z
+updated_at: 2026-08-17T00:16:52Z
+---
+
+Found while adding a regression fixture for csl26-h9jy (a same-initial
+givenname-disambiguation bug). Adding 2 harmless reference entries to
+tests/fixtures/references-expanded.json -- referenced by no existing
+citation of any other style -- regenerated ~2,845 citeproc-js oracle
+snapshots (~186k lines) and cascaded into three more independently
+pinned baselines going stale in sequence, each discovered only by a
+separate CI job going red. Dropped that fixture change entirely rather
+than carry the cost (see PR #1201 / bean csl26-h9jy's "Follow-up
+verification (not committed)" note) -- the bug already had full native
+Rust regression-test coverage, so nothing was actually lost by not
+committing the fixture. But the *mechanism* is worth fixing on its own
+merits, independent of that specific bug.
+
+## Root cause 1: whole-file hash, not per-entry
+
+`scripts/oracle-snapshot.js`'s cache key is a single SHA-256 over the
+*entire contents* of both fixture files concatenated:
+
+```js
+function fixtureHash(refsFixture, citationsFixture) {
+  const h = crypto.createHash('sha256');
+  h.update(fs.readFileSync(refsFixture));
+  h.update(fs.readFileSync(citationsFixture));
+  return h.digest('hex').slice(0, 16);
+}
+```
+
+`references-expanded.json` is `DEFAULT_REFS_FIXTURE` in
+scripts/lib/style-verification.js -- the fallback for every style
+without an explicit `fixture_family`, i.e. nearly the whole corpus.
+Any single-byte change anywhere in either fixture file invalidates
+every style's cached snapshot, regardless of whether that style's
+citations reference anything that changed. The invalidation key is
+coarser than the actual unit of change (which citation/reference IDs
+a given style's fixture entries actually touch).
+
+## Root cause 2: no single regeneration entrypoint
+
+A fixture edit fans out into at least four independently-pinned
+artifacts, discoverable only by pushing and watching CI fail one job
+at a time:
+1. tests/snapshots/csl/*.json (oracle-snapshot.js --all)
+2. Registered coverage-audit manifests' pinned fixture hashes
+   (docs/architecture/audits/*/manifest.yaml, via
+   style-coverage-review.js --update-manifest)
+3. scripts/report-data/embedded-parity-baseline.json (hand-assembled
+   from a report-core.js --all-features run; no dedicated generator
+   script found)
+4. scripts/report-data/oracle-top10-baseline.json (a *separate* tool,
+   oracle-batch-aggregate.js, against raw styles-legacy/ CSL)
+
+The `oracle-refresh` just recipe (`node scripts/oracle-batch-aggregate.js
+styles-legacy/ --top 10`) doesn't even pass `--save`, so it doesn't
+actually write the baseline it's presumably named to refresh.
+
+## Root cause 3 (unconfirmed -- needs someone with history context)
+
+embedded-parity-baseline.json (built from report-core.js, tier=embedded
+styles) and oracle-top10-baseline.json (built from oracle-batch-aggregate.js,
+raw styles-legacy/ CSL) track overlapping citation/bibliography
+pass-counts for overlapping style sets, via two independent code paths
+with two different JSON shapes, checked by two different scripts in two
+different CI steps. Could be intentional (one exercises the migration
+pipeline end-to-end, the other the already-embedded style directly) or
+accidental duplication from two separate initiatives -- not verified
+either way this session.
+
+## Scope
+- [x] Investigated whole-file hash re-keying -- REFUTED, not fixed. Measured:
+      `oracle-snapshot.js` calls `engine.updateItems(Object.keys(testItems))`,
+      so citeproc-js renders every fixture entry into every style's
+      bibliography (apa: 46/47 rows, 29 never cited). Adding/editing any
+      entry in the shared default genuinely changes every snapshot; the
+      whole-file hash is the correct granularity, not too coarse. Full
+      writeup, measurement, and rejected alternatives in
+      docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md. The
+      actionable outcome is a policy, not code: put regression fixtures in a
+      scoped fixture family (`FIXTURE_SET_REFS` in
+      scripts/lib/style-verification.js), not the shared default.
+- [x] Added `just fixture-refresh` (justfile) -- single entrypoint for
+      snapshots + coverage-audit manifests always, plus the two ratcheted
+      baselines behind an explicit `baselines=yes` flag (they stay
+      dedicated-PR-only per baselines/README.md).
+- [x] Audited embedded-parity-baseline.json vs oracle-top10-baseline.json --
+      confirmed intentional, not duplication: one exercises the migration
+      pipeline against raw styles-legacy/ CSL, the other gates hand-tuned
+      embedded YAML directly. Documented in the audit so it doesn't need
+      re-deriving. Keeping both.
+- [x] Fixed `just oracle-refresh` -- now passes `--save` and drives its style
+      list from the baseline's own `metadata.styles` instead of `--top 10`,
+      so it actually writes the file it claims to refresh and refreshes the
+      same style set `check-oracle-regression.js` checks against.
+
+## Summary of Changes
+
+- `docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md` -- full
+  investigation, measurement, rejected alternatives, and fan-out map.
+- `scripts/derive-parity-baseline.js` (+ test) -- new generator for
+  `embedded-parity-baseline.json`, which previously had none.
+- `justfile` -- fixed `oracle-refresh`; added `fixture-refresh` fan-out
+  recipe.
+- `baselines/README.md` -- points at the new recipe.
+- No fixture, snapshot, manifest, or baseline was regenerated in this PR.
+
+Follow-ups filed rather than folded in: `csl26-u87d` (2 styles fail
+oracle-snapshot rendering with a locale-loading error), `csl26-y36e`
+(blocked by `csl26-u87d`; ~2,800 stale version-1 snapshots need a dedicated
+regeneration commit -- discovered via a real `just fixture-refresh` dry run
+that was reverted before committing).

--- a/.beans/csl26-u87d--oracle-snapshotjs-locale-loading-error-on-etudes-c.md
+++ b/.beans/csl26-u87d--oracle-snapshotjs-locale-loading-error-on-etudes-c.md
@@ -1,0 +1,23 @@
+---
+# csl26-u87d
+title: 'oracle-snapshot.js: locale-loading error on etudes-chinoises and organon'
+status: todo
+type: bug
+priority: normal
+tags:
+    - test-infrastructure
+    - scripts
+    - oracle
+created_at: 2026-08-17T00:16:14Z
+updated_at: 2026-08-17T00:16:21Z
+---
+
+node scripts/oracle-snapshot.js --all fails on 2 of 2844 styles-legacy/*.csl with
+"Cannot read properties of undefined (reading 'strings')": etudes-chinoises.csl
+and organon.csl. Both are French-language styles; the error looks like a
+locale-loading gap in renderWithCiteprocJs / loadLocale (scripts/oracle-utils.js),
+not a citeproc-js style-parsing failure per se, but not root-caused this session.
+
+Found while verifying the fixture-refresh fan-out entrypoint added in
+csl26-nrks (see docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md,
+"Known pre-existing gap"). Blocks a full --all snapshot run from exiting 0.

--- a/.beans/csl26-y36e--regenerate-stale-version-1-oracle-snapshots.md
+++ b/.beans/csl26-y36e--regenerate-stale-version-1-oracle-snapshots.md
@@ -1,0 +1,32 @@
+---
+# csl26-y36e
+title: Regenerate stale version-1 oracle snapshots
+status: todo
+type: task
+priority: low
+tags:
+    - test-infrastructure
+    - scripts
+    - oracle
+created_at: 2026-08-17T00:16:28Z
+updated_at: 2026-08-17T00:16:31Z
+blocked_by:
+    - csl26-u87d
+---
+
+scripts/oracle-snapshot.js's SNAPSHOT_VERSION is 2 (adds bibliography_ids),
+but a large share of tests/snapshots/csl/*.json on disk are still version 1
+and were never regenerated after the bump -- isSnapshotCurrent() correctly
+flags them stale, so any --all run rewrites thousands of files at once.
+
+Found while verifying the fixture-refresh fan-out entrypoint added in
+csl26-nrks (docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md,
+"Known pre-existing gap"): a real no-op `just fixture-refresh` run wrote
+2,812 of 2,844 snapshots (170k+ insertions), which is out of proportion to
+review in that tooling PR, so it was reverted there rather than committed.
+
+Blocked by csl26-u87d (2 styles fail to render entirely -- fix that first
+so a full regeneration can exit 0). Regenerating is mechanical
+(`node scripts/oracle-snapshot.js --all`) but the ~2,800-file diff needs a
+dedicated, reviewed commit per the same reasoning baselines/README.md gives
+for baseline refreshes.

--- a/.claude/skills/test-coverage/SKILL.md
+++ b/.claude/skills/test-coverage/SKILL.md
@@ -235,10 +235,28 @@ If a bug report involves one of these types, add a fixture item first.
 
 ## Adding fixture data
 
-When the audit reveals a missing shape, add to
-`tests/fixtures/references-expanded.json` (for core oracle coverage) or to
-the appropriate domain fixture. Use sequential `ITEM-N` IDs in the expanded
-fixture.
+**First decide whether this belongs in the shared default at all.** Every
+entry in `tests/fixtures/references-expanded.json` renders into all ~2,845
+`tests/snapshots/csl/*.json` oracle snapshots (`oracle-snapshot.js` loads the
+full entry set for every legacy style), so any edit to that file is a
+corpus-wide diff — hundreds of thousands of lines — no matter how small the
+change looks. See
+[docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md](../../../docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md).
+
+- **Narrow bug regression** (one style, or a handful): do not touch the
+  shared default. Use a native Rust test instead (no CSL-JSON round-trip —
+  see "Test Style" above), or, if oracle coverage is genuinely needed, a
+  fixture scoped to a `fixture_family` (`scripts/lib/style-verification.js`)
+  consumed only by the smaller `report-core.js` measurement set. Either way:
+  zero snapshot churn.
+- **Genuine corpus-wide coverage gap** (a reference-type shape or citation
+  scenario the whole legacy corpus should exercise): add to
+  `references-expanded.json` or the appropriate domain fixture as below. This
+  is a deliberate, reviewed, corpus-wide change — give it its own commit and
+  follow with `just fixture-refresh` (`just fixture-refresh yes` if it also
+  moves a ratcheted baseline floor).
+
+When it is the latter, use sequential `ITEM-N` IDs in the expanded fixture.
 
 After adding items:
 1. Update `tests/fixtures/coverage-manifest.json` under `reference_types`

--- a/baselines/README.md
+++ b/baselines/README.md
@@ -146,3 +146,16 @@ node scripts/check-core-quality.js \
 
 Refresh committed baselines only in dedicated baseline PRs with a short
 before/after summary and justification for the reset.
+
+## Fixture-Change Fan-Out
+
+Editing `tests/fixtures/references-expanded.json` or
+`tests/fixtures/citations-expanded.json` (the corpus-wide defaults) fans out
+into oracle snapshots, registered coverage-audit manifests, and — only when
+the change is an intended, reviewed baseline reset — the two ratcheted floors
+above. `just fixture-refresh` is the single entrypoint for that fan-out (run
+`just fixture-refresh yes` to also touch the ratcheted floors); see
+[docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md](../docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md)
+for the full map and why a scoped fixture family
+(`scripts/lib/style-verification.js`'s `FIXTURE_SET_REFS`) is usually the
+better target for a new regression fixture than the shared default.

--- a/docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md
+++ b/docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md
@@ -1,0 +1,232 @@
+# Fixture-Change Fan-Out: How to Add a Fixture Without a Corpus-Wide Diff
+
+- **Date:** 2026-08-16
+- **Bean:** `csl26-nrks`
+- **Question:** adding 2 harmless reference entries to
+  `tests/fixtures/references-expanded.json` while working `csl26-h9jy`
+  regenerated ~2,845 citeproc-js oracle snapshots (~186k lines) and then
+  cascaded into three more independently-pinned baselines going stale one CI
+  job at a time, each discovered only when a separate CI job went red. Why
+  does a 2-entry change produce a 187k-line diff, and how do we stop that
+  from happening again?
+
+## The answer: it's where you add the entry, not the cache key
+
+`oracle-snapshot.js`'s cache key (`fixtureHash`, `:103`) hashes exactly two
+files: the shared default references and citations fixtures. Nothing else is
+an input. An entry added to any *other* file — a fixture scoped to a
+`fixture_family`, or a native Rust test with no CSL-JSON fixture at all — is
+therefore never read by that hash, and **zero of the 2,845 snapshots
+invalidate**. The 187k-line diff wasn't a caching bug; it was a consequence
+of adding the entries to `references-expanded.json`, which every one of
+those 2,845 legacy styles' oracle snapshots is generated against.
+
+**The lever that controls blast radius already existed and was simply not
+used: a regression entry belongs in a scoped fixture family, never in the
+shared default.** `scripts/lib/style-verification.js` already defines
+`FIXTURE_SET_REFS` / `FIXTURE_SET_CITATIONS` (`humanities-note`,
+`secondary-roles`, and others), selected per style via `fixture_family` in
+`scripts/report-data/verification-policy.yaml`. `references-expanded.json` is
+`DEFAULT_REFS_FIXTURE` — the fallback for every style without an explicit
+family, i.e. nearly the whole corpus. Editing it is, by definition, a
+corpus-wide change; that was true before this audit and remains true after.
+A same-initials givenname-disambiguation regression fixture like the one
+that prompted this bean belongs in a family fixture (or a new one) scoped to
+the style(s) it's regressing, not in the shared default — or, since the bug
+already had full native Rust regression coverage, no oracle fixture at all.
+
+This is now the enforced default: `.claude/skills/test-coverage/SKILL.md`'s
+"Adding fixture data" section, which previously told contributors to add to
+`references-expanded.json` unconditionally, now leads with this decision
+rule.
+
+The rest of this document is supporting evidence for that answer (why
+re-keying the cache instead wouldn't have helped) and the separate fan-out
+and baseline-duplication questions the bean also raised.
+
+## Why re-keying the cache wouldn't have helped
+
+The bean's original hypothesis was that `scripts/oracle-snapshot.js`'s cache
+key — a single SHA-256 over the entire contents of both fixture files — is
+coarser than the real unit of change, and that re-keying it
+per-style-per-citation-id (or at minimum per referenced entry-set) would make
+a fixture addition scale with what actually changed rather than with corpus
+size. That's a different fix from "add it elsewhere," and it doesn't hold up
+on its own terms: it's not that the hash is wrong, it's that *every entry in
+the shared default is a real input to every style's rendered bibliography*,
+so no cache key over that file's contents can be narrower than "changed."
+
+`renderWithCiteprocJs` (`scripts/oracle-snapshot.js:166`) calls:
+
+```js
+const engine = new CSL.Engine(sys, styleXml);
+engine.updateItems(Object.keys(testItems));
+```
+
+`updateItems` is called with **every ID in the loaded references fixture**,
+not the IDs a style's citations actually reference. citeproc-js therefore
+renders a bibliography row for every fixture entry, cited or not, for every
+style. Measured directly against the committed snapshot:
+
+```
+$ node -e "
+const refs = require('./tests/fixtures/references-expanded.json');
+const ids = Object.keys(refs).filter(k => k !== 'comment');
+const cites = require('./tests/fixtures/citations-expanded.json');
+const used = new Set();
+for (const c of cites) for (const i of c.items) used.add(i.id || i);
+const snap = require('./tests/snapshots/csl/apa.json');
+console.log('refs entries:', ids.length);
+console.log('citations:', cites.length, 'distinct cited ids:', used.size);
+console.log('apa bibliography rows:', snap.bibliography.length);
+console.log('bib rows never cited:', snap.bibliography_ids.filter(id => !used.has(id)).length);
+"
+refs entries: 47
+citations: 20 distinct cited ids: 17
+apa bibliography rows: 46
+bib rows never cited: 29
+```
+
+47 fixture entries produce 46 bibliography rows (one entry is filtered by the
+style), and 29 of those 46 rows — nearly two-thirds — belong to references no
+citation in `citations-expanded.json` ever mentions. They exist purely to
+give the oracle bibliography-only reference-type coverage (dates, contributor
+role combinations, unusual field shapes) that the citation set doesn't
+exercise. Since every style's bibliography is rendered from the full entry
+set, adding, removing, or editing **any** entry in
+`references-expanded.json` genuinely changes every style's rendered output.
+The whole-file hash over that fixture is the correct granularity for what it
+protects — not an over-eager invalidation.
+
+### Rejected alternatives
+
+**Scope `updateItems()` to cited IDs only.** This would let the cache key
+narrow to the entries a style's citations actually touch. Cost: bibliography
+rendering would drop from 46 rows to 17 (the distinct cited IDs) per style,
+for every one of the ~2,845 snapshots — destroying exactly the uncited
+reference-type coverage the fixture was built to carry, and still requiring
+a one-time rewrite of all 2,845 snapshots to apply the narrower rendering.
+Rejected: it trades away test coverage to buy a caching property nothing
+downstream currently needs.
+
+**Canonicalize the hash input instead of hashing raw bytes.** `loadFixtures`
+(`scripts/oracle-snapshot.js:144`) already strips the fixture's `comment` key
+before use, but `fixtureHash` (`:103`) hashes the raw file bytes, so editing
+`comment`, reordering keys, or reformatting whitespace still invalidates
+every snapshot even though nothing citeproc-js sees has changed. This is a
+real, narrow gap — but closing it only protects non-semantic edits; it does
+nothing for the case that actually triggered this bean (adding real entries),
+and still costs a one-time rewrite of all 2,845 snapshots to re-pin the new
+hash. Left as a candidate for a future PR, not bundled here since it doesn't
+address the bean's original incident.
+
+## The fan-out map (Root cause 2)
+
+A fixture edit — scoped or not — still fans out into independently-pinned
+artifacts, previously discoverable only by pushing and watching CI fail one
+job at a time:
+
+1. `tests/snapshots/csl/*.json` — regenerated by `oracle-snapshot.js --all`.
+2. Registered coverage-audit manifests
+   (`docs/architecture/audits/*/manifest.yaml`, registered in
+   `scripts/report-data/report-provenance.yaml`'s `coverage_audits` list) —
+   each manifest pins `fixtures.references.sha256` **and**
+   `expected-observations`, both of which move when a referenced fixture
+   moves. An entrypoint to regenerate these already existed but wasn't wired
+   into a single command: `scripts/refresh-style-coverage-audits.js` iterates
+   every registration and re-runs `style-coverage-review.js` for each.
+3. `scripts/report-data/embedded-parity-baseline.json` — hand-assembled from
+   a `report-core.js --all-features` run; no generator script existed before
+   this change (see below).
+4. `scripts/report-data/oracle-top10-baseline.json` — written by
+   `oracle-batch-aggregate.js --save`, but the `just oracle-refresh` recipe
+   that's presumably meant to drive it never passed `--save` (fixed in this
+   change; see the companion `justfile` diff).
+
+This change adds `just fixture-refresh` as the single entrypoint that owns
+steps 1–4 (baselines 3 and 4 gated behind the explicit
+`just fixture-refresh yes` form — see "What did not change" below), and
+`scripts/derive-parity-baseline.js` as the missing generator for artifact 3.
+
+## Root cause 3, answered: the two baselines measure different pipelines, not the same thing twice
+
+`oracle-top10-baseline.json` and `embedded-parity-baseline.json` track
+overlapping citation/bibliography pass-counts for overlapping style *names*
+(`apa`/`apa-7th`, `ieee`, `cell`/`elsevier-*`), via two different code paths,
+checked by two different CI steps — which looked like it could be accidental
+duplication from two separate initiatives. It isn't:
+
+- `oracle-top10-baseline.json` is written by `oracle-batch-aggregate.js`
+  running against **raw `styles-legacy/*.csl`** for the 10 hard-pinned
+  `PRIORITY_STYLES` (`oracle-batch-aggregate.js:31-49`). Its metadata records
+  `styleSelector: "explicit"` with that pinned style list — it exercises the
+  **migration pipeline end-to-end**: legacy CSL 1.0 XML → `citum-migrate` →
+  render, and catches migration-converter regressions.
+- `embedded-parity-baseline.json` is written from `report-core.js
+  --all-features`, filtered to `tier === "embedded"` — the 19 curated,
+  hand-tuned `styles/embedded/*.yaml` files. It gates exact-parity floors on
+  the **already-migrated, hand-authored style** directly, with no migration
+  step in the loop, and is what `check-core-quality.js --parity-baseline`
+  enforces per `docs/architecture/audits/2026-07-31_EXACT_PARITY_REFOCUS.md`.
+
+Same author styles, same oracle (citeproc-js), different subject under test.
+Verdict: **keep both**, and this document is the confirmation that the split
+is intentional rather than an artifact of scope drift, so a future audit
+doesn't need to re-derive it.
+
+## What changed
+
+- `scripts/derive-parity-baseline.js` (new) — generates
+  `embedded-parity-baseline.json` from a `report-core.js --all-features`
+  report, closing the "no dedicated generator script found" gap in fan-out
+  artifact 3. Reproduces the file's existing shape field-for-field
+  (`generated`/`commit`/`source`/`purpose`/`styles{...}`), since
+  `.github/workflows/fidelity.yml` and `check-core-quality.js` both read that
+  shape positionally.
+- `justfile`: `oracle-refresh` now passes `--save` and derives its style list
+  from the baseline's own `metadata.styles` instead of `--top 10`, so a
+  refresh actually writes the file it claims to refresh, and refreshes the
+  same style set the regression check (`check-oracle-regression.js`) verifies
+  against.
+- `justfile`: new `fixture-refresh` recipe — the single fan-out entrypoint
+  described above.
+
+## What did not change
+
+- The whole-file hash in `fixtureHash` (`scripts/oracle-snapshot.js:103`) —
+  confirmed correct for the entries it protects; see "Why re-keying the cache
+  wouldn't have helped" above.
+- `embedded-parity-baseline.json` and `oracle-top10-baseline.json` remain two
+  files — confirmed intentional; see "Root cause 3" above.
+- `baselines/README.md`'s policy that the two ratcheted CI floors are
+  refreshed "only in dedicated baseline PRs with a short before/after summary
+  and justification" — `fixture-refresh` still requires the explicit
+  `just fixture-refresh yes` form to touch either one; it does not make
+  refreshing them casual.
+- No fixture file, snapshot, manifest, or baseline was regenerated by this
+  change itself — this is tooling and documentation only.
+
+## Known pre-existing gap surfaced while verifying this change
+
+Running `node scripts/oracle-snapshot.js --all` end-to-end (to verify
+`fixture-refresh`) found two styles that currently fail to render and were
+never regenerated after the snapshot format moved to `version: 2`:
+`etudes-chinoises.csl` and `organon.csl`, both failing with `Cannot read
+properties of undefined (reading 'strings')` — a locale-loading error,
+unrelated to this change. The full snapshot corpus also still contains a
+large number of stale `version: 1` entries predating that bump. Neither is
+addressed here (reproducing and fixing the locale bug is a separate task; a
+full corpus regeneration is exactly the kind of large, reviewed change this
+audit's fan-out tooling exists to make deliberate, not something to fold
+into a tooling PR). Filed as follow-up work, not fixed in place: bean
+`csl26-u87d` for the locale-loading error, `csl26-y36e` (blocked by
+`csl26-u87d`) for the version-1 snapshot regeneration.
+
+## Adjacent, not absorbed
+
+Bean `csl26-fvpo` ("oracle-snapshot: include locale files in staleness hash")
+is a related but distinct gap in the same cache key — snapshots are keyed on
+`fixture_hash + csl_hash` only, so editing `scripts/locales-*.xml` silently
+leaves stale snapshots that citeproc-js would render differently. Left
+tracked separately rather than folded in here, since it's a different input
+to the same key, not a fan-out or granularity question.

--- a/justfile
+++ b/justfile
@@ -74,9 +74,15 @@ check-core-quality:
 check-style-coverage-audits:
     node scripts/check-style-coverage-audits.js
 
-# Refresh Top-10 oracle aggregate baselines
+# Refresh the Top-10 oracle aggregate baseline: writes
+# scripts/report-data/oracle-top10-baseline.json (previously this recipe never passed --save,
+# so it measured but never refreshed anything). Reuses the style list already pinned in the
+# baseline's own metadata.styles rather than --top 10, so the refreshed file stays in sync with
+# the exact style set check-oracle-regression.js verifies against.
 oracle-refresh:
-    node scripts/oracle-batch-aggregate.js styles-legacy/ --top 10
+    node scripts/oracle-batch-aggregate.js styles-legacy/ \
+        --styles "$(node -e "process.stdout.write(require('./scripts/report-data/oracle-top10-baseline.json').metadata.styles.join(','))")" \
+        --save scripts/report-data/oracle-top10-baseline.json
 
 # Discover recurring per-concern config shapes across the legacy CSL corpus that no named
 # preset covers (contributors, dates, titles, locators) — a worklist for citum-schema-style presets.

--- a/justfile
+++ b/justfile
@@ -84,6 +84,30 @@ oracle-refresh:
         --styles "$(node -e "process.stdout.write(require('./scripts/report-data/oracle-top10-baseline.json').metadata.styles.join(','))")" \
         --save scripts/report-data/oracle-top10-baseline.json
 
+# Regenerate every artifact a tests/fixtures/ change invalidates (see
+# docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md): oracle snapshots and
+# registered coverage-audit manifests always; the two ratcheted CI-floor baselines
+# (embedded-parity-baseline.json, oracle-top10-baseline.json) only when baselines=yes, since
+# baselines/README.md restricts those refreshes to dedicated, reviewed baseline PRs. Concurrency
+# defaults low — corpus-wide sweeps at default concurrency have crashed lower-memory machines.
+# oracle-snapshot.js currently exits non-zero on 2 pre-existing, tracked-elsewhere failures
+# (csl26-u87d); that's allowed to fail this line without aborting the rest of the fan-out, since
+# neither failing style appears in any gated baseline below.
+fixture-refresh baselines="no":
+    node scripts/oracle-snapshot.js --all --concurrency 2 \
+        || echo "warning: oracle-snapshot.js reported failures -- see csl26-u87d" >&2
+    node scripts/refresh-style-coverage-audits.js
+    if [ "{{baselines}}" = "yes" ]; then \
+        node scripts/report-core.js --all-features > /tmp/fixture-refresh-report.json && \
+        node scripts/derive-parity-baseline.js \
+            --report /tmp/fixture-refresh-report.json \
+            --out scripts/report-data/embedded-parity-baseline.json && \
+        just oracle-refresh; \
+    fi
+    just check-core-quality
+    node scripts/check-oracle-regression.js --baseline scripts/report-data/oracle-top10-baseline.json
+    just check-style-coverage-audits
+
 # Discover recurring per-concern config shapes across the legacy CSL corpus that no named
 # preset covers (contributors, dates, titles, locators) — a worklist for citum-schema-style presets.
 analyze-presets styles="styles-legacy":

--- a/scripts/derive-parity-baseline.js
+++ b/scripts/derive-parity-baseline.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * scripts/derive-parity-baseline.js
+ *
+ * Derives scripts/report-data/embedded-parity-baseline.json from a
+ * `report-core.js --all-features` report. The baseline previously had no
+ * generator — it was hand-assembled from a report run — which made it one of
+ * the pinned artifacts left out of scope when tests/fixtures/ changes (see
+ * docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md).
+ *
+ * Output shape must match the existing committed file field-for-field:
+ * `.github/workflows/fidelity.yml` and `check-core-quality.js
+ * --parity-baseline` both read `styles[].exactParity.{passed,total}`.
+ *
+ * Usage:
+ *   node scripts/report-core.js --all-features > /tmp/core-report.json
+ *   node scripts/derive-parity-baseline.js \
+ *     --report /tmp/core-report.json \
+ *     --out scripts/report-data/embedded-parity-baseline.json
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const DEFAULT_OUT = path.join(PROJECT_ROOT, 'scripts', 'report-data', 'embedded-parity-baseline.json');
+
+// Preserved verbatim from the existing committed baseline so regenerating it
+// doesn't silently reword the contract this file is read under.
+const PURPOSE =
+  'Hard per-style exact-parity floor-gate baseline for the embedded tier, ' +
+  'consumed by scripts/check-core-quality.js --parity-baseline (see ' +
+  'docs/architecture/audits/2026-07-31_EXACT_PARITY_REFOCUS.md). It also ' +
+  'records headline fidelity. Sub-1.0 fidelity ratchets are tracked ' +
+  'separately per-style in scripts/report-data/verification-policy.yaml ' +
+  '(min_pass_rate floors). Regenerate this file after each parity-tuning ' +
+  'wave; the gate never goes backward on passed counts or total ' +
+  '(fixture-drift guard).';
+
+function parseArgs(argv) {
+  const opts = { reportPath: null, outPath: DEFAULT_OUT };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--report') {
+      opts.reportPath = path.resolve(argv[++i]);
+    } else if (argv[i] === '--out') {
+      opts.outPath = path.resolve(argv[++i]);
+    }
+  }
+  return opts;
+}
+
+/**
+ * True if a style's report record can't back a ratcheted floor: report-core.js
+ * omits `exactParity` entirely on its error path, and defaulting a missing
+ * measurement to 0 would silently reset that style's floor to 0/0 instead of
+ * failing loudly.
+ */
+function isUnmeasurable(style) {
+  return Boolean(style.error) || typeof style.exactParity?.total !== 'number';
+}
+
+/** Build the baseline document from a report-core.js report object. */
+function deriveParityBaseline(report) {
+  const embeddedStyles = (report.styles || [])
+    .filter((style) => style.tier === 'embedded')
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const unmeasurable = embeddedStyles.filter(isUnmeasurable);
+  if (unmeasurable.length > 0) {
+    throw new Error(
+      `Refusing to derive a baseline: no exact-parity measurement for ` +
+      `${unmeasurable.map((s) => s.name).join(', ')}. Fix the underlying ` +
+      `report error and re-run rather than writing a 0/0 floor.`
+    );
+  }
+
+  const styles = {};
+  for (const style of embeddedStyles) {
+    styles[style.name] = {
+      tier: style.tier,
+      fidelityScore: style.fidelityScore,
+      qualityScore: style.qualityScore,
+      citations: {
+        passed: style.citations?.passed ?? 0,
+        total: style.citations?.total ?? 0,
+      },
+      bibliography: {
+        passed: style.bibliography?.passed ?? 0,
+        total: style.bibliography?.total ?? 0,
+      },
+      exactParity: {
+        passed: style.exactParity.passed,
+        total: style.exactParity.total,
+        rate: style.exactParity.rate ?? null,
+      },
+    };
+  }
+
+  return {
+    generated: report.generated,
+    commit: report.commit,
+    source: 'scripts/report-core.js',
+    purpose: PURPOSE,
+    styles,
+  };
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (!opts.reportPath) {
+    process.stderr.write(
+      'Usage: node scripts/derive-parity-baseline.js --report <report.json> [--out <path>]\n'
+    );
+    process.exit(1);
+  }
+
+  const report = JSON.parse(fs.readFileSync(opts.reportPath, 'utf8'));
+  let baseline;
+  try {
+    baseline = deriveParityBaseline(report);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  }
+
+  fs.mkdirSync(path.dirname(opts.outPath), { recursive: true });
+  fs.writeFileSync(opts.outPath, JSON.stringify(baseline, null, 2) + '\n', 'utf8');
+  process.stderr.write(`Wrote ${embeddedCount(baseline)} embedded-tier styles to ${opts.outPath}\n`);
+}
+
+function embeddedCount(baseline) {
+  return Object.keys(baseline.styles).length;
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { deriveParityBaseline, parseArgs };

--- a/scripts/derive-parity-baseline.test.js
+++ b/scripts/derive-parity-baseline.test.js
@@ -1,0 +1,140 @@
+// Coverage for scripts/derive-parity-baseline.js — the generator for
+// scripts/report-data/embedded-parity-baseline.json (see
+// docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md). The output
+// shape is a contract: .github/workflows/fidelity.yml and
+// check-core-quality.js --parity-baseline both read styles[].exactParity
+// positionally, so the shape assertions here matter as much as the values.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { deriveParityBaseline } = require('./derive-parity-baseline');
+
+const SCRIPT = path.join(__dirname, 'derive-parity-baseline.js');
+
+function tmpJsonPath(name, data) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dpb-test-'));
+  const filePath = path.join(dir, name);
+  fs.writeFileSync(filePath, JSON.stringify(data));
+  return filePath;
+}
+
+function styleRecord(overrides = {}) {
+  return {
+    name: 'apa-7th',
+    tier: 'embedded',
+    fidelityScore: 1,
+    qualityScore: 0.972,
+    citations: { passed: 20, total: 20 },
+    bibliography: { passed: 47, total: 47 },
+    exactParity: { passed: 33, total: 67, notComparable: 0, divergenceExcluded: 0, rate: 0.493 },
+    ...overrides,
+  };
+}
+
+test('keeps only embedded-tier styles, sorted by name', () => {
+  const report = {
+    generated: '2026-08-16T00:00:00.000Z',
+    commit: 'abc1234',
+    styles: [
+      styleRecord({ name: 'zzz-exemplar', tier: 'exemplar' }),
+      styleRecord({ name: 'ieee' }),
+      styleRecord({ name: 'apa-7th' }),
+    ],
+  };
+
+  const baseline = deriveParityBaseline(report);
+
+  assert.deepEqual(Object.keys(baseline.styles), ['apa-7th', 'ieee']);
+});
+
+test('carries generated/commit through and preserves the fixed purpose text', () => {
+  const report = { generated: '2026-08-16T00:00:00.000Z', commit: 'abc1234', styles: [styleRecord()] };
+
+  const baseline = deriveParityBaseline(report);
+
+  assert.equal(baseline.generated, '2026-08-16T00:00:00.000Z');
+  assert.equal(baseline.commit, 'abc1234');
+  assert.equal(baseline.source, 'scripts/report-core.js');
+  assert.match(baseline.purpose, /Hard per-style exact-parity floor-gate baseline/);
+});
+
+test('per-style shape matches the fields fidelity.yml and check-core-quality.js read', () => {
+  const report = { generated: 'x', commit: 'y', styles: [styleRecord()] };
+
+  const baseline = deriveParityBaseline(report);
+  const entry = baseline.styles['apa-7th'];
+
+  assert.deepEqual(Object.keys(entry).sort(), [
+    'bibliography',
+    'citations',
+    'exactParity',
+    'fidelityScore',
+    'qualityScore',
+    'tier',
+  ].sort());
+  assert.deepEqual(entry.exactParity, { passed: 33, total: 67, rate: 0.493 });
+  assert.deepEqual(entry.citations, { passed: 20, total: 20 });
+  assert.deepEqual(entry.bibliography, { passed: 47, total: 47 });
+});
+
+test('throws rather than defaulting a style with a report error to a 0/0 floor', () => {
+  const report = {
+    generated: 'x',
+    commit: 'y',
+    styles: [styleRecord({ name: 'apa-7th', error: 'style file not found', exactParity: undefined })],
+  };
+
+  assert.throws(() => deriveParityBaseline(report), /apa-7th/);
+});
+
+test('throws when an embedded style is missing exactParity entirely', () => {
+  const report = {
+    generated: 'x',
+    commit: 'y',
+    styles: [styleRecord({ name: 'ieee', exactParity: undefined })],
+  };
+
+  assert.throws(() => deriveParityBaseline(report), /ieee/);
+});
+
+test('CLI exits non-zero and writes nothing when a style is unmeasurable', () => {
+  const report = {
+    generated: 'x',
+    commit: 'y',
+    styles: [styleRecord({ error: 'boom', exactParity: undefined })],
+  };
+  const reportPath = tmpJsonPath('report.json', report);
+  const outPath = path.join(path.dirname(reportPath), 'out.json');
+
+  const result = spawnSync(process.execPath, [SCRIPT, '--report', reportPath, '--out', outPath], {
+    encoding: 'utf8',
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.equal(fs.existsSync(outPath), false);
+});
+
+test('CLI writes the derived baseline to --out', () => {
+  const report = { generated: 'x', commit: 'y', styles: [styleRecord()] };
+  const reportPath = tmpJsonPath('report.json', report);
+  const outPath = path.join(path.dirname(reportPath), 'out.json');
+
+  const result = spawnSync(process.execPath, [SCRIPT, '--report', reportPath, '--out', outPath], {
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const written = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+  assert.deepEqual(Object.keys(written.styles), ['apa-7th']);
+});
+
+test('CLI without --report prints usage and exits non-zero', () => {
+  const result = spawnSync(process.execPath, [SCRIPT], { encoding: 'utf8' });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Usage:/);
+});

--- a/scripts/oracle-batch-aggregate.js
+++ b/scripts/oracle-batch-aggregate.js
@@ -485,12 +485,23 @@ async function main() {
     }
   }
 
-  // Save to file if requested
+  // Save to file if requested. Refuse on a partial run: a style that failed to
+  // render is absent from styleBreakdown, so saving anyway would silently drop
+  // it from a committed baseline (and, on a floor file, erase its ratchet).
+  let saveRefused = false;
   if (savePath) {
-    const outputData = comparison ? { current: summary, comparison } : summary;
-    fs.writeFileSync(savePath, JSON.stringify(outputData, null, 2));
-    if (!jsonOutput) {
-      console.log(`Results saved to: ${savePath}`);
+    if (summary.errors.length > 0) {
+      saveRefused = true;
+      console.error(
+        `Refusing to write ${savePath}: ${summary.errors.length} style(s) failed to render ` +
+        `(${summary.errors.map((e) => e.style).join(', ')}). Fix the failures or drop --save.`
+      );
+    } else {
+      const outputData = comparison ? { current: summary, comparison } : summary;
+      fs.writeFileSync(savePath, JSON.stringify(outputData, null, 2));
+      if (!jsonOutput) {
+        console.log(`Results saved to: ${savePath}`);
+      }
     }
   }
 
@@ -610,6 +621,10 @@ async function main() {
     }
     
     console.log();
+  }
+
+  if (saveRefused) {
+    process.exit(1);
   }
 }
 

--- a/scripts/oracle-batch-aggregate.test.js
+++ b/scripts/oracle-batch-aggregate.test.js
@@ -1,0 +1,28 @@
+// Regression coverage for the --save refusal on a partial run (see
+// docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md and the
+// PR review that flagged it): saving over a committed baseline when any
+// requested style failed to render would silently drop that style from
+// styleBreakdown, corrupting the ratchet.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const SCRIPT = path.join(__dirname, 'oracle-batch-aggregate.js');
+const STYLES_DIR = path.join(__dirname, '..', 'styles-legacy');
+
+test('refuses to save when a requested style fails to render', { skip: !fs.existsSync(STYLES_DIR) }, () => {
+  const outPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'oba-test-')), 'out.json');
+
+  const result = spawnSync(
+    process.execPath,
+    [SCRIPT, STYLES_DIR, '--styles', 'this-style-does-not-exist', '--save', outPath, '--json'],
+    { encoding: 'utf8' }
+  );
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Refusing to write/);
+  assert.equal(fs.existsSync(outPath), false);
+});


### PR DESCRIPTION
**Why did 2 fixture entries cause a 187k-line diff, and how do we stop it?**

Because they were added to `references-expanded.json`, the shared default every one of ~2,845 legacy-style oracle snapshots renders against. That's not a caching bug — it's where the entries went. The fix is workflow, not the cache key:

- Narrow regression fixtures now go in a scoped `fixture_family` file, or a native Rust test — zero snapshot churn. The shared default is still correct for genuine corpus-wide coverage gaps, deliberately, in their own commit.
- `.claude/skills/test-coverage/SKILL.md` (which told contributors to always add to the shared default — the actual root cause) now leads with that rule.
- `docs/architecture/audits/2026-08-16_FIXTURE_CHANGE_FAN_OUT.md` has the full writeup.

When a corpus-wide change *is* intended, it no longer means chasing four artifacts through serial CI failures:

- `just fixture-refresh` — one command for snapshots + coverage-audit manifests, plus the two ratcheted baselines behind `just fixture-refresh yes`.
- `just oracle-refresh` — was missing `--save`, never wrote anything. Fixed.
- `scripts/derive-parity-baseline.js` — generator for `embedded-parity-baseline.json`, which had none.
- `oracle-batch-aggregate.js --save` — now refuses to write if any style failed, instead of silently corrupting the baseline.

No fixture, snapshot, or baseline was touched in this PR. 2 pre-existing broken styles and ~2,800 stale snapshots found along the way are filed as csl26-u87d / csl26-y36e, not fixed here.

CI green.