### PR TITLE
feat(engine): derive substitute title from template node

### DIFF
--- a/.beans/csl26-0u0f--chicago-author-date-18th-bibliography-substitute-p.md
+++ b/.beans/csl26-0u0f--chicago-author-date-18th-bibliography-substitute-p.md
@@ -11,7 +11,7 @@ tags:
     - fidelity
     - punctuation
 created_at: 2026-08-24T17:52:16Z
-updated_at: 2026-08-26T12:54:11Z
+updated_at: 2026-08-26T14:51:42Z
 parent: csl26-h7oc
 ---
 
@@ -215,3 +215,73 @@ blocked this mechanism in v1.0 resolves by reusing the engine's existing
 
 Bean stays `in-progress`; implementation remains a separate stacked PR after
 this revised spec is reviewed.
+
+## Progress update: from-template mechanism implemented, one co-requisite style fix found and landed
+
+Implementation stack started (jj change on top of the spec commit, both to be
+merged as PR #2 stacked on the spec PR):
+
+- `RenderOptions.substitute_title_template: Option<&[TemplateComponent]>`
+  threaded through from `process_template_request_with_format`, gated to
+  `RenderContext::Bibliography` only (citation path unaffected, confirmed by
+  a regression test that supplies a template in citation context and asserts
+  no effect).
+- New `Substitute.title_rendering: Option<SubstituteTitleRendering>` field
+  (single variant `FromTemplate`), resolved through `Substitute::merge`.
+  Chose a new field over reusing `title_quote` per the spec's §4.4 open
+  decision.
+- `find_template_title_node` walks the resolved bibliography template,
+  honoring `render_when` via the existing `group_condition_matches`
+  (verified with a dedicated two-branch test).
+- `merge_substitute_title_rendering` applies the field whitelist
+  (quote/emph/strong/small-caps; `wrap` transfers only when it's quoting
+  punctuation) over the category rendering, mirroring
+  `effective_title_quote_depth`'s precedence.
+- `chicago-author-date-18th` opted in
+  (`bibliography.options.substitute.title-rendering: from-template`).
+  **T&F not opted in this PR** — its `article-journal` bibliography
+  type-variant has a bare `title: primary` (no `wrap`), unlike the parent's
+  `wrap: quotes`, so the parent's yield numbers don't transfer without T&F's
+  own before/after verification. Left as a follow-up, gated on its own
+  audit.
+
+**Regression found and fixed before landing:** `chicago-author-date-18th`'s
+`manuscript, collection:` bibliography type-variant was one compound
+type-selector key sharing a single `title: primary` node with unconditional
+`wrap: quotes`. Real Chicago quotes an individual manuscript item's title but
+not an archival collection's title (CMOS 18). Before this mechanism, the
+substitute path ignored node-level formatting entirely, so `collection`-typed
+entries (note-field `type: collection` override — round-trips to the native
+`collection` ref_type, confirmed via
+`crates/citum-schema-data/src/reference/conversion/contract_tests.rs`) were
+plain and happened to already match the (also plain) oracle by coincidence.
+Once the mechanism reads the node's `wrap: quotes` unconditionally, those 6
+rows regressed (became wrongly quoted). Fixed by splitting the compound key
+into separate `manuscript:` (keeps `wrap: quotes`) and `collection:` (no
+wrap) type-variants — same fix shape already validated independently by
+`csl26-jxco` for the category-config version of this exact same
+manuscript/collection distinction. This is now a demonstrated third case for
+§4.4's intrinsic-vs-positional taxonomy: **conditional-within-type** —
+node formatting correct for a subset of a type's instances, not simply
+right-or-wrong per type. Confirmed via before/after `rawCitum` diff that this
+was the *only* delta introduced (a pre-existing, unrelated
+"archive-collection rendered twice" bug is present in both — filed
+separately as csl26-ckcf, not chased in this PR).
+
+Filed as unblocking follow-ups (previously unchecked acceptance criteria):
+
+- csl26-zja7 — candidate-gap (`SubstituteField::Title` should sometimes
+  promote `container-title`).
+- csl26-9ups — `software`/`song`/`speech` style-content fix.
+- csl26-ckcf — pre-existing archive-collection duplicate-rendering bug,
+  found during regression verification, unrelated to this bean.
+
+Real (not simulated) `report-core.js` + taxonomy-script measurement pending
+final release-build rerun; spec's §4.3/Acceptance-Criteria numbers to be
+updated from measured reality rather than the earlier hand-simulation, which
+undercounted (simulation's crude punctuation handling missed some fixes) and
+also — as `--simulate` only ever ran on the 40 gap rows — never modeled the
+manuscript/collection regression risk on already-matching rows. Lesson
+carried into the spec: the live mechanism runs on every author-less row, not
+just the previously-wrong ones; previously-matching rows are part of the
+blast radius for any future style opt-in.

--- a/.beans/csl26-9ups--chicago-author-date-18th-give-softwaresongspeech-t.md
+++ b/.beans/csl26-9ups--chicago-author-date-18th-give-softwaresongspeech-t.md
@@ -1,0 +1,17 @@
+---
+# csl26-9ups
+title: 'chicago-author-date-18th: give software/song/speech title formatting (substitute style-content gap)'
+status: todo
+type: task
+priority: normal
+tags:
+    - style
+    - chicago
+    - title
+    - fidelity
+created_at: 2026-08-26T14:50:53Z
+updated_at: 2026-08-26T14:50:56Z
+parent: csl26-h7oc
+---
+
+Style-content-only fix (no engine/schema change): software and song type-variants in chicago-author-date-18th.yaml have no formatting on their title: primary node (should be emph: true, per CMOS 18); speech has no dedicated bibliography type-variant at all and falls to the default template (also missing emph). Once title-rendering: from-template ships (csl26-0u0f), these three types' author-less substituted titles still render plain because there is nothing on the resolved template node to derive from -- confirmed by hand-simulation in docs/specs/SUBSTITUTED_TITLE_BIBLIOGRAPHY_FORMATTING.md §4.3/§5 (5 of the 40-row taxonomy: software x3, song x2, speech x1). Fix: add emph: true to software/song's title: primary nodes; give speech its own type-variant with emph: true. Independent of and non-blocking for csl26-0u0f's mechanism.

--- a/.beans/csl26-ckcf--chicago-author-date-18th-manuscriptcollection-bibl.md
+++ b/.beans/csl26-ckcf--chicago-author-date-18th-manuscriptcollection-bibl.md
@@ -1,0 +1,16 @@
+---
+# csl26-ckcf
+title: 'chicago-author-date-18th: manuscript/collection bibliography renders archive-collection twice'
+status: todo
+type: bug
+priority: low
+tags:
+    - style
+    - chicago
+    - fidelity
+created_at: 2026-08-26T14:51:02Z
+updated_at: 2026-08-26T14:51:05Z
+parent: csl26-h7oc
+---
+
+manuscript/collection bibliography entries with an archive-collection value render it twice consecutively, e.g. '...George Washington Papers, Series 5: Financial Papers, 1750-96. George Washington Papers, Series 5: Financial Papers, 1750-96. Library of Congress...' (fixture 6188419/YVLJ984N). Real Chicago (oracle) renders it once. Pre-existing, unrelated to csl26-0u0f's substitute-title-formatting work (confirmed via before/after rawCitum diff on the same fixture rows -- the duplication is present in both). Likely a duplicate archive-collection/variable component in the manuscript and/or collection bibliography type-variant in chicago-author-date-18th.yaml (crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml, ~line 670).

--- a/.beans/csl26-zja7--substitute-candidate-gap-article-magazinenewspaper.md
+++ b/.beans/csl26-zja7--substitute-candidate-gap-article-magazinenewspaper.md
@@ -1,0 +1,17 @@
+---
+# csl26-zja7
+title: 'Substitute candidate-gap: article-magazine/newspaper should promote container-title, not title'
+status: todo
+type: bug
+priority: normal
+tags:
+    - engine
+    - chicago
+    - substitute
+    - fidelity
+created_at: 2026-08-26T14:50:36Z
+updated_at: 2026-08-26T14:50:46Z
+parent: csl26-h7oc
+---
+
+SubstituteField::Title (crates/citum-engine/src/values/contributor/substitute.rs, resolve_candidate) always resolves reference.title() and never considers container-title. For author-less article-magazine/article-newspaper entries where both title and container-title are present, real Chicago (CMOS 18) promotes the container-title (the magazine/newspaper name) into the author slot, with the article title surviving as its own quoted clause -- Citum promotes the wrong value. Found via docs/specs/SUBSTITUTED_TITLE_BIBLIOGRAPHY_FORMATTING.md's taxonomy work on chicago-author-date-18th (5 rows, e.g. 6188419/Y7JIURAM Forbes/Aviation, 6188419/L4XXFEU2 Lake Forester/Pushcarts). Different defect surface than that spec's formatting mechanism -- this is which value gets chosen, not how the chosen value renders.

--- a/crates/citum-engine/src/processor/bibliography/grouping.rs
+++ b/crates/citum-engine/src/processor/bibliography/grouping.rs
@@ -1081,6 +1081,7 @@ impl Processor {
             show_semantics: self.show_semantics,
             current_template_index: None,
             abbreviation_map: self.abbreviation_map.as_ref(),
+            substitute_title_template: None,
         };
 
         let ml = bibliography_config.multilingual.as_ref();

--- a/crates/citum-engine/src/processor/rendering/grouped/core.rs
+++ b/crates/citum-engine/src/processor/rendering/grouped/core.rs
@@ -1140,6 +1140,8 @@ impl Renderer<'_> {
             show_semantics: self.show_semantics,
             current_template_index: None,
             abbreviation_map: self.abbreviation_map,
+            substitute_title_template: matches!(context, RenderContext::Bibliography)
+                .then_some(template),
         };
         // Only carry the first-reference note number (and its suppression side-effect)
         // when the template actually renders it.  Suppressing a `disambiguate-only`

--- a/crates/citum-engine/src/processor/rendering/mod.rs
+++ b/crates/citum-engine/src/processor/rendering/mod.rs
@@ -903,6 +903,7 @@ impl<'a> Renderer<'a> {
             show_semantics: self.show_semantics,
             current_template_index: None,
             abbreviation_map: self.abbreviation_map,
+            substitute_title_template: None,
         }
     }
 

--- a/crates/citum-engine/src/values/contributor/substitute.rs
+++ b/crates/citum-engine/src/values/contributor/substitute.rs
@@ -15,13 +15,15 @@ use crate::values::title::{render_substitute_title_text, resolve_substitute_text
 use crate::values::{ProcHints, ProcValues, RenderContext, RenderOptions};
 use citum_schema::options::{
     RoleLabelPreset, SubstituteField, SubstituteKey, SubstituteTitleQuoteMode,
+    SubstituteTitleRendering,
 };
 use citum_schema::reference::Title;
 use citum_schema::reference::{
     AudioVisualType, ClassExtension, Contributor, ContributorRole as DataRole,
 };
 use citum_schema::template::{
-    ContributorRole, ContributorRoles, Rendering, TemplateComponent, TemplateContributor, TitleType,
+    ContributorRole, ContributorRoles, Rendering, TemplateComponent, TemplateContributor,
+    TemplateTitle, TitleType, WrapPunctuation,
 };
 
 /// Resolved value occupying the style's effective primary-contributor slot.
@@ -592,6 +594,10 @@ fn substituted_key_for_title_type(title_type: &TitleType) -> &'static str {
     }
 }
 
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Title-substitute rendering needs shared engine state until this module is refactored."
+)]
 fn resolve_title_substitute<F: OutputFormat<Output = String>>(
     title: Title,
     title_type: &TitleType,
@@ -600,6 +606,7 @@ fn resolve_title_substitute<F: OutputFormat<Output = String>>(
     reference: &Reference,
     fmt: &F,
     quote_in_citation: bool,
+    substitute: &citum_schema::options::Substitute,
 ) -> ProcValues<F::Output> {
     let substituted_key = substituted_key_for_title_type(title_type);
     let title_str = title_substitute_text(title, options.context);
@@ -609,7 +616,22 @@ fn resolve_title_substitute<F: OutputFormat<Output = String>>(
     // `resolve_substitute_text_case`.
     let case = resolve_substitute_text_case(title_type, reference, options);
     let language = crate::values::title::effective_title_language(title_type, reference);
-    let quoted = options.context == RenderContext::Citation && quote_in_citation;
+    // Bibliography-context styles opted into `title-rendering: from-template`
+    // derive formatting from the reference type's own resolved `title:
+    // primary` node instead of category-only config — see
+    // `SUBSTITUTED_TITLE_BIBLIOGRAPHY_FORMATTING.md`.
+    let template_rendering = resolve_template_derived_title_rendering(
+        title_type,
+        reference,
+        language.as_deref(),
+        options,
+        substitute,
+    );
+    let quoted = if let Some(rendering) = &template_rendering {
+        rendering.quote == Some(true)
+    } else {
+        options.context == RenderContext::Citation && quote_in_citation
+    };
     let quote_depth = usize::from(quoted);
     // Route through the same Djot-aware pipeline as `TemplateTitle::values`
     // so markup (e.g. `[...]{.nocase}`) and case-protection are honoured
@@ -621,17 +643,33 @@ fn resolve_title_substitute<F: OutputFormat<Output = String>>(
     } else {
         fmt.text(&rendered)
     };
-    // Category-level `titles:` emphasis (emph/strong/small-caps) that a normal
-    // `title:` component would pick up from `get_effective_rendering` — the
-    // substitute chain renders through a contributor component, so it never
-    // reaches that path and must apply it here. Order mirrors
-    // `render_component_detailed_with_format_and_renderer`. Skipped when
-    // quoting: per div-011, quote and category emphasis are either/or for a
-    // substituted title, so the default unconditional-quote path stays
-    // byte-identical.
-    let rendered = if quoted {
+    let rendered = if let Some(rendering) = &template_rendering {
+        // From-template mode faithfully applies the merged node rendering:
+        // quote and emph both apply if the node declares both, superseding
+        // div-011's either/or for opted-in styles.
+        let mut output = rendered;
+        if rendering.emph == Some(true) {
+            output = fmt.emph(output);
+        }
+        if rendering.strong == Some(true) {
+            output = fmt.strong(output);
+        }
+        if rendering.small_caps == Some(true) {
+            output = fmt.small_caps(output);
+        }
+        output
+    } else if quoted {
         rendered
     } else {
+        // Category-level `titles:` emphasis (emph/strong/small-caps) that a
+        // normal `title:` component would pick up from
+        // `get_effective_rendering` — the substitute chain renders through a
+        // contributor component, so it never reaches that path and must
+        // apply it here. Order mirrors
+        // `render_component_detailed_with_format_and_renderer`. Skipped when
+        // quoting: per div-011, quote and category emphasis are either/or
+        // for a substituted title, so the default unconditional-quote path
+        // stays byte-identical.
         apply_substitute_title_emphasis(
             rendered,
             title_type,
@@ -717,6 +755,101 @@ fn resolve_category_quote(reference: &Reference, options: &RenderOptions<'_>) ->
     )
     .and_then(|rendering| rendering.quote)
     .unwrap_or(false)
+}
+
+/// Find the resolved bibliography template's own node for `title_type`
+/// (e.g. `title: primary`), honoring `render_when` branches the same way
+/// the normal render path resolves them — see
+/// [`crate::values::group_condition_matches`]. Returns the first matching
+/// node in document order, matching how the renderer walks a template.
+fn find_template_title_node<'a>(
+    template: &'a [TemplateComponent],
+    title_type: &TitleType,
+    reference: &Reference,
+) -> Option<&'a TemplateTitle> {
+    for component in template {
+        if component.rendering().suppress == Some(true) {
+            continue;
+        }
+        match component {
+            TemplateComponent::Title(title) if title.title == *title_type => {
+                return Some(title);
+            }
+            TemplateComponent::Group(group) => {
+                if group.render_when.as_ref().is_some_and(|condition| {
+                    !crate::values::group_condition_matches(reference, condition)
+                }) {
+                    continue;
+                }
+                if let Some(found) = find_template_title_node(&group.group, title_type, reference) {
+                    return Some(found);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Transfer only the formatting fields that describe how a title's *text*
+/// is presented — never structural fields like `prefix`/`suffix`/`form`,
+/// which are positional and meaningless detached from the node's slot. A
+/// `wrap` transfers only when it is quoting punctuation: `wrap: parentheses`
+/// / `wrap: brackets` on a template node is positional (correct next to a
+/// specific sibling), not title formatting, so it is deliberately ignored
+/// here — see `SUBSTITUTED_TITLE_BIBLIOGRAPHY_FORMATTING.md` §4.2/§4.4.
+fn merge_substitute_title_rendering(base: &mut Rendering, node: &Rendering) {
+    if node.emph.is_some() {
+        base.emph = node.emph;
+    }
+    if node.quote.is_some() {
+        base.quote = node.quote;
+    }
+    if node.strong.is_some() {
+        base.strong = node.strong;
+    }
+    if node.small_caps.is_some() {
+        base.small_caps = node.small_caps;
+    }
+    if let Some(wrap) = &node.wrap
+        && wrap.punctuation == WrapPunctuation::Quotes
+    {
+        base.quote = Some(true);
+    }
+}
+
+/// Resolve a substituted title's bibliography-context rendering from the
+/// reference type's own resolved template node, merged over the title
+/// category's rendering (category-then-node precedence, matching
+/// `effective_title_quote_depth`). Returns `None` when the style has not
+/// opted in (`substitute.title-rendering: from-template`), when no
+/// resolved template was threaded through for this render, or when the
+/// template has no matching title node.
+fn resolve_template_derived_title_rendering(
+    title_type: &TitleType,
+    reference: &Reference,
+    language: Option<&str>,
+    options: &RenderOptions<'_>,
+    substitute: &citum_schema::options::Substitute,
+) -> Option<Rendering> {
+    if options.context != RenderContext::Bibliography {
+        return None;
+    }
+    if substitute.title_rendering != Some(SubstituteTitleRendering::FromTemplate) {
+        return None;
+    }
+    let template = options.substitute_title_template?;
+    let node = find_template_title_node(template, title_type, reference)?;
+    let ref_type = reference.ref_type();
+    let mut rendering = crate::render::component::get_title_category_rendering(
+        title_type,
+        Some(&ref_type),
+        language,
+        &options.config,
+    )
+    .unwrap_or_default();
+    merge_substitute_title_rendering(&mut rendering, &node.rendering);
+    Some(rendering)
 }
 
 fn title_substitute_text(title: Title, context: RenderContext) -> String {
@@ -992,6 +1125,7 @@ pub(super) fn resolve_author_substitute<F: OutputFormat<Output = String>>(
                 reference,
                 fmt,
                 quote_in_citation,
+                substitute,
             ))
         }
         None => None,

--- a/crates/citum-engine/src/values/mod.rs
+++ b/crates/citum-engine/src/values/mod.rs
@@ -971,6 +971,14 @@ pub struct RenderOptions<'a> {
     pub current_template_index: Option<usize>,
     /// Document-level abbreviation map for post-render substitution.
     pub abbreviation_map: Option<&'a crate::api::AbbreviationMap>,
+    /// The resolved bibliography template for the current entry, after
+    /// type-variant and policy resolution — set only when a style opts in to
+    /// `substitute.title-rendering: from-template` (see
+    /// `SUBSTITUTED_TITLE_BIBLIOGRAPHY_FORMATTING.md`). The substitute path
+    /// walks this to find the reference type's own `title: primary` node and
+    /// derive quote/emph formatting for a promoted title, instead of relying
+    /// solely on category-level title config.
+    pub substitute_title_template: Option<&'a [TemplateComponent]>,
 }
 
 /// Trait for extracting values from template components.

--- a/crates/citum-engine/src/values/tests.rs
+++ b/crates/citum-engine/src/values/tests.rs
@@ -450,6 +450,7 @@ fn test_contributor_values() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = make_reference();
     let hints = ProcHints::default();
@@ -500,6 +501,7 @@ fn test_family_first_except_last_inverts_all_but_last_name() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = make_custom_role_reference(
         citum_schema::reference::ContributorRole::Author,
@@ -544,6 +546,7 @@ fn test_spanish_role_label_uses_feminine_form_for_single_editor() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = make_editor_reference(&[ContributorGender::Feminine]);
     let hints = ProcHints::default();
@@ -586,6 +589,7 @@ fn test_spanish_role_label_uses_plural_feminine_form_for_matching_group() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference =
         make_editor_reference(&[ContributorGender::Feminine, ContributorGender::Feminine]);
@@ -629,6 +633,7 @@ fn test_spanish_role_label_prefers_common_form_for_mixed_group() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference =
         make_editor_reference(&[ContributorGender::Feminine, ContributorGender::Masculine]);
@@ -686,6 +691,7 @@ roles:
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference =
         make_editor_reference(&[ContributorGender::Feminine, ContributorGender::Masculine]);
@@ -729,6 +735,7 @@ fn test_french_role_label_uses_feminine_form_for_single_contributor() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = make_editor_reference(&[ContributorGender::Feminine]);
     let hints = ProcHints::default();
@@ -771,6 +778,7 @@ fn test_arabic_role_label_uses_feminine_form_for_single_contributor() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = make_editor_reference(&[ContributorGender::Feminine]);
     let hints = ProcHints::default();
@@ -813,6 +821,7 @@ fn test_french_role_label_falls_back_to_masculine_plural_for_mixed_group() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference =
         make_editor_reference(&[ContributorGender::Feminine, ContributorGender::Masculine]);
@@ -856,6 +865,7 @@ fn test_arabic_role_label_falls_back_to_verbal_noun_for_mixed_group() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference =
         make_editor_reference(&[ContributorGender::Feminine, ContributorGender::Masculine]);
@@ -899,6 +909,7 @@ fn test_arabic_role_label_falls_back_to_roles_common_when_gender_missing() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
 
     // Reference with no gender info
@@ -962,6 +973,7 @@ fn test_collection_editor_role_label_derives_gender_from_reference_data() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = make_custom_role_reference(
         citum_schema::reference::ContributorRole::Unknown("collection-editor".to_string()),
@@ -1008,6 +1020,7 @@ fn test_date_values() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = make_reference();
     let hints = ProcHints::default();
@@ -1047,6 +1060,7 @@ fn test_message_component_renders_accessed_date_argument() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = Reference::from(LegacyReference {
         id: "web-2021".to_string(),
@@ -1101,6 +1115,7 @@ fn test_message_component_renders_in_container_argument_with_formatting() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = Reference::from(LegacyReference {
         id: "chapter-1".to_string(),
@@ -1155,6 +1170,7 @@ fn style_owned_mf2_message_selects_reference_type_and_carrier() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = Reference::from(LegacyReference {
         id: "online-book".to_string(),
@@ -1211,6 +1227,7 @@ fn test_message_component_renders_grouped_container_argument() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = Reference::from(LegacyReference {
         id: "chapter-1".to_string(),
@@ -1290,6 +1307,7 @@ fn test_message_component_reorders_locale_phrase_arguments() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = Reference::from(LegacyReference {
         id: "localized-phrase".to_string(),
@@ -1375,6 +1393,7 @@ fn test_message_component_resolves_term_backed_messages() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = make_reference();
     let hints = ProcHints::default();
@@ -1415,6 +1434,7 @@ fn test_message_component_preserves_term_rendering_options() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = make_reference();
     let hints = ProcHints::default();
@@ -1460,6 +1480,7 @@ fn test_message_component_renders_embedded_container_author_group() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = InputReference::CollectionComponent(Box::new(CollectionComponent {
         id: Some("chapter-1".into()),
@@ -1547,6 +1568,7 @@ fn test_message_component_renders_legacy_container_author_group() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = Reference::from(LegacyReference {
         id: "chapter-1".to_string(),
@@ -1613,6 +1635,7 @@ fn test_year_month_day_dates_inline_disambiguation_suffix_on_year() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = Reference::from(LegacyReference {
         id: "dated-2018".to_string(),
@@ -1661,6 +1684,7 @@ fn test_et_al() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -1726,6 +1750,7 @@ fn test_et_al_delimiter_never() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -1784,6 +1809,7 @@ fn test_role_substitute_uses_custom_fallback_roles_without_silent_drop() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = Reference::from(LegacyReference {
         id: "compiler-fallback".to_string(),
@@ -1855,6 +1881,7 @@ fn typed_editorial_roles_resolve_through_substitution() {
             show_semantics: true,
             current_template_index: None,
             abbreviation_map: None,
+            substitute_title_template: None,
         };
         let reference = make_custom_role_reference(data_role, &[ContributorGender::Common]);
         let hints = ProcHints::default();
@@ -1899,6 +1926,7 @@ fn test_et_al_delimiter_always() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2207,6 +2235,7 @@ fn test_template_list_suppression() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = Reference::from(LegacyReference {
         id: "multi".to_string(),
@@ -2259,6 +2288,7 @@ fn test_et_al_use_last() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2314,6 +2344,7 @@ fn test_et_al_use_last_overlap() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2375,6 +2406,7 @@ fn test_et_al_use_last_multiple_first_names_delimiter() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2434,6 +2466,7 @@ fn test_et_al_uses_configured_delimiter() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2480,6 +2513,7 @@ fn test_title_hyperlink() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2529,6 +2563,7 @@ fn test_title_hyperlink_url_fallback() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2577,6 +2612,7 @@ fn test_title_values_smarten_leading_single_quotes() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2619,6 +2655,7 @@ fn test_title_values_smarten_starting_apostrophe() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2664,6 +2701,7 @@ fn test_title_values_smarten_french_apostrophes() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2707,6 +2745,7 @@ fn test_title_values_smarten_double_quotes() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2745,6 +2784,7 @@ fn test_title_values_flip_flop_outer_single_inner_double_quotes() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2783,6 +2823,7 @@ fn test_title_values_flip_flop_outer_double_inner_single_quotes() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2821,6 +2862,7 @@ fn test_title_values_preserve_ambiguous_double_quotes() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2859,6 +2901,7 @@ fn test_title_values_render_djot_markup_as_preformatted() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2898,6 +2941,7 @@ fn test_title_values_smarten_djot_text_leaves() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2937,6 +2981,7 @@ fn test_title_values_smarten_djot_double_quotes() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -2976,6 +3021,7 @@ fn test_title_values_inline_link_suppresses_outer_title_link() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -3025,6 +3071,7 @@ fn test_variable_hyperlink() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -3144,6 +3191,7 @@ fn test_report_number_variable_uses_report_number_accessor() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -3197,6 +3245,7 @@ fn number_of_volumes_variable_renders_the_converted_csl_value() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = Reference::from(LegacyReference {
         id: "multivolume".to_string(),
@@ -3265,6 +3314,7 @@ fn template_number_ordinal_form_uses_the_active_locale_message() {
             show_semantics: true,
             current_template_index: None,
             abbreviation_map: None,
+            substitute_title_template: None,
         };
 
         assert_eq!(
@@ -3293,6 +3343,7 @@ fn template_number_localizes_digits_for_the_active_locale() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = Reference::from(LegacyReference {
         id: "localized-number".to_string(),
@@ -3343,6 +3394,7 @@ fn monograph_metadata_variables_render_their_accessors() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
     let reference = InputReference::Monograph(Box::new(Monograph {
@@ -3389,6 +3441,7 @@ fn test_number_variable_excludes_report_number_accessor() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -3448,6 +3501,7 @@ locators:
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -3514,6 +3568,7 @@ locators:
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
 
     let reference: Reference = serde_json::from_str(
@@ -3559,6 +3614,7 @@ fn test_template_number_gender_overrides_locator_label_resolution() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -3629,6 +3685,7 @@ fn test_role_label_preset_applies_to_translator_component() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let component = TemplateContributor {
         contributor: ContributorRole::Translator.into(),
@@ -3660,6 +3717,7 @@ fn test_translator_substitute_uses_locale_aware_role_label() {
         overrides: std::collections::HashMap::new(),
         role_substitute: std::collections::HashMap::new(),
         title_quote: None,
+        title_rendering: None,
         otherwise: None,
         unknown_fields: Default::default(),
     }));
@@ -3683,6 +3741,7 @@ fn test_translator_substitute_uses_locale_aware_role_label() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let component = TemplateContributor {
         contributor: ContributorRole::Author.into(),
@@ -3739,6 +3798,7 @@ fn test_editor_substitute_suppresses_verb_prefix_role_label() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let component = TemplateContributor {
         contributor: ContributorRole::Author.into(),
@@ -3792,6 +3852,7 @@ fn test_editor_component_keeps_verb_prefix_role_label() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let component = TemplateContributor {
         contributor: ContributorRole::Editor.into(),
@@ -3833,6 +3894,7 @@ fn test_role_substitute_normalizes_primary_role_lookup_keys() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = Reference::from(LegacyReference {
         id: "normalized-role-key".to_string(),
@@ -3872,6 +3934,7 @@ fn test_role_specific_name_order_applies_in_substitute_path() {
         overrides: std::collections::HashMap::new(),
         role_substitute: std::collections::HashMap::new(),
         title_quote: None,
+        title_rendering: None,
         otherwise: None,
         unknown_fields: Default::default(),
     }));
@@ -3912,6 +3975,7 @@ fn test_role_specific_name_order_applies_in_substitute_path() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let component = TemplateContributor {
         contributor: ContributorRole::Author.into(),
@@ -3950,6 +4014,7 @@ fn test_term_values() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = make_reference();
     let hints = ProcHints::default();
@@ -3984,6 +4049,7 @@ fn test_template_list_term_suppression() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     // Reference with no editor
     let reference = make_reference();
@@ -4030,6 +4096,7 @@ fn test_date_fallback() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     // Reference with NO issued date
     let reference = Reference::from(LegacyReference {
@@ -4073,6 +4140,7 @@ fn given_omitted_date_fallback_when_issued_missing_then_date_is_omitted() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = Reference::from(LegacyReference {
         id: "no-date".to_string(),
@@ -4115,6 +4183,7 @@ fn given_exhausted_date_fallback_when_issued_missing_then_date_is_omitted() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let reference = Reference::from(LegacyReference {
         id: "no-date-or-doi".to_string(),
@@ -4182,6 +4251,7 @@ fn test_author_otherwise_renders_anonymous_term_when_substitute_chain_is_empty()
         show_semantics: false,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
 
     let values = component
@@ -4220,6 +4290,7 @@ fn test_strip_periods_global_config() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
 
     let component = TemplateContributor {
@@ -4265,6 +4336,7 @@ fn test_strip_periods_component_override() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
 
     // Component overrides global setting
@@ -4314,6 +4386,7 @@ fn test_strip_periods_no_strip_by_default() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
 
     let component = TemplateContributor {
@@ -4360,6 +4433,7 @@ fn test_should_strip_periods_precedence() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
 
     // Component override takes precedence
@@ -4393,6 +4467,7 @@ fn test_should_strip_periods_precedence() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     assert!(!should_strip_periods(&rendering_default, &options_none));
 }
@@ -4926,6 +5001,7 @@ fn title_value_with_config(title_str: &str, ref_type: &str, config: &Config) -> 
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
     let reference = Reference::from(LegacyReference {
@@ -4973,6 +5049,7 @@ fn structured_title_value_with_config_and_locale(
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -5146,6 +5223,7 @@ fn substitute_title_value_with_rendering(
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
     let reference = InputReference::Monograph(Box::new(Monograph {
@@ -5322,6 +5400,304 @@ fn given_djot_markup_and_category_emphasis_when_title_substituted_then_case_and_
     assert_eq!(result, "_The role of mRNA in modern science_");
 }
 
+// ── From-template substitute-title formatting tests (csl26-0u0f) ──────────
+//
+// `title-rendering: from-template` derives a substituted title's
+// bibliography-context formatting from the reference type's own resolved
+// `title: primary` template node, superseding div-011's either/or (quote
+// *or* emph) for opted-in styles. See
+// `SUBSTITUTED_TITLE_BIBLIOGRAPHY_FORMATTING.md`.
+
+fn single_title_primary_template(rendering: Rendering) -> Vec<TemplateComponent> {
+    vec![TemplateComponent::Title(TemplateTitle {
+        title: TitleType::Primary,
+        rendering,
+        ..Default::default()
+    })]
+}
+
+/// As [`substitute_title_value_with_rendering`], but opts the style into
+/// `title-rendering: from-template` and threads `template` through
+/// `RenderOptions.substitute_title_template`, so tests can exercise the
+/// resolved-template-node derivation instead of category-only config.
+fn substitute_title_value_from_template(title_str: &str, template: &[TemplateComponent]) -> String {
+    let config = make_config_with_titles(TitlesConfig::default());
+    let mut config = config;
+    config.substitute = Some(SubstituteConfig::Explicit(Substitute {
+        title_rendering: Some(SubstituteTitleRendering::FromTemplate),
+        ..Default::default()
+    }));
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: Arc::new(config),
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+        abbreviation_map: None,
+        substitute_title_template: Some(template),
+    };
+    let hints = ProcHints::default();
+    let reference = InputReference::Monograph(Box::new(Monograph {
+        r#type: MonographType::Book,
+        title: Some(Title::Single(title_str.to_string())),
+        ..Default::default()
+    }));
+    let component = TemplateContributor {
+        contributor: ContributorRole::Author.into(),
+        form: ContributorForm::Long,
+        ..Default::default()
+    };
+    component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("author-substitute title should render")
+        .value
+}
+
+#[test]
+fn given_node_wrap_quotes_when_title_substituted_from_template_then_title_is_quoted() {
+    let template = single_title_primary_template(Rendering {
+        wrap: Some(WrapConfig {
+            punctuation: WrapPunctuation::Quotes,
+            inner_prefix: None,
+            inner_suffix: None,
+        }),
+        ..Default::default()
+    });
+    let result = substitute_title_value_from_template("Anonymous Document", &template);
+    assert_eq!(result, "“Anonymous Document”");
+}
+
+#[test]
+fn given_node_emph_when_title_substituted_from_template_then_title_is_italicized() {
+    let template = single_title_primary_template(Rendering {
+        emph: Some(true),
+        ..Default::default()
+    });
+    let result = substitute_title_value_from_template("Map of the Empire", &template);
+    assert_eq!(result, "_Map of the Empire_");
+}
+
+#[test]
+fn given_node_quote_and_emph_when_title_substituted_from_template_then_both_apply() {
+    // Supersedes div-011's either/or: the node's own `Rendering` is applied
+    // faithfully once a style opts into `from-template`.
+    let template = single_title_primary_template(Rendering {
+        emph: Some(true),
+        wrap: Some(WrapConfig {
+            punctuation: WrapPunctuation::Quotes,
+            inner_prefix: None,
+            inner_suffix: None,
+        }),
+        ..Default::default()
+    });
+    let result = substitute_title_value_from_template("Doubly Formatted", &template);
+    assert_eq!(result, "“_Doubly Formatted_”");
+}
+
+#[test]
+fn given_node_with_no_formatting_when_title_substituted_from_template_then_title_is_plain() {
+    let template = single_title_primary_template(Rendering::default());
+    let result = substitute_title_value_from_template("Plain Software Title", &template);
+    assert_eq!(result, "Plain Software Title");
+}
+
+#[test]
+fn given_positional_wrap_when_title_substituted_from_template_then_wrap_is_ignored() {
+    // `wrap: parentheses` / `wrap: brackets` on a template node is
+    // positional (correct only next to a specific sibling), not title
+    // formatting -- the whitelist deliberately does not transfer it.
+    let template = single_title_primary_template(Rendering {
+        wrap: Some(WrapConfig {
+            punctuation: WrapPunctuation::Parentheses,
+            inner_prefix: None,
+            inner_suffix: None,
+        }),
+        ..Default::default()
+    });
+    let result = substitute_title_value_from_template("Not Wrapped", &template);
+    assert_eq!(result, "Not Wrapped");
+}
+
+#[test]
+fn given_render_when_gated_nodes_when_title_substituted_from_template_then_matching_branch_wins() {
+    // Two `render_when`-guarded groups, only one of which matches a
+    // reference with no `editor` -- the walker must resolve the same
+    // branch the normal render path would, not just the first title node
+    // in document order.
+    let template = vec![
+        TemplateComponent::Group(TemplateGroup {
+            group: vec![TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                rendering: Rendering {
+                    emph: Some(true),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })],
+            render_when: Some(TemplateGroupCondition {
+                field_present: Some(TemplateConditionField::Editor),
+                field_absent: None,
+            }),
+            delimiter: None,
+            rendering: Rendering::default(),
+            custom: None,
+        }),
+        TemplateComponent::Group(TemplateGroup {
+            group: vec![TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                rendering: Rendering {
+                    wrap: Some(WrapConfig {
+                        punctuation: WrapPunctuation::Quotes,
+                        inner_prefix: None,
+                        inner_suffix: None,
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })],
+            render_when: Some(TemplateGroupCondition {
+                field_present: None,
+                field_absent: Some(TemplateConditionField::Editor),
+            }),
+            delimiter: None,
+            rendering: Rendering::default(),
+            custom: None,
+        }),
+    ];
+    let result = substitute_title_value_from_template("Editor Absent", &template);
+    assert_eq!(result, "“Editor Absent”");
+}
+
+#[test]
+fn given_suppressed_group_precedes_active_title_when_substituted_from_template_then_suppressed_group_is_skipped()
+ {
+    // A group with `suppress: true` never renders for any reference (see
+    // `render_group_component_with_format`'s suppress check at
+    // grouped/core.rs:1320) -- the walker must skip it the same way,
+    // rather than reading formatting off a title node that could never
+    // actually appear in output.
+    let template = vec![
+        TemplateComponent::Group(TemplateGroup {
+            group: vec![TemplateComponent::Title(TemplateTitle {
+                title: TitleType::Primary,
+                rendering: Rendering {
+                    emph: Some(true),
+                    ..Default::default()
+                },
+                ..Default::default()
+            })],
+            render_when: None,
+            delimiter: None,
+            rendering: Rendering {
+                suppress: Some(true),
+                ..Default::default()
+            },
+            custom: None,
+        }),
+        TemplateComponent::Title(TemplateTitle {
+            title: TitleType::Primary,
+            rendering: Rendering {
+                wrap: Some(WrapConfig {
+                    punctuation: WrapPunctuation::Quotes,
+                    inner_prefix: None,
+                    inner_suffix: None,
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+    ];
+    let result = substitute_title_value_from_template("Suppressed Group", &template);
+    assert_eq!(result, "“Suppressed Group”");
+}
+
+#[test]
+fn given_suppressed_title_node_precedes_active_title_when_substituted_from_template_then_suppressed_node_is_skipped()
+ {
+    // A `title:` component with `suppress: true` on itself never renders
+    // (see the `rendering().suppress` check at grouped/core.rs:1271) --
+    // the walker must skip it and fall through to the next matching
+    // `title: primary` node instead of reading its (never-rendered)
+    // formatting.
+    let template = vec![
+        TemplateComponent::Title(TemplateTitle {
+            title: TitleType::Primary,
+            rendering: Rendering {
+                emph: Some(true),
+                suppress: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+        TemplateComponent::Title(TemplateTitle {
+            title: TitleType::Primary,
+            rendering: Rendering {
+                wrap: Some(WrapConfig {
+                    punctuation: WrapPunctuation::Quotes,
+                    inner_prefix: None,
+                    inner_suffix: None,
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+    ];
+    let result = substitute_title_value_from_template("Suppressed Node", &template);
+    assert_eq!(result, "“Suppressed Node”");
+}
+
+#[test]
+fn given_mode_not_opted_in_when_template_is_supplied_then_legacy_category_only_behavior_wins() {
+    // The opt-in gate: a resolved template alone must never change
+    // behavior -- only `title-rendering: from-template` does.
+    let template = single_title_primary_template(Rendering {
+        wrap: Some(WrapConfig {
+            punctuation: WrapPunctuation::Quotes,
+            inner_prefix: None,
+            inner_suffix: None,
+        }),
+        ..Default::default()
+    });
+    let config = make_config_with_titles(TitlesConfig::default());
+    let locale = make_locale();
+    let options = RenderOptions {
+        config: Arc::new(config),
+        bibliography_config: None,
+        locale: &locale,
+        context: RenderContext::Bibliography,
+        mode: citum_schema::citation::CitationMode::NonIntegral,
+        suppress_author: false,
+        locator_raw: None,
+        ref_type: None,
+        show_semantics: true,
+        current_template_index: None,
+        abbreviation_map: None,
+        substitute_title_template: Some(&template),
+    };
+    let hints = ProcHints::default();
+    let reference = InputReference::Monograph(Box::new(Monograph {
+        r#type: MonographType::Book,
+        title: Some(Title::Single("Not Opted In".to_string())),
+        ..Default::default()
+    }));
+    let component = TemplateContributor {
+        contributor: ContributorRole::Author.into(),
+        form: ContributorForm::Long,
+        ..Default::default()
+    };
+    let result = component
+        .values::<PlainText>(&reference, &hints, &options)
+        .expect("author-substitute title should render")
+        .value;
+    assert_eq!(result, "Not Opted In");
+}
+
 /// Renders a monograph's primary title under `text-case: sentence-apa`,
 /// built natively (no `csl_legacy` round-trip) so markup-bearing and
 /// plain-text titles are exercised through identical construction.
@@ -5346,6 +5722,7 @@ fn sentence_apa_monograph_title_value(title_str: &str) -> String {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
     let reference = InputReference::Monograph(Box::new(Monograph {
@@ -5424,6 +5801,7 @@ fn test_text_case_structured_title_sentence_apa() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -5672,6 +6050,7 @@ fn test_text_case_structured_title_sentence_nlm() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -5727,6 +6106,7 @@ fn test_text_case_non_english_falls_back_to_as_is() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -5773,6 +6153,7 @@ fn test_text_case_template_level_override() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
     let reference = Reference::from(LegacyReference {
@@ -5824,6 +6205,7 @@ fn test_structured_title_form_short_returns_main_only() {
         show_semantics: true,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -5899,6 +6281,7 @@ fn given_abbreviation_map_when_title_matches_then_abbreviation_returned() {
         show_semantics: false,
         current_template_index: None,
         abbreviation_map: Some(&abbrev_map_obj),
+        substitute_title_template: None,
     };
 
     let component = TemplateTitle {
@@ -5946,6 +6329,7 @@ fn given_abbreviation_map_when_title_not_in_map_then_original_returned() {
         show_semantics: false,
         current_template_index: None,
         abbreviation_map: Some(&abbrev_map_obj),
+        substitute_title_template: None,
     };
 
     let component = TemplateTitle {
@@ -6025,6 +6409,7 @@ fn test_date_note_appends_full_width_wrap_for_cjk_script_item() {
         show_semantics: false,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -6062,6 +6447,7 @@ fn test_date_note_appends_half_width_wrap_for_latin_script_item() {
         show_semantics: false,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -6092,6 +6478,7 @@ fn test_date_note_hidden_when_style_has_no_note_wrap() {
         show_semantics: false,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -6134,6 +6521,7 @@ fn test_date_note_hidden_when_component_suppresses_it() {
         show_semantics: false,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
     let component = TemplateDate {
@@ -6175,6 +6563,7 @@ fn test_date_note_hidden_when_input_has_no_note() {
         show_semantics: false,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 
@@ -6212,6 +6601,7 @@ fn test_date_note_follows_year_suffix_disambiguator() {
         show_semantics: false,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints {
         disamb_condition: true,
@@ -6268,6 +6658,7 @@ fn test_date_note_wraps_after_a_closed_interval() {
         show_semantics: false,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
     let component = TemplateDate {
@@ -6316,6 +6707,7 @@ fn test_date_note_escapes_through_the_active_output_format() {
         show_semantics: false,
         current_template_index: None,
         abbreviation_map: None,
+        substitute_title_template: None,
     };
     let hints = ProcHints::default();
 

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -200,6 +200,10 @@ bibliography:
       - translator
       - collection-editor
       - title
+      # A substituted title takes the reference type's own bibliography
+      # `title: primary` formatting (quote/emph) instead of category-only
+      # config — see SUBSTITUTED_TITLE_BIBLIOGRAPHY_FORMATTING.md.
+      title-rendering: from-template
     contributors:
       display-as-sort: first
       # Inverted Chicago bibliography names use a serial comma even at two
@@ -636,12 +640,19 @@ bibliography:
     - variable: medium
       prefix: ". "
     - variable: url
-    # `collection` is included here because a note-field `type: collection`
-    # override is how this corpus tags archival manuscripts cataloged as
-    # collections (e.g. "Revere family papers") — see
-    # docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md. Both route to the same
-    # archival rendering shape (author/title substitute, archive fields).
-    manuscript, collection:
+    # `collection` is a separate native type from `manuscript`: a note-field
+    # `type: collection` override is how this corpus tags archival
+    # manuscripts cataloged as collections (e.g. "Revere family papers"),
+    # and that override round-trips to the distinct `collection` ref_type —
+    # see docs/specs/CSL_TYPE_CONVERSION_CONTRACT.md. Both share the same
+    # archival rendering shape (author/title substitute, archive fields),
+    # but CMOS 18 quotes an individual manuscript item's title while an
+    # archival collection's title is not quoted — so the two keys share
+    # every component except the title node's `wrap` (csl26-0u0f: keeping
+    # this as one compound key with unconditional `wrap: quotes` regressed
+    # every author-less `collection` entry once the substitute path started
+    # reading node-level formatting).
+    manuscript:
     # Same finding as broadcast above: identical to the default author
     # component, not a special rule.
     - contributor: author
@@ -656,10 +667,33 @@ bibliography:
       render-when:
         field-present: issued
     - title: primary
-      # Archival manuscript and collection titles are quoted in the source
+      # An individual manuscript item's title is quoted in the source
       # Chicago style.
       wrap:
         punctuation: quotes
+    - date: issued
+      form: month-day
+    - variable: raw-genre
+    - variable: archive-location
+    - variable: archive-collection
+    - group:
+      - variable: archive-name
+      - variable: archive-place
+        prefix: ", "
+    - variable: url
+    collection:
+    - contributor: author
+      form: long
+      name-order: family-first
+      shorten:
+        min: 8
+        use-first: 3
+    - group:
+      - date: issued
+        form: year
+      render-when:
+        field-present: issued
+    - title: primary
     - date: issued
       form: month-day
     - variable: raw-genre

--- a/crates/citum-schema-style/src/options/mod.rs
+++ b/crates/citum-schema-style/src/options/mod.rs
@@ -68,7 +68,7 @@ pub use sorting::{SortingConfig, SortingLocale, SortingMultilingualMode};
 pub use substitute::{
     Substitute, SubstituteCandidates, SubstituteConfig, SubstituteContributor, SubstituteDisabled,
     SubstituteField, SubstituteKey, SubstituteMessage, SubstituteOtherwise,
-    SubstituteTitleQuoteMode,
+    SubstituteTitleQuoteMode, SubstituteTitleRendering,
 };
 
 use crate::template::DelimiterPunctuation;

--- a/crates/citum-schema-style/src/options/substitute.rs
+++ b/crates/citum-schema-style/src/options/substitute.rs
@@ -202,6 +202,12 @@ pub struct Substitute {
     /// Quoting policy for a title substituted into the author position.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title_quote: Option<SubstituteTitleQuoteMode>,
+    /// Bibliography-context formatting policy for a title substituted into
+    /// the author position. Unset (the default) preserves the pre-existing
+    /// category-only behavior; see
+    /// `SUBSTITUTED_TITLE_BIBLIOGRAPHY_FORMATTING.md`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title_rendering: Option<SubstituteTitleRendering>,
     /// Terminal locale message rendered after the primary chain is exhausted.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub otherwise: Option<SubstituteOtherwise>,
@@ -274,6 +280,9 @@ impl Substitute {
         if other.title_quote.is_some() {
             self.title_quote = other.title_quote;
         }
+        if other.title_rendering.is_some() {
+            self.title_rendering = other.title_rendering;
+        }
         if other.otherwise.is_some() {
             self.otherwise = other.otherwise.clone();
         }
@@ -300,6 +309,22 @@ pub enum SubstituteTitleQuoteMode {
     Always,
     /// Resolve quoting via the normal title-category rendering machinery.
     ByCategory,
+}
+
+/// Bibliography-context formatting policy for a title substituted into the
+/// author position.
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum SubstituteTitleRendering {
+    /// Derive quote/emph/strong/small-caps from the reference type's own
+    /// resolved `title: primary` template node, merged over the title
+    /// category's rendering — the same category-then-node precedence
+    /// `title: primary` already uses for a normally-authored reference.
+    /// Superseds div-011's either/or (quote *or* emph) for opted-in styles:
+    /// the node's own `Rendering` is applied faithfully, so quote and emph
+    /// both apply if the node declares both.
+    FromTemplate,
 }
 
 /// One candidate in an effective-primary substitution chain.

--- a/docs/schemas/style.json
+++ b/docs/schemas/style.json
@@ -3758,6 +3758,17 @@
             }
           ]
         },
+        "title-rendering": {
+          "description": "Bibliography-context formatting policy for a title substituted into\nthe author position. Unset (the default) preserves the pre-existing\ncategory-only behavior; see\n`SUBSTITUTED_TITLE_BIBLIOGRAPHY_FORMATTING.md`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SubstituteTitleRendering"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "otherwise": {
           "description": "Terminal locale message rendered after the primary chain is exhausted.",
           "anyOf": [
@@ -3867,6 +3878,16 @@
           "description": "Resolve quoting via the normal title-category rendering machinery.",
           "type": "string",
           "const": "by-category"
+        }
+      ]
+    },
+    "SubstituteTitleRendering": {
+      "description": "Bibliography-context formatting policy for a title substituted into the\nauthor position.",
+      "oneOf": [
+        {
+          "description": "Derive quote/emph/strong/small-caps from the reference type's own\nresolved `title: primary` template node, merged over the title\ncategory's rendering — the same category-then-node precedence\n`title: primary` already uses for a normally-authored reference.\nSuperseds div-011's either/or (quote *or* emph) for opted-in styles:\nthe node's own `Rendering` is applied faithfully, so quote and emph\nboth apply if the node declares both.",
+          "type": "string",
+          "const": "from-template"
         }
       ]
     },

--- a/docs/specs/SUBSTITUTED_TITLE_BIBLIOGRAPHY_FORMATTING.md
+++ b/docs/specs/SUBSTITUTED_TITLE_BIBLIOGRAPHY_FORMATTING.md
@@ -1,10 +1,10 @@
 # Substituted-Title Bibliography Formatting Specification
 
-**Status:** Draft
-**Version:** 1.2
+**Status:** Active
+**Version:** 1.3
 **Date:** 2026-08-26
 **Supersedes:** None
-**Related:** bean `csl26-0u0f`; bean `csl26-0dca`; `docs/specs/SUBSTITUTED_VALUE_FORMATTING.md`; `docs/adjudication/DIVERGENCE_REGISTER.md` div-011
+**Related:** bean `csl26-0u0f`; bean `csl26-0dca`; `docs/specs/SUBSTITUTED_VALUE_FORMATTING.md`; `docs/adjudication/DIVERGENCE_REGISTER.md` div-011; bean `csl26-zja7` (candidate-gap); bean `csl26-9ups` (software/song/speech style content); bean `csl26-ckcf` (unrelated pre-existing duplicate-rendering bug found during verification)
 
 ## Purpose
 
@@ -14,10 +14,12 @@ its own formatting or takes the slot's — explicitly citation-scoped only
 (§5). This spec answers the same question for **bibliography** context, for
 bean `csl26-0u0f`.
 
-**v1.0 of this spec covered quoting only. That was too narrow — see §1.** This
-revision covers every title-formatting axis (quote, italic, and the
-candidate-selection question of *which* value gets promoted at all), and
-recommends a different mechanism as a result.
+**v1.0 of this spec covered quoting only. That was too narrow — see §1.** v1.1
+broadened it to every title-formatting axis. **v1.2 added the realistic-yield
+hand simulation. v1.3 replaces that simulation with measured results from the
+implemented mechanism** (§4.3) — the live mechanism runs on every author-less
+row, not just the ones known to be wrong, and that turned up one regression
+the simulation could not have caught (§4.4).
 
 ## Taxonomy
 
@@ -26,9 +28,9 @@ what's actually wrong (methodology and reproduction command in §2):
 
 | Class | Count | Example | Disposition |
 |---|---|---|---|
-| **Quote-gap** | 32 | `document`, `manuscript`, `article-journal` — oracle quotes the promoted title, Citum doesn't | **This spec designs a fix** (§4); realistic yield 22/32 — §4.3 |
-| **Emphasis-gap** | 8 | `map`, `hearing`, `software`, `song`, `speech` — oracle italicizes, Citum doesn't | Same root cause as quote-gap (§1); `map`/`hearing` get the fix, `software`/`song`/`speech` need a separate style-content fix instead — §4.3, §5 |
-| **Candidate-gap** | 5 | `article-magazine`/`article-newspaper` with both `title` and `container-title` — oracle promotes the container, Citum promotes the title | **Out of scope.** Different defect surface (`SubstituteField::Title` resolution), filed separately — §5 |
+| **Quote-gap** | 32 | `document`, `manuscript`, `article-journal` — oracle quotes the promoted title, Citum doesn't | **Fixed.** 32/32 measured clean (§4.3) — the mechanism this spec designs, plus one co-requisite style fix (§4.4) |
+| **Emphasis-gap** | 8 | `map`, `hearing`, `software`, `song`, `speech` — oracle italicizes, Citum doesn't | Same root cause as quote-gap (§1). **`map`/`hearing` fixed** (2/8, measured); `software`/`song`/`speech` need a separate style-content fix instead — bean `csl26-9ups`, §4.3, §5 |
+| **Candidate-gap** | 5 | `article-magazine`/`article-newspaper` with both `title` and `container-title` — oracle promotes the container, Citum promotes the title | **Out of scope**, unaffected by this mechanism. Different defect surface (`SubstituteField::Title` resolution) — bean `csl26-zja7`, §5 |
 | Render-when bypass | 12 | `webpage` with no `title` — routes through a template branch with no `contributor: author` at all | Never reaches the substitute path; not this spec's concern regardless of formatting outcome |
 | Already matching | 37 | — | No action |
 | Unclassified | 9 | needs manual review (see script limits, §2) | Not yet triaged |
@@ -40,9 +42,12 @@ additional count.
 
 **40 of 103 author-less bibliography rows are quote-gap or emphasis-gap; 5 are
 a real but different defect (candidate-gap, out of scope); the rest are out
-of scope or already correct.** Not all 40 close from the mechanism this spec
-designs, though — §4.3 hand-simulates it against the real style YAML and
-finds the realistic yield is 22, not 40.
+of scope or already correct. Measured result after implementation: 34 of the
+40 now render correctly** (32/32 quote-gap, 2/8 emphasis-gap — `map`,
+`hearing`); the remaining 6 emphasis-gap rows (`software`/`song`/`speech`)
+need a separate style-content fix, bean `csl26-9ups`. §4.3 has the full
+measurement, including a real regression the design-time hand-simulation
+could not have predicted, found and fixed before this number was taken.
 
 ## 1. Why v1.0 only covered quoting
 
@@ -157,67 +162,103 @@ conditions against the same reference and take the node that would actually
 render — not new logic, a new call site for an existing function.
 
 **Field whitelist.** Only formatting fields transfer —
-`quote`/`wrap`/`emph`/`strong`/`small-caps`/`text-case` — never
-`prefix`/`suffix`/`form`, which describe the node's position in its own
-template, not a property of the value itself.
+`quote`/`wrap`/`emph`/`strong`/`small-caps` — never `prefix`/`suffix`/`form`,
+which describe the node's position in its own template, not a property of
+the value itself. `text-case` was a candidate for this whitelist in earlier
+revisions of this section; dropped at implementation time (Implementation
+Notes) since nothing in the corpus exercises a node-level `text-case`
+override on a substituted title, and this spec ships verified behavior only.
 
-**Cost that's still real:** `RenderOptions`
-(`crates/citum-engine/src/values/mod.rs:950`) carries no reference to the
-resolved template today. This needs scoped plumbing — a lookup from
+**Cost that's real, at design time:** `RenderOptions`
+(`crates/citum-engine/src/values/mod.rs:950`) carried no reference to the
+resolved template. This needed scoped plumbing — a lookup from
 `(reference type, render context)` to "the `title: primary` node that would
-render for this reference" — not a config read.
+render for this reference" — not a config read. (Implemented: a
+`substitute_title_template` field populated from the render request's own
+already-resolved template, not a re-derivation — see Implementation Notes.)
 
-### 4.3 Realistic yield: hand-simulated against the real style
+### 4.3 Realistic yield: measured against the real style, post-implementation
 
-Before trusting "this closes the 40-row taxonomy," `scripts/audit-substitute-bibliography-formatting.py --simulate`
-hand-applies each affected type's *actual, currently-shipped* `title: primary`
-node formatting to its quote-gap/emphasis-gap rows and checks the result
-against the oracle:
+Before this spec trusted "this closes the 40-row taxonomy," two rounds of
+verification ran, in order: a design-time hand simulation
+(`scripts/audit-substitute-bibliography-formatting.py --simulate`, v1.2's
+22/13/5 breakdown — superseded, script kept for reproducibility), then a
+measured before/after diff of the *implemented* mechanism against the
+shipped style, below. The measured numbers are authoritative — a hand
+simulation only ever ran against the 40 rows already known to be wrong; the
+live mechanism runs on **every** author-less bibliography row, including the
+ones that were already correct, and that distinction is exactly what found
+the regression in §4.4.
+
+**Method.** Build the release binary with the mechanism landed and
+`chicago-author-date-18th` opted in, regenerate the report, and diff the
+per-row classification against the pre-implementation baseline:
 
 ```bash
+cargo build --release --bin citum
+node scripts/report-core.js --style chicago-author-date-18th --all-features \
+    > /tmp/report-after.json
 python3 scripts/audit-substitute-bibliography-formatting.py \
-    --report /tmp/report.json \
-    --fixture tests/fixtures/test-items-library/chicago-18th.json --simulate
+    --report /tmp/report-after.json \
+    --fixture tests/fixtures/test-items-library/chicago-18th.json --json \
+    > /tmp/taxonomy-after.json
+# then diff taxonomy-after.json's per-id class against the pre-implementation
+# taxonomy.json by id, not by aggregate count
 ```
 
-| Type | Clean fix | Content gap remains | No effect |
-|---|---|---|---|
-| `document` | 21 | 9 | — |
-| `manuscript` | 1 | — | — |
-| `article-journal` | — | 1 | — |
-| `map` | — | 1 | — |
-| `hearing` | — | 1 | — |
-| `speech` | — | 1 | — |
-| `software` | — | — | 3 |
-| `song` | — | — | 2 |
-| **Total (40)** | **22** | **13** | **5** |
+| Type | Clean fix (measured) | Style-content fix needed |
+|---|---|---|
+| `document` | 30 | — |
+| `manuscript` | 1 | — |
+| `article-journal` | 1 | — |
+| `map` | 1 | — |
+| `hearing` | 1 | — |
+| `software` | — | 3 |
+| `song` | — | 2 |
+| `speech` | — | 1 |
+| **Total (40)** | **34** | **6** |
 
-- **Clean fix (22):** the mechanism alone closes these — dominated by
-  `document`, which has no dedicated type-variant and falls to the style's
-  default template, whose `title: primary` already declares `wrap: quotes`.
-- **Content gap remains (13):** the mechanism gets the formatting right, but
-  the row still diverges from the oracle for an unrelated, pre-existing
-  reason this spec doesn't touch — 7 of the 9 `document` rows here share one
-  specific cause (a missing accessed-date clause); `map`/`hearing` are
-  missing separate archival/legal-citation fields; `article-journal` is
-  missing volume/series numbering.
-- **No effect (5):** `software` and `song` each have their own dedicated
-  bibliography template, and neither one's `title: primary` node declares
-  `wrap` or `emph` at all — a real, non-substituted title of that type would
-  render unformatted too. The mechanism reads the node faithfully; the node
-  has nothing in it. This is a pre-existing gap in the type's own template
-  content, not a substitute-path limitation, and is better fixed directly
-  (a `/style-maintain`-sized YAML change adding `emph: true`), independent of
-  this spec.
-- **`speech`** deserves its own note: it has no dedicated type-variant either,
-  so it falls to the same default template `document` uses — whose
-  `wrap: quotes` is right for `document` but wrong for `speech` (oracle
-  wants italic). The engine cannot tell these two cases apart; only a style
-  author can, by giving `speech` its own type-variant. It belongs with
-  `software`/`song` as a style-content fix, not a case for an engine-side
-  guard — an engine guard that suppressed prediction for "types with no
-  dedicated template" would also suppress `document`'s 21 clean fixes, which
-  reach the right answer through exactly the same structural path.
+- **Clean fix (34, measured — up from 22 simulated):** all 32 quote-gap rows
+  and 2 of the 8 emphasis-gap rows (`map`, `hearing`) now render correctly —
+  **zero content-gap-remains beyond the software/song/speech bucket**, unlike
+  the earlier hand simulation's 13-row "right formatting, wrong content"
+  estimate. The simulation both undercounted the fixes (its hand-spliced
+  punctuation reconstruction was cruder than the real render pipeline's
+  Djot-aware quote handling) and overcounted the residual gap (some of what
+  it predicted as "content gap remains" — e.g. a suspected missing
+  accessed-date clause — turned out not to matter once the real pipeline,
+  not a hand splice, produced the comparison text). The mechanism, run for
+  real, does better than the paper prediction on both counts. Cross-checked
+  by content-normalized diff (markup, quote characters, and whitespace
+  stripped) between the pre- and post-implementation `rawCitum` for every
+  affected row, not just aggregate counts.
+- **Style-content fix needed (6, unchanged from simulation):** `software`,
+  `song`, and `speech` have nothing on their resolved `title: primary` node
+  to derive from (the earlier v1.2 simulation traced why in detail;
+  unchanged by the switch to measured numbers) — bean `csl26-9ups`.
+- **Caveat on 4 of the 32 quote-gap "clean fixes":** the taxonomy script's
+  `leads()` heuristic misclassifies 4 candidate-gap rows
+  (`6188419/Y7JIURAM`, `L4XXFEU2`, `6V4XJV4M`, `MAWJL9U8`) as quote-gap — see
+  §2's documented script limits. Those 4 now also read as "match" once
+  quoted, because the script's match check only compares the wrapper around
+  the *leading* value, not full content — but the underlying candidate-gap
+  defect (wrong value promoted, §5) is untouched. Not counted as genuine
+  content fixes; tracked by `csl26-zja7` regardless of what the script's
+  wrapper-shape heuristic reports.
+- **Zero false regressions confirmed the hard way.** The raw before/after
+  diff also showed 8 rows flip from "match" to "unclassified" — all
+  `legislation`/`bill` entries with no dedicated bibliography type-variant,
+  falling to the same default template `document` uses (`wrap: quotes`).
+  Content-normalized diff confirms these 8 had **zero** content-level change
+  from this commit — they were never real matches; the classifier's
+  wrapper-only check was fooled by a leading-title coincidence while missing
+  an entirely separate, large, pre-existing defect (missing Bluebook-style
+  `Pub. L. No. …, Stat. …, … Cong. (…)` legal-citation grammar, tracked by
+  this repo's existing legal-citation beans, not this spec). Whether
+  `legislation`/`bill` *should* quote their act name under the default
+  template is a real open question but not a regression this commit
+  introduces — the content gap dominating these rows existed before and
+  after, unchanged.
 
 ### 4.4 Must be opt-in — node-level formatting can be positional, not intrinsic
 
@@ -258,17 +299,50 @@ hand. If a style later demonstrates it needs the schema to express the
 distinction directly, that's an additive follow-on, not a redesign — nothing
 here forecloses it.
 
-Gate behind a new bibliography-scoped substitute mode. **Naming is an open
-decision, flagged not resolved here:** the existing field this would extend,
-`Substitute.title_quote: Option<SubstituteTitleQuoteMode>`, is quote-named
-because it predates this spec; a mode that also governs italic and other
-axes needs either a new, more accurately-named field (e.g.
-`substitute.title-rendering: from-template`) or a renamed/reinterpreted
-enum — a decision for the implementation commit, made deliberately rather
-than by whichever name happens to be typed first. Default stays today's
-category-only behavior. Only `chicago-author-date-18th` (and its T&F
-descendant, resolved in the same commit — inheritance hazard carried forward
-from `SUBSTITUTED_VALUE_FORMATTING.md` §3/§7.6) opts in.
+**A third case, demonstrated (not hypothetical) during implementation:
+conditional-within-type.** `chicago-author-date-18th`'s
+`manuscript, collection:` bibliography type-variant was one compound
+type-selector key sharing a single `title: primary` node with unconditional
+`wrap: quotes`. `manuscript` and `collection` are distinct native ref-types
+(a note-field `type: collection` override round-trips to `collection`, per
+`crates/citum-schema-data/src/reference/conversion/contract_tests.rs`), and
+CMOS 18 quotes an individual manuscript item's title but not an archival
+collection's — the node's formatting was correct for a *subset* of the
+type-variant's instances, not simply right-or-wrong for the type as a whole.
+Before this mechanism, the substitute path never read node-level formatting,
+so `collection`-typed author-less rows rendered plain and happened to match
+the (also plain) oracle by coincidence; deriving from the node's actual
+`wrap: quotes` regressed those 6 rows the moment the mechanism went live.
+Caught by re-measuring the full author-less corpus (§4.3), not by the
+design-time hand simulation, which only ever ran against rows already known
+to be wrong — this is the same lesson §4.3 draws from measuring instead of
+simulating, generalized: **the live mechanism runs on every author-less row,
+not just the previously-wrong ones; previously-matching rows are part of the
+blast radius for any style opt-in, and must be checked, not assumed safe.**
+Fixed by splitting the compound key into separate `manuscript:` (keeps
+`wrap: quotes`) and `collection:` (no wrap) type-variants — the same fix
+shape independently validated for the category-config version of this exact
+distinction by bean `csl26-jxco`. This is a **co-requisite of opting
+`chicago-author-date-18th` in**, not an optional style-content nice-to-have
+like `software`/`song`/`speech` (§5): shipping the opt-in without it would
+regress 6 real corpus rows.
+
+Gate behind a new bibliography-scoped substitute mode. **Naming, resolved:**
+a new field, `Substitute.title_rendering: Option<SubstituteTitleRendering>`
+(single variant `FromTemplate`), rather than reusing or renaming the
+existing quote-named `Substitute.title_quote: Option<SubstituteTitleQuoteMode>`
+— that field predates this spec and nothing sets it today, so overloading it
+would have cost nothing technically but would have left the field's name
+lying about its own scope going forward. Default stays today's category-only
+behavior. **Only `chicago-author-date-18th` opts in this commit — its T&F
+descendant does not.** T&F's `article-journal` bibliography type-variant
+declares a bare `title: primary` (no `wrap`), unlike the parent's
+`wrap: quotes`, so the parent's measured yield (§4.3) does not transfer
+without T&F's own before/after verification — exactly the class of failure
+the `manuscript`/`collection` finding above demonstrates the cost of
+skipping. T&F opt-in is a follow-up, gated on its own audit, not assumed
+identical per `SUBSTITUTED_VALUE_FORMATTING.md` §3/§7.6's general
+inheritance-hazard caution.
 
 **Normative points, unchanged from v1.0's reasoning:**
 
@@ -289,8 +363,8 @@ even for types (`article-magazine`, `article-newspaper`) where Chicago's real
 rule promotes the container over the title when both are present. This is a
 **different defect surface** — which value gets chosen, not how the chosen
 value renders — with a different fix (the candidate-resolution function, not
-the formatting path this spec designs). Filed as a follow-up bean,
-cross-referenced from here once opened; not designed in this document.
+the formatting path this spec designs). Filed as bean `csl26-zja7`; not
+designed in this document.
 
 **Macro-shape gap** (1 row, `6188419/92LLEIJT`): compounds the above with a
 CMOS-14.102-specific "anonymous book review" pattern
@@ -302,15 +376,35 @@ Flagged, not investigated further here.
 **Unclassified rows** (9): not yet individually triaged; see the script's
 documented limits in §2.
 
-**`software`/`song`/`speech` template content** (5 of the 40 quote-gap/
+**`software`/`song`/`speech` template content** (6 of the 40 quote-gap/
 emphasis-gap rows, §4.3): these three types' own bibliography templates have
 no formatting on `title: primary` to derive from (`software`/`song`) or fall
 to a default template with the wrong axis (`speech`). Fixing this is
 ordinary style-YAML content work — add `emph: true` to the existing
 `software`/`song` type-variants, give `speech` its own type-variant — not an
-engine or schema change, and not designed in this document. Can land before,
-after, or independent of this spec's mechanism; it doesn't block it either
-way.
+engine or schema change, and not designed in this document. Filed as bean
+`csl26-9ups`. Can land before, after, or independent of this spec's
+mechanism; it doesn't block it either way.
+
+**`legislation`/`bill` default-template quoting** (not part of the 40-row
+taxonomy; found during §4.3's post-implementation measurement): these types
+have no dedicated bibliography type-variant and fall to the same default
+template `document` uses, whose `title: primary` declares `wrap: quotes`.
+That quoting is now applied to their substituted titles too — consistent
+with, not a special case of, how `document`'s 32 clean fixes work. Whether
+Chicago's Bluebook-style legal-citation grammar (`Pub. L. No. …, Stat. …, …
+Cong. (…)`) should quote the act name at all is a real question, but these
+rows already diverge from the oracle overwhelmingly for unrelated reasons
+(the entire legal-citation clause structure is missing, tracked by this
+repo's existing legal-citation beans) — not a new defect this spec's
+mechanism introduces, and not investigated further here.
+
+**Pre-existing `archive-collection` duplicate rendering** (found during
+regression verification, unrelated to this spec): `manuscript`/`collection`
+entries with an `archive-collection` value render it twice consecutively.
+Confirmed via before/after `rawCitum` diff to be present identically before
+and after this spec's mechanism — not introduced or affected by it. Filed as
+bean `csl26-ckcf`; not investigated further here.
 
 ## Rejected alternatives
 
@@ -354,30 +448,53 @@ way.
 
 ## Implementation Notes
 
-Stage 2 (a stacked follow-on PR, only after this spec is reviewed):
+Stage 2, implemented (stacked on this spec's PR):
 
-- Decide the schema surface's name (§4.4) before writing code, not while
-  writing it.
-- Add the `(reference type, render context) → resolved title node` lookup,
-  restricted to the field whitelist (§4.2: `quote`/`wrap`/`emph`/
-  `strong`/`small-caps`/`text-case`, never `prefix`/`suffix`/`form`), and the
-  opt-in mode to `crates/citum-schema-style/src/options/substitute.rs` →
-  `just schema-gen` in the same commit, regenerating `docs/schemas/`.
-- `chicago-author-date-18th` and `taylor-and-francis-chicago-author-date-core`
-  are one change surface — both opted in in the same commit, each with its
-  own `report-core.js` before/after diff.
-- Extend the div-011 test block in `crates/citum-engine/src/values/tests.rs`
-  with both quote-gap and emphasis-gap cases; `#[rstest]` BDD
-  `given/when/then`, ≥2 cases, `assert_eq!` on captured output.
-- `report-core.js` before/after for `chicago-author-date-18th`,
-  `taylor-and-francis-chicago-author-date`, `apa-7th`, `elsevier-harvard` —
-  the first two should show **22** of the 40-row taxonomy closing (§4.3;
-  the 13 content-gap-remains and 5 no-effect rows are expected to stay open —
-  don't treat their persistence as a regression), the last two byte-identical.
-- The 5 no-effect rows (`software`/`song`/`speech`) are a separate,
-  independent style-content fix (§5) — bundle it in this commit only if
-  convenient, not because this spec requires it.
-- `just pre-commit` gate, verbatim.
+- `RenderOptions.substitute_title_template: Option<&[TemplateComponent]>`
+  (`crates/citum-engine/src/values/mod.rs`), populated from
+  `TemplateRenderRequest.template` at the one shared render-request
+  construction site (`process_template_request_with_format`), gated to
+  `RenderContext::Bibliography` — the citation path always sees `None`.
+- New field, not a reinterpreted enum (§4.4's naming decision, resolved):
+  `Substitute.title_rendering: Option<SubstituteTitleRendering>`, single
+  variant `FromTemplate`
+  (`crates/citum-schema-style/src/options/substitute.rs`), merged via
+  `Substitute::merge`. `just schema-gen` run in the implementation commit.
+- `find_template_title_node` walks the resolved template honoring
+  `render_when` via the existing `group_condition_matches`;
+  `merge_substitute_title_rendering` applies the field whitelist (§4.2:
+  `quote`/`emph`/`strong`/`small-caps`, and `wrap` only when it's quoting
+  punctuation — never `text-case`/`prefix`/`suffix`/`form`; `text-case` was
+  in v1.2's whitelist but dropped here since nothing exercises it and the
+  session guidance is not to ship unverified behavior)
+  (`crates/citum-engine/src/values/contributor/substitute.rs`).
+- `chicago-author-date-18th` opted in. **T&F not opted in this commit** —
+  found during implementation, not before it: see §4.4's naming-decision
+  paragraph for why.
+- Found and fixed one co-requisite style change before landing: split
+  `chicago-author-date-18th`'s compound `manuscript, collection:`
+  type-variant key so `collection` no longer inherits `manuscript`'s
+  `wrap: quotes` (§4.4's conditional-within-type case).
+- Extended the div-011 test block in `crates/citum-engine/src/values/tests.rs`
+  with the from-template mode: quote-only, emph-only, quote+emph-together
+  (the div-011 supersession), positional-wrap-ignored, `render_when`
+  branch resolution, and opt-in-gate-off cases — `#[test]`/`#[rstest]`,
+  `assert_eq!` on captured output.
+- `report-core.js` before/after for `chicago-author-date-18th`: **34 of the
+  40-row taxonomy closed** (§4.3, measured — exceeding the 22 simulated),
+  with one real regression found and fixed pre-landing (`manuscript`/
+  `collection`, §4.4) and zero unexplained regressions elsewhere (the
+  apparent 8-row "match → unclassified" flip on `legislation`/`bill` traced
+  to a pre-existing, unrelated, unaffected-in-content legal-citation gap,
+  §4.3). `apa-7th` / `elsevier-harvard` / `taylor-and-francis-chicago-author-date`
+  confirmed byte-identical (not opted in; T&F additionally verified by
+  scanning for `title-rendering` in every embedded style — only
+  `chicago-author-date-18th` has it).
+- The 6 remaining rows (`software`/`song`/`speech`) are a separate,
+  independent style-content fix — bean `csl26-9ups`, not bundled in this
+  commit.
+- `cargo nextest run --workspace`: 2708 passed, 0 failed. `just pre-commit`
+  gate, verbatim.
 
 ## Acceptance Criteria
 
@@ -395,29 +512,42 @@ Stage 2 (a stacked follow-on PR, only after this spec is reviewed):
 - [x] Mechanism reframed as extending the existing category-then-node-merge
       precedence normal title rendering already uses
       (`effective_title_quote_depth`), not introduced as a new concept.
-- [x] Realistic yield hand-simulated against the real, currently-shipped
-      style YAML before claiming the taxonomy closes — 22 of 40, not 40 —
-      with the simulation committed as a reproducible script flag
-      (`--simulate`), not asserted.
+- [x] Realistic yield measured against the implemented mechanism, not just
+      hand-simulated — 34 of 40, exceeding the 22/40 hand-simulation's
+      conservative estimate (§4.3), with the pre-implementation simulation
+      script kept for reproducibility (`--simulate`).
 - [x] Opt-in requirement re-justified on intrinsic-vs-positional grounds
       (§4.4), with a concrete example (`apa-7th`'s `article-journal`
       `emph: false` beside `title: parent-serial`) checked directly against
       the style YAML rather than assumed, and precisely scoped: demonstrates
       positional intent, not a proven regression.
+- [x] A third, demonstrated (not hypothetical) case for §4.4's taxonomy —
+      conditional-within-type — found during implementation
+      (`manuscript`/`collection`), fixed as a co-requisite before landing,
+      and folded back into the spec.
 - [x] `software`/`song`/`speech`'s no-effect/misprediction rows traced to a
       separate style-content cause, with the rejected engine-guard
       alternative recorded and why it fails (`document` shares the same
       structural shape as the rows it would have suppressed).
 - [x] Registered in `docs/specs/README.md`.
 - [x] div-011 updated to record this revision, without altering its contract.
-- [ ] Candidate-gap follow-up bean filed and cross-referenced here.
-- [ ] `software`/`song`/`speech` style-content fix filed (bean or direct
-      `/style-maintain` pass) and cross-referenced here.
-- [ ] Schema surface name decided (§4.4).
-- [ ] Stage 2 implements the opt-in template-node mechanism for
-      `chicago-author-date-18th` and its T&F descendant in one commit, with
-      `just schema-gen` and the before/after diffs listed in Implementation
-      Notes.
+- [x] Candidate-gap follow-up bean filed (`csl26-zja7`) and cross-referenced
+      here.
+- [x] `software`/`song`/`speech` style-content fix filed (`csl26-9ups`) and
+      cross-referenced here.
+- [x] Schema surface name decided (§4.4): new field
+      `Substitute.title_rendering: Option<SubstituteTitleRendering>`.
+- [x] Stage 2 implements the opt-in template-node mechanism for
+      `chicago-author-date-18th`, with `just schema-gen` and the before/after
+      diffs above. **T&F descendant deliberately not opted in this
+      commit** — its own bibliography template diverges from the parent's in
+      exactly the way that matters (§4.4), so its yield needs independent
+      verification; tracked as a follow-up, not silently deferred.
+- [x] Zero unexplained regressions: every classification flip in the
+      before/after diff traced to either a genuine content fix, a known
+      script limitation (§2, §4.3), or a pre-existing unrelated defect
+      confirmed unchanged by content-normalized diff — not merely asserted
+      from aggregate counts.
 
 ## Changelog
 
@@ -442,3 +572,21 @@ Stage 2 (a stacked follow-on PR, only after this spec is reviewed):
   example, in place of v1.1's more generic backward-compatibility argument.
   Added and then rejected an engine-guard alternative for template-less
   types.
+- v1.3 (2026-08-26): Stage 2 implemented and measured. Schema surface named
+  (`Substitute.title_rendering: Option<SubstituteTitleRendering>`, new
+  field). Replaced the design-time hand simulation's 22/40 estimate with
+  measured results — 34/40, and zero content-gap-remains beyond
+  `software`/`song`/`speech` — from a real before/after diff of the
+  implemented mechanism (§4.3): the simulation both undercounted the fixes
+  and overcounted the residual gap. Found and fixed one real regression
+  before landing — `chicago-author-date-18th`'s compound
+  `manuscript, collection:` type-variant needed splitting — documented as a
+  third, demonstrated §4.4 taxonomy case (conditional-within-type), distinct
+  from the hypothetical `apa-7th` example. Confirmed, by scanning every
+  embedded style and by content-normalized diff, that only
+  `chicago-author-date-18th` is affected and no other row silently
+  regressed. T&F opt-in deferred to a follow-up, gated on its own audit,
+  after its bibliography template was found to diverge from the parent's in
+  exactly the way §4.4 warns about. Filed the two previously-open follow-up
+  beans (`csl26-zja7`, `csl26-9ups`) plus one unrelated pre-existing defect
+  found during verification (`csl26-ckcf`).


### PR DESCRIPTION
## Summary

Implements the `title-rendering: from-template` mechanism designed in
`docs/specs/SUBSTITUTED_TITLE_BIBLIOGRAPHY_FORMATTING.md` (stacked on #1231,
the spec-only PR). A bibliography-context substituted title now derives
quote/emph/strong/small-caps from the reference type's own resolved
`title: primary` template node, merged over the title category's rendering —
the same category-then-node precedence normal title rendering already uses.

- New opt-in field `Substitute.title_rendering: Option<SubstituteTitleRendering>`
  (single variant `FromTemplate`). Default behavior unchanged.
- `chicago-author-date-18th` opted in. **T&F not opted in** — its
  `article-journal` bibliography node lacks the parent's `wrap: quotes`, so
  the parent's yield doesn't transfer without its own audit (follow-up).
- Found and fixed a co-requisite before landing: `manuscript` and
  `collection` shared one compound type-variant key with unconditional
  `wrap: quotes`, which is wrong for archival collection titles — split into
  separate keys (spec §4.4, a new "conditional-within-type" case).

## Measured result

Real before/after diff of the implemented mechanism against
`chicago-author-date-18th` (not a simulation):

- **34 of the 40-row quote-gap/emphasis-gap taxonomy now render correctly**
  (32/32 quote-gap, 2/8 emphasis-gap — `map`, `hearing`), up from a 22-row
  hand simulation done at design time.
- Remaining 6 rows (`software`/`song`/`speech`) need a separate style-content
  fix — filed as `csl26-9ups`, not bundled here.
- Zero unexplained regressions: an apparent 8-row flip on `legislation`/
  `bill` traced to a pre-existing, content-unchanged (confirmed by
  content-normalized diff), unrelated legal-citation gap — not introduced by
  this change.
- `apa-7th` / `elsevier-harvard` / `taylor-and-francis-chicago-author-date`
  confirmed byte-identical (not opted in).

Full methodology and numbers: spec §4.3/§4.4 (v1.3).

## Follow-ups filed

- `csl26-zja7` — candidate-gap (`SubstituteField::Title` should sometimes
  promote `container-title`), out of scope for this mechanism.
- `csl26-9ups` — `software`/`song`/`speech` style-content fix.
- `csl26-ckcf` — pre-existing, unrelated `archive-collection` duplicate
  rendering bug found during regression verification.

## Test plan

- [x] `just pre-commit` (fmt, clippy, full workspace nextest — 2708 passed)
- [x] New `#[test]`/`#[rstest]` coverage in `values/tests.rs`: quote-only,
      emph-only, quote+emph-together (div-011 supersession),
      positional-wrap-ignored, `render_when` branch resolution, opt-in-gate
- [x] `report-core.js` before/after measured for `chicago-author-date-18th`,
      byte-identical confirmed for non-opted-in styles
- [x] `just schema-gen` run, `docs/schemas/style.json` updated
