### PR TITLE
feat(scripts): add parity residual --diff mode

### DIFF
--- a/.beans/archive/csl26-r90t--add-diff-mode-to-analyze-parity-residualsjs.md
+++ b/.beans/archive/csl26-r90t--add-diff-mode-to-analyze-parity-residualsjs.md
@@ -1,0 +1,49 @@
+---
+# csl26-r90t
+title: Add --diff mode to analyze-parity-residuals.js
+status: completed
+type: task
+priority: high
+tags:
+    - tooling
+    - style
+    - chicago
+    - fidelity
+created_at: 2026-08-24T11:50:01Z
+updated_at: 2026-08-24T12:01:06Z
+parent: csl26-h7oc
+---
+
+Add a --diff <before.json> mode to scripts/analyze-parity-residuals.js: exactMatch delta (newly-passing/newly-failing), per-label instance-count delta, rows-by-label-count histogram, and a near-miss queue (rows with exactly 1 remaining label). Wire into docs/guides/STYLE_WORKFLOW_EXECUTION.md's Waves section + step 3c, and .claude/skills/style-tune/SKILL.md's Execution Loop/Verification/Output Contract. See docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md and bean csl26-jxco for the motivating analysis (wave 1+2 topline pass-count was flat/small while label-instance count and near-miss queue moved substantially -- this closes the gap between what's mandated and what's tooled).
+
+## Summary of Changes
+
+Added `--diff <before.json>` mode to `scripts/analyze-parity-residuals.js`:
+new functions `allRows`, `rowKey`, `exactMatchMap`, `diffExactMatch`,
+`diffLabelCounts`, `mergeLabelCounts`, `labelCountHistogram`,
+`nearMissQueue`, `diffStyles`, `diffReports`, plus `printDiffHuman`/
+`printDiffSection` for the human-readable output and `--json` support.
+Verified against this session's real wave 1/2 before/after reports --
+reproduces the hand-computed numbers exactly (exactMatch flat 498/1629,
+label-instances 1936->1874, histogram 598/348/148 -> 653/300/141 at
+1/2/3-label buckets). Self-diff sanity check (same file as before/after)
+confirms all-zero deltas. 12 new unit tests added to
+`scripts/analyze-parity-residuals.test.js` (26/26 passing), full
+`node --test scripts/*.test.js scripts/lib/*.test.js` suite green (341/341).
+
+Caught and fixed a real bug during verification: `rowKey` was built with a
+stray NUL-byte separator between kind and id while `diffExactMatch`'s
+`key.split` used a plain space, silently breaking the id/kind decomposition
+for every newly-passing/newly-failing row (and turning the source file into
+a "binary" file for grep). Fixed by switching the separator to a plain
+space (reference ids in this corpus never contain spaces).
+
+Wired into `docs/guides/STYLE_WORKFLOW_EXECUTION.md` (Waves section: hard
+requirement to report exactMatch delta + label-instance delta + near-miss
+count via `--diff`; step 3c: names the concrete command; version bumped
+1.4->1.5, changelog entry added) and `.claude/skills/style-tune/SKILL.md`
+(Execution Loop step 3, Verification "Regression check" + new "Next-target
+queue" bullet, Output Contract).
+
+No wave-ledger file added (decided: hold off, `--diff --json` covers the
+need on demand).

--- a/.claude/skills/style-tune/SKILL.md
+++ b/.claude/skills/style-tune/SKILL.md
@@ -72,12 +72,13 @@ Follow the full `tune` loop from `docs/guides/STYLE_WORKFLOW_EXECUTION.md`:
    by leverage** with `node scripts/analyze-parity-residuals.js <report.json>`
    and work its greedy-set-cover order biggest-class-first, not by whichever
    entry is on screen → classify each residual → smallest correct fix or
-   ledger entry → re-run. **Confirm with per-entry `exactMatch` comparison,
-   not just the aggregate `passed` count** — a fix routed through a shared
-   category (e.g. a `titles.type-mapping` entry) can flip several
-   previously-passing entries to failing while flipping more failing
-   entries to passing, and a rising aggregate count alone cannot rule that
-   out. Continue until no further residual is classifiable
+   ledger entry → re-run. **Confirm with
+   `node scripts/analyze-parity-residuals.js <after.json> --diff <before.json>`,
+   not just the aggregate `passed` count** — require its `newlyFailing` list
+   empty across every style; a fix routed through a shared category (e.g. a
+   `titles.type-mapping` entry) can flip several previously-passing entries
+   to failing while flipping more failing entries to passing, and a rising
+   aggregate count alone cannot rule that out. Continue until no further residual is classifiable
    without escalation; regenerate `embedded-parity-baseline.json` from the
    full portfolio (not `--style`-scoped) per the shared-ancestor rule to
    ratchet the new floor in. **A pass may not stop while a ≥20-row defect
@@ -120,8 +121,9 @@ Every completed tune pass delivers:
 - seed baseline: oracle fidelity %, exact-parity passed/total, SQI score
 - final: oracle fidelity %, exact-parity passed/total, SQI score
 - fidelity changes made (per mismatch cluster)
-- exact-parity changes made (per residual class), and any new
-  `parity-adjudication.json` entries with their state
+- exact-parity changes made (per residual class), label-instance delta and
+  remaining near-miss count from `analyze-parity-residuals.js --diff`, and
+  any new `parity-adjudication.json` entries with their state
 - coverage-audit status and, when registered, render-disposition and joined
   exact-parity deltas
 - if a `style.chain` ancestor shared with other embedded-core styles changed,
@@ -139,9 +141,13 @@ Every completed tune pass delivers:
   (add `--by-type <fixture>` for a per-reference-type breakdown; add
   `--list "<label>"` to drill a ranked class down to its individual
   entries once you're ready to fix rather than triage)
-- Regression check: diff `exactMatch` per entry id between the before/after
-  reports (not just the aggregate `passed` count) before treating any
-  exact-parity fix as clean
+- Regression check: `node scripts/analyze-parity-residuals.js <after.json>
+  --diff <before.json>`, and require `newlyFailing` empty across every style
+  (not just the aggregate `passed` count) before treating any exact-parity
+  fix as clean
+- Next-target queue: the same `--diff` run's near-miss list (rows carrying
+  exactly one remaining defect label) is the next pass's ready-to-convert
+  target list — work from it before re-triaging the full residual
 - SQI: `node scripts/report-core.js --style <name>`
 - Render smoke-check: `cargo run --bin citum -- render refs -b tests/fixtures/references-expanded.json -s crates/citum-schema-style/embedded/styles/<name>.yaml`
 - QA handoff: `../style-qa/SKILL.md` with `tier: embedded-core`

--- a/docs/guides/STYLE_WORKFLOW_EXECUTION.md
+++ b/docs/guides/STYLE_WORKFLOW_EXECUTION.md
@@ -1,7 +1,7 @@
 # Style Workflow Execution
 
 **Status:** Active
-**Version:** 1.4
+**Version:** 1.5
 **Date:** 2026-08-23
 **Related:** [STYLE_WORKFLOW_DECISION_RULES.md](../policies/STYLE_WORKFLOW_DECISION_RULES.md),
 [MIGRATE_RESEARCH_RICH_INPUTS.md](../specs/MIGRATE_RESEARCH_RICH_INPUTS.md),
@@ -143,6 +143,19 @@ A style wave is a bounded cohort executed through repeated `upgrade`, `migrate`,
   root first and then `upgrade` to reduce the public handles.
 - Do not add a separate public "wave" command surface; waves are an execution
   pattern, not a new mode.
+- Every wave reports three numbers via
+  `node scripts/analyze-parity-residuals.js <after.json> --diff <before.json>`,
+  not the aggregate `passed` count alone: the exactMatch delta (newly-passing
+  / newly-failing), the total label-instance delta, and the remaining
+  near-miss (rows one label from passing) count. This is a hard requirement,
+  not advisory — same standing as the per-entry `exactMatch` regression check
+  below, which it supersedes with a named tool. Rows in a leverage-ordered
+  residual population commonly carry 2+ overlapping defect labels and do not
+  flip to `passed` until every one clears, so the aggregate count can stay
+  flat across a wave that is doing real, measurable work; label-instance
+  delta and near-miss count are the leading indicators that catch that
+  progress. Report per-type floors (e.g. `book`, `article-journal`) as
+  already required elsewhere — do not restate them here.
 
 ## The `tune` loop (embedded-core styles)
 
@@ -209,19 +222,22 @@ number that mattered.
       authority.
    c. Apply the smallest correct fix. Re-run and confirm the `passed` count
       rose and fidelity did not regress. **The aggregate `passed` count is
-      not sufficient regression evidence on its own** — compare `exactMatch`
-      per entry id between the before/after reports (a style previously
-      passing that now fails is a regression even when the aggregate count
-      still rose net). A fix that routes a rendering decision through a
-      shared category (e.g. a `titles.type-mapping` entry affecting several
-      reference types at once) can flip several previously-passing entries
-      to failing while flipping more failing entries to passing, and the
-      net aggregate delta alone cannot distinguish that from a clean win.
-      This is not a hypothetical: a 2026-08-23 Chicago wave-1 pass landed a
-      change that looked like a clean +5-entry net win by aggregate count
-      and was hiding 3 regressions, caught only by this per-entry check —
-      see [2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md](../architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md)'s
-      postscript.
+      not sufficient regression evidence on its own** — run
+      `node scripts/analyze-parity-residuals.js <after.json> --diff <before.json>`
+      and require its `newlyFailing` list to be empty across every style in
+      the report (a style previously passing that now fails is a regression
+      even when the aggregate count still rose net). A fix that routes a
+      rendering decision through a shared category (e.g. a
+      `titles.type-mapping` entry affecting several reference types at once)
+      can flip several previously-passing entries to failing while flipping
+      more failing entries to passing, and the net aggregate delta alone
+      cannot distinguish that from a clean win. This is not a hypothetical: a
+      2026-08-23 Chicago wave-1 pass landed a change that looked like a clean
+      +5-entry net win by aggregate count and was hiding 3 regressions,
+      caught only by this per-entry check — see
+      [2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md](../architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md)'s
+      postscript. The same `--diff` run's label-instance deltas and near-miss
+      queue are the wave-report numbers required under "## Waves" above.
    d. Continue until no further residual is classifiable without escalation,
       or the floor is raised as far as this pass supports; regenerate
       `embedded-parity-baseline.json` to ratchet the new floor in. Always
@@ -266,6 +282,14 @@ number that mattered.
 - [x] `tune` loop is defined here once, not in individual skill files.
 
 ## Changelog
+- 2026-08-24: Named `scripts/analyze-parity-residuals.js`'s new `--diff`
+  mode as the required tool for step 3c's per-entry regression check, and made a wave's
+  report format a hard requirement under "## Waves": exactMatch delta,
+  total label-instance delta, and remaining near-miss count, not the
+  aggregate `passed` count alone. Prompted by a Chicago wave-1/wave-2
+  before/after comparison where the aggregate count stayed flat across a
+  wave that had, in fact, moved 55 rows from "2 defects away" to "1 defect
+  away" — invisible without the label-instance and near-miss numbers.
 - 2026-08-23: Required per-entry `exactMatch` regression comparison (not
   just the aggregate `passed` count) in exact-parity loop step 3c, after a
   Chicago wave-1 pass landed a change that looked like a clean net win by

--- a/scripts/analyze-parity-residuals.js
+++ b/scripts/analyze-parity-residuals.js
@@ -28,6 +28,23 @@
  *   node scripts/analyze-parity-residuals.js /tmp/r.json --json
  *   node scripts/analyze-parity-residuals.js /tmp/r.json --by-type <refs.json>
  *   node scripts/analyze-parity-residuals.js /tmp/r.json --list "A1 title-case not applied"
+ *   node scripts/analyze-parity-residuals.js /tmp/after.json --diff /tmp/before.json
+ *   node scripts/analyze-parity-residuals.js /tmp/after.json --diff /tmp/before.json --json
+ *
+ * --diff <before.json> compares this report (the "after") against an
+ * earlier one, per style plus a summed "ALL STYLES" aggregate: exactMatch
+ * delta (newly-passing / newly-failing rows -- the regression signal
+ * docs/guides/STYLE_WORKFLOW_EXECUTION.md's exact-parity loop, step 3c,
+ * requires before treating any aggregate `passed` increase as a clean win),
+ * per-label instance-count delta, a rows-by-label-count histogram, and a
+ * near-miss queue (rows carrying exactly one remaining label -- the next
+ * wave's ready-to-convert target list). Rows commonly carry 2+ overlapping
+ * labels and don't flip to exactMatch until every one clears, so a wave can
+ * do real, measurable work while the aggregate `passed` count stays flat;
+ * --diff surfaces that progress directly instead of requiring it to be
+ * reconstructed by hand, which is how the 2026-08-23 audit's wave 1/2
+ * postscript first found it -- see
+ * docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md.
  *
  * --by-type additionally joins each failing bibliography row's reference
  * `type` from a CSL-JSON-shaped fixture file (an object keyed by id, or an
@@ -253,6 +270,48 @@ function failingRows(styleReport) {
   return rows;
 }
 
+/**
+ * Every row (pass and fail) from one style report, with the same source
+ * arrays and gating as `failingRows` (`oracleDetail` gated on
+ * `exactParityEligible`, `citationEntries` ungated) but keeping
+ * `exactMatch` on each row instead of filtering to failures. `failingRows`
+ * alone can't see newly-passing rows, so a diff needs this separately.
+ */
+function allRows(styleReport) {
+  const rows = [];
+  for (const e of styleReport.oracleDetail || []) {
+    if (e.exactParityEligible) {
+      rows.push({ kind: 'bib', id: e.id, oracle: e.exactOracle, citum: e.exactCitum, exactMatch: e.exactMatch });
+    }
+  }
+  for (const e of styleReport.citationEntries || []) {
+    rows.push({ kind: 'cite', id: e.id, oracle: e.exactOracle, citum: e.exactCitum, exactMatch: e.exactMatch });
+  }
+  return rows;
+}
+
+function rowKey(row) {
+  return `${row.kind} ${row.id}`;
+}
+
+/**
+ * Per-row exactMatch map for one style report, keyed by `(kind, id)` (see
+ * `listLabel`'s note below: a report can carry the same id twice across
+ * merged benchmark runs). Duplicates fold with AND -- any failing instance
+ * marks the key failing. Conservative default for regression detection: a
+ * row that fails in even one duplicate should not be reported as cleanly
+ * passing.
+ */
+function exactMatchMap(styleReport) {
+  const map = new Map();
+  for (const row of allRows(styleReport)) {
+    const key = rowKey(row);
+    const existing = map.get(key);
+    map.set(key, existing === undefined ? row.exactMatch : existing && row.exactMatch);
+  }
+  return map;
+}
+
 function loadTypeMap(fixturePath) {
   const raw = JSON.parse(fs.readFileSync(fixturePath, 'utf8'));
   const items = Array.isArray(raw) ? raw : raw.items || raw;
@@ -336,14 +395,197 @@ function analyzeStyle(styleReport, typeMap) {
   };
 }
 
+// ─── Diff (wave before/after comparison) ───────────────────────────────────
+//
+// Rows in this corpus commonly carry 2-4 overlapping defect labels and
+// don't flip to exactMatch until every one of them clears. That means a
+// leverage-ordered wave can do real, measurable work -- clearing labels off
+// rows -- while the aggregate `passed` count stays flat, because the rows
+// it touched still have other labels outstanding. The functions below
+// surface that underlying signal directly instead of requiring it to be
+// reconstructed by hand (as the 2026-08-23 audit's wave 1/2 postscript was),
+// and give the `newlyFailing` regression check that
+// docs/guides/STYLE_WORKFLOW_EXECUTION.md's exact-parity loop (step 3c)
+// already mandates in prose but has never had a named tool for.
+
+/**
+ * Diff two style reports' per-row exactMatch state. `newlyFailing` is the
+ * regression signal: a fix routed through a shared category (e.g. a
+ * `titles.type-mapping` entry) can flip several previously-passing rows to
+ * failing while flipping more failing rows to passing, and a rising
+ * aggregate `passed` count alone cannot distinguish that from a clean win.
+ */
+function diffExactMatch(beforeStyle, afterStyle) {
+  const beforeMap = exactMatchMap(beforeStyle);
+  const afterMap = exactMatchMap(afterStyle);
+  const afterRowsByKey = new Map(allRows(afterStyle).map((r) => [rowKey(r), r]));
+
+  const newlyPassing = [];
+  const newlyFailing = [];
+  for (const [key, wasPassing] of beforeMap) {
+    if (!afterMap.has(key)) continue;
+    const isPassing = afterMap.get(key);
+    if (wasPassing === isPassing) continue;
+    const [kind, id] = key.split(' ');
+    if (isPassing) {
+      newlyPassing.push({ kind, id });
+    } else {
+      const row = afterRowsByKey.get(key);
+      newlyFailing.push({ kind, id, oracle: row ? row.oracle : undefined, citum: row ? row.citum : undefined });
+    }
+  }
+
+  return {
+    newlyPassing,
+    newlyFailing,
+    before: { passed: beforeStyle.exactParity.passed, total: beforeStyle.exactParity.total },
+    after: { passed: afterStyle.exactParity.passed, total: afterStyle.exactParity.total },
+  };
+}
+
+/**
+ * Diff two `analyzeStyle(...).labelCounts` arrays. Pure diff of already-
+ * computed output -- no new labeling logic. Sorted by |delta| descending
+ * (biggest moves first), label name ascending as a tiebreaker.
+ */
+function diffLabelCounts(beforeAnalysis, afterAnalysis) {
+  const beforeMap = new Map(beforeAnalysis.labelCounts.map((l) => [l.label, l.rows]));
+  const afterMap = new Map(afterAnalysis.labelCounts.map((l) => [l.label, l.rows]));
+  const labels = new Set([...beforeMap.keys(), ...afterMap.keys()]);
+  const result = [...labels].map((label) => {
+    const before = beforeMap.get(label) || 0;
+    const after = afterMap.get(label) || 0;
+    return { label, before, after, delta: after - before };
+  });
+  result.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta) || a.label.localeCompare(b.label));
+  return result;
+}
+
+/** Sum `rows` per label across several `analyzeStyle(...).labelCounts` arrays. */
+function mergeLabelCounts(analyses) {
+  const totals = new Map();
+  for (const a of analyses) {
+    for (const { label, rows } of a.labelCounts) {
+      totals.set(label, (totals.get(label) || 0) + rows);
+    }
+  }
+  return [...totals.entries()].map(([label, rows]) => ({ label, rows }));
+}
+
+/**
+ * Bucket failing rows by how many defect labels they carry. A row with N
+ * labels needs all N cleared before it flips to exactMatch -- this
+ * histogram is the leading indicator that a wave is converging the
+ * residual population even when the aggregate `passed` count hasn't moved:
+ * rows migrate from higher buckets to lower ones before any of them reach
+ * zero.
+ */
+function labelCountHistogram(styleReport) {
+  const histogram = {};
+  for (const row of failingRows(styleReport)) {
+    const n = labelsFor(row.oracle, row.citum).length;
+    histogram[n] = (histogram[n] || 0) + 1;
+  }
+  return histogram;
+}
+
+/**
+ * Rows carrying exactly one remaining defect label -- the row-level
+ * complement to `analyzeStyle`'s `soleCause` counts. This is the next
+ * wave's ready-to-convert target list: fixing that one label flips the row
+ * to exactMatch.
+ */
+function nearMissQueue(styleReport) {
+  const seen = new Set();
+  const out = [];
+  for (const row of failingRows(styleReport)) {
+    const key = rowKey(row);
+    if (seen.has(key)) continue;
+    const labels = labelsFor(row.oracle, row.citum);
+    if (labels.length !== 1) continue;
+    seen.add(key);
+    out.push({ kind: row.kind, id: row.id, label: labels[0], oracle: row.oracle, citum: row.citum });
+  }
+  out.sort((a, b) => a.label.localeCompare(b.label) || a.id.localeCompare(b.id));
+  return out;
+}
+
+function diffStyles(beforeStyle, afterStyle, beforeAnalysis, afterAnalysis) {
+  const ba = beforeAnalysis || analyzeStyle(beforeStyle);
+  const aa = afterAnalysis || analyzeStyle(afterStyle);
+  return {
+    name: afterStyle.name,
+    exactMatch: diffExactMatch(beforeStyle, afterStyle),
+    labelDeltas: diffLabelCounts(ba, aa),
+    histogramBefore: labelCountHistogram(beforeStyle),
+    histogramAfter: labelCountHistogram(afterStyle),
+    nearMiss: nearMissQueue(afterStyle),
+  };
+}
+
+function sumHistograms(histograms) {
+  const out = {};
+  for (const h of histograms) {
+    for (const [k, v] of Object.entries(h)) out[k] = (out[k] || 0) + v;
+  }
+  return out;
+}
+
+/**
+ * Diff two full reports (as produced by `report-core.js --all-features`,
+ * typically without `--style` so multiple styles are present -- that is
+ * the normal input shape, not an edge case, since a cross-style regression
+ * check needs it). Styles present in only one report are listed under
+ * `addedStyles`/`removedStyles` rather than silently dropped from the diff.
+ */
+function diffReports(beforeReport, afterReport) {
+  const beforeByName = new Map((beforeReport.styles || []).map((s) => [s.name, s]));
+  const afterByName = new Map((afterReport.styles || []).map((s) => [s.name, s]));
+  const common = [...afterByName.keys()].filter((name) => beforeByName.has(name));
+
+  const beforeAnalyses = common.map((name) => analyzeStyle(beforeByName.get(name)));
+  const afterAnalyses = common.map((name) => analyzeStyle(afterByName.get(name)));
+
+  const styles = common.map((name, i) =>
+    diffStyles(beforeByName.get(name), afterByName.get(name), beforeAnalyses[i], afterAnalyses[i])
+  );
+
+  const aggregate = {
+    exactMatch: {
+      newlyPassing: styles.flatMap((s) => s.exactMatch.newlyPassing.map((r) => ({ style: s.name, ...r }))),
+      newlyFailing: styles.flatMap((s) => s.exactMatch.newlyFailing.map((r) => ({ style: s.name, ...r }))),
+      before: {
+        passed: styles.reduce((n, s) => n + s.exactMatch.before.passed, 0),
+        total: styles.reduce((n, s) => n + s.exactMatch.before.total, 0),
+      },
+      after: {
+        passed: styles.reduce((n, s) => n + s.exactMatch.after.passed, 0),
+        total: styles.reduce((n, s) => n + s.exactMatch.after.total, 0),
+      },
+    },
+    labelDeltas: diffLabelCounts({ labelCounts: mergeLabelCounts(beforeAnalyses) }, { labelCounts: mergeLabelCounts(afterAnalyses) }),
+    histogramBefore: sumHistograms(styles.map((s) => s.histogramBefore)),
+    histogramAfter: sumHistograms(styles.map((s) => s.histogramAfter)),
+    nearMiss: styles.flatMap((s) => s.nearMiss.map((r) => ({ style: s.name, ...r }))),
+  };
+
+  return {
+    styles,
+    aggregate,
+    addedStyles: [...afterByName.keys()].filter((name) => !beforeByName.has(name)),
+    removedStyles: [...beforeByName.keys()].filter((name) => !afterByName.has(name)),
+  };
+}
+
 // ─── CLI ─────────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const opts = { json: false, byType: null, input: null, list: null };
+  const opts = { json: false, byType: null, input: null, list: null, diff: null };
   for (let i = 0; i < argv.length; i += 1) {
     if (argv[i] === '--json') opts.json = true;
     else if (argv[i] === '--by-type') opts.byType = path.resolve(argv[(i += 1)]);
     else if (argv[i] === '--list') opts.list = argv[(i += 1)];
+    else if (argv[i] === '--diff') opts.diff = path.resolve(argv[(i += 1)]);
     else if (!opts.input) opts.input = argv[i];
   }
   return opts;
@@ -397,17 +639,78 @@ function printHuman(result) {
   }
 }
 
+/** Print one diff section (a per-style diff, or the aggregate) in the shared column style. */
+function printDiffSection(label, diff) {
+  const { exactMatch, labelDeltas, histogramBefore, histogramAfter, nearMiss } = diff;
+  console.log(`\n### ${label}`);
+  console.log(
+    `  exactMatch: ${exactMatch.before.passed}/${exactMatch.before.total} -> ` +
+      `${exactMatch.after.passed}/${exactMatch.after.total} ` +
+      `(+${exactMatch.newlyPassing.length} newly passing, ${exactMatch.newlyFailing.length} newly failing)`
+  );
+  if (exactMatch.newlyFailing.length) {
+    console.log('  REGRESSIONS:');
+    for (const r of exactMatch.newlyFailing) {
+      const where = r.style ? `${r.style} ` : '';
+      console.log(`    [${where}${r.kind} ${r.id}]`);
+      console.log(`      O: ${r.oracle}`);
+      console.log(`      C: ${r.citum}`);
+    }
+  }
+  const nonzeroDeltas = labelDeltas.filter((d) => d.delta !== 0);
+  if (nonzeroDeltas.length) {
+    console.log('  label-instance deltas (nonzero only):');
+    for (const { label: l, before, after, delta } of nonzeroDeltas) {
+      const sign = delta > 0 ? '+' : '';
+      console.log(`    ${l.padEnd(44)} ${String(before).padStart(4)} -> ${String(after).padStart(4)} (${sign}${delta})`);
+    }
+  }
+  const keys = new Set([...Object.keys(histogramBefore), ...Object.keys(histogramAfter)]);
+  if (keys.size) {
+    console.log('  rows-by-label-count histogram:');
+    console.log(`    ${'n-labels'.padEnd(10)}${'before'.padEnd(8)}after`);
+    for (const k of [...keys].sort((a, b) => Number(a) - Number(b))) {
+      console.log(`    ${k.padEnd(10)}${String(histogramBefore[k] || 0).padEnd(8)}${histogramAfter[k] || 0}`);
+    }
+  }
+  console.log(`  near-miss queue (rows 1 label from passing): ${nearMiss.length}`);
+}
+
+function printDiffHuman(result) {
+  for (const style of result.styles) {
+    printDiffSection(style.name, style);
+  }
+  printDiffSection('ALL STYLES (aggregate)', result.aggregate);
+  if (result.addedStyles.length) {
+    console.log(`\n(styles only in the after report, not diffed: ${result.addedStyles.join(', ')})`);
+  }
+  if (result.removedStyles.length) {
+    console.log(`\n(styles only in the before report, not diffed: ${result.removedStyles.join(', ')})`);
+  }
+}
+
 function main() {
   const opts = parseArgs(process.argv.slice(2));
   if (!opts.input) {
     console.error(
       'usage: analyze-parity-residuals.js <report.json> [--json] [--by-type <refs.json>] ' +
-        '[--list "<label>"]'
+        '[--list "<label>"] [--diff <before-report.json>]'
     );
     return 2;
   }
   const report = JSON.parse(fs.readFileSync(opts.input, 'utf8'));
   const styles = report.styles || [];
+
+  if (opts.diff) {
+    const beforeReport = JSON.parse(fs.readFileSync(opts.diff, 'utf8'));
+    const result = diffReports(beforeReport, report);
+    if (opts.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      printDiffHuman(result);
+    }
+    return 0;
+  }
 
   if (opts.list) {
     for (const style of styles) {
@@ -449,4 +752,14 @@ module.exports = {
   loadTypeMap,
   listLabel,
   LABEL_RULES,
+  allRows,
+  rowKey,
+  exactMatchMap,
+  diffExactMatch,
+  diffLabelCounts,
+  mergeLabelCounts,
+  labelCountHistogram,
+  nearMissQueue,
+  diffStyles,
+  diffReports,
 };

--- a/scripts/analyze-parity-residuals.test.js
+++ b/scripts/analyze-parity-residuals.test.js
@@ -12,6 +12,14 @@ const {
   greedySetCover,
   analyzeStyle,
   listLabel,
+  allRows,
+  exactMatchMap,
+  diffExactMatch,
+  diffLabelCounts,
+  mergeLabelCounts,
+  labelCountHistogram,
+  nearMissQueue,
+  diffReports,
 } = require('./analyze-parity-residuals.js');
 
 test('diffOps: identical strings produce no opcodes', () => {
@@ -203,4 +211,215 @@ test('listLabel: drills a class down to its actual entries, deduped by id', () =
     ['r1']
   );
   assert.ok(entries[0].labels.includes('A1 title-case not applied'));
+});
+
+// ─── Diff (wave before/after comparison) ───────────────────────────────────
+
+test('allRows: includes both passing and failing rows, with exactMatch on each', () => {
+  const styleReport = {
+    oracleDetail: [
+      { id: 'b1', exactParityEligible: true, exactMatch: true, exactOracle: 'X', exactCitum: 'X' },
+      { id: 'b2', exactParityEligible: true, exactMatch: false, exactOracle: 'Y', exactCitum: 'y' },
+      { id: 'b3', exactParityEligible: false, exactMatch: false, exactOracle: 'Z', exactCitum: 'z' },
+    ],
+    citationEntries: [{ id: 'c1', exactMatch: true, exactOracle: 'W', exactCitum: 'W' }],
+  };
+  const rows = allRows(styleReport);
+  assert.deepEqual(
+    rows.map((r) => [r.kind, r.id, r.exactMatch]),
+    [
+      ['bib', 'b1', true],
+      ['bib', 'b2', false],
+      ['cite', 'c1', true],
+    ]
+  );
+});
+
+test('exactMatchMap: duplicate (kind,id) rows fold with AND -- any failure wins', () => {
+  const styleReport = {
+    oracleDetail: [
+      { id: 'b1', exactParityEligible: true, exactMatch: true, exactOracle: 'X', exactCitum: 'X' },
+      { id: 'b1', exactParityEligible: true, exactMatch: false, exactOracle: 'X', exactCitum: 'x' },
+    ],
+    citationEntries: [],
+  };
+  const map = exactMatchMap(styleReport);
+  assert.equal(map.get('bib b1'), false);
+});
+
+test('diffExactMatch: detects newly-passing and newly-failing rows, ignoring unchanged ones', () => {
+  const before = {
+    exactParity: { passed: 1, total: 3 },
+    oracleDetail: [
+      { id: 'b1', exactParityEligible: true, exactMatch: false, exactOracle: 'A', exactCitum: 'a' },
+      { id: 'b2', exactParityEligible: true, exactMatch: true, exactOracle: 'B', exactCitum: 'B' },
+      { id: 'b3', exactParityEligible: true, exactMatch: true, exactOracle: 'C', exactCitum: 'C' },
+    ],
+    citationEntries: [],
+  };
+  const after = {
+    exactParity: { passed: 1, total: 3 },
+    oracleDetail: [
+      { id: 'b1', exactParityEligible: true, exactMatch: true, exactOracle: 'A', exactCitum: 'A' },
+      { id: 'b2', exactParityEligible: true, exactMatch: true, exactOracle: 'B', exactCitum: 'B' },
+      { id: 'b3', exactParityEligible: true, exactMatch: false, exactOracle: 'C', exactCitum: 'c' },
+    ],
+    citationEntries: [],
+  };
+  const diff = diffExactMatch(before, after);
+  assert.deepEqual(diff.newlyPassing, [{ kind: 'bib', id: 'b1' }]);
+  assert.deepEqual(diff.newlyFailing, [{ kind: 'bib', id: 'b3', oracle: 'C', citum: 'c' }]);
+  assert.deepEqual(diff.before, { passed: 1, total: 3 });
+  assert.deepEqual(diff.after, { passed: 1, total: 3 });
+});
+
+test('diffExactMatch: rows present in only one report are not reported as changed', () => {
+  const before = {
+    exactParity: { passed: 0, total: 1 },
+    oracleDetail: [{ id: 'b1', exactParityEligible: true, exactMatch: false, exactOracle: 'A', exactCitum: 'a' }],
+    citationEntries: [],
+  };
+  const after = {
+    exactParity: { passed: 1, total: 1 },
+    oracleDetail: [{ id: 'b2', exactParityEligible: true, exactMatch: true, exactOracle: 'B', exactCitum: 'B' }],
+    citationEntries: [],
+  };
+  const diff = diffExactMatch(before, after);
+  assert.deepEqual(diff.newlyPassing, []);
+  assert.deepEqual(diff.newlyFailing, []);
+});
+
+test('diffLabelCounts: computes before/after/delta and sorts by |delta| descending', () => {
+  const beforeAnalysis = {
+    labelCounts: [
+      { label: 'A1 title-case not applied', rows: 64 },
+      { label: 'B title quote boundary', rows: 10 },
+    ],
+  };
+  const afterAnalysis = {
+    labelCounts: [
+      { label: 'A1 title-case not applied', rows: 39 },
+      { label: 'B title quote boundary', rows: 10 },
+      { label: 'N punctuation/delimiter only', rows: 5 },
+    ],
+  };
+  const result = diffLabelCounts(beforeAnalysis, afterAnalysis);
+  assert.deepEqual(result, [
+    { label: 'A1 title-case not applied', before: 64, after: 39, delta: -25 },
+    { label: 'N punctuation/delimiter only', before: 0, after: 5, delta: 5 },
+    { label: 'B title quote boundary', before: 10, after: 10, delta: 0 },
+  ]);
+});
+
+test('mergeLabelCounts: sums rows per label across several analyses', () => {
+  const analyses = [
+    { labelCounts: [{ label: 'X', rows: 3 }, { label: 'Y', rows: 1 }] },
+    { labelCounts: [{ label: 'X', rows: 2 }] },
+  ];
+  const merged = mergeLabelCounts(analyses);
+  const map = new Map(merged.map((l) => [l.label, l.rows]));
+  assert.equal(map.get('X'), 5);
+  assert.equal(map.get('Y'), 1);
+});
+
+test('labelCountHistogram: buckets failing rows by how many labels each carries', () => {
+  const styleReport = {
+    oracleDetail: [
+      // 1 label: punctuation only.
+      { id: 'r1', exactParityEligible: true, exactMatch: false, exactOracle: 'Foo, Bar (2020): 42.', exactCitum: 'Foo, Bar (2020), 42.' },
+      // 2 labels: quote boundary + title case not applied.
+      {
+        id: 'r2',
+        exactParityEligible: true,
+        exactMatch: false,
+        exactOracle: '“Mesopotamia: Between Two Rivers.” 1957.',
+        exactCitum: 'Mesopotamia: between two rivers. 1957.',
+      },
+    ],
+    citationEntries: [],
+  };
+  const histogram = labelCountHistogram(styleReport);
+  assert.equal(histogram['1'], 1);
+  assert.equal(histogram['2'], 1);
+});
+
+test('nearMissQueue: only rows with exactly one label, deduped by (kind,id)', () => {
+  const styleReport = {
+    oracleDetail: [
+      // 1 label, appears twice (merged benchmark runs) -- must appear once.
+      { id: 'r1', exactParityEligible: true, exactMatch: false, exactOracle: 'Foo, Bar (2020): 42.', exactCitum: 'Foo, Bar (2020), 42.' },
+      { id: 'r1', exactParityEligible: true, exactMatch: false, exactOracle: 'Foo, Bar (2020): 42.', exactCitum: 'Foo, Bar (2020), 42.' },
+      // 2 labels -- excluded.
+      {
+        id: 'r2',
+        exactParityEligible: true,
+        exactMatch: false,
+        exactOracle: '“Mesopotamia: Between Two Rivers.” 1957.',
+        exactCitum: 'Mesopotamia: between two rivers. 1957.',
+      },
+    ],
+    citationEntries: [],
+  };
+  const queue = nearMissQueue(styleReport);
+  assert.deepEqual(
+    queue.map((r) => r.id),
+    ['r1']
+  );
+  assert.equal(queue[0].label, 'N punctuation/delimiter only');
+});
+
+test('diffReports: end-to-end aggregate matches per-style sums, and reports added/removed styles', () => {
+  const makeStyle = (name, passed, total, rows) => ({
+    name,
+    exactParity: { passed, total },
+    fidelityScore: 1,
+    oracleDetail: rows,
+    citationEntries: [],
+  });
+  const before = {
+    styles: [
+      makeStyle('style-a', 0, 1, [{ id: 'r1', exactParityEligible: true, exactMatch: false, exactOracle: 'A', exactCitum: 'a' }]),
+      makeStyle('style-only-before', 0, 1, [{ id: 'r1', exactParityEligible: true, exactMatch: false, exactOracle: 'A', exactCitum: 'a' }]),
+    ],
+  };
+  const after = {
+    styles: [
+      makeStyle('style-a', 1, 1, [{ id: 'r1', exactParityEligible: true, exactMatch: true, exactOracle: 'A', exactCitum: 'A' }]),
+      makeStyle('style-only-after', 1, 1, [{ id: 'r1', exactParityEligible: true, exactMatch: true, exactOracle: 'B', exactCitum: 'B' }]),
+    ],
+  };
+  const result = diffReports(before, after);
+  assert.deepEqual(
+    result.styles.map((s) => s.name),
+    ['style-a']
+  );
+  assert.deepEqual(result.aggregate.exactMatch.newlyPassing, [{ style: 'style-a', kind: 'bib', id: 'r1' }]);
+  assert.deepEqual(result.aggregate.exactMatch.newlyFailing, []);
+  assert.deepEqual(result.aggregate.exactMatch.before, { passed: 0, total: 1 });
+  assert.deepEqual(result.aggregate.exactMatch.after, { passed: 1, total: 1 });
+  assert.deepEqual(result.addedStyles, ['style-only-after']);
+  assert.deepEqual(result.removedStyles, ['style-only-before']);
+});
+
+test('diffReports: self-diff (identical before/after) reports zero deltas everywhere', () => {
+  const report = {
+    styles: [
+      {
+        name: 'style-a',
+        exactParity: { passed: 1, total: 2 },
+        fidelityScore: 1,
+        oracleDetail: [
+          { id: 'r1', exactParityEligible: true, exactMatch: true, exactOracle: 'A', exactCitum: 'A' },
+          { id: 'r2', exactParityEligible: true, exactMatch: false, exactOracle: 'B', exactCitum: 'b' },
+        ],
+        citationEntries: [],
+      },
+    ],
+  };
+  const result = diffReports(report, report);
+  assert.deepEqual(result.styles[0].exactMatch.newlyPassing, []);
+  assert.deepEqual(result.styles[0].exactMatch.newlyFailing, []);
+  assert.ok(result.styles[0].labelDeltas.every((d) => d.delta === 0));
+  assert.deepEqual(result.addedStyles, []);
+  assert.deepEqual(result.removedStyles, []);
 });


### PR DESCRIPTION
Rows in this corpus carry 2-4 overlapping defect labels and don't
flip to exactMatch until the last one clears, so the aggregate
passed count can stay flat across a wave doing real work. --diff
surfaces the leading signal directly (exactMatch delta, per-label
instance delta, rows-by-label-count histogram, near-miss queue)
instead of requiring it be reconstructed by hand, and gives step
3c's per-entry regression check a named tool for the first time.

Wire the requirement into STYLE_WORKFLOW_EXECUTION.md's Waves
section and step 3c, and style-tune/SKILL.md's execution loop,
verification, and output contract.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>