### PR TITLE
chore(styles): add yaml schema hint to all styles

### DIFF
--- a/.beans/archive/csl26-154x--add-yaml-language-server-schema-hint-to-all-style.md
+++ b/.beans/archive/csl26-154x--add-yaml-language-server-schema-hint-to-all-style.md
@@ -1,0 +1,19 @@
+---
+# csl26-154x
+title: Add yaml-language-server schema hint to all style files
+status: completed
+type: task
+priority: normal
+tags:
+    - tooling
+    - chore
+    - style
+created_at: 2026-08-26T22:27:43Z
+updated_at: 2026-08-26T22:28:18Z
+---
+
+50 of 56 style YAML files lack the # yaml-language-server: $schema=... hint line that apa-7th.yaml and the experimental styles already carry. Add it as the first line of each so editors get schema validation/completion.
+
+## Summary of Changes
+
+Added `# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json` as the first line of all 50 style YAML files that lacked it (6 already had it: apa-7th and 5 experimental styles). Verified with `node scripts/validate-schemas.js --scope=styles,locales` — all pass.

--- a/.github/workflows/fidelity.yml
+++ b/.github/workflows/fidelity.yml
@@ -56,7 +56,19 @@ jobs:
           style_files="$(printf '%s\n' "$changed" | grep -E '^styles/(embedded/)?[^/]+\.yaml$' || true)"
 
           if [ -n "$style_files" ] && [ -z "$broad" ]; then
-            styles="$(printf '%s\n' "$style_files" | sed -E 's#^styles/(embedded/)?##; s#\.yaml$##' | sort -u | paste -sd, -)"
+            # report-core.js's SKIPPED_STYLES excludes these from its corpus
+            # entirely (no CSL oracle, or hidden inheritance roots) — passing
+            # one to --styles crashes with "Unknown style name(s)". Keep this
+            # list in sync with SKIPPED_STYLES in scripts/report-core.js.
+            styles="$(printf '%s\n' "$style_files" \
+              | sed -E 's#^styles/(embedded/)?##; s#\.yaml$##' \
+              | grep -vE '^(alpha|chicago-18-base|chicago-notes-18th-script)$' \
+              | sort -u | paste -sd, -)"
+          else
+            styles=""
+          fi
+
+          if [ -n "$styles" ]; then
             echo "mode=selected" >> "$GITHUB_OUTPUT"
             echo "styles=$styles" >> "$GITHUB_OUTPUT"
             echo "Running fidelity for changed styles: $styles"

--- a/crates/citum-schema-style/embedded/styles/american-medical-association.yaml
+++ b/crates/citum-schema-style/embedded/styles/american-medical-association.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: American Medical Association Manual of Style 11th edition
   description: 'AMA Manual of Style: A Guide for Authors and Editors (11th ed.)'

--- a/crates/citum-schema-style/embedded/styles/apa-7th.yaml
+++ b/crates/citum-schema-style/embedded/styles/apa-7th.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: American Psychological Association 7th edition
   fields:

--- a/crates/citum-schema-style/embedded/styles/chicago-18-base.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-18-base.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Chicago Manual of Style 18th edition — shared component base (hidden)
   description: >-

--- a/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-author-date-18th.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 extends: chicago-18-base
 info:
   title: Chicago Manual of Style 18th edition (author-date)

--- a/crates/citum-schema-style/embedded/styles/chicago-notes-18th-script.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-notes-18th-script.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Chicago Manual of Style 18th edition (notes) — romanized + original script
   description: >-

--- a/crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 extends: chicago-18-base
 info:
   title: Chicago Manual of Style 18th edition (notes without bibliography)

--- a/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 extends: chicago-notes-18th
 info:
   title: Chicago Manual of Style 18th edition (shortened notes and bibliography)

--- a/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography.yaml
+++ b/crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Chicago Manual of Style 18th edition (shortened notes and bibliography)
   description: Chicago-style source citations (with Bluebook for legal citations), shortened author-title notes and bibliography system

--- a/crates/citum-schema-style/embedded/styles/elsevier-harvard-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/elsevier-harvard-core.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Elsevier (author-date/Harvard, with titles)
   fields:

--- a/crates/citum-schema-style/embedded/styles/elsevier-harvard.yaml
+++ b/crates/citum-schema-style/embedded/styles/elsevier-harvard.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Elsevier (author-date/Harvard, with titles)
   fields:

--- a/crates/citum-schema-style/embedded/styles/elsevier-vancouver-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/elsevier-vancouver-core.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Elsevier - NLM/Vancouver (citation-sequence)
   description: A style for some Elsevier journals, resembles Vancouver style

--- a/crates/citum-schema-style/embedded/styles/elsevier-vancouver.yaml
+++ b/crates/citum-schema-style/embedded/styles/elsevier-vancouver.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Elsevier - NLM/Vancouver (citation-sequence)
   description: A style for some Elsevier journals, resembles Vancouver style

--- a/crates/citum-schema-style/embedded/styles/elsevier-with-titles-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/elsevier-with-titles-core.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Elsevier (numeric, with titles)
   description: A style for many of Elsevier's journals that includes article titles in the reference list

--- a/crates/citum-schema-style/embedded/styles/elsevier-with-titles.yaml
+++ b/crates/citum-schema-style/embedded/styles/elsevier-with-titles.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Elsevier (numeric, with titles)
   description: A style for many of Elsevier's journals that includes article titles in the reference list

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-author-date.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-author-date.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 extends: gb-t-7714-2025-base
 version: 0.71.0
 info:

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-base.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-base.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 version: 0.71.0
 info:
   title: GB/T 7714—2025 shared bibliography base (hidden)

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-note.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-note.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 extends: gb-t-7714-2025-base
 version: 0.71.0
 info:

--- a/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-numeric.yaml
+++ b/crates/citum-schema-style/embedded/styles/gb-t-7714-2025-numeric.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 extends: gb-t-7714-2025-base
 version: 0.71.0
 info:

--- a/crates/citum-schema-style/embedded/styles/ieee.yaml
+++ b/crates/citum-schema-style/embedded/styles/ieee.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: IEEE Reference Guide version 11.29.2023
   description: IEEE style as per the 2023 guidelines.

--- a/crates/citum-schema-style/embedded/styles/modern-language-association.yaml
+++ b/crates/citum-schema-style/embedded/styles/modern-language-association.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Modern Language Association Handbook 9th edition (in-text citations)
   description: MLA source citations, in-text citations system (chapter 6)

--- a/crates/citum-schema-style/embedded/styles/springer-basic-author-date-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/springer-basic-author-date-core.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Springer - Basic (author-date)
   description: Springer Author Date Style for the disciplines Medicine, Biomedicine, Life Sciences, Chemistry, Geosciences, Computer Science, Engineering, Economics. This style is based on Harvard style and recommendations of the Council of Biology Editors.

--- a/crates/citum-schema-style/embedded/styles/springer-basic-author-date.yaml
+++ b/crates/citum-schema-style/embedded/styles/springer-basic-author-date.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Springer - Basic (author-date)
   description: Springer Author Date Style for the disciplines Medicine, Biomedicine, Life Sciences, Chemistry, Geosciences, Computer Science, Engineering, Economics. This style is based on Harvard style and recommendations of the Council of Biology Editors.

--- a/crates/citum-schema-style/embedded/styles/springer-basic-brackets-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/springer-basic-brackets-core.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Springer - Basic (numeric, brackets)
   description: Springer Numbered Style for the disciplines Medicine, Biomedicine, Life Sciences, Chemistry, Geosciences, Computer Science, Engineering, Economics. This style is based on Harvard style and recommendations of the Council of Biology Editors.

--- a/crates/citum-schema-style/embedded/styles/springer-basic-brackets.yaml
+++ b/crates/citum-schema-style/embedded/styles/springer-basic-brackets.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Springer - Basic (numeric, brackets)
   description: Springer Numbered Style for the disciplines Medicine, Biomedicine, Life Sciences, Chemistry, Geosciences, Computer Science, Engineering, Economics. This style is based on Harvard style and recommendations of the Council of Biology Editors.

--- a/crates/citum-schema-style/embedded/styles/springer-vancouver-brackets-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/springer-vancouver-brackets-core.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Springer - NLM/Vancouver (citation-sequence, brackets)
   description: Based on the document "Key Style Points 2.0 І December 2024".

--- a/crates/citum-schema-style/embedded/styles/springer-vancouver-brackets.yaml
+++ b/crates/citum-schema-style/embedded/styles/springer-vancouver-brackets.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Springer - NLM/Vancouver (citation-sequence, brackets)
   description: Based on the document "Key Style Points 2.0 І December 2024".

--- a/crates/citum-schema-style/embedded/styles/taylor-and-francis-chicago-author-date-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/taylor-and-francis-chicago-author-date-core.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: 'Taylor & Francis Journals Standard Reference Style Guide: Chicago'
   id: taylor-and-francis-chicago-author-date-core

--- a/crates/citum-schema-style/embedded/styles/taylor-and-francis-chicago-author-date.yaml
+++ b/crates/citum-schema-style/embedded/styles/taylor-and-francis-chicago-author-date.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: 'Taylor & Francis Journals Standard Reference Style Guide: Chicago'
   description: 'Taylor & Francis Journals adaptation of Chicago-style, author-date system, using style

--- a/crates/citum-schema-style/embedded/styles/taylor-and-francis-council-of-science-editors-author-date-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/taylor-and-francis-council-of-science-editors-author-date-core.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Taylor & Francis - Council of Science Editors (author-date)
   description: The Council of Science Editors style for T&F journals as per guidelines (version 2.0, 18 Jan 2018).

--- a/crates/citum-schema-style/embedded/styles/taylor-and-francis-council-of-science-editors-author-date.yaml
+++ b/crates/citum-schema-style/embedded/styles/taylor-and-francis-council-of-science-editors-author-date.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Taylor & Francis - Council of Science Editors (author-date)
   description: The Council of Science Editors style for T&F journals as per guidelines (version 2.0, 18 Jan 2018).

--- a/crates/citum-schema-style/embedded/styles/taylor-and-francis-national-library-of-medicine-core.yaml
+++ b/crates/citum-schema-style/embedded/styles/taylor-and-francis-national-library-of-medicine-core.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Taylor & Francis - National Library of Medicine (citation-sequence, brackets)
   description: 'NLM style as used by T & F : Brackets, no et-al, no issue numbers, locators in text possible as per Version 2.2 from 30 May 2023.'

--- a/crates/citum-schema-style/embedded/styles/taylor-and-francis-national-library-of-medicine.yaml
+++ b/crates/citum-schema-style/embedded/styles/taylor-and-francis-national-library-of-medicine.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Taylor & Francis - National Library of Medicine (citation-sequence, brackets)
   description: 'NLM style as used by T & F : Brackets, no et-al, no issue numbers, locators in text possible as per Version 2.2 from 30 May 2023.'

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml
@@ -10,20 +10,20 @@ source:
 style:
   id: chicago-shortened-notes-bibliography
   path: crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography.yaml
-  sha256: 5ee7afd5c74169d8882747d8ab6ede8b84aa12cd1760e1f0f3f544198cd1be94
+  sha256: 0350678436d9d2827d896e0ee16b8724c3542e6e8b9c0b369f5b80d1425972f5
   chain:
     - id: chicago-shortened-notes-bibliography
       path: crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography.yaml
-      sha256: 5ee7afd5c74169d8882747d8ab6ede8b84aa12cd1760e1f0f3f544198cd1be94
+      sha256: 0350678436d9d2827d896e0ee16b8724c3542e6e8b9c0b369f5b80d1425972f5
     - id: chicago-shortened-notes-bibliography-core
       path: crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml
-      sha256: ce674bebad0888fcc608b3fc9d89c3752a0a1f88b5aff8ddf3e4b60422ab50df
+      sha256: 6f1d5dcaf9eb67f7fff4787884c9eb8c0c3d31b03331ef3ba0305df66bef23a7
     - id: chicago-notes-18th
       path: crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml
-      sha256: 52f6130154400cb4cd7b6b680ae8d16128faf314e92c9b8cd23ca3f1ba0ad6f1
+      sha256: 13cf8bbf1ff43af3649a07c47a19ba23ea24e2f0065b77f6b1e40a9b2c2af6fa
     - id: chicago-18-base
       path: crates/citum-schema-style/embedded/styles/chicago-18-base.yaml
-      sha256: fa8cadf78de3efabec01f7e1d524d5f1e51b0682fab247b92f2c46f6352f2c74
+      sha256: 2cfc1a483740f6e14f56d3433a0b72ba5195de7518f000d3af7bd5f14ccc3b43
 fixtures:
   references:
     id: references-expanded

--- a/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.json
+++ b/docs/architecture/audits/2026-08-09-shortened-notes-coverage/packet.json
@@ -115,7 +115,7 @@
     ],
     "manifest": {
       "path": "docs/architecture/audits/2026-08-09-shortened-notes-coverage/manifest.yaml",
-      "sha256": "f3a6509d7b3c6dedb8612d296299c473bcaa7a6b90d00e74e674abff28d264e5"
+      "sha256": "02bd7a5b8b01dcf03932b9abb9274bbe9711e1e2f569d0dc44e7737796c7739a"
     },
     "relevance": {
       "default": "relevant",
@@ -159,28 +159,28 @@
         {
           "id": "chicago-shortened-notes-bibliography",
           "path": "crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography.yaml",
-          "sha256": "5ee7afd5c74169d8882747d8ab6ede8b84aa12cd1760e1f0f3f544198cd1be94"
+          "sha256": "0350678436d9d2827d896e0ee16b8724c3542e6e8b9c0b369f5b80d1425972f5"
         },
         {
           "id": "chicago-shortened-notes-bibliography-core",
           "path": "crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography-core.yaml",
-          "sha256": "ce674bebad0888fcc608b3fc9d89c3752a0a1f88b5aff8ddf3e4b60422ab50df"
+          "sha256": "6f1d5dcaf9eb67f7fff4787884c9eb8c0c3d31b03331ef3ba0305df66bef23a7"
         },
         {
           "id": "chicago-notes-18th",
           "path": "crates/citum-schema-style/embedded/styles/chicago-notes-18th.yaml",
-          "sha256": "52f6130154400cb4cd7b6b680ae8d16128faf314e92c9b8cd23ca3f1ba0ad6f1"
+          "sha256": "13cf8bbf1ff43af3649a07c47a19ba23ea24e2f0065b77f6b1e40a9b2c2af6fa"
         },
         {
           "id": "chicago-18-base",
           "path": "crates/citum-schema-style/embedded/styles/chicago-18-base.yaml",
-          "sha256": "fa8cadf78de3efabec01f7e1d524d5f1e51b0682fab247b92f2c46f6352f2c74"
+          "sha256": "2cfc1a483740f6e14f56d3433a0b72ba5195de7518f000d3af7bd5f14ccc3b43"
         }
       ],
       "id": "chicago-shortened-notes-bibliography",
       "path": "crates/citum-schema-style/embedded/styles/chicago-shortened-notes-bibliography.yaml",
       "resolvedSha256": "6dc52378865a482a312922f04daa7a63b6f9e75dc80ecdb9efa70f7bd7619975",
-      "sha256": "5ee7afd5c74169d8882747d8ab6ede8b84aa12cd1760e1f0f3f544198cd1be94"
+      "sha256": "0350678436d9d2827d896e0ee16b8724c3542e6e8b9c0b369f5b80d1425972f5"
     },
     "surfaces": [
       "bibliography",

--- a/styles/alpha.yaml
+++ b/styles/alpha.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 version: '0.10.0'
 info:
   title: Alpha (biblatex-alpha)

--- a/styles/american-chemical-society.yaml
+++ b/styles/american-chemical-society.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: ACS Guide 2022 revision
   description: The American Chemical Society style

--- a/styles/american-mathematical-society-label.yaml
+++ b/styles/american-mathematical-society-label.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 extends: elsevier-with-titles
 info:
   title: American Mathematical Society (label)

--- a/styles/american-medical-association-alphabetical.yaml
+++ b/styles/american-medical-association-alphabetical.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 extends: american-medical-association
 info:
   title: AMA Manual of Style 11th edition (sorted alphabetically)

--- a/styles/american-society-of-mechanical-engineers.yaml
+++ b/styles/american-society-of-mechanical-engineers.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 extends: ieee
 info:
   title: American Society of Mechanical Engineers

--- a/styles/chicago-notes-bibliography-17th-edition.yaml
+++ b/styles/chicago-notes-bibliography-17th-edition.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Chicago Manual of Style 17th edition (notes and bibliography)
   description: Chicago-style source citations (with Bluebook for legal citations), notes and bibliography system, 17th edition

--- a/styles/elsevier-vancouver-author-date.yaml
+++ b/styles/elsevier-vancouver-author-date.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 extends: elsevier-vancouver
 info:
   title: Elsevier - NLM/Vancouver (name-year)

--- a/styles/entomological-society-of-america.yaml
+++ b/styles/entomological-society-of-america.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 extends: elsevier-harvard
 info:
   title: Entomological Society of America

--- a/styles/experimental/chicago-author-date.yaml
+++ b/styles/experimental/chicago-author-date.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: "Chicago Manual of Style 18th edition (author-date)"
   id: "chicago-author-date"

--- a/styles/experimental/multilingual-partitioned.yaml
+++ b/styles/experimental/multilingual-partitioned.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 # Minimal style to demonstrate automatic bibliography partitioning.
 #
 # Partitions by LANGUAGE, not by script.

--- a/styles/harvard-cite-them-right.yaml
+++ b/styles/harvard-cite-them-right.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Cite Them Right 12th edition (author-date/Harvard)
   description: Harvard according to Cite Them Right, 11th edition.

--- a/styles/international-journal-of-wildland-fire.yaml
+++ b/styles/international-journal-of-wildland-fire.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 extends: springer-basic-author-date
 info:
   title: International Journal of Wildland Fire

--- a/styles/mhra-notes.yaml
+++ b/styles/mhra-notes.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: MHRA Style Guide 4th edition (notes)
   id: http://www.zotero.org/styles/mhra-notes

--- a/styles/nature.yaml
+++ b/styles/nature.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Nature
   fields:

--- a/styles/numeric-comp.yaml
+++ b/styles/numeric-comp.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Numeric Compound
   description: >

--- a/styles/oscola-no-ibid.yaml
+++ b/styles/oscola-no-ibid.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: OSCOLA 4th edition (no ibid.)
   description: 'Oxford University Standard for Citation of Legal Authorities, notes system, no ibid. For a Zotero group showing data entry: https://zotero.org/groups/2205533/collections/AC7ETLN4'

--- a/styles/oscola.yaml
+++ b/styles/oscola.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Oxford University Standard for Citation of Legal Authorities 4th edition
   description: 'Oxford University Standard for Citation of Legal Authorities, notes system. For a Zotero group showing data entry: https://zotero.org/groups/2205533/collections/AC7ETLN4'

--- a/styles/royal-society-of-chemistry.yaml
+++ b/styles/royal-society-of-chemistry.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Royal Society of Chemistry
   description: The Royal Society of Chemistry journal style.

--- a/styles/thomson-reuters-legal-tax-and-accounting-australia.yaml
+++ b/styles/thomson-reuters-legal-tax-and-accounting-australia.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json
 info:
   title: Thomson Reuters - Legal, Tax & Accounting Australia
   description: Style for a series of Thomson Reuters law publications for Australia


### PR DESCRIPTION
## Summary
- Adds `# yaml-language-server: $schema=https://docs.citum.org/schemas/style.json` as the first line of the 50 style YAML files that lacked it (apa-7th and 5 experimental styles already had it)
- No content/behavior change — schema editor hint only

## Test plan
- [x] `node scripts/validate-schemas.js --scope=styles,locales` — all pass
