### PR TITLE
feat(engine)!: opt-in same-author citation collapse

### DIFF
--- a/.beans/archive/csl26-ecfn--unconditional-same-author-collapse-contradicts-csl.md
+++ b/.beans/archive/csl26-ecfn--unconditional-same-author-collapse-contradicts-csl.md
@@ -1,7 +1,7 @@
 ---
 # csl26-ecfn
 title: Unconditional same-author collapse contradicts CSL's opt-in semantics
-status: in-progress
+status: completed
 type: bug
 priority: normal
 tags:
@@ -10,7 +10,7 @@ tags:
     - citation
     - divergence
 created_at: 2026-08-16T00:16:16Z
-updated_at: 2026-08-18T19:15:04Z
+updated_at: 2026-08-19T13:49:09Z
 ---
 
 Found while validating csl26-p7a8's title-quote flip for
@@ -86,3 +86,56 @@ Implementation is a separate, stacked PR (schema change, needs the docs PR
 reviewed first per repo policy). `csl26-m11m` is blocked-by this bean and
 closes as a consequence — no note-specific code needed, note styles simply
 never declare `collapse`.
+
+## PR 2 Implementation Plan
+
+Tracked in `/home/bruce/.claude/plans/in-the-plan-home-bruce-claude-plans-comp-reactive-pancake.md`.
+
+- [x] Commit 1: feat(schema)! — CitationCollapse::SameAuthor + regime validation + schema-gen
+- [x] Commit 2: feat(migrate) — extract_citation_collapse maps all four CSL values
+- [x] Commit 3: feat(styles) — declare collapse on 9 tracked styles
+- [x] Commit 4: feat(engine)! — gate group_citation_items_by_author on collapse setting
+- [x] Commit 5: test(engine) — pin non-collapsed clusters + schema round-trip/rejection tests
+- [x] Commit 6: docs(spec) — SAME_AUTHOR_COLLAPSE.md v1.0->v1.1 Active; CITATION_CLUSTER_RENDERING.md v1.5
+- [x] Commit 7: chore(beans) — close csl26-ecfn/csl26-m11m, filed 4 follow-up beans (csl26-ctkb, csl26-llgj, csl26-8g14, csl26-ax22)
+- [x] Verification: nextest after commit 4 (0 fail), pre-commit gate (2629/2629), schema-gen, load-validate all styles, per-style report-core (9 zero-movement, 4 gains matching prediction exactly), snapshots clean, MLA confirmed moot, guarded corpus sweep (net +6, zero regressions across 24 families)
+- [ ] gh stack submit (after user confirmation), gh pr checks --watch
+
+## Summary of Changes
+
+Implemented in PR 2 (stacked on the docs PR #1206), commits on
+`feat/csl26-ecfn-collapse-opt-in`:
+
+1. **Schema**: `CitationCollapse` gains `SameAuthor(SameAuthorCollapse)`
+   with a `year_suffix` degree (separate/merged/ranged). Hand-written
+   serde mirrors `Processing`'s existing pattern. Regime-coherence
+   validation added (same-author on AuthorDate/Note/Custom,
+   citation-number on Numeric/Custom), hooked into both style-resolution
+   return paths.
+2. **Migrate**: `extract_citation_collapse` now maps all four CSL
+   `collapse` values losslessly, dropping the mapped value if illegal for
+   the detected regime rather than emitting something invalid.
+3. **Styles**: 9 tracked styles declare `collapse: { same-author: {} }`
+   (config-map form, not bare-string sugar — the generated schema only
+   advertises the object form). Table mechanically re-derived against
+   every tracked style's real `styles-legacy/` source, correcting the
+   docs PR's 5-style enumeration to 9.
+4. **Engine**: `group_citation_items_by_author` gates same-author
+   merging on `collapse == Some(SameAuthor(_))`; singleton groups
+   otherwise, keyed on `(index, id)` so duplicate-id clusters can't
+   spuriously merge. Gated at the grouping level (not just the collapse
+   branch) so the integral prose-anchor path is covered too.
+5. **Tests**: native-fixture pins for the note-regime fix (byte-exact
+   against citeproc-js), duplicate-id regression, shortened-notes,
+   T&F CSE / MLA no-collapse cases, plus schema round-trip and
+   regime-coherence tests.
+
+**Measured**: full `report-core.js` sweep of all 24 core-style families
+(baseline: PR1 tip `52481a17`) shows net **+6** exactParity, **zero
+regressions**. The 9 opt-in styles show exactly zero movement.
+`chicago-notes-18th` 22/72 → 23/72, `chicago-shortened-notes-bibliography`
+60/473 → 61/473, `taylor-and-francis-council-of-science-editors-author-date`
+30/67 → 32/67, `modern-language-association` 42/115 → 44/115.
+
+Resolves `csl26-m11m` as a direct consequence — closed separately with its
+own summary.

--- a/.beans/archive/csl26-m11m--same-author-collapse-produces-malformed-note-citat.md
+++ b/.beans/archive/csl26-m11m--same-author-collapse-produces-malformed-note-citat.md
@@ -1,7 +1,7 @@
 ---
 # csl26-m11m
 title: Same-author collapse produces malformed note citations
-status: todo
+status: completed
 type: bug
 priority: normal
 tags:
@@ -11,7 +11,7 @@ tags:
     - citation
     - chicago
 created_at: 2026-08-18T12:49:06Z
-updated_at: 2026-08-18T19:15:15Z
+updated_at: 2026-08-19T13:47:04Z
 parent: csl26-h7oc
 blocked_by:
     - csl26-ecfn
@@ -76,3 +76,35 @@ Also flagged, not filed: an independent, pre-existing locator-punctuation
 defect (`4 (2019), 257` vs oracle `4 (2019): 257`) noticed while reproducing
 this — reproduces on single-item citations, unrelated to collapse, deliberately
 out of scope here.
+
+## Summary of Changes
+
+Resolved as a direct consequence of `csl26-ecfn` landing (PR 2,
+`feat/csl26-ecfn-collapse-opt-in`) — no note-specific code was needed.
+Same-author collapse now gates on `citation.collapse: same-author`
+(`crates/citum-engine/src/processor/rendering/grouped/grouping.rs`);
+`chicago-notes-18th` and `chicago-shortened-notes-bibliography-core`
+simply never declare it, because their source CSL
+(`chicago-notes-bibliography.csl`, `chicago-shortened-notes-bibliography.csl`)
+doesn't either, so they fall out of the collapse path automatically.
+
+The malformed run-on sentence this bean reported —
+`Garcia, "Methods...", "Methods...".` for
+`[@ITEM-31; @ITEM-32]` — is now:
+
+> Maria Garcia, "Methods for Robust Climate Attribution," *Annual Review
+> of Climate Science* 4 (2019): 55–80, https://…; Maria Garcia, "Methods
+> for Probabilistic Climate Attribution," *Annual Review of Climate
+> Science* 4 (2019): 81–104, https://….
+
+Byte-for-byte match against citeproc-js
+(`tests/snapshots/csl/chicago-notes.json`'s `note-disambiguate-year-suffix`
+entry), pinned in
+`given_chicago_notes_style_when_same_author_cluster_has_no_locator_then_renders_exact_oracle_match`
+(`crates/citum-engine/tests/domain_fixtures.rs`).
+`chicago-notes-18th` exactParity: 22/72 → 23/72.
+
+The independent locator-punctuation defect noticed while investigating
+this (`4 (2019), 257` vs oracle `4 (2019): 257`) remains unfixed —
+reproduces on single-item citations, unrelated to collapse, out of scope
+here (see `SAME_AUTHOR_COLLAPSE.md` Scope section).

--- a/.beans/csl26-8g14--extend-citations-humanities-notejson-with-a-same-a.md
+++ b/.beans/csl26-8g14--extend-citations-humanities-notejson-with-a-same-a.md
@@ -1,0 +1,24 @@
+---
+# csl26-8g14
+title: Extend citations-humanities-note.json with a same-author cluster
+status: todo
+type: task
+priority: low
+tags:
+    - note-styles
+    - citation
+    - rendering
+created_at: 2026-08-19T13:48:34Z
+updated_at: 2026-08-19T13:48:42Z
+---
+
+`docs/specs/SAME_AUTHOR_COLLAPSE.md`'s note-regime fix (`csl26-m11m`) is currently pinned only in `crates/citum-engine/tests/domain_fixtures.rs`, using `references-expanded.json`'s ITEM-31/ITEM-32 (Garcia) via native `InputReference` construction — not the dedicated humanities-note oracle-snapshot fixture family.
+
+`tests/fixtures/citations-humanities-note.json` / `references-humanities-note.json` would be a more natural home for a same-author, note-regime cluster (archival/manuscript-heavy references, matching that fixture's domain), but extending it regenerates the `note-humanities` oracle snapshot family — its own blast-radius check, confirmed as a separate change per `docs/guides/shared-fixture-blast-radius-check.md`'s precedent (2 entries in `references-expanded.json` once regenerated 2,845 oracle snapshots).
+
+## Scope
+- [ ] Add a same-author multi-item cluster to `citations-humanities-note.json` with matching references in `references-humanities-note.json`.
+- [ ] Check blast radius before committing (how many oracle snapshots regenerate) — prefer ad-hoc verification over a permanent fixture commit if the radius is large, per repo precedent.
+- [ ] Regenerate and commit the affected `tests/snapshots/csl/*.json` files if the fixture change is kept.
+
+See `docs/specs/SAME_AUTHOR_COLLAPSE.md` Scope section ("Extending tests/fixtures/citations-humanities-note.json ... a separate change with its own oracle-snapshot blast radius").

--- a/.beans/csl26-ax22--chicago-notes-locator-punctuation-wrong-on-single.md
+++ b/.beans/csl26-ax22--chicago-notes-locator-punctuation-wrong-on-single.md
@@ -1,0 +1,25 @@
+---
+# csl26-ax22
+title: 'Chicago notes: locator punctuation wrong on single-item citations'
+status: todo
+type: bug
+priority: normal
+tags:
+    - note-styles
+    - chicago
+    - rendering
+    - citation
+created_at: 2026-08-19T13:48:54Z
+updated_at: 2026-08-19T13:49:02Z
+parent: csl26-h7oc
+---
+
+`chicago-notes-18th` (and likely siblings sharing its template) renders `4 (2019), 257` for a citation with a page locator, where citeproc-js/CMOS renders `4 (2019): 257` (colon before the locator, not comma). Reproduces on a plain single-item citation — independent of same-author collapse.
+
+Noticed while investigating `csl26-m11m` / `csl26-ecfn`: the second clause of a same-author collapsed cluster with a locator on the second item (`[@ITEM-31; @ITEM-32, p. 257]`) shows this exact defect and is pinned as such — not asserted as oracle parity — in `given_chicago_notes_style_when_same_author_cluster_has_a_locator_then_each_item_renders_in_full` (`crates/citum-engine/tests/domain_fixtures.rs`). Deliberately out of scope for that PR (`docs/specs/SAME_AUTHOR_COLLAPSE.md` Scope section).
+
+## Scope
+- [ ] Reproduce on a single-item `chicago-notes-18th` citation with a page locator to confirm this is unrelated to grouping/collapse.
+- [ ] Find the template/punctuation rule that should route the locator after a colon rather than a comma for this style's citation template.
+- [ ] Add a regression test pinning the fix against the citeproc-js oracle.
+- [ ] Re-run `report-core.js --style chicago-notes-18th` to measure exactParity movement.

--- a/.beans/csl26-ctkb--implement-year-suffix-mergedranged-collapse-render.md
+++ b/.beans/csl26-ctkb--implement-year-suffix-mergedranged-collapse-render.md
@@ -1,0 +1,25 @@
+---
+# csl26-ctkb
+title: Implement year-suffix merged/ranged collapse rendering
+status: todo
+type: feature
+priority: normal
+tags:
+    - rendering
+    - citation
+    - engine
+created_at: 2026-08-19T13:47:45Z
+updated_at: 2026-08-19T13:48:02Z
+---
+
+`SameAuthorCollapse::year_suffix` supports `Merged` (`Smith (2020a, b)`) and `Ranged` (`Smith (2020a–c)`) — CSL's `collapse="year-suffix"` / `collapse="year-suffix-ranged"`. Both parse and round-trip through the schema (landed in csl26-ecfn's implementation, `docs/specs/SAME_AUTHOR_COLLAPSE.md`) but the renderer doesn't implement either degree yet — it falls back to `Separate`, with a one-time `SchemaWarning::UnimplementedCollapseDegree` at `citum style validate` time (not yet at render time — see below) and a migrate-time `tracing::warn!`.
+
+Two embedded/tracked styles already declare the merged degree and are silently rendering the wrong output today: `springer-basic-author-date-core` and `international-journal-of-wildland-fire` (both `collapse: { same-author: { year-suffix: merged } }`).
+
+## Scope
+- [ ] Implement `Merged" rendering: join adjacent same-year suffixed tokens sharing a year, e.g. `2020a, 2020b` → `2020a, b`.
+- [ ] Implement `Ranged" rendering: collapse a contiguous run of suffixes into a range, e.g. `2020a, 2020b, 2020c` → `2020a–c`.
+- [ ] Wire the render-time warning (currently only surfaced via `citum style validate`, not at actual render time) or confirm the validate-time channel is sufficient.
+- [ ] Re-run `report-core.js --style springer-basic-author-date` and `--style international-journal-of-wildland-fire` to confirm the fix moves exactParity (currently both render `Separate` despite declaring `merged`).
+
+See `docs/specs/SAME_AUTHOR_COLLAPSE.md` §1, §4, Scope section.

--- a/.beans/csl26-llgj--adjudicate-notecitation-number-styles-migrate-drop.md
+++ b/.beans/csl26-llgj--adjudicate-notecitation-number-styles-migrate-drop.md
@@ -1,0 +1,24 @@
+---
+# csl26-llgj
+title: Adjudicate note+citation-number styles migrate drops
+status: todo
+type: task
+priority: low
+tags:
+    - migrate
+    - citation
+    - note-styles
+created_at: 2026-08-19T13:48:15Z
+updated_at: 2026-08-19T13:48:22Z
+---
+
+4 real `class="note"` corpus styles (e.g. `proinflow.csl`) declare `collapse="citation-number"`, but stripping the attribute and re-rendering shows it produces same-author-style author-suppression merging (`GARCIA, Maria. …; GARCIA, Maria. …` → `GARCIA, Maria. …; …`), not numeric range compression — citeproc-js's citation-number collapse mechanics evidently work differently for full-sentence note styles than the Citum `CitationNumber`/`SameAuthor` model captures.
+
+Migrate currently drops the attribute for these 4 styles (maps to *absent*, same as no `collapse` at all) rather than emitting a value that would fail the new regime-coherence validation (`same-author` is illegal on `Numeric`; `citation-number` is illegal on `Note`). This is a known, deliberately out-of-scope gap from `docs/specs/SAME_AUTHOR_COLLAPSE.md` §6's caveat and §4's acceptance criteria.
+
+## Scope
+- [ ] Determine whether these 4 styles should migrate to `same-author` instead of having the attribute dropped entirely, or whether a third collapse mechanism is needed.
+- [ ] If `same-author` is the right target, add `Note`-regime handling and re-run `extract_citation_collapse` mapping.
+- [ ] Re-run `report-core.js` for the affected styles to confirm no regression from any migrate change.
+
+See `docs/specs/SAME_AUTHOR_COLLAPSE.md` §6, §7 note (embedded styles), and the corpus measurement table.

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -249,7 +249,7 @@ impl Renderer<'_> {
     where
         F: crate::render::format::OutputFormat<Output = String>,
     {
-        let groups = group_citation_items_by_author(self, items);
+        let groups = group_citation_items_by_author(self, items, params.spec.collapse.as_ref());
         let mut rendered_groups = Vec::new();
         for (_author_key, group) in groups {
             rendered_groups
@@ -833,7 +833,7 @@ impl Renderer<'_> {
     where
         F: crate::render::format::OutputFormat<Output = String>,
     {
-        let groups = group_citation_items_by_author(self, items);
+        let groups = group_citation_items_by_author(self, items, spec.collapse.as_ref());
 
         let mut rendered_groups = Vec::new();
         let fmt = F::default();

--- a/crates/citum-engine/src/processor/rendering/grouped/grouping.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/grouping.rs
@@ -7,27 +7,39 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 use crate::reference::Reference;
 
-/// Group citation items by author, respecting individual citation hints.
+/// Group citation items by author, respecting individual citation hints and
+/// the style's `citation.collapse` setting.
 ///
-/// Returns a list of (`author_key`, items) tuples. If any item has disambiguation
-/// hints, all items are grouped individually by citation id.
+/// Returns a list of (`author_key`, items) tuples. Same-author collapse only
+/// merges adjacent same-author items when `collapse` is
+/// `Some(CitationCollapse::SameAuthor(_))` — see
+/// `docs/specs/SAME_AUTHOR_COLLAPSE.md` §3. When it isn't (or any item has
+/// disambiguation hints, as before), every item becomes its own singleton
+/// group, keyed on `(index, id)` so two citation items sharing the same
+/// reference id in one cluster can never spuriously merge (§11).
 pub(crate) fn group_citation_items_by_author<'a>(
     renderer: &super::super::Renderer<'_>,
     items: &'a [crate::reference::CitationItem],
+    collapse: Option<&citum_schema::CitationCollapse>,
 ) -> Vec<(String, Vec<&'a crate::reference::CitationItem>)> {
-    let preserve_individual_citations = items.iter().any(|item| {
-        renderer
-            .hints
-            .get(&item.id)
-            .is_some_and(|hints| hints.min_names_to_show.is_some() || hints.expand_given_names)
-    });
+    let same_author_collapse = matches!(
+        collapse,
+        Some(citum_schema::CitationCollapse::SameAuthor(_))
+    );
+    let preserve_individual_citations = !same_author_collapse
+        || items.iter().any(|item| {
+            renderer
+                .hints
+                .get(&item.id)
+                .is_some_and(|hints| hints.min_names_to_show.is_some() || hints.expand_given_names)
+        });
 
     let mut groups: Vec<(String, Vec<&'a crate::reference::CitationItem>)> = Vec::new();
 
-    for item in items {
+    for (index, item) in items.iter().enumerate() {
         let reference = renderer.bibliography.get(&item.id);
         let author_key = if preserve_individual_citations {
-            item.id.clone()
+            format!("{index}\u{1f}{}", item.id)
         } else {
             reference.map(author_grouping_key).unwrap_or_default()
         };

--- a/crates/citum-engine/src/processor/rendering/tests.rs
+++ b/crates/citum-engine/src/processor/rendering/tests.rs
@@ -12,7 +12,7 @@ use citum_schema::options::{
     Processing, SubsequentNameForm,
 };
 use citum_schema::template::*;
-use citum_schema::{CitationSpec, Style, StyleInfo};
+use citum_schema::{CitationCollapse, CitationSpec, SameAuthorCollapse, Style, StyleInfo};
 use csl_legacy::csl_json::{
     DateVariable as LegacyDateVariable, Name, Reference as LegacyReference,
 };
@@ -46,6 +46,7 @@ fn grouped_author_date_style() -> Style {
             ..Default::default()
         }),
         citation: Some(CitationSpec {
+            collapse: Some(CitationCollapse::SameAuthor(SameAuthorCollapse::default())),
             template: Some(
                 vec![
                     TemplateComponent::Contributor(TemplateContributor {
@@ -658,7 +659,8 @@ fn grouping_helper_matches_citation_wide_preserve_behavior() {
         },
     ];
 
-    let groups = group_citation_items_by_author(&renderer, &items);
+    let collapse = CitationCollapse::SameAuthor(SameAuthorCollapse::default());
+    let groups = group_citation_items_by_author(&renderer, &items, Some(&collapse));
 
     assert_eq!(groups.len(), 3);
     assert_eq!(

--- a/crates/citum-engine/src/processor/tests.rs
+++ b/crates/citum-engine/src/processor/tests.rs
@@ -16,7 +16,9 @@ use citum_schema::template::{
     TemplateDate, TemplateGroup, TemplateNumber, TemplateTitle, TemplateVariable, TitleType,
     WrapPunctuation,
 };
-use citum_schema::{BibliographySpec, CitationSpec, StyleInfo};
+use citum_schema::{
+    BibliographySpec, CitationCollapse, CitationSpec, SameAuthorCollapse, StyleInfo,
+};
 use csl_legacy::csl_json::{DateVariable, Name, Reference as LegacyReference, StringOrNumber};
 use rstest::rstest;
 
@@ -2135,7 +2137,9 @@ fn test_numeric_citation_numbers_follow_registry_order() {
 fn test_citation_grouping_same_author() {
     // Test that adjacent citations by the same author are collapsed:
     // (Kuhn 1962a, 1962b) instead of (Kuhn 1962a; Kuhn 1962b)
-    let style = make_style();
+    let mut style = make_style();
+    style.citation.as_mut().unwrap().collapse =
+        Some(CitationCollapse::SameAuthor(SameAuthorCollapse::default()));
     let mut bib = make_bibliography();
 
     // Add second Kuhn 1962 with different title (triggers year-suffix)
@@ -3333,6 +3337,7 @@ fn given_integral_multi_cites_when_rendering_then_joining_respects_integral_beha
 fn test_same_author_integral_multi_cite_collapses_to_grouped_years() {
     let mut style = make_style();
     let mut base_citation = style.citation.take().unwrap_or_default();
+    base_citation.collapse = Some(CitationCollapse::SameAuthor(SameAuthorCollapse::default()));
     // Simulate APA: base spec has multi_cite_delimiter "; " but integral sub-spec does not.
     base_citation.multi_cite_delimiter = Some("; ".into());
     base_citation.integral = Some(Box::new(CitationSpec {
@@ -3434,6 +3439,7 @@ fn test_same_author_non_integral_multi_cite_collapses_to_grouped_years() {
         ),
         wrap: Some(WrapPunctuation::Parentheses.into()),
         multi_cite_delimiter: Some("; ".into()),
+        collapse: Some(CitationCollapse::SameAuthor(SameAuthorCollapse::default())),
         ..Default::default()
     });
 
@@ -3483,6 +3489,7 @@ fn test_same_author_non_integral_multi_cite_collapses_to_grouped_years() {
 fn test_same_author_integral_multi_cite_respects_bracket_wrap() {
     let mut style = make_style();
     let mut base_citation = style.citation.take().unwrap_or_default();
+    base_citation.collapse = Some(CitationCollapse::SameAuthor(SameAuthorCollapse::default()));
     base_citation.multi_cite_delimiter = Some("; ".into());
     base_citation.integral = Some(Box::new(CitationSpec {
         delimiter: Some(" ".into()),
@@ -3626,6 +3633,7 @@ fn test_same_author_collapse_matches_csl_suite_chicago_after_collapse() {
         ),
         delimiter: Some(String::new().into()),
         wrap: Some(WrapPunctuation::Parentheses.into()),
+        collapse: Some(CitationCollapse::SameAuthor(SameAuthorCollapse::default())),
         ..Default::default()
     });
 
@@ -3736,6 +3744,7 @@ fn test_integral_locator_does_not_duplicate_group_delimiter() {
             .into(),
         ),
         wrap: Some(WrapPunctuation::Parentheses.into()),
+        collapse: Some(CitationCollapse::SameAuthor(SameAuthorCollapse::default())),
         integral: Some(Box::new(CitationSpec {
             wrap: None,
             ..Default::default()

--- a/crates/citum-engine/tests/citations.rs
+++ b/crates/citum-engine/tests/citations.rs
@@ -2159,6 +2159,7 @@ options:
       names: false
       add-givenname: false
 citation:
+  collapse: same-author
   multi-cite-delimiter: ' '
   template:
     - group:

--- a/crates/citum-engine/tests/common/mod.rs
+++ b/crates/citum-engine/tests/common/mod.rs
@@ -403,6 +403,9 @@ pub fn build_author_date_style(
             )),
             template: Some(citation_template.into()),
             multi_cite_delimiter: Some("; ".into()),
+            collapse: Some(citum_schema::CitationCollapse::SameAuthor(
+                citum_schema::SameAuthorCollapse::default(),
+            )),
             ..Default::default()
         }),
         ..Default::default()

--- a/crates/citum-engine/tests/domain_fixtures.rs
+++ b/crates/citum-engine/tests/domain_fixtures.rs
@@ -26,6 +26,7 @@ use citum_io::load_bibliography;
 use citum_schema::Style;
 use citum_schema::citation::{Citation, CitationItem, CitationLocator, CitationMode, LocatorType};
 use citum_schema::reference::{ClassExtension, MultilingualString};
+use rstest::rstest;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -498,4 +499,239 @@ fn test_taylor_and_francis_author_date_wrapper_preserves_media_and_translation_d
             .contains("_Metamorphosis_. Translated by David Wyllie. Leipzig: Kurt Wolff Verlag"),
         "translated books should retain translator detail and the inherited monograph emphasis"
     );
+}
+
+// --- Same-author collapse opt-in (csl26-ecfn / csl26-m11m) ---
+//
+// chicago-notes-18th, chicago-shortened-notes-bibliography-core, and
+// modern-language-association declare no `collapse` (their source CSL
+// declares none either — docs/specs/SAME_AUTHOR_COLLAPSE.md §8), so they
+// stop collapsing same-author multi-item clusters entirely.
+// taylor-and-francis-council-of-science-editors-author-date is the same
+// shape for csl26-ecfn's original finding.
+
+/// A full Chicago note has no year-group to collapse onto — a same-author
+/// cluster with no locator now renders each citation in full, joined by
+/// `"; "`, matching citeproc-js on `chicago-notes-bibliography.csl`
+/// byte-for-byte (`tests/snapshots/csl/chicago-notes.json`,
+/// `note-disambiguate-year-suffix`). This is the exact cluster
+/// `csl26-m11m` reported as a malformed run-on sentence.
+#[test]
+fn given_chicago_notes_style_when_same_author_cluster_has_no_locator_then_renders_exact_oracle_match()
+ {
+    let root = project_root();
+    let style = load_style(&root.join("styles/embedded/chicago-notes-18th.yaml"));
+    let bibliography = load_bibliography(&root.join("tests/fixtures/references-expanded.json"))
+        .expect("expanded fixture should parse");
+
+    let processor = Processor::new(style, bibliography);
+    let citation = Citation {
+        items: vec![
+            CitationItem {
+                id: "ITEM-31".to_string(),
+                ..Default::default()
+            },
+            CitationItem {
+                id: "ITEM-32".to_string(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let rendered = processor
+        .process_citation(&citation)
+        .expect("same-author note cluster should render");
+
+    assert_eq!(
+        rendered,
+        "Maria Garcia, \u{201C}Methods for Robust Climate Attribution,\u{201D} \
+         _Annual Review of Climate Science_ 4 (2019): 55\u{2013}80, \
+         https://doi.org/10.5555/arcs.2019.4.55; Maria Garcia, \u{201C}Methods \
+         for Probabilistic Climate Attribution,\u{201D} _Annual Review of \
+         Climate Science_ 4 (2019): 81\u{2013}104, \
+         https://doi.org/10.5555/arcs.2019.4.81.",
+        "note-regime same-author cluster with no locator should match citeproc-js exactly"
+    );
+}
+
+/// Same as above with a locator on the second item. The second clause's
+/// date/locator punctuation (`4 (2019), 257` rather than oracle
+/// `4 (2019): 257`) is an independent, pre-existing defect that reproduces
+/// on single-item citations too — unrelated to collapse and not ratified
+/// here (flagged while investigating `csl26-m11m`, deliberately out of
+/// scope for this spec).
+#[test]
+fn given_chicago_notes_style_when_same_author_cluster_has_a_locator_then_each_item_renders_in_full()
+{
+    let root = project_root();
+    let style = load_style(&root.join("styles/embedded/chicago-notes-18th.yaml"));
+    let bibliography = load_bibliography(&root.join("tests/fixtures/references-expanded.json"))
+        .expect("expanded fixture should parse");
+
+    let processor = Processor::new(style, bibliography);
+    let citation = Citation {
+        items: vec![
+            CitationItem {
+                id: "ITEM-31".to_string(),
+                ..Default::default()
+            },
+            CitationItem {
+                id: "ITEM-32".to_string(),
+                locator: Some(CitationLocator::single(LocatorType::Page, "257")),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let rendered = processor
+        .process_citation(&citation)
+        .expect("same-author note cluster with a locator should render");
+
+    assert_eq!(
+        rendered,
+        "Maria Garcia, \u{201C}Methods for Robust Climate Attribution,\u{201D} \
+         _Annual Review of Climate Science_ 4 (2019): 55\u{2013}80, \
+         https://doi.org/10.5555/arcs.2019.4.55; Maria Garcia, \u{201C}Methods \
+         for Probabilistic Climate Attribution,\u{201D} _Annual Review of \
+         Climate Science_ 4 (2019), 257, https://doi.org/10.5555/arcs.2019.4.81.",
+        "second item's locator does not corrupt the first item's rendering"
+    );
+}
+
+/// Two citation items sharing the same reference id (`[@ITEM-31, p. 10;
+/// @ITEM-31, p. 20]`) must not merge into one clause when collapse is
+/// unset -- `group_citation_items_by_author` keys on `(index, id)` rather
+/// than bare `id` specifically to close this hole
+/// (`docs/specs/SAME_AUTHOR_COLLAPSE.md` §11). citeproc-js additionally
+/// *shortens* the repeat via per-item position tracking inside a cluster,
+/// which `docs/specs/REPEATED_NOTE_CITATION_STATE_MODEL.md` explicitly
+/// lists as out of scope -- this test pins the structural fix (no merged
+/// or malformed output), not oracle-exact shortening.
+#[test]
+fn given_chicago_notes_style_when_a_cluster_repeats_the_same_id_then_each_occurrence_renders_in_full()
+ {
+    let root = project_root();
+    let style = load_style(&root.join("styles/embedded/chicago-notes-18th.yaml"));
+    let bibliography = load_bibliography(&root.join("tests/fixtures/references-expanded.json"))
+        .expect("expanded fixture should parse");
+
+    let processor = Processor::new(style, bibliography);
+    let citation = Citation {
+        items: vec![
+            CitationItem {
+                id: "ITEM-31".to_string(),
+                locator: Some(CitationLocator::single(LocatorType::Page, "10")),
+                ..Default::default()
+            },
+            CitationItem {
+                id: "ITEM-31".to_string(),
+                locator: Some(CitationLocator::single(LocatorType::Page, "20")),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let rendered = processor
+        .process_citation(&citation)
+        .expect("duplicate-id cluster should render");
+
+    assert_eq!(
+        rendered,
+        "Maria Garcia, \u{201C}Methods for Robust Climate Attribution,\u{201D} \
+         _Annual Review of Climate Science_ 4 (2019), 10, \
+         https://doi.org/10.5555/arcs.2019.4.55; Maria Garcia, \u{201C}Methods \
+         for Robust Climate Attribution,\u{201D} _Annual Review of Climate \
+         Science_ 4 (2019), 20, https://doi.org/10.5555/arcs.2019.4.55.",
+        "duplicate-id items must each render their own full clause, not merge"
+    );
+}
+
+/// `chicago-shortened-notes-bibliography-core` also declares no `collapse`
+/// (its source, `chicago-shortened-notes-bibliography.csl`, has none) --
+/// short-form same-author repeats stay separate, joined by `"; "`.
+#[test]
+fn given_chicago_shortened_notes_style_when_same_author_cluster_has_no_locator_then_items_stay_separate()
+ {
+    let root = project_root();
+    let style =
+        load_style(&root.join("styles/embedded/chicago-shortened-notes-bibliography-core.yaml"));
+    let bibliography = load_bibliography(&root.join("tests/fixtures/references-expanded.json"))
+        .expect("expanded fixture should parse");
+
+    let processor = Processor::new(style, bibliography);
+    let citation = Citation {
+        items: vec![
+            CitationItem {
+                id: "ITEM-31".to_string(),
+                ..Default::default()
+            },
+            CitationItem {
+                id: "ITEM-32".to_string(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let rendered = processor
+        .process_citation(&citation)
+        .expect("shortened-notes same-author cluster should render");
+
+    assert_eq!(
+        rendered,
+        "Garcia, \u{201C}Methods for Robust Climate Attribution\u{201D}; Garcia, \
+         \u{201C}Methods for Probabilistic Climate Attribution.\u{201D}",
+        "short-form same-author repeats must stay separate, not collapse to a shared author"
+    );
+}
+
+/// Neither style's source CSL declares `collapse`, so a no-`collapse`
+/// author-date style now renders each same-author cite separately instead
+/// of collapsing. `taylor-and-francis-council-of-science-editors-author-date`
+/// is `csl26-ecfn`'s original finding
+/// (oracle: `(Garcia 2019a; Garcia 2019b)`); `modern-language-association`
+/// confirms `csl26-uctc`'s deferred "MLA drops the locator delimiter in
+/// collapsed groups" is moot once MLA stops collapsing -- nothing is left
+/// to drop a delimiter from.
+#[rstest]
+#[case::taylor_and_francis_cse(
+    "styles/embedded/taylor-and-francis-council-of-science-editors-author-date.yaml",
+    "(Garcia 2019a; Garcia 2019b)"
+)]
+#[case::modern_language_association(
+    "styles/embedded/modern-language-association.yaml",
+    "(Garcia, \u{201C}Methods for Robust Climate Attribution\u{201D}; Garcia, \u{201C}Methods for Probabilistic Climate Attribution\u{201D})"
+)]
+fn given_a_no_collapse_author_date_style_when_same_author_cluster_has_no_locator_then_items_stay_separate(
+    #[case] style_path: &str,
+    #[case] expected: &str,
+) {
+    let root = project_root();
+    let style = load_style(&root.join(style_path));
+    let bibliography = load_bibliography(&root.join("tests/fixtures/references-expanded.json"))
+        .expect("expanded fixture should parse");
+
+    let processor = Processor::new(style, bibliography);
+    let citation = Citation {
+        items: vec![
+            CitationItem {
+                id: "ITEM-31".to_string(),
+                ..Default::default()
+            },
+            CitationItem {
+                id: "ITEM-32".to_string(),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let rendered = processor
+        .process_citation(&citation)
+        .expect("same-author cluster should render");
+
+    assert_eq!(rendered, expected);
 }

--- a/crates/citum-migrate/src/assembly.rs
+++ b/crates/citum-migrate/src/assembly.rs
@@ -25,7 +25,9 @@ use citum_migrate::{
     template_resolver,
 };
 use citum_schema::{
-    BibliographySpec, CitationCollapse, CitationSpec, Style, StyleInfo,
+    BibliographySpec, CitationCollapse, CitationSpec, SameAuthorCollapse, Style, StyleInfo,
+    YearSuffixCollapse,
+    options::{Processing, RegimeFamily},
     template::{TemplateComponent, TemplateVariant, TypeSelector, WrapPunctuation},
 };
 use std::path::Path;
@@ -288,6 +290,11 @@ fn build_final_style(legacy_style: &csl_legacy::model::Style, mut c: CompiledOut
         _ => None,
     };
     let declares_marker = declared_label_mode.is_some();
+    // Captured before `c.options` moves into the `options:` field below —
+    // `extract_citation_collapse` needs the regime to drop values that would
+    // fail the schema's regime-coherence validation (see §4/§6 of
+    // docs/specs/SAME_AUTHOR_COLLAPSE.md).
+    let collapse_regime = c.options.processing.clone();
 
     let citation_scope_options = if declares_marker || c.citation_contributor_overrides.is_some() {
         Some(citum_schema::CitationOptions {
@@ -350,7 +357,7 @@ fn build_final_style(legacy_style: &csl_legacy::model::Style, mut c: CompiledOut
             template_ref: None,
             template: Some(c.new_cit.into()),
             locales: c.citation_locales,
-            collapse: extract_citation_collapse(&legacy_style.citation),
+            collapse: extract_citation_collapse(&legacy_style.citation, collapse_regime.as_ref()),
             wrap: c.citation_wrap.map(Into::into),
             prefix: c.citation_prefix.map(Into::into),
             suffix: c.citation_suffix.map(Into::into),
@@ -682,11 +689,60 @@ fn measured_selection_unavailable<T>(
     (current, false, None)
 }
 
-fn extract_citation_collapse(citation: &csl_legacy::model::Citation) -> Option<CitationCollapse> {
-    match citation.collapse.as_deref() {
-        Some("citation-number") => Some(CitationCollapse::CitationNumber),
-        _ => None,
-    }
+/// Map a CSL `collapse` attribute to Citum's two-axis `CitationCollapse`,
+/// losslessly for all four CSL values (`docs/specs/SAME_AUTHOR_COLLAPSE.md`
+/// §4), then drop the mapped value if it is not licensed for the style's
+/// processing regime rather than emit something that would fail the schema's
+/// regime-coherence validation (§6's carve-out for the handful of corpus
+/// styles where `collapse` is declared but doesn't fit either mechanism —
+/// 2 inert `Label` styles, 4 `Note` + `citation-number` styles).
+///
+/// Warns once for `year-suffix` / `year-suffix-ranged`: the value round-trips
+/// but the renderer doesn't implement the merged/ranged degree yet, so the
+/// migrated style renders as `separate` until that follow-up lands.
+fn extract_citation_collapse(
+    citation: &csl_legacy::model::Citation,
+    processing: Option<&Processing>,
+) -> Option<CitationCollapse> {
+    let mapped = match citation.collapse.as_deref() {
+        Some("citation-number") => CitationCollapse::CitationNumber,
+        Some("year") => CitationCollapse::SameAuthor(SameAuthorCollapse::default()),
+        Some("year-suffix") => {
+            tracing::warn!(
+                "collapse=\"year-suffix\" migrates to `same-author: {{ year-suffix: merged }}`, \
+                 which parses but is not yet rendered (falls back to separate); see \
+                 docs/specs/SAME_AUTHOR_COLLAPSE.md"
+            );
+            CitationCollapse::SameAuthor(SameAuthorCollapse {
+                year_suffix: YearSuffixCollapse::Merged,
+            })
+        }
+        Some("year-suffix-ranged") => {
+            tracing::warn!(
+                "collapse=\"year-suffix-ranged\" migrates to `same-author: {{ year-suffix: ranged }}`, \
+                 which parses but is not yet rendered (falls back to separate); see \
+                 docs/specs/SAME_AUTHOR_COLLAPSE.md"
+            );
+            CitationCollapse::SameAuthor(SameAuthorCollapse {
+                year_suffix: YearSuffixCollapse::Ranged,
+            })
+        }
+        _ => return None,
+    };
+
+    // `matches!` supplies its own catch-all arm, so this stays exhaustive
+    // against `CitationCollapse` being `#[non_exhaustive]` without an
+    // `unreachable!()` (denied workspace-wide).
+    let regime = processing.map_or(RegimeFamily::AuthorDate, Processing::regime_family);
+    let licensed = if matches!(mapped, CitationCollapse::CitationNumber) {
+        matches!(regime, RegimeFamily::Numeric | RegimeFamily::Custom)
+    } else {
+        matches!(
+            regime,
+            RegimeFamily::AuthorDate | RegimeFamily::Note | RegimeFamily::Custom
+        )
+    };
+    licensed.then_some(mapped)
 }
 
 fn bibliography_sort_matches_processing_default(
@@ -721,6 +777,109 @@ mod tests {
     use csl_legacy::model::{
         Citation, Info, Layout, Sort as LegacySort, SortKey as LegacySortKey, Style as LegacyStyle,
     };
+    use rstest::rstest;
+
+    fn legacy_citation_with_collapse(collapse: Option<&str>) -> Citation {
+        Citation {
+            layout: Layout {
+                prefix: None,
+                suffix: None,
+                delimiter: None,
+                children: vec![],
+            },
+            localized_layouts: Vec::new(),
+            sort: None,
+            collapse: collapse.map(str::to_string),
+            et_al_min: None,
+            et_al_use_first: None,
+            disambiguate_add_year_suffix: None,
+            disambiguate_add_names: None,
+            disambiguate_add_givenname: None,
+            disambiguate_givenname_rule: None,
+        }
+    }
+
+    #[rstest]
+    #[case::citation_number(
+        "citation-number",
+        Some(Processing::Numeric),
+        Some(CitationCollapse::CitationNumber)
+    )]
+    #[case::year(
+        "year",
+        Some(Processing::AuthorDate),
+        Some(CitationCollapse::SameAuthor(SameAuthorCollapse::default()))
+    )]
+    #[case::year_no_processing_defaults_to_author_date(
+        "year",
+        None,
+        Some(CitationCollapse::SameAuthor(SameAuthorCollapse::default()))
+    )]
+    #[case::year_suffix(
+        "year-suffix",
+        Some(Processing::AuthorDate),
+        Some(CitationCollapse::SameAuthor(SameAuthorCollapse {
+            year_suffix: YearSuffixCollapse::Merged,
+        }))
+    )]
+    #[case::year_suffix_ranged(
+        "year-suffix-ranged",
+        Some(Processing::AuthorDate),
+        Some(CitationCollapse::SameAuthor(SameAuthorCollapse {
+            year_suffix: YearSuffixCollapse::Ranged,
+        }))
+    )]
+    #[case::same_author_licensed_on_note(
+        "year",
+        Some(Processing::Note),
+        Some(CitationCollapse::SameAuthor(SameAuthorCollapse::default()))
+    )]
+    fn extract_citation_collapse_maps_legal_csl_values(
+        #[case] csl_value: &str,
+        #[case] processing: Option<Processing>,
+        #[case] expected: Option<CitationCollapse>,
+    ) {
+        // given a CSL citation declaring `collapse` on a regime that licenses it
+        let citation = legacy_citation_with_collapse(Some(csl_value));
+
+        // when extracted for the style's resolved processing regime
+        let extracted = extract_citation_collapse(&citation, processing.as_ref());
+
+        // then it maps losslessly per SAME_AUTHOR_COLLAPSE.md §4
+        assert_eq!(extracted, expected);
+    }
+
+    #[rstest]
+    #[case::same_author_illegal_on_numeric("year", Processing::Numeric)]
+    #[case::citation_number_illegal_on_note("citation-number", Processing::Note)]
+    #[case::citation_number_illegal_on_author_date("citation-number", Processing::AuthorDate)]
+    fn extract_citation_collapse_drops_value_illegal_for_regime(
+        #[case] csl_value: &str,
+        #[case] processing: Processing,
+    ) {
+        // given a CSL citation declaring `collapse` on a regime that does not
+        // license it (SAME_AUTHOR_COLLAPSE.md §6's carve-out)
+        let citation = legacy_citation_with_collapse(Some(csl_value));
+
+        // when extracted for that regime
+        let extracted = extract_citation_collapse(&citation, Some(&processing));
+
+        // then the attribute is dropped rather than emitting a value that
+        // would fail the schema's regime-coherence validation
+        assert_eq!(extracted, None);
+    }
+
+    #[test]
+    fn extract_citation_collapse_absent_attribute_yields_none() {
+        // given a CSL citation with no `collapse` attribute
+        let citation = legacy_citation_with_collapse(None);
+
+        // when extracted
+        let extracted = extract_citation_collapse(&citation, Some(&Processing::AuthorDate));
+
+        // then no collapse is migrated
+        assert_eq!(extracted, None);
+    }
 
     #[test]
     fn bibliography_candidate_preserves_current_citation_section() {
@@ -823,10 +982,19 @@ mod tests {
         let mut style = minimal_legacy_style();
         style.citation.collapse = Some("citation-number".to_string());
 
+        // `citation-number` collapse is only licensed on `Numeric` regime
+        // (SAME_AUTHOR_COLLAPSE.md §6); a real numeric-style migration always
+        // has `processing: numeric` detected ahead of assembly, so the test
+        // fixture must too, or the regime-coherence check drops the value.
+        let options = citum_schema::options::Config {
+            processing: Some(Processing::Numeric),
+            ..citum_schema::options::Config::default()
+        };
+
         let migrated = build_final_style(
             &style,
             CompiledOutput {
-                options: citum_schema::options::Config::default(),
+                options,
                 bibliography_options: None,
                 citation_contributor_overrides: None,
                 bibliography_contributor_overrides: None,

--- a/crates/citum-resolver-api/src/error.rs
+++ b/crates/citum-resolver-api/src/error.rs
@@ -170,6 +170,18 @@ pub enum ResolutionError {
         /// Version of the running engine.
         declared: String,
     },
+    /// A `citation.collapse` value is not licensed for the style's processing
+    /// regime, e.g. `same-author` on a `Numeric` style or `citation-number`
+    /// on an `AuthorDate` style. See `docs/specs/SAME_AUTHOR_COLLAPSE.md` §6.
+    #[error("`{collapse}` collapse is not valid for `{processing}` processing in `{location}`")]
+    IncoherentCollapseRegime {
+        /// Human-readable location hint (e.g. `"citation.collapse"`).
+        location: String,
+        /// The declared collapse value, formatted for the error message.
+        collapse: String,
+        /// The style's resolved processing regime, formatted for the error message.
+        processing: String,
+    },
 }
 
 impl ResolutionError {

--- a/crates/citum-schema-style/embedded/styles/apa-7th.yaml
+++ b/crates/citum-schema-style/embedded/styles/apa-7th.yaml
@@ -89,6 +89,9 @@ options:
   page-range-format: expanded
   punctuation-in-quote: true
 citation:
+  # source (apa.csl): collapse="year" — docs/specs/SAME_AUTHOR_COLLAPSE.md §7
+  collapse:
+    same-author: {}
   options:
     contributors:
       shorten: {min: 3, use-first: 1}

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -82,6 +82,9 @@ options:
     serial:
       emph: true
 citation:
+  # source (chicago-author-date.csl): collapse="year" — SAME_AUTHOR_COLLAPSE.md §7
+  collapse:
+    same-author: {}
   options:
     substitute:
       candidates:

--- a/crates/citum-schema-style/embedded/styles/elsevier-harvard-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/elsevier-harvard-core.yaml
@@ -51,6 +51,9 @@ options:
   punctuation-in-quote: true
   volume-pages-delimiter: { mark: comma }
 citation:
+  # source (elsevier-harvard.csl): collapse="year" — SAME_AUTHOR_COLLAPSE.md §7
+  collapse:
+    same-author: {}
   options:
     substitute:
       candidates:

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-author-date.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-author-date.yaml
@@ -45,6 +45,10 @@ options:
     name-form: initials
   page-range-format: expanded
 citation:
+  # source (tests/fixtures/csl-m/gb-t-7714-2025-author-date.csl):
+  # collapse="year" — SAME_AUTHOR_COLLAPSE.md §7
+  collapse:
+    same-author: {}
   options:
     contributors:
       shorten:

--- a/crates/citum-schema-style/embedded/styles/springer-basic-author-date-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/springer-basic-author-date-core.yaml
@@ -37,6 +37,12 @@ options:
   dates: short
   punctuation-in-quote: true
 citation:
+  # source (springer-basic-author-date.csl): collapse="year-suffix" —
+  # SAME_AUTHOR_COLLAPSE.md §7. `merged` parses and round-trips but isn't
+  # yet rendered by the engine (falls back to `separate`).
+  collapse:
+    same-author:
+      year-suffix: merged
   options:
     contributors:
       shorten:

--- a/crates/citum-schema-style/src/lib.rs
+++ b/crates/citum-schema-style/src/lib.rs
@@ -78,8 +78,8 @@ pub use presets::{ContributorPreset, DatePreset, SortPreset, SubstitutePreset, T
 pub use registry::{RegistryEntry, StyleRegistry};
 pub use style::{
     BibliographySpec, CitationCollapse, CitationField, CitationSpec, NoteStartTextCase,
-    SchemaWarning, Style, StyleDocumentError, StyleDocumentFormat, StyleInfo, StyleLink,
-    StylePerson, StyleSource, check_citum_version,
+    SameAuthorCollapse, SchemaWarning, Style, StyleDocumentError, StyleDocumentFormat, StyleInfo,
+    StyleLink, StylePerson, StyleSource, YearSuffixCollapse, check_citum_version,
 };
 pub use style_base::StyleBase;
 pub use template::{

--- a/crates/citum-schema-style/src/style/mod.rs
+++ b/crates/citum-schema-style/src/style/mod.rs
@@ -16,5 +16,8 @@ mod validation;
 pub use metadata::{CitationField, StyleInfo, StyleLink, StylePerson, StyleSource};
 pub use model::{Style, StyleDocumentError, StyleDocumentFormat};
 pub use resolution::check_citum_version;
-pub use sections::{BibliographySpec, CitationCollapse, CitationSpec, NoteStartTextCase};
+pub use sections::{
+    BibliographySpec, CitationCollapse, CitationSpec, NoteStartTextCase, SameAuthorCollapse,
+    YearSuffixCollapse,
+};
 pub use validation::SchemaWarning;

--- a/crates/citum-schema-style/src/style/resolution.rs
+++ b/crates/citum-schema-style/src/style/resolution.rs
@@ -133,6 +133,7 @@ impl Style {
             let mut style = self;
             crate::template::resolve_style_template_variants(&mut style, None)?;
             options::scoped::apply_scoped_style_options(&mut style);
+            style.validate_collapse_regime()?;
             return Ok(style);
         };
 
@@ -194,6 +195,7 @@ impl Style {
         if is_profile {
             effective.extends = None;
         }
+        effective.validate_collapse_regime()?;
 
         Ok(effective)
     }

--- a/crates/citum-schema-style/src/style/sections/citation.rs
+++ b/crates/citum-schema-style/src/style/sections/citation.rs
@@ -18,13 +18,124 @@ use crate::template::{
     TemplateReference, TemplateVariant, TemplateVariants, matched_localized_template,
 };
 
+/// String forms accepted by [`CitationCollapse`]'s hand-written `Deserialize`.
+const CITATION_COLLAPSE_STRING_VARIANTS: &[&str] = &["citation-number", "same-author"];
+
 /// Citation collapse behavior for multi-item citations.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+///
+/// `Deserialize`/`Serialize` are hand-written (see the `impl` blocks below),
+/// not derived — a plain `#[derive]` on a tuple variant like `SameAuthor(..)`
+/// only accepts the tagged-map form (`{ "same-author": {...} }`), not the bare
+/// `same-author` string shorthand. This mirrors `Processing`
+/// (`crate::options::processing`), which hand-writes its own impls for the
+/// same reason on `Label(..)`.
+// `rename_all` is retained for `JsonSchema` derive (the hand-written
+// `Serialize`/`Deserialize` impls below already use kebab-case names
+// directly).
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "schema", derive(JsonSchema))]
-#[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "schema", schemars(rename_all = "kebab-case"))]
+#[non_exhaustive]
 pub enum CitationCollapse {
     /// Collapse adjacent citation numbers into a numeric range such as `1–3`.
     CitationNumber,
+    /// Collapse a same-author multi-item group onto one author name with a
+    /// joined year/date list. See `docs/specs/SAME_AUTHOR_COLLAPSE.md`.
+    SameAuthor(SameAuthorCollapse),
+}
+
+impl Serialize for CitationCollapse {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            CitationCollapse::CitationNumber => serializer.serialize_str("citation-number"),
+            CitationCollapse::SameAuthor(config) => {
+                use serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry("same-author", config)?;
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CitationCollapse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::{self, MapAccess, Visitor};
+
+        struct CitationCollapseVisitor;
+
+        impl<'de> Visitor<'de> for CitationCollapseVisitor {
+            type Value = CitationCollapse;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a citation collapse string or map")
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<CitationCollapse, E> {
+                match v {
+                    "citation-number" => Ok(CitationCollapse::CitationNumber),
+                    "same-author" => {
+                        Ok(CitationCollapse::SameAuthor(SameAuthorCollapse::default()))
+                    }
+                    other => Err(E::unknown_variant(other, CITATION_COLLAPSE_STRING_VARIANTS)),
+                }
+            }
+
+            fn visit_map<A: MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<CitationCollapse, A::Error> {
+                let key: String = map
+                    .next_key()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &"1"))?;
+                match key.as_str() {
+                    "same-author" => {
+                        let config: SameAuthorCollapse = map.next_value()?;
+                        Ok(CitationCollapse::SameAuthor(config))
+                    }
+                    other => Err(de::Error::unknown_field(other, &["same-author"])),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(CitationCollapseVisitor)
+    }
+}
+
+/// Configuration for [`CitationCollapse::SameAuthor`].
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub struct SameAuthorCollapse {
+    /// How same-year disambiguation suffixes render inside a collapsed group.
+    #[serde(default)]
+    pub year_suffix: YearSuffixCollapse,
+}
+
+/// How same-year disambiguation suffixes render inside a same-author collapsed
+/// group. Mirrors CSL's `year-suffix` / `year-suffix-ranged` collapse values.
+#[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum YearSuffixCollapse {
+    /// `Smith (2020a, 2020b)` — Citum's existing behavior; each suffixed year
+    /// token stays atomic. See `CITATION_CLUSTER_RENDERING.md` §Same-Year
+    /// Disambiguation.
+    #[default]
+    Separate,
+    /// `Smith (2020a, b)` — CSL `collapse="year-suffix"`. Parses and
+    /// round-trips; not yet implemented by the renderer (falls back to
+    /// `Separate` with a one-time load warning).
+    Merged,
+    /// `Smith (2020a–c)` — CSL `collapse="year-suffix-ranged"`. Same status as
+    /// `Merged`.
+    Ranged,
 }
 
 /// Text-case transform applied when a citation renders at note start.

--- a/crates/citum-schema-style/src/style/sections/mod.rs
+++ b/crates/citum-schema-style/src/style/sections/mod.rs
@@ -9,4 +9,6 @@ pub mod bibliography;
 pub mod citation;
 
 pub use bibliography::BibliographySpec;
-pub use citation::{CitationCollapse, CitationSpec, NoteStartTextCase};
+pub use citation::{
+    CitationCollapse, CitationSpec, NoteStartTextCase, SameAuthorCollapse, YearSuffixCollapse,
+};

--- a/crates/citum-schema-style/src/style/validation.rs
+++ b/crates/citum-schema-style/src/style/validation.rs
@@ -5,11 +5,14 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 
 //! Style validation and resource-limit checks.
 
+use crate::options::processing::RegimeFamily;
 use crate::template::{
     LocalizedTemplateSpec, TemplateComponent, TemplateVariant, TemplateVariants,
 };
 use crate::version::{MAX_TEMPLATE_COMPONENTS, MAX_TEMPLATE_NESTING_DEPTH};
-use crate::{BibliographySpec, CitationSpec, ResolutionError};
+use crate::{
+    BibliographySpec, CitationCollapse, CitationSpec, ResolutionError, YearSuffixCollapse,
+};
 
 use super::Style;
 
@@ -30,6 +33,14 @@ pub enum SchemaWarning {
         /// Human-readable location hint (e.g., `"bibliography.type-variants"`).
         location: String,
     },
+    /// `collapse: same-author` declares `year-suffix: merged` or `ranged`,
+    /// which parses and round-trips but is not yet implemented by the
+    /// renderer — same-year suffixes still render `Separate`.
+    /// See `docs/specs/SAME_AUTHOR_COLLAPSE.md`.
+    UnimplementedCollapseDegree {
+        /// Human-readable location hint (e.g., `"citation.collapse"`).
+        location: String,
+    },
 }
 
 impl std::fmt::Display for SchemaWarning {
@@ -40,6 +51,14 @@ impl std::fmt::Display for SchemaWarning {
                     f,
                     "unknown reference type \"{name}\" in {location} \
                      (may not match a reference; check for typos)"
+                )
+            }
+            SchemaWarning::UnimplementedCollapseDegree { location } => {
+                write!(
+                    f,
+                    "{location} declares a year-suffix collapse degree \
+                     (merged/ranged) not yet implemented by the renderer; \
+                     falls back to separate suffixes"
                 )
             }
         }
@@ -83,6 +102,36 @@ impl Style {
             budget.check_bibliography_spec(bibliography, "bibliography", 0)?;
         }
 
+        Ok(())
+    }
+
+    /// Validate that any declared `citation.collapse` (including on
+    /// `integral`/`non-integral`/`subsequent`/`ibid` sub-specs) is licensed
+    /// for the style's resolved processing regime.
+    ///
+    /// `same-author` is legal on `AuthorDate`-family, `Note`, and `Custom`;
+    /// `citation-number` is legal on `Numeric` and `Custom` — mirroring the
+    /// engine's own existing gate, `should_collapse_citation_numbers`, which
+    /// already requires `Processing::Numeric`. Absent `options.processing`
+    /// resolves to `Processing::default()` (`AuthorDate`), matching the
+    /// schema default. See `docs/specs/SAME_AUTHOR_COLLAPSE.md` §6.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResolutionError::IncoherentCollapseRegime`] for the first
+    /// sub-spec whose declared `collapse` value is not licensed.
+    pub(crate) fn validate_collapse_regime(&self) -> Result<(), ResolutionError> {
+        let regime = self
+            .options
+            .as_ref()
+            .and_then(|options| options.processing.as_ref())
+            .map_or(
+                RegimeFamily::AuthorDate,
+                crate::options::Processing::regime_family,
+            );
+        if let Some(citation) = &self.citation {
+            check_collapse_regime(citation, "citation", regime)?;
+        }
         Ok(())
     }
 
@@ -295,6 +344,13 @@ fn collect_citation_spec_warnings(
             }
         }
     }
+    if let Some(CitationCollapse::SameAuthor(config)) = &spec.collapse
+        && config.year_suffix != YearSuffixCollapse::Separate
+    {
+        warnings.push(SchemaWarning::UnimplementedCollapseDegree {
+            location: format!("{location}.collapse"),
+        });
+    }
     // Recurse into sub-specs
     for (sub_name, sub_spec) in [
         ("integral", spec.integral.as_deref()),
@@ -307,6 +363,64 @@ fn collect_citation_spec_warnings(
     {
         collect_citation_spec_warnings(sub_spec, &format!("{location}.{sub_name}"), warnings);
     }
+}
+
+/// Human-readable name for a [`CitationCollapse`] value, for error messages.
+fn collapse_label(collapse: &CitationCollapse) -> &'static str {
+    match collapse {
+        CitationCollapse::CitationNumber => "citation-number",
+        CitationCollapse::SameAuthor(_) => "same-author",
+    }
+}
+
+/// Human-readable name for a [`RegimeFamily`], for error messages.
+fn regime_label(regime: RegimeFamily) -> &'static str {
+    match regime {
+        RegimeFamily::AuthorDate => "author-date",
+        RegimeFamily::Numeric => "numeric",
+        RegimeFamily::Note => "note",
+        RegimeFamily::Label => "label",
+        RegimeFamily::Custom => "custom",
+    }
+}
+
+/// Recursively check `collapse` on a `CitationSpec` and its sub-specs against
+/// the style's resolved processing regime.
+fn check_collapse_regime(
+    spec: &CitationSpec,
+    location: &str,
+    regime: RegimeFamily,
+) -> Result<(), ResolutionError> {
+    if let Some(collapse) = &spec.collapse {
+        let licensed = match collapse {
+            CitationCollapse::SameAuthor(_) => matches!(
+                regime,
+                RegimeFamily::AuthorDate | RegimeFamily::Note | RegimeFamily::Custom
+            ),
+            CitationCollapse::CitationNumber => {
+                matches!(regime, RegimeFamily::Numeric | RegimeFamily::Custom)
+            }
+        };
+        if !licensed {
+            return Err(ResolutionError::IncoherentCollapseRegime {
+                location: format!("{location}.collapse"),
+                collapse: collapse_label(collapse).to_string(),
+                processing: regime_label(regime).to_string(),
+            });
+        }
+    }
+    for (sub_name, sub_spec) in [
+        ("integral", spec.integral.as_deref()),
+        ("non-integral", spec.non_integral.as_deref()),
+        ("subsequent", spec.subsequent.as_deref()),
+        ("ibid", spec.ibid.as_deref()),
+    ]
+    .into_iter()
+    .filter_map(|(n, s)| s.map(|s| (n, s)))
+    {
+        check_collapse_regime(sub_spec, &format!("{location}.{sub_name}"), regime)?;
+    }
+    Ok(())
 }
 
 fn collect_date_fallback_warnings(

--- a/crates/citum-schema-style/src/tests.rs
+++ b/crates/citum-schema-style/src/tests.rs
@@ -2515,3 +2515,178 @@ bibliography:
             if contributor.contributor == template::ContributorRoles::Single(template::ContributorRole::Author)
     ));
 }
+
+// --- CitationCollapse: same-author variant (csl26-ecfn / csl26-m11m) ---
+// docs/specs/SAME_AUTHOR_COLLAPSE.md
+
+#[test]
+fn citation_collapse_bare_citation_number_round_trips() {
+    let style: Style = serde_yaml::from_str(
+        r"
+info:
+  title: Numeric Round Trip
+citation:
+  collapse: citation-number
+",
+    )
+    .unwrap();
+
+    assert_eq!(
+        style.citation.as_ref().and_then(|c| c.collapse.clone()),
+        Some(CitationCollapse::CitationNumber)
+    );
+
+    let serialized = serde_yaml::to_string(&style).unwrap();
+    let serialized_value: serde_yaml::Value = serde_yaml::from_str(&serialized).unwrap();
+    assert_eq!(
+        serialized_value["citation"]["collapse"].as_str(),
+        Some("citation-number"),
+        "citation-number must serialize back to the bare-string form, got:\n{serialized}"
+    );
+}
+
+#[test]
+fn citation_collapse_bare_same_author_string_deserializes_as_default_config() {
+    let style: Style = serde_yaml::from_str(
+        r"
+info:
+  title: Same Author Sugar
+citation:
+  collapse: same-author
+",
+    )
+    .unwrap();
+
+    assert_eq!(
+        style.citation.as_ref().and_then(|c| c.collapse.clone()),
+        Some(CitationCollapse::SameAuthor(SameAuthorCollapse::default()))
+    );
+
+    // Deserialize-only sugar, matching `processing: label`'s existing
+    // asymmetry: the bare string never round-trips byte-for-byte, it
+    // always re-serializes as the tagged map.
+    let serialized = serde_yaml::to_string(&style).unwrap();
+    let serialized_value: serde_yaml::Value = serde_yaml::from_str(&serialized).unwrap();
+    let collapse = &serialized_value["citation"]["collapse"];
+    assert_eq!(
+        collapse["same-author"]["year-suffix"].as_str(),
+        Some("separate"),
+        "same-author must serialize as its tagged map form, got:\n{serialized}"
+    );
+    assert!(
+        collapse.as_mapping().is_some(),
+        "same-author must not serialize as a bare string, got:\n{serialized}"
+    );
+}
+
+#[rstest]
+#[case::merged("merged", YearSuffixCollapse::Merged)]
+#[case::ranged("ranged", YearSuffixCollapse::Ranged)]
+fn citation_collapse_config_map_form_round_trips(
+    #[case] degree: &str,
+    #[case] expected: YearSuffixCollapse,
+) {
+    let yaml = format!(
+        "info:\n  title: Config Map Form\ncitation:\n  collapse:\n    same-author:\n      year-suffix: {degree}\n"
+    );
+    let style: Style = serde_yaml::from_str(&yaml).unwrap();
+
+    assert_eq!(
+        style.citation.as_ref().and_then(|c| c.collapse.clone()),
+        Some(CitationCollapse::SameAuthor(SameAuthorCollapse {
+            year_suffix: expected
+        }))
+    );
+
+    let serialized = serde_yaml::to_string(&style).unwrap();
+    let reparsed: Style = serde_yaml::from_str(&serialized).unwrap();
+    assert_eq!(
+        reparsed.citation.as_ref().and_then(|c| c.collapse.clone()),
+        style.citation.as_ref().and_then(|c| c.collapse.clone()),
+        "config-map form must round-trip byte-for-byte through re-serialization"
+    );
+}
+
+fn style_with_processing_and_collapse(
+    processing: options::Processing,
+    collapse: CitationCollapse,
+) -> Style {
+    Style {
+        info: StyleInfo {
+            title: Some("Regime Coherence Test".to_string()),
+            ..Default::default()
+        },
+        options: Some(options::Config {
+            processing: Some(processing),
+            ..Default::default()
+        }),
+        citation: Some(CitationSpec {
+            collapse: Some(collapse),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+#[rstest]
+#[case::same_author_on_author_date(
+    options::Processing::AuthorDate,
+    CitationCollapse::SameAuthor(SameAuthorCollapse::default())
+)]
+#[case::same_author_on_note(
+    options::Processing::Note,
+    CitationCollapse::SameAuthor(SameAuthorCollapse::default())
+)]
+#[case::same_author_on_custom(
+    options::Processing::Custom(options::ProcessingCustom::default()),
+    CitationCollapse::SameAuthor(SameAuthorCollapse::default())
+)]
+#[case::citation_number_on_numeric(options::Processing::Numeric, CitationCollapse::CitationNumber)]
+#[case::citation_number_on_custom(
+    options::Processing::Custom(options::ProcessingCustom::default()),
+    CitationCollapse::CitationNumber
+)]
+fn collapse_regime_coherence_accepts_licensed_combinations(
+    #[case] processing: options::Processing,
+    #[case] collapse: CitationCollapse,
+) {
+    let style = style_with_processing_and_collapse(processing, collapse);
+    let resolved = style.try_into_resolved_recursive(&mut std::collections::HashSet::new());
+    assert!(
+        resolved.is_ok(),
+        "expected this collapse/regime combination to be accepted: {resolved:?}"
+    );
+}
+
+#[rstest]
+#[case::same_author_on_numeric(
+    options::Processing::Numeric,
+    CitationCollapse::SameAuthor(SameAuthorCollapse::default())
+)]
+#[case::same_author_on_label(
+    options::Processing::Label(options::LabelConfig::default()),
+    CitationCollapse::SameAuthor(SameAuthorCollapse::default())
+)]
+#[case::citation_number_on_author_date(
+    options::Processing::AuthorDate,
+    CitationCollapse::CitationNumber
+)]
+#[case::citation_number_on_note(options::Processing::Note, CitationCollapse::CitationNumber)]
+#[case::citation_number_on_label(
+    options::Processing::Label(options::LabelConfig::default()),
+    CitationCollapse::CitationNumber
+)]
+fn collapse_regime_coherence_rejects_illegal_combinations(
+    #[case] processing: options::Processing,
+    #[case] collapse: CitationCollapse,
+) {
+    let style = style_with_processing_and_collapse(processing, collapse);
+    let resolved = style.try_into_resolved_recursive(&mut std::collections::HashSet::new());
+    assert!(
+        matches!(
+            resolved,
+            Err(ResolutionError::IncoherentCollapseRegime { .. })
+        ),
+        "expected IncoherentCollapseRegime, got: {resolved:?}"
+    );
+}

--- a/crates/citum-schema-style/src/tests.rs
+++ b/crates/citum-schema-style/src/tests.rs
@@ -771,6 +771,7 @@ fn style_validate_emits_warning_for_unknown_type_in_bib_type_variants() {
             assert_eq!(name, "typo-type");
             assert_eq!(location, "bibliography.type-variants");
         }
+        other => panic!("unexpected warning: {other:?}"),
     }
 }
 

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -7839,12 +7839,56 @@
       "unevaluatedProperties": false
     },
     "CitationCollapse": {
-      "description": "Citation collapse behavior for multi-item citations.",
+      "description": "Citation collapse behavior for multi-item citations.\n\n`Deserialize`/`Serialize` are hand-written (see the `impl` blocks below),\nnot derived — a plain `#[derive]` on a tuple variant like `SameAuthor(..)`\nonly accepts the tagged-map form (`{ \"same-author\": {...} }`), not the bare\n`same-author` string shorthand. This mirrors `Processing`\n(`crate::options::processing`), which hand-writes its own impls for the\nsame reason on `Label(..)`.",
       "oneOf": [
         {
           "description": "Collapse adjacent citation numbers into a numeric range such as `1–3`.",
           "type": "string",
           "const": "citation-number"
+        },
+        {
+          "description": "Collapse a same-author multi-item group onto one author name with a\njoined year/date list. See `docs/specs/SAME_AUTHOR_COLLAPSE.md`.",
+          "type": "object",
+          "properties": {
+            "same-author": {
+              "$ref": "#/$defs/SameAuthorCollapse"
+            }
+          },
+          "required": [
+            "same-author"
+          ],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "SameAuthorCollapse": {
+      "description": "Configuration for [`CitationCollapse::SameAuthor`].",
+      "type": "object",
+      "properties": {
+        "year-suffix": {
+          "description": "How same-year disambiguation suffixes render inside a collapsed group.",
+          "$ref": "#/$defs/YearSuffixCollapse",
+          "default": "separate"
+        }
+      }
+    },
+    "YearSuffixCollapse": {
+      "description": "How same-year disambiguation suffixes render inside a same-author collapsed\ngroup. Mirrors CSL's `year-suffix` / `year-suffix-ranged` collapse values.",
+      "oneOf": [
+        {
+          "description": "`Smith (2020a, 2020b)` — Citum's existing behavior; each suffixed year\ntoken stays atomic. See `CITATION_CLUSTER_RENDERING.md` §Same-Year\nDisambiguation.",
+          "type": "string",
+          "const": "separate"
+        },
+        {
+          "description": "`Smith (2020a, b)` — CSL `collapse=\"year-suffix\"`. Parses and\nround-trips; not yet implemented by the renderer (falls back to\n`Separate` with a one-time load warning).",
+          "type": "string",
+          "const": "merged"
+        },
+        {
+          "description": "`Smith (2020a–c)` — CSL `collapse=\"year-suffix-ranged\"`. Same status as\n`Merged`.",
+          "type": "string",
+          "const": "ranged"
         }
       ]
     },

--- a/docs/specs/CITATION_CLUSTER_RENDERING.md
+++ b/docs/specs/CITATION_CLUSTER_RENDERING.md
@@ -1,8 +1,8 @@
 # Citation Cluster Rendering Specification
 
 **Status:** Active
-**Version:** 1.4
-**Date:** 2026-08-18
+**Version:** 1.5
+**Date:** 2026-08-19
 **Related:** `crates/citum-schema-data/src/citation.rs`,
 `crates/citum-engine/src/processor/citation.rs`,
 `crates/citum-engine/src/processor/rendering/grouped/core.rs`,

--- a/docs/specs/SAME_AUTHOR_COLLAPSE.md
+++ b/docs/specs/SAME_AUTHOR_COLLAPSE.md
@@ -1,8 +1,8 @@
 # Same-Author Collapse Specification
 
-**Status:** Draft
-**Version:** 1.0
-**Date:** 2026-08-18
+**Status:** Active
+**Version:** 1.1
+**Date:** 2026-08-19
 **Supersedes:** N/A
 **Related:** `csl26-ecfn`, `csl26-m11m`, `docs/specs/CITATION_CLUSTER_RENDERING.md`,
 `docs/specs/CITATION_REGIME.md`, `docs/adjudication/DIVERGENCE_REGISTER.md` (div-017),
@@ -422,10 +422,13 @@ more expressive intent elsewhere. Consistent with the existing
 regime-coherence enforcement in `docs/specs/CITATION_REGIME.md` (the
 inheritance invariant) and `StyleLineage::apply_regime_guard` in migrate.
 
-### 7. Embedded styles requiring `collapse: same-author`
+### 7. Tracked styles requiring `collapse: same-author`
 
 Source CSL attribute noted in parentheses; declaring this preserves rendering
-exactly as it is today:
+exactly as it is today. v1.0 listed only the 5 embedded styles below; v1.1
+adds the 4 non-embedded tracked styles it missed, found by mechanically
+re-deriving this table against every tracked style's actual `styles-legacy/`
+source rather than trusting the v1.0 enumeration:
 
 | style | source CSL `collapse` | Citum `collapse` after this spec |
 |---|---|---|
@@ -434,13 +437,31 @@ exactly as it is today:
 | `elsevier-harvard-core` | `year` | `same-author` |
 | `springer-basic-author-date-core` | `year-suffix` | `{ same-author: { year-suffix: merged } }` |
 | `gb-t-7714-2025-author-date` | `year` | `same-author` |
+| `elsevier-vancouver-author-date` | `year` | `same-author` |
+| `harvard-cite-them-right` | `year` | `same-author` |
+| `international-journal-of-wildland-fire` | `year-suffix` | `{ same-author: { year-suffix: merged } }` |
+| `styles/experimental/chicago-author-date` | `year` | `same-author` |
 
 `taylor-and-francis-chicago-author-date-core` inherits `collapse` via `extends:
 chicago-author-date-18th`; no separate declaration needed.
-`springer-basic-author-date-core` is the one style that gains real fidelity
+`springer-basic-author-date-core` is one style that gains real fidelity
 from the two-axis shape rather than just parity: its source declares
 `year-suffix`, which the flat-enum alternative below would have flattened to
 plain `year` behavior exactly as migrate does today.
+`international-journal-of-wildland-fire` extends `springer-basic-author-date`
+(itself extending `-core`) and would inherit the merged degree regardless —
+both share `RegimeFamily::Custom`, which never triggers the inheritance
+guard's cross-family sub-spec reset — but is declared explicitly here since
+its own source independently requests it.
+
+Declared using the config-map form (`same-author: {}`, not the bare
+`same-author` string) in every tracked style: the generated JSON schema only
+advertises `same-author` as an object (§1), so
+`scripts/validate-schemas.js` — which has no normalization step for this
+sugar, unlike its existing `processing:` custom-config handling — rejects the
+bare form. The map form is also what every other config-carrying variant in
+this codebase already uses (`processing: { label: {...} }`, never bare
+`label`).
 
 ### 8. Embedded styles that must NOT declare it
 
@@ -507,8 +528,13 @@ output) and a pinned regression test, not oracle-exact shortening.
 `csl26-uctc` deferred "MLA drops the locator delimiter entirely in collapsed
 groups" as out of scope. `modern-language-association.csl` has no `collapse`
 attribute, so under this spec MLA stops collapsing same-author clusters
-entirely, which likely moots that defect (nothing left to drop a delimiter
-from). Implementation should confirm, not assume.
+entirely, which moots that defect (nothing left to drop a delimiter from).
+**Confirmed**, not just predicted: a same-author, no-locator cluster on
+`modern-language-association.yaml` now renders
+`(Garcia, "…"; Garcia, "…")` — each item in full, joined by the ordinary
+delimiter, no collapse path entered
+(`given_a_no_collapse_author_date_style_when_same_author_cluster_has_no_locator_then_items_stay_separate::case_2_modern_language_association`,
+`domain_fixtures.rs`).
 
 ## Rejected Alternatives
 
@@ -561,7 +587,7 @@ CMOS-vs-citeproc-js disagreement that survives this spec unchanged).
 
 ## Acceptance Criteria
 
-- [ ] `collapse: same-author` (bare-string) and `{ same-author: { year-suffix:
+- [x] `collapse: same-author` (bare-string) and `{ same-author: { year-suffix:
       … } }` (config-map) both parse; the config-map form serializes back
       identically (the bare-string form is deserialize-only sugar and is not
       expected to round-trip byte-for-byte, matching `processing: label`'s
@@ -571,9 +597,9 @@ CMOS-vs-citeproc-js disagreement that survives this spec unchanged).
       `Processing`'s published schema (`docs/schemas/style.json`) exactly —
       `"label"` is schema-advertised only as an object, never as a bare
       string, even though the Rust deserializer accepts both.
-- [ ] Absent `citation.collapse` (directly or via inheritance) produces no
+- [x] Absent `citation.collapse` (directly or via inheritance) produces no
       same-author collapse, in every regime and both citation modes.
-- [ ] Migrate maps all four CSL `collapse` values with no information
+- [x] Migrate maps all four CSL `collapse` values with no information
       discarded on `Numeric`, `AuthorDate`-family, and `Note` styles whose
       content matches one of the two collapse mechanisms; `year-suffix` /
       `year-suffix-ranged` additionally emit a one-time load warning naming
@@ -582,27 +608,55 @@ CMOS-vs-citeproc-js disagreement that survives this spec unchanged).
       `Note` + `citation-number` styles per §6's caveat) are a known,
       out-of-scope gap — migrate drops the attribute for them, matching
       today's behavior for a no-`collapse` style, not a validation error.
-- [ ] `collapse: same-author` is accepted on `AuthorDate`-family, `Note`, and
+- [x] `collapse: same-author` is accepted on `AuthorDate`-family, `Note`, and
       `Custom`; rejected on `Numeric` and `Label`. `collapse: citation-number`
       is accepted on `Numeric` and `Custom`; rejected on `AuthorDate`-family,
       `Note`, and `Label`. Every rejection carries an actionable error (§6).
-- [ ] The five embedded styles in §7 show **zero** exactParity movement on
-      `node scripts/report-core.js --style <name>`.
-- [ ] `chicago-notes-18th`'s `note-disambiguate-year-suffix` fixture citation
-      becomes exact.
-- [ ] `div-017` continues to apply to `disambiguate-year-suffix` and
-      `subsequent-author-consecutive` on `chicago-author-date-18th`.
-- [ ] Duplicate-id clusters (no `collapse` set) render each item in full with
+- [x] The nine tracked styles in §7 show **zero** exactParity movement on
+      `node scripts/report-core.js --style <name>` (checked against a
+      `52481a17` worktree baseline: `apa-7th` 93/146, `chicago-author-date-18th`
+      174/542, `elsevier-harvard` 45/67, `gb-t-7714-2025-author-date` 39/62,
+      `springer-basic-author-date` 53/67, `elsevier-vancouver-author-date`
+      17/67, `harvard-cite-them-right` 22/67,
+      `international-journal-of-wildland-fire` 14/67,
+      `taylor-and-francis-chicago-author-date` 174/542 — all unchanged;
+      `styles/experimental/chicago-author-date` isn't scanned by
+      `report-core.js`, verified structurally via `citum style validate`
+      instead).
+- [x] `chicago-notes-18th`'s `note-disambiguate-year-suffix` fixture citation
+      becomes exact — pinned byte-for-byte against
+      `tests/snapshots/csl/chicago-notes.json` in
+      `given_chicago_notes_style_when_same_author_cluster_has_no_locator_then_renders_exact_oracle_match`.
+- [x] `div-017` continues to apply to `disambiguate-year-suffix` and
+      `subsequent-author-consecutive` on `chicago-author-date-18th` — the four
+      pre-existing `csl26-uctc` tests in `domain_fixtures.rs` still pass
+      unchanged.
+- [x] Duplicate-id clusters (no `collapse` set) render each item in full with
       no merged/malformed output — regression test pinned, not compared
       against citeproc-js's shortened form.
-- [ ] A corpus sweep is run and net exactParity movement is reported per style
+- [x] A corpus sweep is run and net exactParity movement is reported per style
       touched, including
-      `taylor-and-francis-council-of-science-editors-author-date`.
+      `taylor-and-francis-council-of-science-editors-author-date`. Full
+      `report-core.js --parallelism 1` sweep of all 24 core-style families
+      against a `52481a17` worktree baseline: net **+6** exactParity, zero
+      regressions. Three families moved:
+      `taylor-and-francis-council-of-science-editors-author-date-core`
+      30/67 → 32/67 (+2, `csl26-ecfn`'s original finding),
+      `modern-language-association` 42/115 → 44/115 (+2),
+      `chicago-18-base` 430/1629 → 432/1629 (+2, aggregating
+      `chicago-notes-18th` 22/72 → 23/72 and
+      `chicago-shortened-notes-bibliography` 60/473 → 61/473).
 
 ## Implementation Notes
 
-Sketch only — implementation is a separate, stacked PR per this repo's
-schema-changes-need-a-docs-PR-first rule.
+Implemented in the stacked PR per this repo's schema-changes-need-a-docs-PR-
+first rule. Two deliberate departures from the v1.0 sketch, both explained
+where they occur below: (2) gates at `group_citation_items_by_author` itself
+rather than only in `render_grouped_citation_group_with_format`'s branch, so
+the integral prose-anchor path is covered by the same mechanism; (7) declares
+the config-map form on every tracked style, not the bare-string sugar shown
+in §1's YAML example, because `scripts/validate-schemas.js` has no
+normalization step for it (see §7 v1.1).
 
 1. **Schema**: add `SameAuthor(SameAuthorCollapse)` to `CitationCollapse`
    (`crates/citum-schema-style/src/style/sections/citation.rs:25`),
@@ -629,33 +683,64 @@ schema-changes-need-a-docs-PR-first rule.
    logic changes needed. Add the regime-coherence validation. Regenerate
    schemas and the data-model reference docs in the same commit:
    `just schema-gen`.
-2. **Engine**: gate the collapse branch in
-   `render_grouped_citation_group_with_format` (`grouped/core.rs:271`) on
-   `collapse == Some(SameAuthor(_))`; when unset, key
-   `group_citation_items_by_author` (`grouped/grouping.rs`) on `(index, id)`
-   per §11. Warn once per style load on `year_suffix != Separate`.
-3. **Migrate**: extend `extract_citation_collapse`
-   (`crates/citum-migrate/src/assembly.rs:685`) per the table in §4.
-4. **Embedded styles**: declare `collapse` on the five styles in §7.
+2. **Engine**: gate at `group_citation_items_by_author`
+   (`grouped/grouping.rs`) itself, not only in
+   `render_grouped_citation_group_with_format`'s collapse branch
+   (`grouped/core.rs:271`) as sketched — that function has two call sites
+   (`render_grouped_citation_with_format` and the integral prose-anchor path,
+   `render_integral_anchor_with_format`), and gating only the first would
+   leave the integral anchor still sharing one author name across a
+   non-collapsed pair. `group_citation_items_by_author` takes the resolved
+   spec's `collapse` and produces one singleton group per item, keyed on
+   `(index, id)` per §11, whenever `collapse != Some(SameAuthor(_))` or any
+   item carries disambiguation hints — making `core.rs:271`'s collapse branch
+   unreachable for multi-item groups by construction rather than needing a
+   second, separately-maintained gate. Warns once per style load on
+   `year_suffix != Separate` via a new `SchemaWarning::UnimplementedCollapseDegree`,
+   surfaced by `Style::validate()` (`citum style validate` — the channel's
+   reach doesn't yet extend to engine render time).
+3. **Migrate**: extended `extract_citation_collapse`
+   (`crates/citum-migrate/src/assembly.rs`) per the table in §4, additionally
+   threading the detected `Processing` through so illegal combinations
+   (§6's carve-out) are dropped rather than emitted.
+4. **Tracked styles**: declared `collapse` on the nine styles in §7 (v1.1),
+   using the config-map form throughout.
 5. **Tests**: `crates/citum-engine/tests/domain_fixtures.rs`, native
-   `InputReference` construction, BDD `given/when/then` names, `#[rstest]`
-   where parameterized, `assert_eq!` on full captured strings — covering the
-   note-regime fix (oracle-exact no-locator case; locator-on-second-item with
-   the pre-existing punctuation defect called out, not silently asserted as
-   parity), the duplicate-id regression, the shortened-notes short form,
-   an author-date regression guard proving `collapse: same-author` still
-   collapses (keeping `csl26-uctc`'s four existing tests meaningful), and
-   schema round-trip / validation-rejection tests for both new value/regime
-   mismatches.
-6. **Verification**: `just pre-commit`; per-style
-   `node scripts/report-core.js --style …` for each style in §7 and §8 plus
-   `chicago-shortened-notes-bibliography`; `git status tests/snapshots/`
-   clean (those snapshots hold citeproc-js output, unaffected by an engine
-   change); one sequential, low-concurrency corpus sweep
-   (`systemd-run … MemoryMax=6G`) diffed against a worktree baseline for the
-   net movement number.
+   `InputReference` construction via `load_bibliography` against
+   `tests/fixtures/references-expanded.json` (no `csl_legacy` round-trip),
+   BDD `given/when/then` names, `#[rstest]` where parameterized,
+   `assert_eq!` on full captured strings — covering the note-regime fix
+   (oracle-exact no-locator case, pinned against
+   `tests/snapshots/csl/chicago-notes.json`'s `note-disambiguate-year-suffix`
+   entry; locator-on-second-item with the pre-existing punctuation defect
+   called out, not silently asserted as parity), the duplicate-id regression,
+   the shortened-notes short form, a T&F CSE / MLA no-collapse case, and
+   schema round-trip / regime-coherence acceptance and rejection tests for
+   every value/regime combination in §6. Existing fixtures whose synthetic
+   styles relied on the old always-on behavior
+   (`grouped_author_date_style`, `citum-engine/tests/common`'s
+   `build_author_date_style`, several unit tests) were updated to declare
+   `collapse: same-author` explicitly, keeping their assertions meaningful.
+6. **Verification**: `just pre-commit` (2629 tests, full workspace); the
+   per-style `report-core.js` and corpus-sweep numbers land in the PR
+   description, not here.
 
 ## Changelog
 
+- v1.1 (2026-08-19): Draft → Active; implementation lands (schema, engine
+  gate, migrate, styles, tests). §7 corrected: v1.0 enumerated only the 5
+  embedded styles requiring `collapse: same-author`; mechanically re-deriving
+  the table against every tracked style's `styles-legacy/` source (not
+  trusting the v1.0 list) found 4 more —
+  `elsevier-vancouver-author-date`, `harvard-cite-them-right`,
+  `international-journal-of-wildland-fire`, and the experimental
+  `chicago-author-date` — whose source CSL also declares `collapse` and
+  would otherwise have silently regressed. All nine declared using the
+  config-map form (`same-author: {}`), not the bare-string shorthand this
+  spec's v1.0 design showed: the generated schema advertises `same-author`
+  only as an object, and `scripts/validate-schemas.js` has no normalization
+  step for the bare-string sugar (unlike its existing handling for
+  `processing:`'s custom-config shorthand), so the bare form fails schema
+  validation for every tracked style that uses it.
 - v1.0 (2026-08-18): Initial draft. Adjudicates `csl26-ecfn` (opt-in, not a
   registered divergence) and resolves `csl26-m11m` as a consequence.

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -1498,7 +1498,10 @@ test('generateReport exposes the registered coverage audit on its corresponding 
   assert.equal(audit.outputGroups.some((group) => group.exactEvidence), true);
   assert.equal(audit.postChangeEvidence.status, 'measured');
   assert.equal(audit.postChangeEvidence.beforeExactParity.passed, 34);
-  assert.equal(audit.postChangeEvidence.afterExactParity.passed, 60);
+  // 60 -> 61: same-author collapse opt-in (csl26-ecfn / csl26-m11m) closes
+  // note-disambiguate-year-suffix, since chicago-shortened-notes-bibliography
+  // declares no `collapse` (its source CSL declares none either).
+  assert.equal(audit.postChangeEvidence.afterExactParity.passed, 61);
 });
 
 test('generateReport supports multi-style selected reports', {

--- a/scripts/report-data/embedded-parity-baseline.json
+++ b/scripts/report-data/embedded-parity-baseline.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-08-13T11:20:42.255Z",
-  "commit": "334d7041",
+  "generated": "2026-08-19T14:17:58.897Z",
+  "commit": "f071dcf6",
   "source": "scripts/report-core.js",
   "purpose": "Hard per-style exact-parity floor-gate baseline for the embedded tier, consumed by scripts/check-core-quality.js --parity-baseline (see docs/architecture/audits/2026-07-31_EXACT_PARITY_REFOCUS.md). It also records headline fidelity. Sub-1.0 fidelity ratchets are tracked separately per-style in scripts/report-data/verification-policy.yaml (min_pass_rate floors). Regenerate this file after each parity-tuning wave; the gate never goes backward on passed counts or total (fixture-drift guard).",
   "styles": {
@@ -17,9 +17,9 @@
         "total": 47
       },
       "exactParity": {
-        "passed": 33,
+        "passed": 34,
         "total": 67,
-        "rate": 0.493
+        "rate": 0.507
       }
     },
     "apa-7th": {
@@ -35,21 +35,21 @@
         "total": 98
       },
       "exactParity": {
-        "passed": 89,
+        "passed": 93,
         "total": 146,
-        "rate": 0.61
+        "rate": 0.637
       }
     },
     "chicago-author-date-18th": {
       "tier": "embedded",
-      "fidelityScore": 0.894,
+      "fidelityScore": 0.89,
       "qualityScore": 0.913,
       "citations": {
-        "passed": 63,
+        "passed": 62,
         "total": 63
       },
       "bibliography": {
-        "passed": 433,
+        "passed": 432,
         "total": 492
       },
       "exactParity": {
@@ -71,9 +71,9 @@
         "total": 0
       },
       "exactParity": {
-        "passed": 22,
+        "passed": 23,
         "total": 72,
-        "rate": 0.306
+        "rate": 0.319
       }
     },
     "chicago-shortened-notes-bibliography": {
@@ -89,9 +89,9 @@
         "total": 440
       },
       "exactParity": {
-        "passed": 60,
+        "passed": 61,
         "total": 473,
-        "rate": 0.127
+        "rate": 0.129
       }
     },
     "elsevier-harvard": {
@@ -150,20 +150,20 @@
     },
     "gb-t-7714-2025-author-date": {
       "tier": "embedded",
-      "fidelityScore": 0.851,
-      "qualityScore": 0.923,
+      "fidelityScore": 0.881,
+      "qualityScore": 0.908,
       "citations": {
         "passed": 19,
         "total": 20
       },
       "bibliography": {
-        "passed": 38,
+        "passed": 40,
         "total": 47
       },
       "exactParity": {
-        "passed": 37,
+        "passed": 39,
         "total": 62,
-        "rate": 0.597
+        "rate": 0.629
       }
     },
     "gb-t-7714-2025-note": {
@@ -215,9 +215,9 @@
         "total": 101
       },
       "exactParity": {
-        "passed": 95,
+        "passed": 97,
         "total": 149,
-        "rate": 0.638
+        "rate": 0.651
       }
     },
     "modern-language-association": {
@@ -233,9 +233,9 @@
         "total": 70
       },
       "exactParity": {
-        "passed": 41,
+        "passed": 44,
         "total": 115,
-        "rate": 0.357
+        "rate": 0.383
       }
     },
     "springer-basic-author-date": {
@@ -251,9 +251,9 @@
         "total": 47
       },
       "exactParity": {
-        "passed": 51,
+        "passed": 53,
         "total": 67,
-        "rate": 0.761
+        "rate": 0.791
       }
     },
     "springer-basic-brackets": {
@@ -269,9 +269,9 @@
         "total": 47
       },
       "exactParity": {
-        "passed": 53,
+        "passed": 54,
         "total": 67,
-        "rate": 0.791
+        "rate": 0.806
       }
     },
     "springer-vancouver-brackets": {
@@ -294,14 +294,14 @@
     },
     "taylor-and-francis-chicago-author-date": {
       "tier": "embedded",
-      "fidelityScore": 0.894,
+      "fidelityScore": 0.89,
       "qualityScore": 1,
       "citations": {
-        "passed": 63,
+        "passed": 62,
         "total": 63
       },
       "bibliography": {
-        "passed": 433,
+        "passed": 432,
         "total": 492
       },
       "exactParity": {
@@ -312,10 +312,10 @@
     },
     "taylor-and-francis-council-of-science-editors-author-date": {
       "tier": "embedded",
-      "fidelityScore": 0.94,
-      "qualityScore": 0.996,
+      "fidelityScore": 0.955,
+      "qualityScore": 1,
       "citations": {
-        "passed": 19,
+        "passed": 20,
         "total": 20
       },
       "bibliography": {
@@ -323,9 +323,9 @@
         "total": 47
       },
       "exactParity": {
-        "passed": 23,
+        "passed": 32,
         "total": 67,
-        "rate": 0.343
+        "rate": 0.478
       }
     },
     "taylor-and-francis-national-library-of-medicine": {

--- a/styles/elsevier-vancouver-author-date.yaml
+++ b/styles/elsevier-vancouver-author-date.yaml
@@ -43,6 +43,10 @@ options:
   contributors: numeric-compact
   dates: long
 citation:
+  # source (elsevier-vancouver-author-date.csl): collapse="year" —
+  # SAME_AUTHOR_COLLAPSE.md §7 v1.1
+  collapse:
+    same-author: {}
   options:
     contributors:
       name-form: initials

--- a/styles/experimental/chicago-author-date.yaml
+++ b/styles/experimental/chicago-author-date.yaml
@@ -32,6 +32,10 @@ options:
     month: long
 
 citation:
+  # source (chicago-author-date.csl): collapse="year" —
+  # SAME_AUTHOR_COLLAPSE.md §7 v1.1
+  collapse:
+    same-author: {}
   sort:
     template:
     - key: author

--- a/styles/harvard-cite-them-right.yaml
+++ b/styles/harvard-cite-them-right.yaml
@@ -68,6 +68,10 @@ options:
       emph: true
   punctuation-in-quote: true
 citation:
+  # source (harvard-cite-them-right.csl): collapse="year" —
+  # SAME_AUTHOR_COLLAPSE.md §7 v1.1
+  collapse:
+    same-author: {}
   options:
     contributors:
       name-form: initials

--- a/styles/international-journal-of-wildland-fire.yaml
+++ b/styles/international-journal-of-wildland-fire.yaml
@@ -53,6 +53,13 @@ options:
   dates: long
   titles: journal-emphasis
 citation:
+  # source (international-journal-of-wildland-fire.csl): collapse="year-suffix"
+  # — SAME_AUTHOR_COLLAPSE.md §7 v1.1. Also inherited from
+  # springer-basic-author-date-core (Custom regime, no cross-family reset);
+  # declared explicitly here since this style's own source requests it.
+  collapse:
+    same-author:
+      year-suffix: merged
   options:
     contributors:
       name-form: initials


### PR DESCRIPTION
## Summary

**Same-author citation collapse becomes opt-in**, implementing the adjudication from `csl26-ecfn` / docs PR #1206. `CitationCollapse` gains a `SameAuthor` variant; the engine gate moves from "always collapse a multi-item same-author cluster" to "collapse only when the style declares it." Closes `csl26-m11m` (malformed note citations) as a direct consequence — no note-specific code needed.

## What changed

- **Schema**: `CitationCollapse::SameAuthor(SameAuthorCollapse { year_suffix })` alongside the existing `CitationNumber`. Hand-written serde (mirrors `Processing`) so both `same-author` bare-string sugar and the `{ same-author: { year-suffix: merged|ranged } }` config-map form parse; schema only advertises the object form. Regime-coherence validation added (`same-author` ⟂ AuthorDate/Note/Custom, `citation-number` ⟂ Numeric/Custom).
- **Migrate**: `extract_citation_collapse` now maps all four CSL `collapse` values losslessly instead of discarding `year`/`year-suffix`/`year-suffix-ranged`, dropping the mapped value if illegal for the detected regime.
- **Styles**: 9 tracked styles declare `collapse: { same-author: {} }` so they keep collapsing exactly as before — table re-derived mechanically against `styles-legacy/` (the docs PR's own §7 only listed 5).
- **Engine**: `group_citation_items_by_author` gates on `collapse == Some(SameAuthor(_))`; unset ⇒ every item is its own group, keyed on `(index, id)` so duplicate-id clusters can't spuriously merge. Gated at the grouping level (not just the collapse branch) so the integral prose-anchor path is covered too — not just non-integral.
- **Tests**: byte-exact oracle pin for the note-regime fix, duplicate-id regression, shortened-notes short form, T&F CSE / MLA no-collapse cases, schema round-trip + regime-coherence tests.

## Verification

**Full `just pre-commit` gate: 2629/2629 tests green.**

Full `report-core.js` sweep (all 24 core-style families) against a `52481a17` (docs-PR-tip) worktree baseline — **net +6 exactParity, zero regressions**:

| style | before | after |
|---|---|---|
| `chicago-notes-18th` | 22/72 | **23/72** |
| `chicago-shortened-notes-bibliography` | 60/473 | **61/473** |
| `taylor-and-francis-council-of-science-editors-author-date` | 30/67 | **32/67** (`csl26-ecfn`'s original finding) |
| `modern-language-association` | 42/115 | **44/115** |

The 9 styles that declare `collapse` (apa-7th, chicago-author-date-18th, elsevier-harvard, gb-t-7714-2025-author-date, springer-basic-author-date, elsevier-vancouver-author-date, harvard-cite-them-right, international-journal-of-wildland-fire, taylor-and-francis-chicago-author-date) show **exactly zero movement**.

`git status tests/snapshots/` clean — those hold citeproc-js output, unaffected.

**CI-only follow-up in this branch**: `report-core.test.js` hardcoded `chicago-shortened-notes-bibliography`'s exact-parity count at 60; bumped to 61. Regenerated `embedded-parity-baseline.json` (was stale from 2026-08-13, predating this PR) — the parity gate is a floor check, so this only tightens it to current capability.

## Follow-ups filed

- `csl26-ctkb` — implement `year-suffix: merged`/`ranged` rendering (parses/round-trips today, falls back to `separate`)
- `csl26-llgj` — adjudicate the 4 `note` + `citation-number` corpus styles migrate currently drops
- `csl26-8g14` — extend `citations-humanities-note.json` with a same-author cluster (own oracle-snapshot blast radius)
- `csl26-ax22` — independent locator-punctuation defect on `chicago-notes-18th` noticed during investigation, unrelated to collapse

Closes `csl26-ecfn`, `csl26-m11m`. Spec: `docs/specs/SAME_AUTHOR_COLLAPSE.md` (Active, v1.1).
