### PR TITLE
docs(spec): range/collapse config audit + spec

### DIFF
--- a/.beans/archive/csl26-zepc--pr1-rangecollapse-config-audit-design-spec.md
+++ b/.beans/archive/csl26-zepc--pr1-rangecollapse-config-audit-design-spec.md
@@ -1,0 +1,20 @@
+---
+# csl26-zepc
+title: 'PR1: range/collapse config audit + design spec'
+status: completed
+type: task
+priority: high
+tags:
+    - engine
+    - schema
+    - docs
+created_at: 2026-08-26T22:30:06Z
+updated_at: 2026-08-26T22:32:18Z
+parent: csl26-awlo
+---
+
+Docs-only PR. Write docs/architecture/audits/2026-08-26_RANGE_COLLAPSE_CONFIG.md (the 12+ surface inventory + incoherence evidence) and docs/specs/RANGE_COLLAPSE_MODEL.md (Draft — resolution-chain questions for review, not settled answers, per the schema-changes-need-docs-pr-first rule). No code changes; skips build gate.
+
+## Summary of Changes
+
+Wrote docs/architecture/audits/2026-08-26_RANGE_COLLAPSE_CONFIG.md (12+ surface inventory, 7 concrete incoherences with file:line evidence, chi-chapter-locator reproducer) and docs/specs/RANGE_COLLAPSE_MODEL.md (Draft — 5 design questions with candidate answers, rejected alternatives, acceptance criteria). No code changes. Companion bean csl26-rgys (missing collapse: citation-number) and csl26-7yxy (Chicago hardcoded messages) filed as related/follow-on, both under the csl26-awlo epic.

--- a/.beans/csl26-7yxy--chicago-styles-hardcode-english-proseterms-in-opti.md
+++ b/.beans/csl26-7yxy--chicago-styles-hardcode-english-proseterms-in-opti.md
@@ -1,0 +1,16 @@
+---
+# csl26-7yxy
+title: Chicago styles hardcode English prose/terms in options.messages
+status: todo
+type: task
+priority: normal
+tags:
+    - chicago
+    - style
+    - localization
+created_at: 2026-08-26T22:30:21Z
+updated_at: 2026-08-26T22:30:24Z
+parent: csl26-awlo
+---
+
+13 pattern.chicago-* message definitions with literal English values across 4 style files (chicago-author-date-18th.yaml:36, chicago-notes-18th.yaml:38, chicago-shortened-notes-bibliography-core.yaml:38, taylor-and-francis-chicago-author-date-core.yaml:11), 3 keys duplicated verbatim across 3 files. Invisible to STYLE010 (scripts/style-structure-lint.js), which only scans prefix:/suffix: lines, not options.messages blocks — csl26-dfq0's localization sweep never saw this class. Two fixes: (1) chicago-volume/-volume-lower/chicago-version duplicate existing locale terms (term.volume.short etc, locales/en-US.yaml:846) — delete the messages, use number: volume + label-form: short instead (resolve_number_label in values/number.rs:110). (2) chicago-of/chicago-of-number/chicago-episode are genuine prose — move to locales/en-US.yaml's existing pattern.chicago-* run (line 1048), not the en-US-chicago override (author-date/notes don't set locale-override). Add STYLE011 lint rule for this class (report-only, like STYLE010). Acceptance bar per dfq0 precedent: 0 oracle entries changed, plus -L de-DE showing translated output. Independent of csl26-awlo's range/collapse redesign — no Rust changes, can land in parallel. Related: csl26-dfq0, csl26-boha (migrate-side emission, distinct).

--- a/.beans/csl26-awlo--rangecollapse-config-coherence.md
+++ b/.beans/csl26-awlo--rangecollapse-config-coherence.md
@@ -1,0 +1,17 @@
+---
+# csl26-awlo
+title: Range/collapse config coherence
+status: todo
+type: epic
+priority: high
+tags:
+    - engine
+    - schema
+    - style
+    - chicago
+created_at: 2026-08-26T22:30:01Z
+updated_at: 2026-08-26T22:30:06Z
+parent: csl26-w0hf
+---
+
+The number-range/collapse configuration is 12+ uncoordinated surfaces (page-range-format, locators.range-format, dates.range-format, citation-number collapse markers, compound sub-label collapse, delimiters) with no shared model, inconsistent optionality, hardcoded literals in some paths, and zero docs/guides/style-authoring coverage. Triggered by chi-chapter-locator: (Wilson 2019, 112-118) vs oracle's 112-18 — the locator preset hardcodes PageRangeFormat::Expanded, shadowing the style's page-range-format: chicago16. Full audit in docs/architecture/audits/2026-08-26_RANGE_COLLAPSE_CONFIG.md; design questions in docs/specs/RANGE_COLLAPSE_MODEL.md (Draft). Related: csl26-dfq0 (localization precedent), csl26-boha (migrate-side message emission, distinct), csl26-cl4q (open-ended ranges, must fit the new model).

--- a/.beans/csl26-rgys--9-embedded-styles-lost-collapse-citation-number-in.md
+++ b/.beans/csl26-rgys--9-embedded-styles-lost-collapse-citation-number-in.md
@@ -1,0 +1,16 @@
+---
+# csl26-rgys
+title: '9 embedded styles lost collapse: citation-number in migration'
+status: todo
+type: bug
+priority: normal
+tags:
+    - style
+    - migrate
+    - chicago
+created_at: 2026-08-26T22:30:13Z
+updated_at: 2026-08-26T22:30:21Z
+parent: csl26-awlo
+---
+
+Cross-checked every style's info.source.csl-id against styles-legacy/*.csl <citation collapse=...>: 9 styles declare a collapse in CSL and have none in the YAML. 5 embedded -core styles already carry processing: numeric (elsevier-vancouver-core, elsevier-with-titles-core, springer-basic-brackets-core, springer-vancouver-brackets-core, taylor-and-francis-national-library-of-medicine-core) — one-line fix, add collapse: citation-number. 2 have no processing: key at all (american-medical-association-alphabetical, american-society-of-mechanical-engineers), which is why extract_citation_collapse (crates/citum-migrate/src/assembly.rs:707) dropped it — adding processing: numeric changes more than collapse, needs per-style oracle evidence. entomological-society-of-america declares collapse="year" (same-author mechanism, not citation-number) — separate check. american-mathematical-society-label is correctly absent (inert Label regime). Overlaps surface #9 of csl26-awlo's audit; wait for that spec before implementing so the fix lands in the coherent model, not ad hoc.

--- a/docs/architecture/audits/2026-08-26_RANGE_COLLAPSE_CONFIG.md
+++ b/docs/architecture/audits/2026-08-26_RANGE_COLLAPSE_CONFIG.md
@@ -1,0 +1,178 @@
+# Number-range abbreviation is inconsistent across the citation
+
+- **Date:** 2026-08-26
+- **Bean:** `csl26-zepc` (epic: `csl26-awlo`)
+- **Audience:** PM / style domain expert. Implementation evidence for
+  engineers is in the appendix.
+
+## What's wrong
+
+Most citation styles abbreviate a page range: Chicago writes `112–118` as
+`112–18`, not the full four digits on both ends. Citum gets this right in the
+bibliography but not in the in-text citation, for the same reference, in the
+same style:
+
+```
+Bibliography entry (correct):
+  Kuhn, Thomas S. 1970. "Scientific Paradigms and Normal Science."
+  Philosophy of Science 37 (1): 1–13.
+
+In-text citation, same book, same style (wrong):
+  (Wilson 2019, 112–118)     ← Citum
+  (Wilson 2019, 112–18)      ← what Chicago/citeproc-js actually does
+```
+
+That's the bug that started this audit. Looking for it turned up something
+bigger: **abbreviation behavior isn't one setting that's occasionally
+misapplied — it's five different code paths that each decide, on their own,
+whether and how to shorten a number range**, and they don't agree with each
+other. Some respect the style's stated abbreviation rule; some ignore it
+entirely; two of them don't even use the same punctuation mark for the range
+dash. A style author writing YAML currently has no reliable way to say "make
+every range in this style follow rule X" — only "make ranges in the
+bibliography page count follow rule X, and hope the rest come out right."
+
+## Where it shows up
+
+| Where a range appears | Follows the style's stated rule? |
+|---|---|
+| Bibliography page count (`Philosophy of Science 37 (1): 1–13`) | ✅ Yes |
+| In-text citation locator (`Wilson 2019, 112–18`) | ❌ No — always renders in full, no matter what the style asks for |
+| Publication-date year ranges (`2021–26`) | ⚠️ Partially — there's a rule, but it's a completely separate on/off switch from the page-range rule above, so the two can (and do) disagree within one style |
+| Consecutive citation numbers in numeric styles (`[1–3]`) | ✅ Works, but always fully expanded — a numeric style that wants the CMOS-style short form (`[1–3]` vs. `[1-3]` vs. some other convention) can't ask for it |
+| Same-author, same-year suffix runs (`Smith 2020a–c`) | Works, but through a fourth independent switch |
+| Alphabetic sub-entry runs in a compound citation (`1a-c`) | Works, but joins with a plain hyphen (`-`) instead of the en dash (`–`) every other range in the document uses |
+
+Four different features, four different on/off switches, and the two that
+use a dash disagree on which dash. None of the four can be told "use the
+style's page-range rule" — each one hardcodes its own answer, so the actual
+behavior a reader sees depends on *which kind* of range it is, not on
+anything the style author configured.
+
+## Why this happened
+
+Page-range abbreviation was implemented once, correctly, for the bibliography
+page count. When locators, dates, citation-number lists, and compound
+sub-entries were added later, each one got its own small, separate switch
+instead of reusing the first one — so today there is no single place a style
+author (or Citum itself) can point to and say "this is how ranges abbreviate
+in this style." Two of the newer switches (citation-number ranges and
+same-author year-suffix ranges) don't even expose a switch — the dash they
+use is a hardcoded literal in the Rust code, so no style, however it's
+written, can change it.
+
+There's also a documentation gap: `docs/guides/style-authoring/` — the guide
+a style author would actually read — never explains any of this. The one
+mention of range abbreviation in the guide is a locale message that, per the
+appendix below, nothing in the engine actually reads.
+
+## What this means for the fix
+
+This is a design problem, not a one-line bug fix. The locator bug could be
+patched in isolation, but patching it without addressing the rest would leave
+three more silently-inconsistent switches in place, plus the dead
+documentation. `docs/specs/RANGE_COLLAPSE_MODEL.md` proposes one shared rule
+that all five switches follow, and asks for a decision on the handful of
+places where the "shared rule" needs a judgment call — that's the doc worth
+reading and deciding on next.
+
+A separate, narrower defect — 9 styles that lost their citation-number
+abbreviation entirely somewhere in the CSL 1.0 → Citum conversion — is
+tracked as `csl26-rgys`. It's related, but it's a data-migration gap, not a
+design gap, so it's kept out of this audit and should wait for the design
+decision above rather than being patched ad hoc.
+
+---
+
+## Appendix: implementation surfaces (for engineers)
+
+Twelve config fields and four rendering code paths implement the six rows
+above. Full inventory, with `file:line` evidence for every claim in the body
+of this audit:
+
+| # | Surface | Type | Consumer(s) | Note |
+|---|---|---|---|---|
+| 1 | `options.page-range-format` | `Option<PageRangeFormat>` (5 variants: `expanded`, `minimal`, `minimal-two`, `chicago`, `chicago16`) | `citum-engine/src/values/number.rs:47` | Only reached by the `page` variable (bibliography row) |
+| 2 | `options.page-range-delimiter` | `Option<String>` | `citum-engine/src/values/number.rs:42` | Falls back to locale #12 when unset — only surface that does |
+| 3 | `citation.options.page-range-format` | `Option<PageRangeFormat>` | `citum-schema-style/src/options/mod.rs:292` → merges into `Config` | Scoped format override with no sibling scoped delimiter field; see incoherence 4 |
+| 4 | `bibliography.options.page-range-format` | `Option<PageRangeFormat>` | `options/mod.rs:415` → merges into `Config` | Scoped format override with no sibling scoped delimiter field; see incoherence 4 |
+| 5 | `options.locators.range-format` | `PageRangeFormat`, **non-optional, hardcoded default `Expanded`** | `citum-engine/src/values/locator.rs:225` (`effective_range_format`) | Shadows #1 for every locator kind — this is the citation-locator row |
+| 6 | `options.locators.kinds.<kind>.range-format` | `Option<PageRangeFormat>` | same fn, checked first | Already optional; the pattern #5 should follow |
+| 7 | `options.dates.range-format` | `DateRangeFormat` (2 variants: `expanded`, `chicago`) | `citum-engine/src/values/date.rs:510` | Parallel enum to #1, not the same type — the date-range row |
+| 8 | `options.dates.range-delimiter` | `String`, default `"–"` | `citum-engine/src/values/date.rs:422,855` | Parallel to #2, independent field |
+| 9 | `citation.collapse: citation-number` | enum variant, no associated config | `citum-engine/src/processor/rendering/collapse.rs:85` (`collapse_numeric_citation_chunks`) | Builds `format!("{n}–{m}")` — literal en-dash, always fully expanded, ignores #2 and #12 entirely. The citation-number-list row |
+| 10 | `citation.collapse.same-author.year_suffix: ranged` | enum variant | `citum-engine/src/processor/rendering/grouped/year_suffix.rs:22` (`RANGE_DELIMITER` const) | A **third**, independently hardcoded `"–"` literal — the const's own doc comment notes it deliberately does *not* reuse #2/#12. The same-author-suffix row |
+| 11 | `bibliography.options.compound-numeric.collapse-subentries` | `bool` | `citum-engine/src/processor/rendering/mod.rs:487` | **Not** a range-formatting consumer — gates whether subentry grouping happens at all. The actual alphabetic range join (`collapse.rs:198`, `format!("{a}-{b}")`, literal ASCII hyphen, comma-joined) is instead gated by `compound_numeric.sub_label == Alphabetic`, a separate field. The compound-sub-entry row |
+| 12 | locale `grammar-options.page-range-delimiter` | `String` | `number.rs:43`, `locator.rs:97,116,151,183` | The one value multiple consumers share — but reached through two different resolution rules (see incoherence 2) |
+| 13 | locale `messages: pattern.page-range` | MF2 message (`"{$start}–{$end}"`) | **nothing reads it** | Defined in `en-US`, `es-ES`, `eu-ES`, `fr-FR`, `tr-TR`; referenced by zero styles and zero engine code — this is the "one mention in the style-authoring guide" that turns out to be dead |
+
+Also checked and confirmed **not** a range-formatting consumer:
+`NumberVariable::Volume` / `::Issue` (`values/number.rs:26,28`) render via a
+bare `reference.volume()/.issue().to_string()` — a hyphenated volume value
+like `"3-4"` passes through unnormalized, touching none of #1/#2/#5/#12.
+
+### Reproducer
+
+```
+$ citum render refs -s styles/embedded/chicago-author-date-18th.yaml \
+    -b <chapter with pages "112-118"> -c <citation with locator page 112-118> -m cite
+
+Citum:      (Wilson 2019, 112–118)
+citeproc-js: (Wilson 2019, 112–18)
+```
+
+`chicago-author-date-18th.yaml` sets `options.page-range-format: chicago16`
+(inherited from `chicago-18-base.yaml:11`) and `options.locators: note`. The
+bibliography `page` variable reads that setting correctly. The citation
+locator does not, because it never sees it — surface #5.
+
+### Concrete incoherences
+
+**1. Format shadowing.** #5 is non-optional and every `LocatorPreset::config()`
+arm (`options/locators.rs:199` Note, `:221` AuthorDate, `:230` Numeric)
+hardcodes `PageRangeFormat::Expanded`, so #1 is structurally unreachable for
+any locator in any style using a preset — which is every style in the
+portfolio except the four with an explicit `locators:` map
+(`american-medical-association`, `oscola`, `oscola-no-ibid`, `mhra-notes`).
+Only `mhra-notes.yaml:11` sets #5 directly, to `expanded`.
+
+**2. Delimiter resolution runs backwards between the two nearest surfaces.**
+`values/number.rs:42-44` resolves #2 first, falling back to locale #12 only
+when the style leaves #2 unset. `values/locator.rs:97,116,151,183` reads #12
+directly and never consults #2 at all — the same axis, two different and
+incompatible resolution rules, in the same crate.
+
+**3. Three independently hardcoded dash literals.** `collapse.rs:85`
+(citation-number ranges, `"–"` en-dash, always fully expanded — a numeric
+style that wants `[1-3]` collapsed to `[1–3]` gets it, but one that wants the
+CSL `minimal` abbreviation instead has no way to ask), `collapse.rs:198`
+(compound sub-labels, `"-"` ASCII hyphen — a different character from the
+other two), and `year_suffix.rs:22`'s `RANGE_DELIMITER` const (en-dash again,
+with a comment explicitly declining to reuse #2/#12). None of the three reads
+any config surface.
+
+**4. Scoped formats have no sibling delimiter override.** `CitationOptions`
+and `BibliographyOptions` expose `page_range_format` but not
+`page_range_delimiter`. Their `Config` conversions set
+`page_range_delimiter: None` (`options/mod.rs:855-856`, `:989-990`), and
+`Config::merged` preserves the style-level delimiter because `None` does not
+override it. A style can therefore choose a scoped abbreviation format, but it
+cannot pair that choice with a scoped delimiter; it must use the style-level
+or locale delimiter.
+
+**5. Two parallel enums encode the same idea.** `PageRangeFormat` (5 variants)
+and `DateRangeFormat` (2 variants) are distinct Rust types with no conversion
+between them, yet `values/date.rs:530` already calls
+`values::number::format_chicago_range_end` — the page-range module's own
+Chicago-abbreviation algorithm — to implement `DateRangeFormat::Chicago`. The
+algorithm is shared; the configuration vocabulary that selects it is not.
+
+**6. Dead surface.** #13 (`pattern.page-range`) is authored in five locale
+files and consumed by nothing. Either it predates #1-#12 as an earlier design
+for the same problem, or it was never wired up.
+
+**7. Zero public documentation.** `grep -ri range docs/guides/style-authoring/*.html`
+returns exactly one hit: the dead #13, in `locales.html`. A style author
+reading the guide has no way to learn that `page-range-format`,
+`locators.range-format`, `dates.range-format`, and `collapse` exist, let alone
+how they interact.

--- a/docs/specs/RANGE_COLLAPSE_MODEL.md
+++ b/docs/specs/RANGE_COLLAPSE_MODEL.md
@@ -1,0 +1,248 @@
+# Range/Collapse Model Specification
+
+**Status:** Draft
+**Version:** 1.0
+**Date:** 2026-08-28
+**Supersedes:** (none — no prior spec covers this ground)
+**Related:** `docs/architecture/audits/2026-08-26_RANGE_COLLAPSE_CONFIG.md`
+(the evidence behind this spec — read that first), `docs/specs/EDTF_DATE_RANGE_FORMATTING.md`
+(dates keep independent policy from pages, already shipped — see Decision 1),
+`docs/adjudication/DIVERGENCE_REGISTER.md` (`div-017`, `div-009` — the
+existing mechanism for intentional citeproc-js divergence, used in Decision
+2 and Acceptance Criteria), `csl26-awlo` (epic), `csl26-cl4q` (open-ended
+ranges, e.g. `"12ff"` — must fit this model), `csl26-rgys` (9 styles missing
+citation-number abbreviation — implementation should wait for this spec),
+`docs/policies/LOCALIZATION_INTEGRITY.md`
+
+## Purpose
+
+Citum abbreviates number ranges (`112–118` → `112–18`) correctly in one
+place — the bibliography page count — and inconsistently everywhere else a
+range can appear: citation locators, publication-date ranges, citation-number
+lists, same-author suffix runs, and compound sub-entries.
+
+**One range-rendering model: contextual inheritance, explicit overrides, and
+semantic defaults.** Two separate questions this spec keeps apart:
+
+- **Mechanism** — every range-producing surface uses the same
+  configuration-resolution system, with an explicit override always
+  available and nothing hardcoded at the call site. Decided: yes,
+  unconditionally (Decision 1).
+- **Default value inheritance** — what a surface gets when it doesn't
+  override. Not automatically the same value everywhere: a citation number
+  and a page number are both "numbers that can range," but they aren't the
+  same *kind* of thing. Resolved by the semantic-class layer in Decision 1
+  and the locator default in Decision 2.
+
+A rendered range also has two independent formatting properties that this
+spec keeps distinct rather than folding into one knob: **endpoint
+abbreviation** (`112–118` → `112–18`) and the **delimiter** character
+joining the two numbers (`–` vs `-` vs a locale-specific form). They often
+travel together but are resolved through separate chains (appendix).
+
+## Scope
+
+Configuration resolution for closed numeric ranges — endpoint abbreviation
+and delimiter selection — for page variables, citation locators,
+citation-number sequences, compound sub-entry sequences, date ranges, and
+same-author suffix sequences.
+
+Out of scope: whether adjacent values collapse into a range at all
+(`citation.collapse` and friends — untouched), open-ended ranges like
+`"12ff"` (`csl26-cl4q`), and the distinct parsing/formatting logic date and
+letter endpoints require beyond what they can share with numeric endpoints.
+
+**Nothing here removes an override a style author already has.** Every
+example below is the actual YAML. Locators, citation-number lists,
+same-author suffixes, and compound entries currently have *no* field to
+set their own abbreviation behavior — this spec gives them the same
+override mechanism `mhra-notes.yaml` already uses for locators today
+(`options.locators.range-format: expanded`).
+
+## Decisions
+
+| # | Decision | Resolution |
+|---|---|---|
+| 1 | One configuration-resolution mechanism for every range, organized by semantic class; generic field names instead of page-specific ones | `range-format` / `range-delimiter` replace `page-range-format` / `page-range-delimiter`; every surface gets an explicit-override path; defaults are set per semantic class, not flatly |
+| 2 | Does the style-wide default apply to every locator kind, or only pages? | **All kinds**, by design. Per-kind override (already in the schema) is how a style opts a specific kind back out |
+| 3 | Citation-scoped and bibliography-scoped range settings — fix or remove? | **Remove.** Zero of 17 styles that set `page-range-format` use a scoped copy distinct from the style-level value |
+
+### 1. One mechanism, generic naming, semantic-class defaults
+
+Today only the bibliography page count reads the style's declared
+abbreviation rule; locators, citation-number lists, same-author suffixes,
+and compound entries either have no field at all or a disconnected one.
+Fix, with no change required to existing style YAML:
+
+```yaml
+# chicago-author-date-18th.yaml, today — bibliography abbreviates (1–13),
+# the in-text locator doesn't, because it isn't wired to anything
+options:
+  page-range-format: chicago16
+  locators: note
+```
+
+```yaml
+# same file, after this spec — the locator now inherits chicago16 too;
+# no YAML change needed to fix the bug
+options:
+  page-range-format: chicago16   # → range-format, see naming below
+  locators: note
+```
+
+An author who wants one surface to diverge keeps the exact mechanism that
+exists today — `mhra-notes.yaml` already writes this:
+
+```yaml
+options:
+  locators:
+    range-format: expanded    # explicit override, wins over any inherited default
+```
+
+**Naming.** `range-format` / `range-delimiter` replace `page-range-format` /
+`page-range-delimiter` at the style-options level. Not a new convention —
+`options.dates.range-format` (shipped) already uses the generic name, scoped
+under `dates:`. This makes the schema consistent with what's already in
+production rather than introducing a second pattern. `PageRangeFormat`
+becomes a generically-named Rust type (appendix); `chicago16` is retained as
+an accepted value spelling.
+
+**Semantic classes** — a surface's default comes from its class, not one
+flat value:
+
+- **Numeric textual locators** — pages, chapters, paragraphs, notes,
+  sections. Inherit the style-wide default (Decision 2: all kinds).
+- **Dates/years** — independent policy, per `EDTF_DATE_RANGE_FORMATTING.md`
+  (shipped). Shares the value vocabulary and algorithm
+  (`values/date.rs:530` already calls `format_chicago_range_end`, the same
+  function pages use), not the configuration field.
+- **Identifier sequences** — citation numbers, compound-entry numbers.
+  List positions, not prose numerals; no inherited bearing from the page/
+  date elision rule. Defaults independently.
+- **Suffix sequences** — `2020a–c`. Letter endpoints; shares only the
+  delimiter/collapsing mechanism, not an abbreviation policy.
+
+Inheritance chain: `explicit surface override → semantic-class default →
+style-wide default → Expanded`.
+
+### 2. Locator default: all kinds
+
+The style-wide default applies to every locator kind. The per-kind override
+is how a style opts a *specific* kind back out — not how it opts one in:
+
+```yaml
+options:
+  range-format: chicago16
+  locators:
+    kinds:
+      chapter:
+        range-format: expanded   # opts this one kind out of the style default
+```
+
+If this moves any style's oracle-verified output away from citeproc-js
+(citeproc-js only abbreviates page locators), that's registered as an
+intentional divergence in `docs/adjudication/DIVERGENCE_REGISTER.md`, the
+project's existing mechanism for exactly this (`div-017`, `div-009`) — not
+silently absorbed as a parity change.
+
+### 3. Citation/bibliography-scoped range settings: removed
+
+```yaml
+# expressible today, unused in the corpus
+citation:
+  options:
+    page-range-format: minimal
+bibliography:
+  options:
+    page-range-format: chicago16
+```
+
+Zero of the 17 styles that set `page-range-format` use a scope-specific
+value. Formatting policy attaches to the semantic type of a range, not to
+the rendering region it appears in — a page count is a page count whether
+it's in a citation or the bibliography. Remove
+`CitationOptions`/`BibliographyOptions`'s copy of the field. This also
+closes the "add a scoped delimiter" question — there's no scoped format
+left for one to pair with.
+
+## Acceptance Criteria
+
+- [ ] `range-format`/`range-delimiter` resolve for every surface in scope,
+      with an explicit override available at each
+- [ ] `chi-chapter-locator` renders `112–18`, matching citeproc-js
+- [ ] `mhra-notes`' explicit `locators.range-format: expanded` still wins —
+      explicit overrides beat every inherited default
+- [ ] `CitationOptions`/`BibliographyOptions` no longer carry a
+      `page-range-format`/`range-format` field
+- [ ] `docs/guides/style-authoring/` documents the resulting model
+- [ ] Unintentional oracle-verified output changes are regressions and block
+      the implementation PR. Any style where the all-kinds locator default
+      (Decision 2) diverges from citeproc-js gets a `div-0NN` entry in
+      `DIVERGENCE_REGISTER.md`, following the `div-017`/`div-009` pattern
+
+---
+
+## Appendix: implementation notes (for engineers)
+
+Full surface inventory and evidence: see the audit doc linked above.
+
+- **Naming.** `PageRangeFormat` → a generic type name (e.g.
+  `NumberRangeFormat`); `chicago16` retained as an accepted spelling.
+- **Dates stay a separate field.** `DateRangeFormat` is not merged into
+  `range-format` — `dates.range-format` remains its own key, per the shipped
+  EDTF spec. What unifies: value vocabulary and the underlying algorithm.
+- **Delimiter chain**: scope option → style option → locale
+  `grammar-options.page-range-delimiter`, applied identically by the page
+  variable (`values/number.rs`), locators (`values/locator.rs`),
+  citation-number ranges (`collapse.rs:85`), compound sub-labels
+  (`collapse.rs:198`), and same-author suffix ranges (`year_suffix.rs:22`),
+  retiring all three currently-hardcoded literals. Whether
+  citation-number/compound/suffix ranges use the *page* delimiter term or a
+  distinct locale term (citeproc-js's `citation-range-delimiter` concept) is
+  open — resolve during implementation if no corpus evidence forces the
+  answer earlier.
+- **Locator kind gating**: `locators.kinds.<kind>.range-format` →
+  `locators.range-format` → `options.range-format` → `Expanded`, applied to
+  every kind (Decision 2). `LocatorConfig::range_format` becomes
+  `Option<RangeFormat>` (currently non-optional, hardcoded `Expanded` —
+  audit incoherence 1); the three `LocatorPreset::config()` arms set `None`.
+  **Rejected:** resolving the style default at preset-injection time
+  instead — the four styles with an explicit `locators:` map
+  (`american-medical-association`, `oscola`, `oscola-no-ibid`,
+  `mhra-notes`) never go through `LocatorPreset::config()` and would still
+  miss the fallback.
+- **Scoped-field removal**: delete `page_range_format` from
+  `CitationOptions`/`BibliographyOptions` (`options/mod.rs:292`, `:415`) and
+  their `to_config()` conversions (`:855-856`, `:989-990`).
+- **Also found, unrelated to any decision above**: `pattern.page-range`
+  (an MF2 locale message in 5 locale files) is dead — nothing reads it
+  (audit incoherence 6). Delete it during implementation.
+- **Rejected (general)**: resolving format/delimiter freshly at each call
+  site instead of at config-merge time — this is the current state that
+  produced three independent hardcoded literals.
+- **Architecture test.** The implementation should express all of the
+  following through configuration and one shared resolution API, with no
+  duplicated precedence logic across `number.rs`, `locator.rs`,
+  `collapse.rs`, `year_suffix.rs`, and `date.rs`:
+
+  ```yaml
+  options:
+    range-format: chicago
+    locators:
+      kinds:
+        chapter:
+          range-format: expanded   # opt one kind out
+    citation-numbers:
+      range-format: expanded       # identifier sequences stay their own default
+    dates:
+      range-format: expanded       # independent policy, per EDTF spec
+  ```
+
+- `just schema-gen` required in the implementation commit.
+
+## Changelog
+
+- v1.0 (2026-08-28): Resolved for implementation — generic `range-format`/
+  `range-delimiter` naming; locator default applies to all kinds with
+  per-kind opt-out; citation/bibliography-scoped range settings removed
+  (0/17 corpus usage). See PR #1235 for drafting history.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -156,6 +156,7 @@ note. The `—` marker in the Tests column means no targeted test exists yet.
 | [`TITLE_TEXT_CASE.md`](./TITLE_TEXT_CASE.md) — modeling and applying title-like text-case transformations | Active | `bibliography.rs` |
 | [`TITLE_NAME_INFLECTION.md`](./TITLE_NAME_INFLECTION.md) — grammatical inflection of title-adjacent names | Active | `bibliography.rs` |
 | [`PUNCTUATION_NORMALIZATION.md`](./PUNCTUATION_NORMALIZATION.md) — normalization of punctuation at rendered output boundaries | Draft | `bibliography.rs`, `citations.rs` |
+| [`RANGE_COLLAPSE_MODEL.md`](./RANGE_COLLAPSE_MODEL.md) — shared configuration resolution for range abbreviation and delimiters | Draft | — |
 | [`DJOT_RICH_TEXT.md`](./DJOT_RICH_TEXT.md) — Djot as the rich-text markup substrate for note/abstract fields | Active | `document.rs::djot_adapter` |
 | [`SHORT_NAME.md`](./SHORT_NAME.md) — short-name rendering for abbreviated contributor identifiers | Active | `bibliography.rs::title_short_resolution` |
 | [`ABBREVIATION_MAP.md`](./ABBREVIATION_MAP.md) — abbreviation lookup map for journal and publisher names | Active | `bibliography.rs` |


### PR DESCRIPTION
## Summary
- Docs-only. Adds `docs/architecture/audits/2026-08-26_RANGE_COLLAPSE_CONFIG.md`: a full inventory of the 12+ config surfaces governing number-range collapsing (page ranges, date ranges, citation-number ranges, compound sub-labels), with file:line evidence for 7 concrete incoherences — most notably that `chi-chapter-locator` renders `112–118` instead of citeproc-js's `112–18` because `LocatorConfig::range_format` is a non-optional, hardcoded-`Expanded` field that shadows the style's `page-range-format: chicago16`
- Adds `docs/specs/RANGE_COLLAPSE_MODEL.md` (Status: Draft) — 5 design questions with candidate answers and rejected alternatives, raised for review before any implementation, per the project's schema-changes-need-a-docs-PR-first convention
- Files 3 beans under new epic `csl26-awlo`: `csl26-zepc` (this PR, completed), `csl26-rgys` (9 styles missing `collapse: citation-number`, separate defect), `csl26-7yxy` (Chicago styles hardcoding English prose/terms in `options.messages`, independent of the range work)

## Test plan
- [x] `./scripts/validate-frontmatter.sh --copilot-strict` — passes (one unrelated pre-existing failure outside this repo)
- Docs-only PR — skips build/test gate per CLAUDE.md
