### PR TITLE
fix(engine): strip djot markup in title sort keys

### DIFF
--- a/.beans/archive/csl26-4wts--title-sort-keys-carry-raw-djot-markup-not-stripped.md
+++ b/.beans/archive/csl26-4wts--title-sort-keys-carry-raw-djot-markup-not-stripped.md
@@ -1,7 +1,7 @@
 ---
 # csl26-4wts
 title: Title sort keys carry raw Djot markup, not stripped/rendered text
-status: todo
+status: completed
 type: bug
 priority: normal
 tags:
@@ -10,7 +10,7 @@ tags:
     - rendering
     - engine
 created_at: 2026-08-14T12:31:11Z
-updated_at: 2026-08-14T12:31:14Z
+updated_at: 2026-08-20T22:20:26Z
 ---
 
 title_sort_key_with_options() -> title_sort_text() in crates/citum-engine/src/sort_support.rs (line ~298) uses title.to_string() directly for the non-multilingual branch:
@@ -31,3 +31,38 @@ Affects both:
 Discovered while fixing csl26-d3kj (Djot markup leaking through the *rendering* of substituted titles). That fix only addressed display text (resolve_title_substitute in crates/citum-engine/src/values/contributor/substitute.rs); it does not touch sort-key derivation, which is a separate code path with its own markup leak.
 
 Fix should strip Djot markup to its visible-text form for sort-key purposes (there is likely a "visible_text" style helper already used elsewhere for LaTeX/markup stripping -- e.g. crates/citum-engine/src/render/latex.rs's visible_text -- worth checking whether an existing Djot equivalent can be reused before writing a new one).
+
+## Summary of Changes
+
+Fixed by stripping Djot markup at the single sort-key funnel point,
+`title_sort_text()` in `crates/citum-engine/src/sort_support.rs`, using the
+existing `Djot::visible_text` lexer (not the display-render pipeline, which
+would leave emphasis delimiters like `_..._` in place for `PlainText`).
+
+- `crates/citum-engine/src/values/title.rs`: promoted `looks_like_djot_markup`
+  to `pub(crate)` so sort-key derivation gates on the same "is this Djot?"
+  predicate the display path uses.
+- `crates/citum-engine/src/sort_support.rs`: `title_sort_text` now strips
+  markup from both branches (plain title and `multilingual_complex_sort_text`'s
+  `complex.original`) before returning. The strip runs before
+  `Locale::strip_sort_articles` in `title_sort_key_with_options`, so a leading
+  article hidden behind markup (`[The Library]{.nocase}`) is still stripped.
+  Added an `#[rstest]` case table covering `.nocase` spans, emphasis, links,
+  markup-before-article ordering, and the literal-`[Dataset]`-bracket
+  carve-out (not markup).
+
+All three sort call sites (`sorting.rs::title_sort_key`,
+`sort_support.rs`'s author-substitute fallback, `disambiguation.rs`) funnel
+through `title_sort_key_with_options`, so no other edit sites were needed.
+
+Verified: `cargo nextest run -p citum-engine sort_support` (26/26 pass),
+`just pre-commit` (2659/2659 pass), and `node scripts/report-core.js
+--all-features` shows zero drift against a `main` baseline (identical
+totals/exactParity/quality scores) — the core-styles fixture corpus has no
+title with Djot markup whose sort position this changes.
+
+## Follow-up (not fixed here)
+
+`multilingual_string_sort_text` (same file) has the identical leak for
+**contributor name** sort keys — an institutional author authored as
+`[IBM]{.nocase}` would sort under `[`. Proposing a follow-up bean.

--- a/.beans/archive/csl26-lirf--contributor-name-sort-keys-carry-raw-djot-markup.md
+++ b/.beans/archive/csl26-lirf--contributor-name-sort-keys-carry-raw-djot-markup.md
@@ -1,0 +1,52 @@
+---
+# csl26-lirf
+title: Contributor name sort keys carry raw Djot markup
+status: completed
+type: bug
+priority: normal
+tags:
+    - sorting
+    - contributor
+    - rendering
+    - engine
+created_at: 2026-08-20T22:20:33Z
+updated_at: 2026-08-20T22:33:58Z
+---
+
+multilingual_string_sort_text() in crates/citum-engine/src/sort_support.rs
+(used by contributor_sort_key() -> structured_name_sort_text() ->
+multilingual_string_sort_text()) returns the raw MultilingualString::Simple
+value or complex.original verbatim for name sort-key purposes, just like
+title_sort_text() did before csl26-4wts. An institutional/literal author
+authored as e.g. "[IBM]{.nocase}" (a literal Contributor::SimpleName or a
+StructuredName family field carrying Djot markup) would sort under '[' instead
+of 'I'.
+
+Follow-up to csl26-4wts (fix(engine): strip djot markup from title sort keys),
+which fixed the identical leak for title sort keys only. Surfaced during that
+fix's review rather than folded in, to keep the PR bounded.
+
+Fix should likely reuse the same strip_markup_for_sort() helper added in
+csl26-4wts (crates/citum-engine/src/sort_support.rs), applied at
+multilingual_string_sort_text()'s return, plus structured_name_original_text()
+if that path is affected too.
+
+## Summary of Changes
+
+Folded into the same PR as csl26-4wts (#1213) rather than left as a
+follow-up, per instruction not to defer bounded fixes that are trivial once
+the infrastructure exists.
+
+- `multilingual_string_sort_text()` in `crates/citum-engine/src/sort_support.rs`
+  now strips markup via the `strip_markup_for_sort()` helper added for
+  csl26-4wts — covers both `Contributor::SimpleName` (e.g. `[IBM]{.nocase}`)
+  and `StructuredName` family/given (via `structured_name_sort_text`).
+- `structured_name_original_text()` (the `is_romanized()` transliteration
+  fallback path) also strips family/given before composing, since it
+  bypasses `multilingual_string_sort_text` and does its own `.to_string()`.
+
+Tests: `given_a_simple_name_with_djot_markup_when_building_the_contributor_sort_key_then_markup_is_stripped`
+(rstest, 2 cases) and
+`given_a_structured_name_with_djot_markup_in_family_when_building_the_contributor_sort_key_then_markup_is_stripped`
+in `sort_support.rs`. Full pre-commit gate (2662/2662) and `report-core.js
+--all-features` (zero drift vs `main`) verified together with csl26-4wts.

--- a/crates/citum-engine/src/sort_support.rs
+++ b/crates/citum-engine/src/sort_support.rs
@@ -8,6 +8,8 @@ SPDX-FileCopyrightText: © 2023-2026 Bruce D'Arcus and Citum contributors
 use std::cmp::Ordering;
 
 use crate::reference::{FlatName, Reference};
+use crate::render::djot::Djot;
+use crate::render::format::OutputFormat;
 use citum_schema::grouping::NameSortOrder;
 use citum_schema::locale::Locale;
 use citum_schema::options::{Config, SortingLocale, SortingMultilingualMode};
@@ -313,8 +315,8 @@ fn structured_name_sort_text(
 }
 
 fn structured_name_original_text(name: &StructuredName, name_order: NameSortOrder) -> String {
-    let family = name.family.to_string();
-    let given = name.given.to_string();
+    let family = strip_markup_for_sort(&name.family.to_string());
+    let given = strip_markup_for_sort(&name.given.to_string());
     compose_family_given_key(&family, &given, name_order)
 }
 
@@ -343,17 +345,34 @@ fn structured_name_sort_as_text(name: &StructuredName, name_order: NameSortOrder
 }
 
 fn title_sort_text(title: &Title, options: &SortKeyOptions) -> String {
-    match title {
+    let text = match title {
         Title::Multilingual(complex) => multilingual_complex_sort_text(complex, options),
         _ => title.to_string(),
+    };
+    strip_markup_for_sort(&text)
+}
+
+/// Reduce a title or name string to its visible text for sort-key purposes,
+/// so authored Djot markup (`[…]{.nocase}`, `_emph_`, `[text](url)`) does not
+/// decide alphabetization — e.g. an institutional author authored as
+/// `[IBM]{.nocase}` sorts under `I`, not `[`. For titles this runs before
+/// [`Locale::strip_sort_articles`] in [`title_sort_key_with_options`], so a
+/// leading article hidden behind markup (e.g. `[The Library]{.nocase}`) is
+/// still stripped.
+fn strip_markup_for_sort(text: &str) -> String {
+    if crate::values::title::looks_like_djot_markup(text) {
+        Djot.visible_text(text).into_owned()
+    } else {
+        text.to_string()
     }
 }
 
 fn multilingual_string_sort_text(string: &MultilingualString, options: &SortKeyOptions) -> String {
-    match string {
+    let text = match string {
         MultilingualString::Simple(value) => value.clone(),
         MultilingualString::Complex(complex) => multilingual_complex_sort_text(complex, options),
-    }
+    };
+    strip_markup_for_sort(&text)
 }
 
 fn multilingual_complex_sort_text(
@@ -455,7 +474,8 @@ fn default_icu_locale() -> IcuLocale {
 )]
 mod tests {
     use super::*;
-    use citum_schema::reference::contributor::ContributorList;
+    use citum_schema::reference::contributor::{ContributorList, SimpleName};
+    use rstest::rstest;
 
     #[test]
     #[cfg(feature = "icu")]
@@ -747,5 +767,85 @@ mod tests {
             single_key < multi_key,
             "expected {single_key:?} < {multi_key:?} (single-author entry sorts before the multi-author entry it prefixes)"
         );
+    }
+
+    /// csl26-4wts: `title_sort_text` used to return the raw title string, so
+    /// authored Djot markup decided alphabetization instead of the visible
+    /// text a reader sees. Covers `.nocase` spans, emphasis, links, markup
+    /// preceding an article (proving the strip runs before
+    /// `strip_sort_articles`), and the literal-bracket carve-out in
+    /// `Djot::visible_runs` (a bare `[Dataset]` is house-style punctuation,
+    /// not markup, and must survive untouched).
+    #[rstest]
+    #[case::nocase_span_sorts_under_visible_text(
+        "[Library of Congress]{.nocase}",
+        "Library of Congress"
+    )]
+    #[case::emphasis_delimiters_stripped(
+        "_Homo Sapiens_ and Modern Science",
+        "Homo Sapiens and Modern Science"
+    )]
+    #[case::link_markup_keeps_link_text_only("[Example](https://example.com)", "Example")]
+    #[case::markup_stripped_before_article_strip("[The Library]{.nocase}", "Library")]
+    #[case::literal_brackets_are_not_markup("[Dataset]", "[Dataset]")]
+    #[case::plain_title_is_unchanged("Plain Title Without Markup", "Plain Title Without Markup")]
+    fn given_a_title_with_djot_markup_when_building_the_title_sort_key_then_markup_is_stripped(
+        #[case] title_str: &str,
+        #[case] expected: &str,
+    ) {
+        let reference = Reference::Monograph(Box::new(citum_schema::reference::Monograph {
+            r#type: citum_schema::reference::MonographType::Book,
+            title: Some(Title::Single(title_str.to_string())),
+            ..Default::default()
+        }));
+        let locale = Locale::en_us();
+        let options = SortKeyOptions::uniform();
+
+        let key = title_sort_key_with_options(&reference, &locale, &options);
+
+        assert_eq!(key, expected);
+    }
+
+    /// csl26-lirf (follow-up to csl26-4wts): `multilingual_string_sort_text`
+    /// had the identical raw-markup leak as titles, for contributor sort
+    /// keys — an institutional author authored as `[IBM]{.nocase}` (a
+    /// `SimpleName`) would sort under `[` instead of `I`.
+    #[rstest]
+    #[case::simple_name_nocase_span_sorts_under_visible_text("[IBM]{.nocase}", "IBM")]
+    #[case::simple_name_plain_is_unchanged("Acme Corp", "Acme Corp")]
+    fn given_a_simple_name_with_djot_markup_when_building_the_contributor_sort_key_then_markup_is_stripped(
+        #[case] name_str: &str,
+        #[case] expected: &str,
+    ) {
+        let contributor = Contributor::SimpleName(SimpleName {
+            name: MultilingualString::Simple(name_str.to_string()),
+            location: None,
+            short_name: None,
+        });
+        let options = SortKeyOptions::uniform();
+
+        let key = contributor_sort_key(&contributor, NameSortOrder::FamilyGiven, &options);
+
+        assert_eq!(key.as_deref(), Some(expected));
+    }
+
+    /// Same leak for a `StructuredName`'s `family`/`given` fields (e.g. a
+    /// person authored with markup rather than an institutional
+    /// `SimpleName`), reached via `structured_name_sort_text`.
+    #[rstest]
+    #[case::nocase_span_in_family("[Smith]{.nocase}", "John", "Smith\u{0}John")]
+    #[case::emphasis_delimiters_in_given("Smith", "_John_", "Smith\u{0}John")]
+    #[case::markup_in_both_family_and_given("[Smith]{.nocase}", "_John_", "Smith\u{0}John")]
+    fn given_a_structured_name_with_djot_markup_when_building_the_contributor_sort_key_then_markup_is_stripped(
+        #[case] family: &str,
+        #[case] given: &str,
+        #[case] expected: &str,
+    ) {
+        let contributor = structured_contributor(family, given);
+        let options = SortKeyOptions::uniform();
+
+        let key = contributor_sort_key(&contributor, NameSortOrder::FamilyGiven, &options);
+
+        assert_eq!(key.as_deref(), Some(expected));
     }
 }

--- a/crates/citum-engine/src/values/title.rs
+++ b/crates/citum-engine/src/values/title.rs
@@ -143,7 +143,13 @@ fn parent_short_title(reference: &Reference, title_type: &TitleType) -> Option<S
     }
 }
 
-fn looks_like_djot_markup(value: &str) -> bool {
+/// Cheap heuristic for whether `value` contains Djot inline markup
+/// (`_emph_`, `*strong*`, `[text](url)`, `[text]{.class}`, `` `code` ``),
+/// used both to route title rendering through the Djot pipeline and to
+/// decide whether a sort key needs markup stripped (see `sort_support`'s
+/// `title_sort_text`) — kept as one predicate so the two paths agree on
+/// what counts as markup.
+pub(crate) fn looks_like_djot_markup(value: &str) -> bool {
     value.contains('_')
         || value.contains('*')
         || value.contains("](")


### PR DESCRIPTION
## Summary

- **Fixes csl26-4wts and csl26-lirf.** Sort-key derivation returned raw strings instead of visible text, so authored Djot markup (`[...]{.nocase}`, `_emph_`, `[text](url)`) decided alphabetization for both **titles** (`title_sort_text`) and **contributor names** (`multilingual_string_sort_text`, `structured_name_original_text`) — e.g. `[Library of Congress]{.nocase}` sorted under `[` instead of `L`, and an institutional author `[IBM]{.nocase}` sorted under `[` instead of `I`.
- Strips markup via the existing `Djot::visible_text` lexer (not the `PlainText` display pipeline, which would leave `_emph_` delimiters in place) through a shared `strip_markup_for_sort()` helper, applied before `strip_sort_articles` runs — so a leading article hidden behind markup (`[The Library]{.nocase}`) is still stripped correctly.
- `looks_like_djot_markup` promoted to `pub(crate)` so sort-key derivation gates on the same predicate as the display path.

## Test plan

- [x] `cargo nextest run -p citum-engine sort_support` — new `#[rstest]` cases: title (`.nocase` span, emphasis, link, markup-before-article ordering, literal-bracket carve-out) and contributor name (`SimpleName` institutional author, `StructuredName` family) all pass
- [x] `just pre-commit` — 2662/2662 tests, fmt, clippy clean
- [x] `node scripts/report-core.js --all-features` — zero drift against a `main` baseline (identical totals/exactParity/quality); core-styles fixture corpus has no title/name whose sort position this changes
