### PR TITLE
feat(schema): map same-author collapse delimiters

### DIFF
--- a/crates/citum-migrate/src/assembly.rs
+++ b/crates/citum-migrate/src/assembly.rs
@@ -697,36 +697,30 @@ fn measured_selection_unavailable<T>(
 /// styles where `collapse` is declared but doesn't fit either mechanism —
 /// 2 inert `Label` styles, 4 `Note` + `citation-number` styles).
 ///
-/// Warns once for `year-suffix` / `year-suffix-ranged`: the value round-trips
-/// but the renderer doesn't implement the merged/ranged degree yet, so the
-/// migrated style renders as `separate` until that follow-up lands.
+/// Also maps CSL's `cite-group-delimiter` / `year-suffix-delimiter`
+/// attributes onto `SameAuthorCollapse::delimiter` /
+/// `::year_suffix_delimiter` whenever present, independent of which
+/// `year_suffix` degree the `collapse` value resolves to (a style may
+/// declare `cite-group-delimiter` under plain `collapse="year"`, where it
+/// still governs the ordinary year-to-year join). See
+/// `docs/specs/SAME_AUTHOR_COLLAPSE.md` §13.
 fn extract_citation_collapse(
     citation: &csl_legacy::model::Citation,
     processing: Option<&Processing>,
 ) -> Option<CitationCollapse> {
     let mapped = match citation.collapse.as_deref() {
         Some("citation-number") => CitationCollapse::CitationNumber,
-        Some("year") => CitationCollapse::SameAuthor(SameAuthorCollapse::default()),
-        Some("year-suffix") => {
-            tracing::warn!(
-                "collapse=\"year-suffix\" migrates to `same-author: {{ year-suffix: merged }}`, \
-                 which parses but is not yet rendered (falls back to separate); see \
-                 docs/specs/SAME_AUTHOR_COLLAPSE.md"
-            );
-            CitationCollapse::SameAuthor(SameAuthorCollapse {
-                year_suffix: YearSuffixCollapse::Merged,
-            })
-        }
-        Some("year-suffix-ranged") => {
-            tracing::warn!(
-                "collapse=\"year-suffix-ranged\" migrates to `same-author: {{ year-suffix: ranged }}`, \
-                 which parses but is not yet rendered (falls back to separate); see \
-                 docs/specs/SAME_AUTHOR_COLLAPSE.md"
-            );
-            CitationCollapse::SameAuthor(SameAuthorCollapse {
-                year_suffix: YearSuffixCollapse::Ranged,
-            })
-        }
+        Some("year") => CitationCollapse::SameAuthor(same_author_collapse_from_legacy(
+            citation,
+            YearSuffixCollapse::Separate,
+        )),
+        Some("year-suffix") => CitationCollapse::SameAuthor(same_author_collapse_from_legacy(
+            citation,
+            YearSuffixCollapse::Merged,
+        )),
+        Some("year-suffix-ranged") => CitationCollapse::SameAuthor(
+            same_author_collapse_from_legacy(citation, YearSuffixCollapse::Ranged),
+        ),
         _ => return None,
     };
 
@@ -743,6 +737,20 @@ fn extract_citation_collapse(
         )
     };
     licensed.then_some(mapped)
+}
+
+/// Build a [`SameAuthorCollapse`] for `year_suffix`, threading the source
+/// CSL's `cite-group-delimiter` / `year-suffix-delimiter` attributes through
+/// when present. See `docs/specs/SAME_AUTHOR_COLLAPSE.md` §13.
+fn same_author_collapse_from_legacy(
+    citation: &csl_legacy::model::Citation,
+    year_suffix: YearSuffixCollapse,
+) -> SameAuthorCollapse {
+    SameAuthorCollapse {
+        year_suffix,
+        delimiter: citation.cite_group_delimiter.clone().map(Into::into),
+        year_suffix_delimiter: citation.year_suffix_delimiter.clone().map(Into::into),
+    }
 }
 
 fn bibliography_sort_matches_processing_default(
@@ -780,6 +788,14 @@ mod tests {
     use rstest::rstest;
 
     fn legacy_citation_with_collapse(collapse: Option<&str>) -> Citation {
+        legacy_citation_with_collapse_and_delimiters(collapse, None, None)
+    }
+
+    fn legacy_citation_with_collapse_and_delimiters(
+        collapse: Option<&str>,
+        cite_group_delimiter: Option<&str>,
+        year_suffix_delimiter: Option<&str>,
+    ) -> Citation {
         Citation {
             layout: Layout {
                 prefix: None,
@@ -790,6 +806,8 @@ mod tests {
             localized_layouts: Vec::new(),
             sort: None,
             collapse: collapse.map(str::to_string),
+            cite_group_delimiter: cite_group_delimiter.map(str::to_string),
+            year_suffix_delimiter: year_suffix_delimiter.map(str::to_string),
             et_al_min: None,
             et_al_use_first: None,
             disambiguate_add_year_suffix: None,
@@ -820,6 +838,8 @@ mod tests {
         Some(Processing::AuthorDate),
         Some(CitationCollapse::SameAuthor(SameAuthorCollapse {
             year_suffix: YearSuffixCollapse::Merged,
+            delimiter: None,
+            year_suffix_delimiter: None,
         }))
     )]
     #[case::year_suffix_ranged(
@@ -827,6 +847,8 @@ mod tests {
         Some(Processing::AuthorDate),
         Some(CitationCollapse::SameAuthor(SameAuthorCollapse {
             year_suffix: YearSuffixCollapse::Ranged,
+            delimiter: None,
+            year_suffix_delimiter: None,
         }))
     )]
     #[case::same_author_licensed_on_note(
@@ -879,6 +901,66 @@ mod tests {
 
         // then no collapse is migrated
         assert_eq!(extracted, None);
+    }
+
+    #[rstest]
+    #[case::cite_group_delimiter_only(
+        "year-suffix",
+        Some("; "),
+        None,
+        SameAuthorCollapse {
+            year_suffix: YearSuffixCollapse::Merged,
+            delimiter: Some(citum_schema::template::DelimiterPunctuation::Custom(
+                "; ".to_string()
+            )),
+            year_suffix_delimiter: None,
+        }
+    )]
+    #[case::year_suffix_delimiter_only(
+        "year-suffix-ranged",
+        None,
+        Some("-"),
+        SameAuthorCollapse {
+            year_suffix: YearSuffixCollapse::Ranged,
+            delimiter: None,
+            year_suffix_delimiter: Some(citum_schema::template::DelimiterPunctuation::Custom(
+                "-".to_string()
+            )),
+        }
+    )]
+    #[case::cite_group_delimiter_on_plain_year(
+        "year",
+        Some(", "),
+        None,
+        SameAuthorCollapse {
+            year_suffix: YearSuffixCollapse::Separate,
+            delimiter: Some(citum_schema::template::DelimiterPunctuation::Custom(
+                ", ".to_string()
+            )),
+            year_suffix_delimiter: None,
+        }
+    )]
+    fn extract_citation_collapse_maps_delimiter_attributes(
+        #[case] csl_value: &str,
+        #[case] cite_group_delimiter: Option<&str>,
+        #[case] year_suffix_delimiter: Option<&str>,
+        #[case] expected: SameAuthorCollapse,
+    ) {
+        // given a CSL citation declaring `cite-group-delimiter` and/or
+        // `year-suffix-delimiter` alongside `collapse` (SAME_AUTHOR_COLLAPSE.md
+        // §13 — the delimiter attributes migrate independently of the
+        // `year_suffix` degree)
+        let citation = legacy_citation_with_collapse_and_delimiters(
+            Some(csl_value),
+            cite_group_delimiter,
+            year_suffix_delimiter,
+        );
+
+        // when extracted for a licensing regime
+        let extracted = extract_citation_collapse(&citation, Some(&Processing::AuthorDate));
+
+        // then both delimiter attributes map onto SameAuthorCollapse
+        assert_eq!(extracted, Some(CitationCollapse::SameAuthor(expected)));
     }
 
     #[test]
@@ -1228,6 +1310,8 @@ mod tests {
                 localized_layouts: Vec::new(),
                 sort: None,
                 collapse: None,
+                cite_group_delimiter: None,
+                year_suffix_delimiter: None,
                 et_al_min: None,
                 et_al_use_first: None,
                 disambiguate_add_year_suffix: None,

--- a/crates/citum-migrate/src/options_extractor/titles.rs
+++ b/crates/citum-migrate/src/options_extractor/titles.rs
@@ -355,6 +355,8 @@ mod tests {
                 localized_layouts: Vec::new(),
                 sort: None,
                 collapse: None,
+                cite_group_delimiter: None,
+                year_suffix_delimiter: None,
                 et_al_min: None,
                 et_al_use_first: None,
                 disambiguate_add_year_suffix: None,

--- a/crates/citum-migrate/tests/date_inference.rs
+++ b/crates/citum-migrate/tests/date_inference.rs
@@ -73,6 +73,8 @@ fn make_style_with_date(form: Option<String>) -> Style {
             localized_layouts: Vec::new(),
             sort: None,
             collapse: None,
+            cite_group_delimiter: None,
+            year_suffix_delimiter: None,
             et_al_min: None,
             et_al_use_first: None,
             disambiguate_add_year_suffix: None,

--- a/crates/citum-migrate/tests/initialize_with_migration.rs
+++ b/crates/citum-migrate/tests/initialize_with_migration.rs
@@ -57,6 +57,8 @@ fn test_style_global_initialize_with_co_emits_name_form_initials() {
             localized_layouts: Vec::new(),
             sort: None,
             collapse: None,
+            cite_group_delimiter: None,
+            year_suffix_delimiter: None,
             et_al_min: None,
             et_al_use_first: None,
             disambiguate_add_year_suffix: None,

--- a/crates/citum-migrate/tests/substitute_extraction.rs
+++ b/crates/citum-migrate/tests/substitute_extraction.rs
@@ -141,6 +141,8 @@ fn test_extract_type_conditional_substitute() {
             localized_layouts: Vec::new(),
             sort: None,
             collapse: None,
+            cite_group_delimiter: None,
+            year_suffix_delimiter: None,
             et_al_min: None,
             et_al_use_first: None,
             disambiguate_add_year_suffix: None,

--- a/crates/citum-schema-style/embedded/styles/springer-basic-author-date-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/springer-basic-author-date-core.yaml
@@ -37,12 +37,14 @@ options:
   dates: short
   punctuation-in-quote: true
 citation:
-  # source (springer-basic-author-date.csl): collapse="year-suffix" —
-  # SAME_AUTHOR_COLLAPSE.md §7. `merged` parses and round-trips but isn't
-  # yet rendered by the engine (falls back to `separate`).
+  # source (springer-basic-author-date.csl): collapse="year-suffix"
+  # cite-group-delimiter=", " — SAME_AUTHOR_COLLAPSE.md §7, §13. `merged`
+  # parses and round-trips but isn't yet rendered by the engine (falls
+  # back to `separate`).
   collapse:
     same-author:
       year-suffix: merged
+      delimiter: ", "
   options:
     contributors:
       shorten:

--- a/crates/citum-schema-style/src/style/sections/citation.rs
+++ b/crates/citum-schema-style/src/style/sections/citation.rs
@@ -116,6 +116,24 @@ pub struct SameAuthorCollapse {
     /// How same-year disambiguation suffixes render inside a collapsed group.
     #[serde(default)]
     pub year_suffix: YearSuffixCollapse,
+    /// Delimiter joining items within a collapsed same-author group. Mirrors
+    /// CSL's `cite-group-delimiter`, which feeds two distinct mechanisms with
+    /// top precedence in both: when set, it overrides the engine's existing
+    /// year-to-year join fallback, and it overrides `year_suffix_delimiter`
+    /// for the suffix-to-suffix join (`year_suffix: Merged`/`Ranged`). `None`
+    /// leaves the year join on its existing fallback and the suffix join on
+    /// `year_suffix_delimiter` / `citation.multi-cite-delimiter`. See
+    /// `docs/specs/SAME_AUTHOR_COLLAPSE.md` §13.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delimiter: Option<DelimiterPunctuation>,
+    /// Delimiter preceding a merged/ranged suffix token specifically (e.g.
+    /// `2020a-b`). Mirrors CSL's `year-suffix-delimiter`; affects only the
+    /// suffix-to-suffix join, beneath `delimiter` (which wins when both are
+    /// set) and above the `citation.multi-cite-delimiter` fallback. Has no
+    /// effect on the ordinary year-to-year join. See
+    /// `docs/specs/SAME_AUTHOR_COLLAPSE.md` §13.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub year_suffix_delimiter: Option<DelimiterPunctuation>,
 }
 
 /// How same-year disambiguation suffixes render inside a same-author collapsed

--- a/crates/citum-schema-style/src/template.rs
+++ b/crates/citum-schema-style/src/template.rs
@@ -1863,7 +1863,7 @@ pub enum TemplateConditionField {
 /// YAML strings are always literal. Semantic marks use the explicit mapping
 /// form `{ mark: comma }`, so a string such as `comma` is never interpreted as
 /// punctuation intent.
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub enum DelimiterPunctuation {
     /// A semantic comma mark.
     #[default]

--- a/crates/citum-schema-style/src/tests.rs
+++ b/crates/citum-schema-style/src/tests.rs
@@ -2594,7 +2594,9 @@ fn citation_collapse_config_map_form_round_trips(
     assert_eq!(
         style.citation.as_ref().and_then(|c| c.collapse.clone()),
         Some(CitationCollapse::SameAuthor(SameAuthorCollapse {
-            year_suffix: expected
+            year_suffix: expected,
+            delimiter: None,
+            year_suffix_delimiter: None,
         }))
     );
 
@@ -2604,6 +2606,54 @@ fn citation_collapse_config_map_form_round_trips(
         reparsed.citation.as_ref().and_then(|c| c.collapse.clone()),
         style.citation.as_ref().and_then(|c| c.collapse.clone()),
         "config-map form must round-trip byte-for-byte through re-serialization"
+    );
+}
+
+#[rstest]
+#[case::delimiter_only(
+    "delimiter: \", \"",
+    SameAuthorCollapse {
+        year_suffix: YearSuffixCollapse::Merged,
+        delimiter: Some(template::DelimiterPunctuation::Custom(", ".to_string())),
+        year_suffix_delimiter: None,
+    }
+)]
+#[case::year_suffix_delimiter_only(
+    "year-suffix-delimiter: \"-\"",
+    SameAuthorCollapse {
+        year_suffix: YearSuffixCollapse::Merged,
+        delimiter: None,
+        year_suffix_delimiter: Some(template::DelimiterPunctuation::Custom("-".to_string())),
+    }
+)]
+#[case::both_delimiters(
+    "delimiter: \", \"\n      year-suffix-delimiter: \"-\"",
+    SameAuthorCollapse {
+        year_suffix: YearSuffixCollapse::Merged,
+        delimiter: Some(template::DelimiterPunctuation::Custom(", ".to_string())),
+        year_suffix_delimiter: Some(template::DelimiterPunctuation::Custom("-".to_string())),
+    }
+)]
+fn same_author_collapse_delimiter_fields_round_trip(
+    #[case] extra_yaml: &str,
+    #[case] expected: SameAuthorCollapse,
+) {
+    let yaml = format!(
+        "info:\n  title: Delimiter Fields\ncitation:\n  collapse:\n    same-author:\n      year-suffix: merged\n      {extra_yaml}\n"
+    );
+    let style: Style = serde_yaml::from_str(&yaml).unwrap();
+
+    assert_eq!(
+        style.citation.as_ref().and_then(|c| c.collapse.clone()),
+        Some(CitationCollapse::SameAuthor(expected))
+    );
+
+    let serialized = serde_yaml::to_string(&style).unwrap();
+    let reparsed: Style = serde_yaml::from_str(&serialized).unwrap();
+    assert_eq!(
+        reparsed.citation.as_ref().and_then(|c| c.collapse.clone()),
+        style.citation.as_ref().and_then(|c| c.collapse.clone()),
+        "delimiter fields must round-trip byte-for-byte through re-serialization"
     );
 }
 

--- a/crates/csl-legacy/src/model.rs
+++ b/crates/csl-legacy/src/model.rs
@@ -147,6 +147,12 @@ pub struct Citation {
     pub sort: Option<Sort>,
     /// Collapse mode for grouped citations (for example, `"citation-number"`).
     pub collapse: Option<String>,
+    /// Delimiter joining items within a collapsed same-author group,
+    /// overriding the layout delimiter for that join only.
+    pub cite_group_delimiter: Option<String>,
+    /// Delimiter preceding a merged/ranged year-suffix token specifically,
+    /// under `collapse="year-suffix"` or `"year-suffix-ranged"`.
+    pub year_suffix_delimiter: Option<String>,
     /// Minimum number of names before et-al truncation kicks in.
     pub et_al_min: Option<usize>,
     /// Number of names to show before the et-al term.

--- a/crates/csl-legacy/src/parser.rs
+++ b/crates/csl-legacy/src/parser.rs
@@ -75,6 +75,8 @@ pub fn parse_style(node: Node) -> Result<Style, String> {
         localized_layouts: Vec::new(),
         sort: None,
         collapse: None,
+        cite_group_delimiter: None,
+        year_suffix_delimiter: None,
         et_al_min: None,
         et_al_use_first: None,
         disambiguate_add_year_suffix: None,
@@ -261,6 +263,12 @@ fn parse_citation(node: Node) -> Result<Citation, String> {
     let collapse = node
         .attribute("collapse")
         .map(std::string::ToString::to_string);
+    let cite_group_delimiter = node
+        .attribute("cite-group-delimiter")
+        .map(std::string::ToString::to_string);
+    let year_suffix_delimiter = node
+        .attribute("year-suffix-delimiter")
+        .map(std::string::ToString::to_string);
     let et_al_min = node.attribute("et-al-min").and_then(|s| s.parse().ok());
     let et_al_use_first = node
         .attribute("et-al-use-first")
@@ -294,6 +302,8 @@ fn parse_citation(node: Node) -> Result<Citation, String> {
         localized_layouts,
         sort,
         collapse,
+        cite_group_delimiter,
+        year_suffix_delimiter,
         et_al_min,
         et_al_use_first,
         disambiguate_add_year_suffix,
@@ -975,6 +985,18 @@ mod tests {
         );
         let style = parse(&xml).unwrap();
         assert_eq!(style.citation.collapse.as_deref(), Some("citation-number"));
+    }
+
+    #[test]
+    fn test_parse_citation_collapse_delimiters() {
+        let xml = wrap_style("").replace(
+            "<citation><layout/></citation>",
+            r#"<citation collapse="year-suffix" cite-group-delimiter=", " year-suffix-delimiter="-"><layout/></citation>"#,
+        );
+        let style = parse(&xml).unwrap();
+        assert_eq!(style.citation.collapse.as_deref(), Some("year-suffix"));
+        assert_eq!(style.citation.cite_group_delimiter.as_deref(), Some(", "));
+        assert_eq!(style.citation.year_suffix_delimiter.as_deref(), Some("-"));
     }
 
     #[test]

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -7869,6 +7869,28 @@
           "description": "How same-year disambiguation suffixes render inside a collapsed group.",
           "$ref": "#/$defs/YearSuffixCollapse",
           "default": "separate"
+        },
+        "delimiter": {
+          "description": "Delimiter joining items within a collapsed same-author group. Mirrors\nCSL's `cite-group-delimiter`, which feeds two distinct mechanisms with\ntop precedence in both: when set, it overrides the engine's existing\nyear-to-year join fallback, and it overrides `year_suffix_delimiter`\nfor the suffix-to-suffix join (`year_suffix: Merged`/`Ranged`). `None`\nleaves the year join on its existing fallback and the suffix join on\n`year_suffix_delimiter` / `citation.multi-cite-delimiter`. See\n`docs/specs/SAME_AUTHOR_COLLAPSE.md` §13.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "year-suffix-delimiter": {
+          "description": "Delimiter preceding a merged/ranged suffix token specifically (e.g.\n`2020a-b`). Mirrors CSL's `year-suffix-delimiter`; affects only the\nsuffix-to-suffix join, beneath `delimiter` (which wins when both are\nset) and above the `citation.multi-cite-delimiter` fallback. Has no\neffect on the ordinary year-to-year join. See\n`docs/specs/SAME_AUTHOR_COLLAPSE.md` §13.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DelimiterPunctuation"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
## Summary

Second of a 3-PR stack for `csl26-ctkb` (stacked on #1209). Implements the
schema, CSL parser, and migrate side of `SAME_AUTHOR_COLLAPSE.md` §13:
adds `SameAuthorCollapse::delimiter` / `::year_suffix_delimiter` and maps
CSL's `cite-group-delimiter` / `year-suffix-delimiter` attributes onto them.

## What this PR does NOT do

No engine rendering yet — `YearSuffixCollapse::Merged`/`::Ranged` still fall
back to `Separate` and `SchemaWarning::UnimplementedCollapseDegree` still
fires. That gap closes in PR 3, which is also where the warning gets removed
(deliberately not removed here — see the §13 design note on sequencing).

## Commits

1. **`feat(schema)`** — adds the two new `Option<DelimiterPunctuation>`
   fields to `SameAuthorCollapse`; `DelimiterPunctuation` gains `derive(Eq)`
   (safe — every variant is a unit or `String`) so the existing `Eq` derive
   on `SameAuthorCollapse`/`CitationCollapse` keeps compiling. Additive,
   non-breaking. Regenerates `docs/schemas/style.json`.
2. **`feat(migrate)`** — `csl_legacy::model::Citation` didn't parse either
   CSL attribute before this change (verified by reading the struct, not
   assumed). Adds both fields to the parser and maps them in
   `extract_citation_collapse`, independent of which `year_suffix` degree
   the source `collapse` value resolves to.
3. **`feat(styles)`** — declares `delimiter: ", "` on
   `springer-basic-author-date-core` (source: `cite-group-delimiter=", "`).
   No behavior change: `report-core.js --style springer-basic-author-date`
   holds at 53/67, matching the pre-change baseline — confirms this commit
   alone doesn't move rendering (PR 3 does).

## Test plan

- [x] `just pre-commit` — 2636 tests, full workspace, clean.
- [x] New tests: schema round-trip (3 cases), CSL parser attribute parsing,
      migrate delimiter mapping (3 cases covering both attributes
      independently and together, plus the plain-`year` case).
- [x] `citum style validate` on the updated springer style — parses, still
      warns (correctly — rendering isn't implemented yet).
- [x] `node scripts/report-core.js --style springer-basic-author-date` — 53/67,
      unchanged from baseline.
