### PR TITLE
fix(styles): quote document/thesis titles (wave 2)

### DIFF
--- a/.beans/csl26-jxco--chicago-title-quote-boundary-all-source-types-at-o.md
+++ b/.beans/csl26-jxco--chicago-title-quote-boundary-all-source-types-at-o.md
@@ -1,7 +1,7 @@
 ---
 # csl26-jxco
 title: 'Chicago: title quote boundary, all source types at once'
-status: todo
+status: in-progress
 type: task
 priority: high
 tags:
@@ -11,7 +11,7 @@ tags:
     - title
     - punctuation
 created_at: 2026-08-23T20:40:45Z
-updated_at: 2026-08-23T22:20:39Z
+updated_at: 2026-08-24T00:52:05Z
 parent: csl26-h7oc
 ---
 
@@ -44,3 +44,91 @@ now also owns:
 
 See docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md's
 postscript for the full wave-1 writeup.
+
+## Wave 2 progress (2026-08-23, session 1)
+
+First verified increment landed: `document: component` added to
+`chicago-author-date-18th`/`taylor-and-francis-chicago-author-date-core`,
+plus `document: component` + `thesis: component` added to
+`chicago-notes-18th`/`chicago-shortened-notes-bibliography-core`. Both
+`document` and `thesis` are quoted+title-cased per the shipped
+`chicago-author-date.csl`'s title choose-block (`article dataset document
+interview manuscript paper-conference personal_communication speech thesis
+webpage`), but the engine's hardcoded type→category fallback either has no
+entry for `document` (falls to `Default`, no transform at all) or wrongly
+hardcodes `thesis` to `Monograph` (italic, not quoted).
+
+Per-entry exactMatch diff (not aggregate) confirmed **zero regressions**
+across all four styles. Real text-level progress verified (title-case +
+quoting now correct) for 26 `document` rows in
+`chicago-author-date-18th`/T&F, 36 `document`+`thesis` rows in
+`chicago-shortened-notes-bibliography`, and the `chi-thesis` citation
+fixture in `chicago-notes-18th`. **Zero rows flipped to full exactMatch**
+this pass -- expected per the audit postscript's entanglement pattern:
+these rows carry additional un-landed defects (acronym case `Phd`/`PhD`,
+missing ProQuest/genre detail, missing "archived" date phrasing) that must
+also clear before the row counts.
+
+Also ran and reverted a probe: adding `quote: true` to
+`chicago-author-date-18th`'s `titles.component` (to try to reach `document`
+rows via the category system, matching how the notes-family styles already
+do it) produced **zero gain** (quote still didn't reach `document` rows) and
+**one regression** (`song` type "Selected Poems" -- a standalone recording
+with no `container-title`, wrongly quoted). Reverted; not part of the
+landed commit.
+
+### Engine gap found (filed, not fixed here -- YAML-only wave)
+
+`chicago-author-date-18th`'s bibliography renders anonymous/no-author
+entries (`document` type -- CMOS annotation titles with no author field) by
+substituting the title into the author position
+(`crates/citum-engine/src/values/contributor/substitute.rs`,
+`resolve_author_substitute` / `resolve_category_quote`). Title-case
+propagates correctly through this path (confirmed: `get_title_category_
+title_rendering` is called and the category's `text-case` applies), but
+**quote does not**, even with `titles.component.quote: true` set. By
+contrast the notes-family styles (`chicago-notes-18th`,
+`chicago-shortened-notes-bibliography-core`), which already carry `quote:
+true` on `titles.component` from wave 1, DO correctly quote their own
+anonymous/substituted entries -- confirmed via the same before/after diff
+(the `document`/`thesis` rows above). So the gap is specific to how
+`chicago-author-date-18th`'s bibliography reaches the substitute path, not
+a general engine limitation. Root cause not isolated further (would need
+tracing why this style's bibliography-side author-substitution differs from
+the notes-family's); scoped as follow-up, not fixed in this YAML-only wave
+per the audit's own layering rule (engine changes need their own reviewed
+scope, family-wide blast radius).
+
+### Deliberately not touched this pass
+
+- `webpage` in `chicago-author-date-18th`: already mapped to `component`
+  with an explicit per-node `wrap: quotes` on its "title present" branch,
+  but corporate-authored entries (e.g. "City of Chicago") render with title
+  BEFORE the organization name and no quotes -- evidence the entry is
+  taking the substitute path (organization stored in `publisher`, not
+  `author`; `publisher` isn't in `bibliography.options.substitute.candidates`,
+  so `title` substitutes instead). This is a contributor-substitution
+  gap (class E, not class B) -- out of this bean's scope.
+- `collection` in the notes-family styles' `type-mapping`: intentionally
+  left out. Per the shipped `.csl`, `collection` is in the never-quote set
+  (`bill collection legislation regulation treaty` -> title case, no
+  quotes), so adding it to `component` (which now carries `quote: true` in
+  both notes-family styles) would regress archival entries exactly as wave
+  1 found. `manuscript`/`motion-picture`/`broadcast`/`song`/`webpage`
+  extension into these styles' type-mapping is still open -- each needs the
+  same per-type verification against the `.csl` choose-block this session
+  used for `document`/`thesis`, not a bulk copy of author-date-18th's list.
+- `map`/`graphic` in `chicago-author-date-18th`: still wrongly quoted
+  (e.g. "The Racial Dot Map"). Per the `.csl`, both are in the
+  never-quote, always-italic set (`book classic graphic hearing map`).
+  Fix needs a dedicated bibliography type-variant (`title: primary, emph:
+  true`, no wrap) -- category reassignment can't remove a node-level
+  `wrap: quotes` that a resolved type-variant doesn't carry (these two
+  currently fall through to the file's default `template:` block, which
+  hardcodes the wrap). Not yet attempted.
+
+Remaining open work for this bean: map/graphic type-variant, webpage
+corporate-author substitution (may need its own bean, class E territory),
+manuscript/motion-picture/broadcast/song/webpage extension into the
+notes-family type-mapping (per-type verified), and tracing the
+chicago-author-date-18th substitute-quote engine gap.

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -79,6 +79,7 @@ options:
       webpage: component
       map: component
       dataset: component
+      document: component
     component:
       text-case: title
     monograph:

--- a/crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
@@ -73,6 +73,15 @@ options:
     type-mapping:
       map: component
       dataset: component
+      # `document` and `thesis` per docs/architecture/audits/2026-08-23_
+      # CHICAGO_PARITY_LEVERAGE_AUDIT.md wave 2 (csl26-jxco): the shipped
+      # chicago-author-date.csl's title choose-block quotes+title-cases both
+      # (`article dataset document interview manuscript paper-conference
+      # personal_communication speech thesis webpage`); the engine's hardcoded
+      # type->category fallback has neither (document falls to Default;
+      # thesis is hardcoded to Monograph/italic, which is wrong for Chicago).
+      document: component
+      thesis: component
     component:
       quote: true
       text-case: title

--- a/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
@@ -63,6 +63,15 @@ options:
     type-mapping:
       map: component
       dataset: component
+      # `document` and `thesis` per docs/architecture/audits/2026-08-23_
+      # CHICAGO_PARITY_LEVERAGE_AUDIT.md wave 2 (csl26-jxco): the shipped
+      # chicago-author-date.csl's title choose-block quotes+title-cases both
+      # (`article dataset document interview manuscript paper-conference
+      # personal_communication speech thesis webpage`); the engine's hardcoded
+      # type->category fallback has neither (document falls to Default;
+      # thesis is hardcoded to Monograph/italic, which is wrong for Chicago).
+      document: component
+      thesis: component
     component:
       quote: true
       text-case: title

--- a/crates/citum-schema-style/embedded/styles/taylor-and-francis-chicago-author-date-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/taylor-and-francis-chicago-author-date-core.yaml
@@ -31,7 +31,14 @@ options:
     # engine gap. See docs/policies/TEXT_CASE_PROTECTION.md and csl26-4kt3 for
     # why proper-noun protection here would need `.nocase` in the source data,
     # which this style cannot supply.
-    type-mapping: ~
+    #
+    # `document` re-added narrowly (not the full parent list — see the
+    # type-mapping-clearing rationale above) per docs/architecture/audits/
+    # 2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md wave 2: without it, `document`
+    # falls to the engine's hardcoded Default title category (no case
+    # transform at all) rather than this style's own `component` category.
+    type-mapping:
+      document: component
     component:
       text-case: sentence
   contributors:

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml
@@ -17,10 +17,10 @@ style:
       sha256: 5ee7afd5c74169d8882747d8ab6ede8b84aa12cd1760e1f0f3f544198cd1be94
     - id: chicago-shortened-notes-bibliography-core
       path: crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
-      sha256: 0a95392eef5297f0dce329d61c3c03d72d77dc8ca50caaf4a513ce598dd87843
+      sha256: acffc5f23e181e89b6894a285065647f6393911c9088fb08951f3dd861da119d
     - id: chicago-notes-18th
       path: crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
-      sha256: 72e784e44f205fa8c22a4c1a34cf9e43b28c9f994f45ded30e35eb02df2f40f7
+      sha256: a87c1bb0152f3fa88550d398e0d9389a09d80f95d8fe26a171a3982b2e3505e5
     - id: chicago-18-base
       path: crates/citum-schema-style/embedded/styles/chicago-18-base.yaml
       sha256: fa8cadf78de3efabec01f7e1d524d5f1e51b0682fab247b92f2c46f6352f2c74

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.json
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.json
@@ -115,7 +115,7 @@
     ],
     "manifest": {
       "path": "docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml",
-      "sha256": "523077f865ba960c1134e5cced29a8794321e3f579382ec088a90e90f12e59f0"
+      "sha256": "496025addf9b0f8e8b306a75a29fa7674c787bc185c86285b46f61518d6c4c81"
     },
     "relevance": {
       "default": "relevant",
@@ -164,12 +164,12 @@
         {
           "id": "chicago-shortened-notes-bibliography-core",
           "path": "crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml",
-          "sha256": "0a95392eef5297f0dce329d61c3c03d72d77dc8ca50caaf4a513ce598dd87843"
+          "sha256": "acffc5f23e181e89b6894a285065647f6393911c9088fb08951f3dd861da119d"
         },
         {
           "id": "chicago-notes-18th",
           "path": "crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml",
-          "sha256": "72e784e44f205fa8c22a4c1a34cf9e43b28c9f994f45ded30e35eb02df2f40f7"
+          "sha256": "a87c1bb0152f3fa88550d398e0d9389a09d80f95d8fe26a171a3982b2e3505e5"
         },
         {
           "id": "chicago-18-base",
@@ -179,7 +179,7 @@
       ],
       "id": "chicago-shortened-notes-bibliography",
       "path": "crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography.yaml",
-      "resolvedSha256": "7fca853405acf781167dddf951f1c39598d0e5e76f0eadedf36a8eb438153193",
+      "resolvedSha256": "6ccd8dc057a61c9c96eb9a6499ae199e37238d08ad7c2e49ecb599d7a040ae00",
       "sha256": "5ee7afd5c74169d8882747d8ab6ede8b84aa12cd1760e1f0f3f544198cd1be94"
     },
     "surfaces": [


### PR DESCRIPTION
Add document/thesis to titles.type-mapping across the four Chicago
18 variants so both get quote+title-case per the shipped
chicago-author-date.csl choose-block, instead of falling through
the engine's hardcoded type->category default (no entry for
document; thesis wrongly hardcoded to italic monograph). Zero
regressions per per-entry exactMatch diff; text-level progress
verified on 60+ rows even where other un-landed defects keep the
row from full exact match.

Part of the title-quote-boundary wave (csl26-jxco); see the bean
for the engine gap found (author-date-18th's bibliography
substitute path doesn't carry category quote) and the remaining
scoped-out items (map/graphic, webpage corporate-author
substitution, collection exclusion rationale).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>