### PR TITLE
fix(styles): chicago classic/hearing quoting

### DIFF
--- a/.beans/csl26-0u0f--chicago-author-date-18th-bibliography-substitute-p.md
+++ b/.beans/csl26-0u0f--chicago-author-date-18th-bibliography-substitute-p.md
@@ -1,0 +1,74 @@
+---
+# csl26-0u0f
+title: 'Chicago author-date-18th: bibliography substitute path drops quote'
+status: in-progress
+type: bug
+priority: high
+tags:
+    - engine
+    - chicago
+    - title
+    - fidelity
+    - punctuation
+created_at: 2026-08-24T17:52:16Z
+updated_at: 2026-08-24T18:17:27Z
+parent: csl26-h7oc
+---
+
+chicago-author-date-18th's bibliography renders anonymous/no-author entries by substituting the title into the author position (`substitute.candidates: [editor, translator, parent-serial, title]`). The greedy-set-cover leverage ranking still puts "B title quote boundary" first after two prior waves targeted it (90 rows, 42 sole-cause) -- this cluster is why.
+
+## Root cause (isolated)
+
+`resolve_title_substitute` (`crates/citum-engine/src/values/contributor/substitute.rs:612`):
+
+```rust
+let quoted = options.context == RenderContext::Citation && quote_in_citation;
+```
+
+In `RenderContext::Bibliography`, `quoted` is **unconditionally `false`**, regardless of `substitute.title_quote` mode or any `titles.<category>.quote` config. This is deliberate, tested behavior from bean `csl26-0dca` / div-011 (2026-08-14): bibliography-context substituted titles never quote, but *do* pick up the category's `emph`/`strong`/`small-caps` instead (an either/or contract, validated against APA/Elsevier-Harvard-shaped styles where the desired result is italics, not quotes).
+
+For chicago-author-date-18th, the relevant category for `document`/`article-journal`/etc. is `component` (`text-case: title`, no `emph` configured) -- so under the either/or contract these rows get **neither** quote nor emphasis, rendering plain where the oracle wants quotes. Confirmed against 19 mechanically-verified clean rows (see below) where quote marks are the *only* diff from oracle.
+
+Setting `titles.component.quote: true` does **not** fix this: that gate never reads category quote config in bibliography context at all (the `quoted` computation short-circuits on `context == Citation` before `quote_in_citation` is even evaluated). Confirmed this isn't a config gap -- it's an architectural one.
+
+## Why the notes-family styles don't share this defect
+
+`chicago-notes-18th` / `chicago-shortened-notes-bibliography-core` use `substitute: editor-translator-short` -- a preset resolving to `[editor, translator]`, with **no `title` candidate at all**. Truly anonymous entries in the notes family never reach `resolve_title_substitute`; the title just renders through its own normal `title: primary` node (with ordinary node-level `wrap: {punctuation: quotes}`), which is unaffected by the substitute-quote gate. This is why the notes family "already works" -- it sidesteps the mechanism entirely, not because it has some working version of the same code path.
+
+This also rules out "just remove `title` from author-date-18th's candidate list" as a quick fix: `docs/specs/SUBSTITUTED_VALUE_FORMATTING.md` §1 confirms chicago-author-date.csl's real citation-context substitute chain (`author-inline -> author-title-substitute-short -> title-short -> title-primary-short`) *does* promote title into the parenthetical citation slot for these same anonymous entries. Dropping `title` from candidates would fix bibliography by accident while breaking citation-context substitution for the same rows -- worse, not better.
+
+## Measured impact (mechanical, not estimated)
+
+Ran a normalized quote-stripped comparison across all 41 sole-cause "B" rows in chicago-author-date-18th (post-wave-3 report, `/tmp/wave3-after-chicago-author-date-18th.json`):
+
+- **19/41 (46%) are clean quote-only diffs** -- fixing the bibliography substitute-quote gate would flip exactly these to passing.
+- **22/41 (54%) have larger structural diffs** the labeler didn't catch: missing container/publisher fields (`Modern Love.` dropped entirely), corporate-author-as-title confusion (`City of Chicago`, `Forbes`, `Endangered Languages Project` rendering as trailing text instead of as author), and content reordering (Coolidge speech, Hitchcock film credit). These are separate, unrelated defects that happen to also carry a quote-boundary symptom -- the near-miss queue's "exactly 1 label" is confirmed here to be an optimistic lower bound, not a reliable flip-count, consistent with the caveat already on file.
+
+So the achievable win from fixing *only* the bibliography substitute-quote gate is **~19 rows in chicago-author-date-18th**, not 41-42. Likely similar order-of-magnitude in `taylor-and-francis-chicago-author-date` (inherits the same `substitute:` config per `STYLE_INHERITANCE.md` rule 4) once independently verified.
+
+## Why this isn't a quick fix
+
+This is a genuine engine/architecture question, not a style-config tweak:
+
+- `docs/adjudication/DIVERGENCE_REGISTER.md` div-011 and its implementing bean `csl26-0dca` pin the current bibliography-never-quotes rule as *tested, intentional* behavior (5+ tests in `crates/citum-engine/src/values/tests.rs` ~L5118-5320), validated for APA/Elsevier-Harvard-shaped styles where bibliography wants italics.
+- `docs/specs/SUBSTITUTED_VALUE_FORMATTING.md` (Draft, v1.3) already covers this exact subsystem in depth -- but its entire analysis and its proposed `TitleQuoteCondition`/`quote-when` engine capability are **citation-scoped only** ("Put `title-quote: by-category` ... in `citation.options` by default. A global title change requires independent evidence that normal citation and bibliography titles should also change" -- §5). It does not address a case where **bibliography**-context substituted titles need to quote, which is exactly what chicago-author-date-18th's oracle output demonstrates.
+- Rejected approaches investigated and ruled out:
+  - **Reuse `Rendering.quote` on the `contributor: author` node itself** (set `quote: true` directly on the type-variant's `contributor: author` component). Rejected: `Rendering.quote` is a shared, generic field already consumed by every component kind's own render path -- on a contributor node it means "quote this contributor's rendered value." The corpus is entirely author-less for the affected rows, so a zero-regression diff would pass while planting a landmine for the same type *with* a real author (would wrap the author's name in quotes). Field-semantics conflation the project's explicit-over-magic principle forbids.
+  - **Set `titles.component.quote: true`.** Verified ineffective (see root cause above) -- the bibliography gate never reads it.
+  - **Drop `title` from `substitute.candidates`.** Would fix bibliography by removing the mechanism, but breaks the citation-context substitute chain for the same rows (confirmed via `SUBSTITUTED_VALUE_FORMATTING.md` §1's citation-context trace of the real `chicago-author-date.csl`).
+  - **A new per-type `Substitute` field** (e.g. `title-quote-types: [document]`). Structurally sound (the `Substitute` struct already has a precedent: `overrides: HashMap<String, SubstituteCandidates>` keyed by ref-type), but this is a schema addition requiring `just schema-gen` and, per this repo's own policy ("schema changes need a docs-only PR first"), a docs-only spec PR before implementation -- not appropriate to land inside a leverage wave.
+
+## Recommendation
+
+Do not implement a fix in this wave. This needs to go through `docs/specs/SUBSTITUTED_VALUE_FORMATTING.md` as a new revision (or a companion spec) that extends its scope to bibliography-context substitute quoting -- specifically:
+1. Whether the div-011 bibliography-never-quotes rule should gain a bibliography-scoped override analogous to the citation-scoped `title-quote: by-category`, or a different mechanism (e.g. per-type `Substitute` override).
+2. An oracle-verified per-style survey (same rigor as the existing spec's §3/§4) confirming which embedded styles actually want bibliography-context substitute quoting, since APA/Elsevier-Harvard's validated bibliography-italic behavior must not regress.
+3. `chicago-author-date-18th`'s own status row already exists in that spec ("Not yet oracle-verified... Blocked on: Explicit fallback coverage + its own oracle run") -- this bean's findings are exactly that oracle-verification groundwork.
+
+## What landed instead (this wave, csl26-vmw3-adjacent)
+
+Confirmed via the shipped `chicago-author-date.csl` choose-block (`book classic graphic hearing map` -- the same never-quote/always-italic set wave 3 fixed for map/graphic) that `classic`/`hearing` share the identical gap wave 3 already fixed and verified for `map`/`graphic`. Extended the same proven pattern:
+- `chicago-author-date-18th.yaml`: renamed the `map, graphic:` type-variant key to `map, graphic, classic, hearing:` (identical block, no other changes).
+- `chicago-notes-18th.yaml` / `chicago-shortened-notes-bibliography-core.yaml`: added `classic: monograph` / `hearing: monograph` to `titles.type-mapping`, alongside the existing `map`/`graphic` entries.
+
+This is a separate, safe, already-validated-pattern fix -- unrelated to the substitute-quote gap above, which remains open pending spec review.

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -901,18 +901,22 @@ bibliography:
       prefix: ", "
     - variable: doi
       prefix: ". https://doi.org/"
-    # `map`/`graphic` previously fell through to this file's default
-    # `template:` (below), whose `title: primary` unconditionally wraps in
-    # quotes. Per the shipped chicago-author-date.csl's title choose-block,
-    # `book classic graphic hearing map` are the never-quote, always-italic
-    # set -- confirmed against the oracle ("Cable, D. 2013. The Racial Dot
-    # Map. Map. University of Virginia..." has no quotes). Structurally
-    # identical to the default template otherwise; only the title node
-    # changes (wrap:quotes -> text-case/emph set explicitly, matching how
-    # `software`'s title:primary above sets text-case without relying on
-    # the shared `component`/`monograph` category). See docs/architecture/
-    # audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md wave 3, csl26-vmw3.
-    map, graphic:
+    # `map`/`graphic`/`classic`/`hearing` previously fell through to this
+    # file's default `template:` (below), whose `title: primary`
+    # unconditionally wraps in quotes. Per the shipped
+    # chicago-author-date.csl's title choose-block, `book classic graphic
+    # hearing map` are the never-quote, always-italic set -- confirmed
+    # against the oracle ("Cable, D. 2013. The Racial Dot Map. Map.
+    # University of Virginia..." has no quotes). `classic`/`hearing` added
+    # in the same wave once the pattern was confirmed to apply identically
+    # (same choose-block bucket, no distinguishing rule for them).
+    # Structurally identical to the default template otherwise; only the
+    # title node changes (wrap:quotes -> text-case/emph set explicitly,
+    # matching how `software`'s title:primary above sets text-case without
+    # relying on the shared `component`/`monograph` category). See
+    # docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md
+    # wave 3, csl26-vmw3.
+    map, graphic, classic, hearing:
     - contributor: author
       form: long
       name-order: family-first

--- a/crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
@@ -82,6 +82,13 @@ options:
       # analogy to dataset/document.
       map: monograph
       graphic: monograph
+      # `classic`/`hearing` share the exact same choose-block bucket as
+      # map/graphic above (never-quote, always-italic) -- added together
+      # with them once confirmed to apply identically. See
+      # docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md
+      # wave 3, csl26-vmw3.
+      classic: monograph
+      hearing: monograph
       dataset: component
       # `document` and `thesis` per docs/architecture/audits/2026-08-23_
       # CHICAGO_PARITY_LEVERAGE_AUDIT.md wave 2 (csl26-jxco): the shipped

--- a/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
@@ -72,6 +72,13 @@ options:
       # analogy to dataset/document.
       map: monograph
       graphic: monograph
+      # `classic`/`hearing` share the exact same choose-block bucket as
+      # map/graphic above (never-quote, always-italic) -- added together
+      # with them once confirmed to apply identically. See
+      # docs/architecture/audits/2026-08-23_CHICAGO_PARITY_LEVERAGE_AUDIT.md
+      # wave 3, csl26-vmw3.
+      classic: monograph
+      hearing: monograph
       dataset: component
       # `document` and `thesis` per docs/architecture/audits/2026-08-23_
       # CHICAGO_PARITY_LEVERAGE_AUDIT.md wave 2 (csl26-jxco): the shipped

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml
@@ -17,10 +17,10 @@ style:
       sha256: 5ee7afd5c74169d8882747d8ab6ede8b84aa12cd1760e1f0f3f544198cd1be94
     - id: chicago-shortened-notes-bibliography-core
       path: crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
-      sha256: f95595ebbc0dac728c9e210e73ab11f27f520965f5dc7b9fc3be9931d4977657
+      sha256: ce674bebad0888fcc608b3fc9d89c3752a0a1f88b5aff8ddf3e4b60422ab50df
     - id: chicago-notes-18th
       path: crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
-      sha256: 8df9d7dfa392b30828d217576b455088c4536f7525cd643b913730ad3b4c4490
+      sha256: 52f6130154400cb4cd7b6b680ae8d16128faf314e92c9b8cd23ca3f1ba0ad6f1
     - id: chicago-18-base
       path: crates/citum-schema-style/embedded/styles/chicago-18-base.yaml
       sha256: fa8cadf78de3efabec01f7e1d524d5f1e51b0682fab247b92f2c46f6352f2c74

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.json
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.json
@@ -115,7 +115,7 @@
     ],
     "manifest": {
       "path": "docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml",
-      "sha256": "8cb437f12aadb8a8e27d961bea68cefc5978cd8bf14e9477836b9261da5b6aa2"
+      "sha256": "f3a6509d7b3c6dedb8612d296299c473bcaa7a6b90d00e74e674abff28d264e5"
     },
     "relevance": {
       "default": "relevant",
@@ -164,12 +164,12 @@
         {
           "id": "chicago-shortened-notes-bibliography-core",
           "path": "crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml",
-          "sha256": "f95595ebbc0dac728c9e210e73ab11f27f520965f5dc7b9fc3be9931d4977657"
+          "sha256": "ce674bebad0888fcc608b3fc9d89c3752a0a1f88b5aff8ddf3e4b60422ab50df"
         },
         {
           "id": "chicago-notes-18th",
           "path": "crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml",
-          "sha256": "8df9d7dfa392b30828d217576b455088c4536f7525cd643b913730ad3b4c4490"
+          "sha256": "52f6130154400cb4cd7b6b680ae8d16128faf314e92c9b8cd23ca3f1ba0ad6f1"
         },
         {
           "id": "chicago-18-base",
@@ -179,7 +179,7 @@
       ],
       "id": "chicago-shortened-notes-bibliography",
       "path": "crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography.yaml",
-      "resolvedSha256": "5a461963f22e3ec6dfd3be63e7a6ff708ff8ff58bd18d7be97f197815908926c",
+      "resolvedSha256": "6dc52378865a482a312922f04daa7a63b6f9e75dc80ecdb9efa70f7bd7619975",
       "sha256": "5ee7afd5c74169d8882747d8ab6ede8b84aa12cd1760e1f0f3f544198cd1be94"
     },
     "surfaces": [


### PR DESCRIPTION
Per the shipped chicago-author-date.csl's title choose-block, `book
classic graphic hearing map` share the same never-quote, always-italic
set that wave 3 (csl26-vmw3) already fixed for map/graphic. Extend the
identical, oracle-confirmed pattern to classic/hearing across
chicago-author-date-18th (type-variant) and the notes-family styles
(type-mapping to monograph).

Also documents the deeper bibliography substitute-quote architecture
gap found while investigating this wave's leverage target (bean
csl26-0u0f): resolve_title_substitute unconditionally disables
quoting for substituted titles in bibliography context, regardless of
category config. Root-caused, three quick fixes ruled out, and
recommended for spec-first review via docs/specs/
SUBSTITUTED_VALUE_FORMATTING.md rather than an in-wave fix.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>