### PR TITLE
fix(engine): add missing title-case stop words

### DIFF
--- a/.beans/archive/csl26-omqk--fix-title-case-stop-word-gaps-aboutafterbeforeinto.md
+++ b/.beans/archive/csl26-omqk--fix-title-case-stop-word-gaps-aboutafterbeforeinto.md
@@ -1,0 +1,47 @@
+---
+# csl26-omqk
+title: Fix title-case stop-word gaps (about/after/before/into/than/under/versus/via/without)
+status: completed
+type: bug
+priority: high
+tags:
+    - fidelity
+    - title-case
+    - engine
+    - chicago
+created_at: 2026-08-24T11:50:11Z
+updated_at: 2026-08-24T12:45:01Z
+parent: csl26-h7oc
+---
+
+TITLE_CASE_STOP_WORDS in crates/citum-engine/src/values/text_case.rs is missing 9 words confirmed present in citeproc-js's real CSL.SKIP_WORDS array and backed by concrete oracle-vs-citum mismatches in current Chicago residuals: about, after, before, into, than, under, versus, via, without. Add with a provenance comment (word-list-only scope, not a full citeproc-js algorithm port) and an rstest-parameterized test. Engine-level change (TextCase::Title), portfolio-wide blast radius -- verify with full-portfolio report-core.js + the new analyze-parity-residuals.js --diff mode + check-core-quality.js --parity-baseline, not just Chicago. Explicitly excludes 'past' (false positive, actually a post/post-weblog sentence-case routing bug), 'c' (false positive, D.C. abbreviation collision), and 'de' (real but non-English-title scoped, needs language-aware handling) -- see follow-up beans.
+
+## Summary of Changes
+
+Added 9 verified words to TITLE_CASE_STOP_WORDS in
+crates/citum-engine/src/values/text_case.rs: about, after, before, into,
+than, under, versus, via, without. Each backed by a concrete oracle-
+lowercase/citum-capitalized row in real Chicago corpus data and confirmed
+present in citeproc-js's real CSL.SKIP_WORDS array
+(scripts/node_modules/citeproc/citeproc_commonjs.js:1076). Added a
+provenance comment on the constant documenting the source and the
+deliberate word-list-only scope (citeproc-js's case algorithm never
+force-lowercases; that architectural difference is not ported here).
+
+Test: one parameterized rstest
+(given_citeproc_skip_word_when_title_case_then_interior_occurrence_stays_lowercase)
+covering all 9 words plus a first/last-position guard case, matching the
+existing rstest pattern in the same file. 66/66 text_case tests pass.
+
+Verified full-portfolio (35 styles, not just Chicago -- this is a shared
+TextCase::Title primitive): report-core.js --all-features before/after +
+analyze-parity-residuals.js --diff (the tool from csl26-r90t, its first
+real dogfood use) shows exactMatch 1811/4425 -> 1814/4425, +3 newly
+passing, **zero newly failing** across all 35 styles. A2 (title-case
+over-applied/stop-word) label-instance count dropped 105 -> 67 (-38).
+check-core-quality.js --parity-baseline shows no exact-parity-baseline
+regression (the pre-existing ~30 fidelity-gate failures are unrelated,
+portfolio-wide pre-existing state, unchanged by this commit). Full
+just pre-commit equivalent green: cargo fmt --check clean, clippy -D
+warnings clean, cargo nextest run 2701/2701 passed (+10 vs pre-fix,
+matching the new test cases).

--- a/.beans/csl26-5uog--title-case-stop-word-list-needs-language-aware-han.md
+++ b/.beans/csl26-5uog--title-case-stop-word-list-needs-language-aware-han.md
@@ -1,0 +1,17 @@
+---
+# csl26-5uog
+title: Title-case stop-word list needs language-aware handling (de/von/van particles)
+status: todo
+type: bug
+priority: low
+tags:
+    - style
+    - chicago
+    - title
+    - multilingual
+created_at: 2026-08-24T11:50:28Z
+updated_at: 2026-08-24T11:50:28Z
+parent: csl26-h7oc
+---
+
+Real title-case defect confined to non-English titles: 'de' should stay lowercase in a Spanish title ('Las Bases de Un Conflicto' -> 'Las Bases de Un Conflicto', not 'Las Bases De Un Conflicto'), matching citeproc-js's CSL.SKIP_WORDS which includes de/von/van/d'. Not added to TITLE_CASE_STOP_WORDS in the wave-2-adjacent stop-word fix (csl26-omqk) because these particles can legitimately be capitalized in genuine English contexts (names, e.g. 'De La Soul'), so a blind English-list addition risks a new divergence. Needs either language detection on the title field before applying the English stop-word list, or a separate per-language stop-word set. Scope/approach undetermined -- triage first.

--- a/.beans/csl26-gall--chicago-postpost-weblog-types-need-sentence-case-n.md
+++ b/.beans/csl26-gall--chicago-postpost-weblog-types-need-sentence-case-n.md
@@ -1,0 +1,17 @@
+---
+# csl26-gall
+title: 'Chicago: post/post-weblog types need sentence-case, not title-case'
+status: todo
+type: bug
+priority: normal
+tags:
+    - style
+    - chicago
+    - title
+    - fidelity
+created_at: 2026-08-24T11:50:28Z
+updated_at: 2026-08-24T11:50:28Z
+parent: csl26-h7oc
+---
+
+citeproc-js's real title choose-block routes post/post-weblog to 'quotes, sentence case' -- Citum currently title-cases these (same category-routing shape as the document/thesis fix landed in the quote-boundary wave, PR #1226, via titles.type-mapping). Discovered via a stop-word-gap false positive: an Instagram post-type item ('9/11 Anniversaries from the Past' vs oracle '9/11 anniversaries from the past') looked like a missing stop word ('past') but the whole title should be sentence case, not title case at all. Likely a fast wave-3-adjacent fix once triaged: map post/post-weblog to a category with no title-case transform (or add an explicit type-variant), verified per-entry against the oracle.

--- a/crates/citum-engine/src/values/text_case.rs
+++ b/crates/citum-engine/src/values/text_case.rs
@@ -417,10 +417,22 @@ pub(crate) fn apply_text_case_markup_aware_with_language(
     }
 }
 
-// English title-case stop words (articles, short conjunctions, short prepositions).
+// English title-case stop words (articles, short conjunctions, prepositions).
+//
+// Sourced from citeproc-js's `CSL.SKIP_WORDS`
+// (scripts/node_modules/citeproc/citeproc_commonjs.js:1076, an npm dependency
+// of scripts/ tooling -- not vendored here), intersected with words observed
+// in real Chicago exact-parity residuals. Scope is deliberately word-list
+// only: citeproc-js's case algorithm never force-lowercases (it only
+// capitalizes words already exactly lowercase), which is architecturally
+// different from this function's normalize-then-recapitalize model -- that
+// difference is NOT ported here. The observed defects were word-list gaps,
+// not algorithm-shape gaps. See docs/architecture/audits/2026-08-23_
+// CHICAGO_PARITY_LEVERAGE_AUDIT.md and bean csl26-omqk.
 const TITLE_CASE_STOP_WORDS: &[&str] = &[
-    "a", "an", "and", "as", "at", "but", "by", "for", "from", "in", "nor", "of", "on", "or", "so",
-    "the", "to", "up", "yet", "along", "between", "during", "with", "v", "vs",
+    "a", "about", "after", "along", "an", "and", "as", "at", "before", "between", "but", "by",
+    "during", "for", "from", "in", "into", "nor", "of", "on", "or", "so", "than", "the", "to",
+    "under", "up", "versus", "via", "vs", "with", "without", "yet", "v",
 ];
 
 /// Hyphen-like characters that join compound words for title-case purposes.
@@ -914,6 +926,24 @@ mod tests {
             ),
             "Fighting for Forests: Protection and Exploitation during the War with China"
         );
+    }
+
+    #[rstest]
+    #[case::about("a book about the war", "A Book about the War")]
+    #[case::after("a study after the fall", "A Study after the Fall")]
+    #[case::before("the years before the storm", "The Years before the Storm")]
+    #[case::into("a journey into the wild", "A Journey into the Wild")]
+    #[case::than("more than a feeling", "More than a Feeling")]
+    #[case::under("a nation under the law", "A Nation under the Law")]
+    #[case::versus("the state versus the people", "The State versus the People")]
+    #[case::via("a passage via the alps", "A Passage via the Alps")]
+    #[case::without("a life without the state", "A Life without the State")]
+    #[case::new_stop_word_in_last_position("a life without", "A Life Without")]
+    fn given_citeproc_skip_word_when_title_case_then_interior_occurrence_stays_lowercase(
+        #[case] input: &str,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(to_title_case(input), expected);
     }
 
     #[test]

--- a/scripts/report-core.test.js
+++ b/scripts/report-core.test.js
@@ -1501,8 +1501,9 @@ test('generateReport exposes the registered coverage audit on its corresponding 
   // Multivolume title/part routing and number-of-volumes support closed
   // the residual cluster registered on 2026-08-09 (81); the 2026-08-23
   // Chicago parity leverage audit's wave 1 (title case) moved it further
-  // to 86 -- see docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md.
-  assert.equal(audit.postChangeEvidence.afterExactParity.passed, 86);
+  // to 86, and the title-case stop-word fix (csl26-omqk) moved it to 87 --
+  // see docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md.
+  assert.equal(audit.postChangeEvidence.afterExactParity.passed, 87);
 });
 
 test('generateReport supports multi-style selected reports', {


### PR DESCRIPTION
TITLE_CASE_STOP_WORDS was missing about/after/before/into/than/
under/versus/via/without, each confirmed against citeproc-js's
real CSL.SKIP_WORDS array and backed by a concrete oracle-vs-citum
mismatch in Chicago residuals (e.g. "Lists This Without" should be
"...this without"). Deliberately word-list only, not a port of
citeproc-js's lowercase-preserving algorithm -- see the comment on
the constant. Explicitly excludes three near-miss candidates that
turned out to be different bugs: past (a post/post-weblog
sentence-case routing defect, csl26-gall), c (false positive via a
"D.C." abbreviation collision), de (real but confined to non-English
titles, csl26-5uog).

Verified full-portfolio, not just Chicago (TextCase::Title is a
shared primitive): exactMatch 1811/4425 -> 1814/4425, +3 newly
passing, zero newly failing across all 35 embedded styles, via
analyze-parity-residuals.js --diff (dogfooding the tool this
change's own bean is stacked on). Full pre-commit gate green,
2701/2701 tests passing.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>