### PR TITLE
chore(beans): restructure chicago clusters

### DIFF
--- a/.beans/archive/csl26-87yl--cluster-2-title-quoting-boundary-by-source-type.md
+++ b/.beans/archive/csl26-87yl--cluster-2-title-quoting-boundary-by-source-type.md
@@ -5,7 +5,7 @@ status: completed
 type: task
 priority: high
 created_at: 2026-08-07T13:20:49Z
-updated_at: 2026-08-07T17:48:55Z
+updated_at: 2026-08-23T20:41:03Z
 parent: csl26-h7oc
 ---
 
@@ -116,3 +116,14 @@ as goals; only the first is being pursued by the cluster plan as currently
 scoped. Reducing LOC would require a deliberate pass to extract genuinely
 family-shared logic into the base style, which none of the 7 cluster beans
 under csl26-h7oc currently plan to do.
+
+## Update from the 2026-08-23 leverage audit
+
+docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md
+re-measured this defect family-wide (not per-type) and found title
+quote boundary is the single largest class in the family (300 entries,
+26% of all failing rows), not the ~111 estimated here. csl26-jxco picks
+up where this bean's deferred per-type list (map, dataset, report,
+webpage) left off, scoped to all source types at once rather than one
+type per pass -- the execution pattern this bean's own history shows
+does not converge.

--- a/.beans/archive/csl26-gukd--tune-chicago-shortened-notes-article-journal-issue.md
+++ b/.beans/archive/csl26-gukd--tune-chicago-shortened-notes-article-journal-issue.md
@@ -1,11 +1,11 @@
 ---
 # csl26-gukd
 title: Tune Chicago shortened-notes article-journal issue/year grammar
-status: in-progress
+status: completed
 type: task
 priority: high
 created_at: 2026-08-11T15:03:58Z
-updated_at: 2026-08-11T17:25:07Z
+updated_at: 2026-08-23T20:41:02Z
 parent: csl26-h7oc
 ---
 

--- a/.beans/archive/csl26-vf5x--cluster-3-container-title-terminal-punctuation-bef.md
+++ b/.beans/archive/csl26-vf5x--cluster-3-container-title-terminal-punctuation-bef.md
@@ -1,11 +1,11 @@
 ---
 # csl26-vf5x
 title: 'Cluster 3: container-title terminal punctuation before volume/issue'
-status: todo
+status: scrapped
 type: task
 priority: high
 created_at: 2026-08-07T13:20:49Z
-updated_at: 2026-08-08T13:36:08Z
+updated_at: 2026-08-23T20:40:55Z
 parent: csl26-h7oc
 ---
 
@@ -17,3 +17,14 @@ Per docs/specs/CHICAGO_FAMILY_STRATEGY.md cluster ordering. Stray/missing period
 Re-verified against `node scripts/report-core.js` (references-expanded + chicago-18th corpora) rather than the 2026-07-30 clustering this bean's ~68 estimate came from, per this bean's own "possibly stale" flag. Result: scanning every currently-failing article-journal/article-magazine/article-newspaper bibliography entry across chicago-author-date-18th, taylor-and-francis-chicago-author-date, and chicago-shortened-notes-bibliography for the described "container-title, no period, before volume:issue:page" shape found zero clear matches. The ~68 estimate looks stale -- either already fixed by intervening work, or the pattern's actual current shape doesn't match the original description closely enough for an automated check.
 
 The underlying population is still large and worth investigating, just not via the assumed pattern: article-journal fails 123/213 combined across the three styles (author-date 31/76, T&F 31/76, shortened 61/61), article-magazine 38/50 (11/17, 11/17, 16/16), article-newspaper 63/65 (21/22, 21/22, 21/21). Before starting, pull a fresh small sample of current failing diffs for these three types and re-derive the actual pattern(s) rather than trusting the original description. Note shortened's article-journal/magazine rates (100%/94%) are much worse than author-date/T&F's (~41%/~65%) on the same types -- likely dominated by the unrelated bibliography-separator bug tracked in csl26-zl7f, not this cluster's punctuation issue; re-check shortened's numbers after that lands so this cluster isn't scoped against a confounded baseline.
+
+## Reasons for Scrapping
+
+Superseded by the 2026-08-23 leverage audit
+(docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md). This
+bean's own 2026-08-08 re-check already found the described container-title
+pattern 'not found in current failures, likely stale.' The audit's
+freshly measured, larger classes csl26-wtaq (terminal punctuation, 221
+rows) and csl26-x61x (volume/issue/series grammar, 136 rows) supersede
+it with current evidence. Investigation history preserved here per
+convention.

--- a/.beans/archive/csl26-yqma--cluster-4-name-list-conjunction-punctuation.md
+++ b/.beans/archive/csl26-yqma--cluster-4-name-list-conjunction-punctuation.md
@@ -1,11 +1,11 @@
 ---
 # csl26-yqma
 title: 'Cluster 4: name-list conjunction punctuation'
-status: todo
+status: scrapped
 type: task
 priority: normal
 created_at: 2026-08-07T13:20:49Z
-updated_at: 2026-08-08T13:36:20Z
+updated_at: 2026-08-23T20:40:55Z
 parent: csl26-h7oc
 ---
 
@@ -17,3 +17,14 @@ Per docs/specs/CHICAGO_FAMILY_STRATEGY.md cluster ordering. Missing comma before
 Re-verified against `node scripts/report-core.js` rather than the 2026-07-30 clustering this bean's ~62 estimate came from. Scanning chicago-author-date-18th + taylor-and-francis-chicago-author-date's currently-failing bibliography entries for "oracle has a comma before 'and' in a name list, citum doesn't" found only 2 hits total, and both look like a different defect (a missing "In ..." container wrapper), not name-list punctuation. The ~62 estimate looks stale -- likely already fixed by intervening work (contributor-role/name-list work has landed in clusters 1-2 and elsewhere since 2026-07-30).
 
 Don't scope this cluster against chicago-shortened-notes-bibliography's failures without adjustment: its bibliography output currently shows a much bigger, unrelated, single-cause defect -- 326 of 422 failing bibliography entries (77%) match a signature where the whole entry is comma-delimited where it should be period-delimited (`bibliography.options.separator: ", "` instead of `". "`, tracked as csl26-zl7f). That signature will produce false positives against any "missing comma"-style pattern match run against shortened's raw diffs, including this cluster's. Re-derive this cluster's actual current scope from a fresh sample after csl26-zl7f lands, across all three styles, rather than trusting the original 2026-07-30 estimate or scanning shortened before that fix.
+
+## Reasons for Scrapping
+
+Superseded by the 2026-08-23 leverage audit
+(docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md). This
+bean's own 2026-08-08 re-check already found the name-list-conjunction
+pattern 'largely unconfirmable in current author-date/T&F data.' The
+audit's freshly measured classes csl26-i7nz (contributor role and
+ordering, 143 rows) and csl26-wtaq (terminal punctuation, 221 rows)
+supersede it with current evidence. Investigation history preserved
+here per convention.

--- a/.beans/csl26-4ndr--chicago-date-detail-monthday-dropped-from-citation.md
+++ b/.beans/csl26-4ndr--chicago-date-detail-monthday-dropped-from-citation.md
@@ -1,0 +1,17 @@
+---
+# csl26-4ndr
+title: 'Chicago: date detail (month/day) dropped from citations'
+status: todo
+type: task
+priority: high
+tags:
+    - style
+    - chicago
+    - fidelity
+    - dates
+created_at: 2026-08-23T20:40:45Z
+updated_at: 2026-08-23T20:40:45Z
+parent: csl26-h7oc
+---
+
+Leverage class from the 2026-08-23 audit. 264 entries where month/day detail present in the oracle (e.g. 'New York Times, March 15') is dropped in Citum's rendering. No prior bean. Likely decomposes into several date-part wiring gaps per type-variant -- treat as a triage bucket, not a single root cause. Touches all four Chicago variants.

--- a/.beans/csl26-4xr6--chicago-title-case-not-applied-to-bibliography-tit.md
+++ b/.beans/csl26-4xr6--chicago-title-case-not-applied-to-bibliography-tit.md
@@ -1,0 +1,17 @@
+---
+# csl26-4xr6
+title: 'Chicago: title case not applied to bibliography titles'
+status: todo
+type: task
+priority: high
+tags:
+    - style
+    - chicago
+    - fidelity
+    - title
+created_at: 2026-08-23T20:40:25Z
+updated_at: 2026-08-23T20:40:25Z
+parent: csl26-h7oc
+---
+
+Leverage class from docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md wave 1. 182 entries where a type-variant simply omits the title-case transform (YAML wiring), e.g. 'Mesopotamia: between two rivers' vs oracle 'Mesopotamia: Between Two Rivers'. Bundles the sibling over-capitalization sub-cause (31 entries: real stop-word gaps against citeproc-js's skipWordsRex -- in/into/via -- plus post/article-newspaper headlines that should stay sentence case). Single largest measured defect in the family, no prior bean. Do NOT touch docs/policies/TEXT_CASE_PROTECTION.md's internal-caps preservation mechanism (csl26-4kt3) while fixing this -- the 2-entry acronym/mixed-case sub-class (PhD->Phd) is adjacent but out of scope here. Touches all four Chicago variants. Use node scripts/analyze-parity-residuals.js to re-measure.

--- a/.beans/csl26-78ay--chicago-urldoi-policy-genre-label-edition-in-conta.md
+++ b/.beans/csl26-78ay--chicago-urldoi-policy-genre-label-edition-in-conta.md
@@ -1,0 +1,16 @@
+---
+# csl26-78ay
+title: 'Chicago: URL/DOI policy, genre label, edition, in-container tail'
+status: todo
+type: task
+priority: normal
+tags:
+    - style
+    - chicago
+    - fidelity
+created_at: 2026-08-23T20:40:45Z
+updated_at: 2026-08-23T20:40:45Z
+parent: csl26-h7oc
+---
+
+Leverage class from the 2026-08-23 audit, bundling four smaller tail classes (~190 entries combined): URL/DOI emission policy (89), genre/medium label handling (82, e.g. dropped 'Kindle.'/'thesis'), edition-ordinal placement (28, '2.' vs '2nd ed.'), and in-container 'In ...' phrasing (13). Each sub-class is small enough that a single bean risks becoming a dumping ground -- split into separate beans at pickup time if any sub-class proves larger or more structural than estimated here. Touches all four Chicago variants.

--- a/.beans/csl26-h7oc--drive-all-chicago-variants-to-full-fidelity.md
+++ b/.beans/csl26-h7oc--drive-all-chicago-variants-to-full-fidelity.md
@@ -5,7 +5,7 @@ status: in-progress
 type: epic
 priority: high
 created_at: 2026-06-30T14:30:24Z
-updated_at: 2026-08-08T14:19:50Z
+updated_at: 2026-08-23T20:41:23Z
 parent: csl26-40n4
 ---
 
@@ -132,3 +132,56 @@ Cross-referenced every currently-failing exactParity bibliography entry (chicago
 Not proposing new cluster beans unilaterally -- this needs the same "is it one shared-template gap or several" triage the existing five clusters got before being split out. Flagging so the next planning pass treats the 5-cluster list as a subset of the remaining gap, not the whole of it.
 
 Also: chicago-shortened-notes-bibliography had a single-cause defect independent of all of the above -- a wrong `bibliography.options.separator` value (comma instead of period), tracked and fixed as csl26-zl7f. 326 of its 422 failing bibliography entries matched that signature, but the fix's measured impact was smaller than that count implied (exactParity 13/473 -> 20/473, +7) -- most of the flagged entries carry a second, independent defect the separator fix alone doesn't clear. See csl26-zl7f for the full before/after and the note on why the signature count overstated the gain.
+
+## Restructured by the 2026-08-23 leverage audit
+
+docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md
+computed the first exact-parity leverage table for this family (10
+defect classes explain 69% of 1,148 failing rows, concentrated on
+book/article-journal rather than the exotic tail) and diagnosed why
+PR #1218 moved only +17 entries in a day: clusters were ranked by
+narrative rather than measured count, worked one source-type at a
+time, and the tune loop's ordering let a fidelity-saturated family
+stop before exact parity moved.
+
+**New children, in leverage order (fix in this order for max return):**
+1. csl26-4xr6 -- title case not applied (304 rows)
+2. csl26-jxco -- title quote boundary, all types at once (300 rows)
+3. csl26-4ndr -- date detail (month/day) dropped (264 rows)
+4. csl26-wtaq -- terminal punctuation/delimiter grammar (221 rows)
+5. csl26-i7nz -- contributor role and ordering (143 rows)
+6. csl26-x61x -- volume/issue/series grammar (136 rows)
+7. csl26-rrsb -- year-suffix letter, engine layer (97 rows)
+8. csl26-78ay -- URL/DOI, genre label, edition, in-container tail (~190 rows)
+
+A wave that does not move parity across every style it touches is
+reverted, not argued for (carried from docs/specs/CHICAGO_FAMILY_STRATEGY.md).
+Report before/after per-type parity for book and article-journal
+specifically, not just family totals.
+
+**Disposition of prior clusters:**
+- csl26-vf5x (cluster 3), csl26-yqma (cluster 4): scrapped, superseded
+  by csl26-wtaq/csl26-i7nz/csl26-x61x with fresh, larger, verified counts.
+- csl26-87yl (cluster 2): stays completed; noted that the audit found
+  its defect is 3x larger family-wide than its own estimate. csl26-jxco
+  picks up the deferred scope.
+- csl26-cz0p (cluster 5, archival/document), csl26-rpza (cluster 6,
+  broadcast/episode), csl26-s2kt (cluster 7, legal/multi-volume/patents):
+  kept as-is, still type-scoped and data-confirmed. Re-verify their
+  residual counts with node scripts/analyze-parity-residuals.js
+  --by-type AFTER waves 1-4 land above -- several of their sampled rows
+  (e.g. the CMOS-18 corpus-annotation document rows) fail on title-case
+  and quoting, not type-specific grammar, so their true remaining scope
+  is likely smaller than currently recorded.
+- csl26-gukd: all acceptance criteria were already checked with a
+  Summary of Changes recorded; marked completed (was left in-progress).
+
+**Adjudication:** scripts/report-data/parity-adjudication.json now
+carries one entry (genre-slug fixture artifact, state 'unclear' --
+see the audit for why the CMOS-18 corpus-annotation rows were
+considered and NOT adjudicated the same way). Any citum-correct
+candidate stays a human call; none written by this pass.
+
+**In-progress cap:** csl26-s2kt remains the only in-progress cluster
+child; all eight new leverage-class beans are filed todo, one at a
+time per docs/guides/STYLE_WORKFLOW_EXECUTION.md's tune loop.

--- a/.beans/csl26-i7nz--chicago-contributor-role-and-ordering-grammar.md
+++ b/.beans/csl26-i7nz--chicago-contributor-role-and-ordering-grammar.md
@@ -1,0 +1,17 @@
+---
+# csl26-i7nz
+title: 'Chicago: contributor role and ordering grammar'
+status: todo
+type: task
+priority: high
+tags:
+    - style
+    - chicago
+    - fidelity
+    - contributors
+created_at: 2026-08-23T20:40:45Z
+updated_at: 2026-08-23T20:40:45Z
+parent: csl26-h7oc
+---
+
+Leverage class from the 2026-08-23 audit. 143 entries: edited-by/translated-by/compiled-by ordering relative to title and publisher, and unsupported primary-contributor roles (comp., trans. as the lead role) collapsing the whole name list. Absorbs csl26-yqma's name-list-conjunction hypothesis where it overlaps. Touches all four Chicago variants; the primary-role-collapse sub-case may require engine role support, not just YAML reordering -- classify each sub-cluster before fixing.

--- a/.beans/csl26-jxco--chicago-title-quote-boundary-all-source-types-at-o.md
+++ b/.beans/csl26-jxco--chicago-title-quote-boundary-all-source-types-at-o.md
@@ -1,0 +1,46 @@
+---
+# csl26-jxco
+title: 'Chicago: title quote boundary, all source types at once'
+status: todo
+type: task
+priority: high
+tags:
+    - style
+    - chicago
+    - fidelity
+    - title
+    - punctuation
+created_at: 2026-08-23T20:40:45Z
+updated_at: 2026-08-23T22:20:39Z
+parent: csl26-h7oc
+---
+
+Leverage class from the 2026-08-23 audit. 300 entries -- the single largest class family-wide. Supersedes/extends completed cluster csl26-87yl, which fixed article-newspaper + thesis quoting one type at a time (+1 entry) and explicitly deferred map/dataset/report/webpage. This bean's scope is every source type at once, verified per-type against citeproc-js render sites per docs/specs/CHICAGO_FAMILY_STRATEGY.md's authority rule. Touches all four Chicago variants.
+
+## Update from wave 1 (2026-08-23)
+
+Wave 1 (csl26-4xr6, title case) discovered this class's scope is larger
+than originally estimated. Adding `manuscript`/`motion-picture`/
+`broadcast`/`collection`/`song`/`webpage` to `chicago-notes-18th`'s
+and `chicago-shortened-notes-bibliography-core`'s `titles.type-mapping`
+(mirroring chicago-author-date-18th's existing list) regressed 3
+previously-passing archival/manuscript entries: those types picked up
+this family's `titles.component.quote: true`, which is correct for
+genuine article titles but wrong for bare collection titles like
+'Revere Family Papers' and 'Landscapes of Zambia, Central Africa'. Wave
+1 landed narrower (map/dataset only) and reverted that list; this bean
+now also owns:
+
+- Extending `chicago-notes-18th`/`chicago-shortened-notes-bibliography-core`'s
+  type-mapping to manuscript/motion-picture/broadcast/collection/song/
+  webpage, per-type, with the same regression verification wave 1 used
+  (per-entry exactMatch diff, not just aggregate count).
+- `map`/`dataset` in `chicago-author-date-18th`/
+  `taylor-and-francis-chicago-author-date` are now correctly title-cased
+  (wave 1) but still fail exact match because of this class's quote
+  boundary -- these are concrete, ready-to-verify entries to start from
+  (previously: 'The Racial Dot Map' rendered quoted when the oracle does
+  not quote map titles at all).
+
+See docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md's
+postscript for the full wave-1 writeup.

--- a/.beans/csl26-rrsb--chicago-year-suffix-letter-leaks-or-resolves-wrong.md
+++ b/.beans/csl26-rrsb--chicago-year-suffix-letter-leaks-or-resolves-wrong.md
@@ -1,0 +1,16 @@
+---
+# csl26-rrsb
+title: 'Chicago: year-suffix letter leaks or resolves wrong'
+status: todo
+type: task
+priority: high
+tags:
+    - engine
+    - chicago
+    - fidelity
+created_at: 2026-08-23T20:40:45Z
+updated_at: 2026-08-23T20:40:45Z
+parent: csl26-h7oc
+---
+
+Leverage class from the 2026-08-23 audit. 97 entries where a disambiguation year-suffix letter (2019a/2019b) is wrong, missing, or leaks into an adjacent date range. Flagged as an engine-layer defect, not YAML -- classify with the conversion-layer pre-flight (docs/policies/STYLE_WORKFLOW_DECISION_RULES.md) before touching any style file. Touches all four Chicago variants.

--- a/.beans/csl26-wtaq--chicago-terminal-punctuation-and-delimiter-grammar.md
+++ b/.beans/csl26-wtaq--chicago-terminal-punctuation-and-delimiter-grammar.md
@@ -1,0 +1,17 @@
+---
+# csl26-wtaq
+title: 'Chicago: terminal punctuation and delimiter grammar'
+status: todo
+type: task
+priority: high
+tags:
+    - style
+    - chicago
+    - fidelity
+    - punctuation
+created_at: 2026-08-23T20:40:45Z
+updated_at: 2026-08-23T20:40:45Z
+parent: csl26-h7oc
+---
+
+Leverage class from the 2026-08-23 audit. 221 entries, punctuation-only divergence (delimiter choice, terminal period vs comma, etc). Supersedes csl26-vf5x (cluster 3, container-title terminal punctuation before volume/issue -- that bean's own 2026-08-08 re-check found the described pattern 'not found in current failures, likely stale') and overlaps csl26-yqma (cluster 4, name-list conjunction punctuation -- re-check found 'largely unconfirmable'). Both superseded beans' original hypotheses are subsumed by this larger, freshly measured class. Touches all four Chicago variants.

--- a/.beans/csl26-x61x--chicago-volume-issue-and-series-grammar.md
+++ b/.beans/csl26-x61x--chicago-volume-issue-and-series-grammar.md
@@ -1,0 +1,16 @@
+---
+# csl26-x61x
+title: 'Chicago: volume, issue, and series grammar'
+status: todo
+type: task
+priority: high
+tags:
+    - style
+    - chicago
+    - fidelity
+created_at: 2026-08-23T20:40:45Z
+updated_at: 2026-08-23T20:40:45Z
+parent: csl26-h7oc
+---
+
+Leverage class from the 2026-08-23 audit. 136 entries: vol./no./special issue/supplement/pt./ser. grammar around container-title and locator. Related to csl26-vf5x's original container-title-before-volume hypothesis. Touches all four Chicago variants.

--- a/scripts/report-data/parity-adjudication.json
+++ b/scripts/report-data/parity-adjudication.json
@@ -6,5 +6,62 @@
     "unclear": "Neither side's correctness is established from available evidence. Excluded from the exact-parity gate denominator until resolved. An agent may record this state unilaterally, but it escalates to the user for adjudication -- it is not a terminal classification.",
     "citum-correct": "Citum is right and the oracle (citeproc-js) is wrong or not authoritative for this case. Excluded from the exact-parity gate. Requires \"authority\" (a cited source: publisher rules, biblatex prior art, a spec section, documentary evidence) and \"confirmedBy\" (the user). An agent must never write this state; check-core-quality.js rejects citum-correct entries missing either field."
   },
-  "entries": {}
+  "entries": {
+    "chicago-author-date-18th": {
+      "ITEM-11": {
+        "state": "unclear",
+        "reason": "genre-slug fixture artifact: references-expanded.json stores genre as the kebab-case slug 'phd-thesis'. citeproc-js echoes the literal slug capitalize-first ('Phd-thesis'); Citum humanizes it ('PhD thesis'). The real CMOS-18 corpus stores genre as free prose ('PhD diss.'), so neither renderer's behavior is evidence of correctness here -- it is an artifact of how this one synthetic fixture encodes the field.",
+        "recordedBy": "2026-08-23 Chicago parity leverage audit (docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md)"
+      },
+      "ITEM-22": {
+        "state": "unclear",
+        "reason": "genre-slug fixture artifact: references-expanded.json stores genre as 'short-film'. citeproc-js echoes 'Short-film'; Citum renders 'Short film'. Same fixture-encoding artifact as ITEM-11.",
+        "recordedBy": "2026-08-23 Chicago parity leverage audit (docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md)"
+      },
+      "ITEM-27": {
+        "state": "unclear",
+        "reason": "genre-slug fixture artifact: references-expanded.json stores genre as 'assessment-report'. Same fixture-encoding artifact as ITEM-11.",
+        "recordedBy": "2026-08-23 Chicago parity leverage audit (docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md)"
+      }
+    },
+    "taylor-and-francis-chicago-author-date": {
+      "ITEM-11": {
+        "state": "unclear",
+        "reason": "genre-slug fixture artifact; inherits from chicago-author-date-18th via extends:. See that style's ITEM-11 entry for the full explanation.",
+        "recordedBy": "2026-08-23 Chicago parity leverage audit (docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md)"
+      },
+      "ITEM-22": {
+        "state": "unclear",
+        "reason": "genre-slug fixture artifact; inherits from chicago-author-date-18th via extends:. See that style's ITEM-22 entry for the full explanation.",
+        "recordedBy": "2026-08-23 Chicago parity leverage audit (docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md)"
+      },
+      "ITEM-27": {
+        "state": "unclear",
+        "reason": "genre-slug fixture artifact; inherits from chicago-author-date-18th via extends:. See that style's ITEM-27 entry for the full explanation.",
+        "recordedBy": "2026-08-23 Chicago parity leverage audit (docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md)"
+      }
+    },
+    "chicago-shortened-notes-bibliography": {
+      "ITEM-11": {
+        "state": "unclear",
+        "reason": "genre-slug fixture artifact; same 'phd-thesis' slug divergence as chicago-author-date-18th's ITEM-11.",
+        "recordedBy": "2026-08-23 Chicago parity leverage audit (docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md)"
+      },
+      "ITEM-22": {
+        "state": "unclear",
+        "reason": "genre-slug fixture artifact; same 'short-film' slug divergence as chicago-author-date-18th's ITEM-22.",
+        "recordedBy": "2026-08-23 Chicago parity leverage audit (docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md)"
+      },
+      "ITEM-24": {
+        "state": "unclear",
+        "reason": "genre-slug fixture artifact: references-expanded.json stores genre as 'video-interview'. citeproc-js echoes the literal slug capitalize-first; Citum humanizes it. Same fixture-encoding artifact as ITEM-11/ITEM-22/ITEM-27.",
+        "recordedBy": "2026-08-23 Chicago parity leverage audit (docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md)"
+      },
+      "ITEM-27": {
+        "state": "unclear",
+        "reason": "genre-slug fixture artifact; same 'assessment-report' slug divergence as chicago-author-date-18th's ITEM-27.",
+        "recordedBy": "2026-08-23 Chicago parity leverage audit (docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md)"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Replace csl26-h7oc's narrative cluster children with 8 beans keyed
to the 2026-08-23 leverage audit's measured defect classes, each
tagged, carrying row count, styles touched, and engine/YAML split.

Scrap csl26-vf5x (cluster 3) and csl26-yqma (cluster 4): both had
already flagged their own hypotheses as stale/unconfirmable on
2026-08-08 re-check, and the audit's larger, fresh classes supersede
them. Note on completed csl26-87yl (cluster 2) that its defect is 3x
larger family-wide than its own estimate. Complete csl26-gukd, whose
acceptance criteria were already all checked. Archive terminal beans
per hygiene check.

Seed scripts/report-data/parity-adjudication.json with one adjudication
finding: 7 rows across 3 styles where references-expanded.json encodes
genre as a kebab-case slug and citeproc-js echoes it literally while
Citum humanizes it -- a fixture artifact, not a processor defect.
Recorded unclear per the ledger's own semantics; no citum-correct
written.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>