### PR TITLE
fix(styles): chicago map/graphic no longer quoted

### DIFF
--- a/.beans/archive/csl26-vmw3--chicago-mapgraphic-wrongly-quoted-should-be-italic.md
+++ b/.beans/archive/csl26-vmw3--chicago-mapgraphic-wrongly-quoted-should-be-italic.md
@@ -1,0 +1,59 @@
+---
+# csl26-vmw3
+title: 'Chicago: map/graphic wrongly quoted (should be italic, no quotes)'
+status: completed
+type: bug
+priority: high
+tags:
+    - style
+    - chicago
+    - title
+    - fidelity
+    - punctuation
+created_at: 2026-08-24T13:24:27Z
+updated_at: 2026-08-24T13:45:45Z
+parent: csl26-h7oc
+---
+
+chicago-author-date-18th.yaml (and taylor-and-francis-chicago-author-date via extends) route map/graphic titles through the file's default fallback bibliography template, which has an unconditional wrap: punctuation: quotes on title:primary. Per the shipped chicago-author-date.csl's real title choose-block, map/graphic are in the never-quote, always-italic set (book classic graphic hearing map -> italic, title case). Concrete example: 'Cable, D. 2013. The Racial Dot Map. Map. University of Virginia...' -- oracle has no quotes, citum wrongly quotes it. Fix needs a dedicated bibliography type-variant for map/graphic (title: primary, emph: true, no wrap) since category reassignment alone can't remove a node-level wrap a resolved type-variant doesn't carry. Also check chicago-notes-18th/chicago-shortened-notes-bibliography-core for the same defect shape. Wave 3 of the title-quote-boundary work (csl26-jxco is the sibling task bean this supersedes/continues for this specific sub-defect) and the checkpoint wave for whether the leverage-ordered process (csl26-r90t tooling) is actually converging: near-miss queue currently 654 rows across the 4 Chicago styles.
+
+## Summary of Changes
+
+chicago-author-date-18th.yaml: added an explicit map, graphic: bibliography
+type-variant (structurally identical to the file's default fallback
+template, only title:primary changed from wrap:quotes to
+text-case:title+emph:true). Taylor & Francis inherits this automatically
+via extends (type-variants merge per-key per
+docs/specs/STYLE_INHERITANCE.md rule 4) -- no separate T&F edit needed,
+confirmed by the diff below covering both styles identically.
+
+chicago-notes-18th.yaml + chicago-shortened-notes-bibliography-core.yaml:
+changed map's type-mapping from component (quote:true, wrongly picked up
+in wave 1 for map's title-case fix) to monograph (title-case + emph, no
+quote); added graphic: monograph (previously unmapped, no title-case at
+all).
+
+Verified per-entry via analyze-parity-residuals.js --diff across all four
+Chicago styles: zero regressions (0 newly failing in every style).
+Zero newly-passing too -- expected and predicted going in: map/graphic
+residuals are heavily entangled with other unaddressed defect classes
+(F genre/medium -- dimensions/medium fields like "Oil on canvas, 9 1/2 x
+13 in." never wired for these types; C year-suffix; J URL/DOI). Real
+progress landed and measured: B (title quote boundary) label-instance
+count dropped 273->253 (-20) family-wide, A1 dropped 125->121 (-4).
+check-core-quality.js --parity-baseline: no exact-parity-baseline
+regression anywhere in the 35-style portfolio. Full pre-commit gate
+green: fmt clean, clippy clean, cargo nextest run 2701/2701 passed
+(unchanged from before -- no Rust code changed).
+
+Tool-limitation finding worth recording: the near-miss queue (rows with
+exactly 1 label) is not a reliable "one fix from passing" guarantee.
+map 6188419/CE2ZR4MM in chicago-shortened-notes-bibliography showed only
+"B title quote boundary" pre-fix, but its full oracle/citum diff has
+substantial other missing content (archive location, dimensions, date)
+that no LABEL_RULES pattern happens to match -- labelsFor only adds
+Z unclassified when *zero* rules match, not when some hunks match a rule
+and others don't. The near-miss count is therefore an optimistic lower
+bound on remaining defects, not an exact one. Not fixed here (tool
+behavior is defensible as designed -- documenting the caveat, not
+proposing a change).

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -901,6 +901,59 @@ bibliography:
       prefix: ", "
     - variable: doi
       prefix: ". https://doi.org/"
+    # `map`/`graphic` previously fell through to this file's default
+    # `template:` (below), whose `title: primary` unconditionally wraps in
+    # quotes. Per the shipped chicago-author-date.csl's title choose-block,
+    # `book classic graphic hearing map` are the never-quote, always-italic
+    # set -- confirmed against the oracle ("Cable, D. 2013. The Racial Dot
+    # Map. Map. University of Virginia..." has no quotes). Structurally
+    # identical to the default template otherwise; only the title node
+    # changes (wrap:quotes -> text-case/emph set explicitly, matching how
+    # `software`'s title:primary above sets text-case without relying on
+    # the shared `component`/`monograph` category). See docs/architecture/
+    # audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md wave 3, csl26-vmw3.
+    map, graphic:
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
+    - date: issued
+      form: year
+    - title: primary
+      text-case: title
+      emph: true
+    - group:
+      - contributor: editor
+        form: verb
+        name-order: given-first
+      - title: parent-monograph
+        emph: true
+    - title: parent-serial
+      emph: true
+    - group:
+      - number: volume
+      - number: issue
+        prefix: " "
+        wrap:
+          punctuation: parentheses
+      prefix: " "
+      delimiter: ""
+    - group:
+      - number: pages
+      prefix: ": "
+      render-when:
+        field-present: volume-or-issue
+    - group:
+      - number: pages
+      prefix: ", "
+      render-when:
+        field-absent: volume-or-issue
+    - variable: publisher
+    - variable: doi
+      prefix: https://doi.org/
+    - variable: url
     software:
     - contributor: author
       form: long

--- a/crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
@@ -71,7 +71,17 @@ options:
     # per-type with verification, not as a bulk copy of author-date-18th's
     # list.
     type-mapping:
-      map: component
+      # `map`/`graphic` route to `monograph` (title-case + emph, no quote),
+      # not `component`: the shipped chicago-author-date.csl's title
+      # choose-block puts `book classic graphic hearing map` in the
+      # never-quote, always-italic set. `map` was originally added as
+      # `component` (wave 1, csl26-4xr6) for its title-case fix alone,
+      # which also pulled in `component`'s `quote: true` -- wrong for map,
+      # caught here in wave 3 (csl26-vmw3) once quoting was checked
+      # per-type against the real .csl rather than assumed safe by
+      # analogy to dataset/document.
+      map: monograph
+      graphic: monograph
       dataset: component
       # `document` and `thesis` per docs/architecture/audits/2026-08-23_
       # CHICAGO_PARITY_LEVERAGE_AUDIT.md wave 2 (csl26-jxco): the shipped

--- a/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
@@ -61,7 +61,17 @@ options:
     # docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md,
     # wave 1.
     type-mapping:
-      map: component
+      # `map`/`graphic` route to `monograph` (title-case + emph, no quote),
+      # not `component`: the shipped chicago-author-date.csl's title
+      # choose-block puts `book classic graphic hearing map` in the
+      # never-quote, always-italic set. `map` was originally added as
+      # `component` (wave 1, csl26-4xr6) for its title-case fix alone,
+      # which also pulled in `component`'s `quote: true` -- wrong for map,
+      # caught here in wave 3 (csl26-vmw3) once quoting was checked
+      # per-type against the real .csl rather than assumed safe by
+      # analogy to dataset/document.
+      map: monograph
+      graphic: monograph
       dataset: component
       # `document` and `thesis` per docs/architecture/audits/2026-08-23_
       # CHICAGO_PARITY_LEVERAGE_AUDIT.md wave 2 (csl26-jxco): the shipped

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml
@@ -17,10 +17,10 @@ style:
       sha256: 5ee7afd5c74169d8882747d8ab6ede8b84aa12cd1760e1f0f3f544198cd1be94
     - id: chicago-shortened-notes-bibliography-core
       path: crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
-      sha256: acffc5f23e181e89b6894a285065647f6393911c9088fb08951f3dd861da119d
+      sha256: f95595ebbc0dac728c9e210e73ab11f27f520965f5dc7b9fc3be9931d4977657
     - id: chicago-notes-18th
       path: crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
-      sha256: a87c1bb0152f3fa88550d398e0d9389a09d80f95d8fe26a171a3982b2e3505e5
+      sha256: 8df9d7dfa392b30828d217576b455088c4536f7525cd643b913730ad3b4c4490
     - id: chicago-18-base
       path: crates/citum-schema-style/embedded/styles/chicago-18-base.yaml
       sha256: fa8cadf78de3efabec01f7e1d524d5f1e51b0682fab247b92f2c46f6352f2c74

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.json
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.json
@@ -115,7 +115,7 @@
     ],
     "manifest": {
       "path": "docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml",
-      "sha256": "496025addf9b0f8e8b306a75a29fa7674c787bc185c86285b46f61518d6c4c81"
+      "sha256": "8cb437f12aadb8a8e27d961bea68cefc5978cd8bf14e9477836b9261da5b6aa2"
     },
     "relevance": {
       "default": "relevant",
@@ -164,12 +164,12 @@
         {
           "id": "chicago-shortened-notes-bibliography-core",
           "path": "crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml",
-          "sha256": "acffc5f23e181e89b6894a285065647f6393911c9088fb08951f3dd861da119d"
+          "sha256": "f95595ebbc0dac728c9e210e73ab11f27f520965f5dc7b9fc3be9931d4977657"
         },
         {
           "id": "chicago-notes-18th",
           "path": "crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml",
-          "sha256": "a87c1bb0152f3fa88550d398e0d9389a09d80f95d8fe26a171a3982b2e3505e5"
+          "sha256": "8df9d7dfa392b30828d217576b455088c4536f7525cd643b913730ad3b4c4490"
         },
         {
           "id": "chicago-18-base",
@@ -179,7 +179,7 @@
       ],
       "id": "chicago-shortened-notes-bibliography",
       "path": "crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography.yaml",
-      "resolvedSha256": "6ccd8dc057a61c9c96eb9a6499ae199e37238d08ad7c2e49ecb599d7a040ae00",
+      "resolvedSha256": "5a461963f22e3ec6dfd3be63e7a6ff708ff8ff58bd18d7be97f197815908926c",
       "sha256": "5ee7afd5c74169d8882747d8ab6ede8b84aa12cd1760e1f0f3f544198cd1be94"
     },
     "surfaces": [


### PR DESCRIPTION
map/graphic titles fell through to unconditional quote wraps
(author-date-18th's default template node, notes-family's
component category quote:true), but the shipped
chicago-author-date.csl puts book/classic/graphic/hearing/map in
the never-quote, always-italic set. Give map/graphic their own
explicit bibliography type-variant in author-date-18th (T&F
inherits it via extends, no separate edit needed) and re-route
map/graphic in the notes-family styles to the monograph category
instead of component.

Zero regressions verified via analyze-parity-residuals.js --diff
across all four styles and check-core-quality.js --parity-baseline
across the full 35-style portfolio. Zero rows flip to full
exactMatch this wave -- expected, these rows are entangled with
unaddressed genre/medium and date-detail defects -- but the
quote-boundary label-instance count dropped 273->253 family-wide,
real measured progress toward the next wave's near-miss queue.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>